### PR TITLE
[codex] Link PHPT serum calcium endpoint

### DIFF
--- a/kb/disorders/Parathyroid_Hyperplasia.yaml
+++ b/kb/disorders/Parathyroid_Hyperplasia.yaml
@@ -1,6 +1,6 @@
 name: Parathyroid Hyperplasia
 creation_date: "2026-05-07T23:30:03Z"
-updated_date: "2026-05-08T00:08:30Z"
+updated_date: "2026-05-11T11:55:36Z"
 category: Complex
 description: >-
   Parathyroid hyperplasia is enlargement of parathyroid tissue due to increased
@@ -597,6 +597,60 @@ genetic:
     explanation: >-
       Supports inclusion of MEN4 within the MEN1-5 hereditary syndromic PHPT
       spectrum; CDKN1B was verified locally with OAK as hgnc:1785.
+biochemical:
+- name: Serum Calcium
+  subtype: Primary MGD
+  presence: Elevated
+  context: >-
+    Corrected total serum calcium is elevated in primary
+    hyperparathyroidism-associated hypercalcemia and is used to monitor
+    calcium-sensing receptor agonist response.
+  readouts:
+  - target: Calcium Homeostasis Disruption
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-095
+    interpretation: >-
+      Higher serum calcium reflects greater hypercalcemia from PHPT-related
+      calcium-homeostasis disruption; calcium-sensing receptor agonist therapy
+      such as cinacalcet is expected to lower this readout.
+    evidence:
+    - reference: PMID:25637076
+      reference_title: "Cinacalcet normalizes serum calcium in a double-blind randomized, placebo-controlled study in patients with primary hyperparathyroidism with contraindications to surgery."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Serum Ca normalized (≤10.3 mg/dl) in 75.8% of cinacalcet- vs 0% of placebo-treated subjects (P<0.001)."
+      explanation: >-
+        This randomized trial directly supports serum calcium as a
+        pharmacodynamic endpoint for cinacalcet response in PHPT.
+  evidence:
+  - reference: PMID:25637076
+    reference_title: "Cinacalcet normalizes serum calcium in a double-blind randomized, placebo-controlled study in patients with primary hyperparathyroidism with contraindications to surgery."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Primary hyperparathyroidism (PHPT) is diagnosed by the presence of
+      hypercalcemia and elevated or nonsuppressed parathyroid hormone (PTH)
+      levels.
+    explanation: >-
+      Establishes hypercalcemia as the defining serum-calcium abnormality in
+      primary hyperparathyroidism.
+  biomarker_term:
+    preferred_term: Calcium
+    term:
+      id: NCIT:C331
+      label: Calcium
+  mappings_list:
+  - preferred_term: Calcium [Mass/volume] in Serum or Plasma
+    term:
+      id: LOINC:17861-6
+      label: Calcium [Mass/volume] in Serum or Plasma
+  - preferred_term: calcium(2+)
+    term:
+      id: CHEBI:22984
+      label: calcium(2+)
 diagnosis:
 - name: Biochemical Diagnosis
   description: >-

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2377,8 +2377,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Primary hyperparathyroidism; population: Patients with hypercalcemia due
     to primary hyperparathyroidism; endpoint: Serum calcium; approval context: traditional; drug mechanism:
     Calcium-sensing receptor agonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Parathyroid Hyperplasia
+  mapped_disease_files:
+  - kb/disorders/Parathyroid_Hyperplasia.yaml
+  mapping_notes: >-
+    Manually mapped to the primary hyperparathyroidism-associated multiglandular
+    disease subtype of Parathyroid Hyperplasia because serum calcium is
+    represented as a pharmacodynamic readout of Calcium Homeostasis Disruption.
+    The FDA row applies to hypercalcemia due to primary hyperparathyroidism
+    broadly, so this is a subtype/context mapping rather than a claim that all
+    primary hyperparathyroidism is parathyroid hyperplasia.
 - row_id: FDA-SE-adult-noncancer-096
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related

--- a/references_cache/PMID_25637076.md
+++ b/references_cache/PMID_25637076.md
@@ -1,0 +1,191 @@
+---
+reference_id: "PMID:25637076"
+title: "Cinacalcet normalizes serum calcium in a double-blind randomized, placebo-controlled study in patients with primary hyperparathyroidism with contraindications to surgery."
+authors:
+- Khan A
+- Bilezikian J
+- Bone H
+- Gurevich A
+- Lakatos P
+- Misiorowski W
+- Rozhinskaya L
+- Trotman ML
+- Tóth M
+journal: Eur J Endocrinol
+year: '2015'
+doi: 10.1530/EJE-14-0877
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Cinacalcet
+- Contraindications
+- Double-Blind Method
+- Endpoint Determination
+- Female
+- Humans
+- "Hypercalcemia/blood, drug therapy, etiology"
+- "Hyperparathyroidism/blood, complications, drug therapy"
+- Male
+- Middle Aged
+- "Naphthalenes/adverse effects, therapeutic use"
+- Parathyroidectomy
+- Phosphorus/blood
+content_type: full_text_xml
+---
+
+# Cinacalcet normalizes serum calcium in a double-blind randomized, placebo-controlled study in patients with primary hyperparathyroidism with contraindications to surgery.
+**Authors:** Khan A, Bilezikian J, Bone H, Gurevich A, Lakatos P, Misiorowski W, Rozhinskaya L, Trotman ML, Tóth M
+**Journal:** Eur J Endocrinol (2015)
+**DOI:** [10.1530/EJE-14-0877](https://doi.org/10.1530/EJE-14-0877)
+
+## Content
+
+1. Eur J Endocrinol. 2015 May;172(5):527-35. doi: 10.1530/EJE-14-0877. Epub 2015
+Jan 30.
+
+Cinacalcet normalizes serum calcium in a double-blind randomized,
+placebo-controlled study in patients with primary hyperparathyroidism with
+contraindications to surgery.
+
+Khan A(1), Bilezikian J(2), Bone H(2), Gurevich A(2), Lakatos P(2), Misiorowski
+W(2), Rozhinskaya L(2), Trotman ML(2), Tóth M(2).
+
+Author information:
+(1)Divisions of Endocrinology and GeriatricsMcMaster University, 331-209 Sheddon
+Avenue, Oakville, Ontario, Canada L6J 1X8College of Physicians and
+SurgeonsColumbia University, New York, New York, USAMichigan Bone and Mineral
+ClinicDetroit, Michigan, USAAmgen (Europe) GmbHZug, Switzerland1st Department of
+MedicineSemmelweis University Medical School, Budapest, HungaryDepartment of
+EndocrinologyMedical Centre of Postgraduate Education, Warsaw,
+PolandEndocrinology Research CentreMoscow, RussiaAmgenInc., Thousand Oaks,
+California, USA2nd Department of MedicineSemmelweis University, Budapest,
+Hungary draliyakhan@gmail.com.
+(2)Divisions of Endocrinology and GeriatricsMcMaster University, 331-209 Sheddon
+Avenue, Oakville, Ontario, Canada L6J 1X8College of Physicians and
+SurgeonsColumbia University, New York, New York, USAMichigan Bone and Mineral
+ClinicDetroit, Michigan, USAAmgen (Europe) GmbHZug, Switzerland1st Department of
+MedicineSemmelweis University Medical School, Budapest, HungaryDepartment of
+EndocrinologyMedical Centre of Postgraduate Education, Warsaw,
+PolandEndocrinology Research CentreMoscow, RussiaAmgenInc., Thousand Oaks,
+California, USA2nd Department of MedicineSemmelweis University, Budapest,
+Hungary.
+
+OBJECTIVE: Primary hyperparathyroidism (PHPT) is diagnosed by the presence of
+hypercalcemia and elevated or nonsuppressed parathyroid hormone (PTH) levels.
+Although surgery is usually curative, some individuals fail or are unable or
+unwilling to undergo parathyroidectomy. In such individuals, targeted medical
+therapy may be of value. Cinacalcet normalized calcium level and lowered PTH in
+patients with PHPT in several phase 2 and open-label studies. We compared
+cinacalcet and placebo in subjects with PHPT unable to undergo
+parathyroidectomy.
+DESIGN: Phase 3, double-blind, multi centere, randomized, placebo-controlled
+study.
+METHODS: Sixty-seven subjects (78% women) with moderate PHPT were randomized
+(1:1) to cinacalcet or placebo for ≤28 weeks.
+MAIN OUTCOME MEASURE: Achievement of a normal mean corrected total serum calcium
+concentration of ≤10.3 mg/dl (2.575 mmol/l).
+RESULTS: Baseline median (quartile 1 (Q1), Q3) serum PTH was 164.0 (131.0,
+211.0) pg/ml and mean (s.d.) serum Ca was 11.77 (0.46) mg/dl. Serum Ca
+normalized (≤10.3 mg/dl) in 75.8% of cinacalcet- vs 0% of placebo-treated
+subjects (P<0.001). Corrected serum Ca decreased by ≥1.0 mg/dl from baseline in
+84.8% of cinacalcet- vs 5.9% of placebo-treated subjects (P<0.001). Least
+squares mean (s.e.m.) plasma PTH change from baseline was -23.80% (4.18%)
+(cinacalcet) vs -1.01% (4.05%) (placebo) (P<0.001). Similar numbers of subjects
+in the cinacalcet and placebo groups reported adverse events (AEs) (27 vs 20)
+and serious AEs (three vs four). Most commonly reported AEs were nausea and
+muscle spasms.
+CONCLUSIONS: These results demonstrate that cinacalcet normalizes serum calcium
+in this PHPT population and appears to be well tolerated.
+
+© 2015 European Society of Endocrinology.
+
+DOI: 10.1530/EJE-14-0877
+PMCID: PMC5729741
+PMID: 25637076 [Indexed for MEDLINE]
+
+Primary hyperparathyroidism (PHPT) is diagnosed by the presence of hypercalcemia and an elevated or nonsuppressed parathyroid hormone (PTH) level (1). PHPT is caused by a solitary adenoma in ~85% of cases, with multi-glandular disease occurring in up to 15% of cases (2). Parathyroid carcinoma is rare (3). Following the introduction of the multiple-channel biochemical analyzers in the early 1970s, the clinical presentation of PHPT changed from a symptomatic condition (e.g., renal stones, fragility fractures, and significant hypercalcemia) to a largely asymptomatic condition (4).
+
+With parathyroid surgery, PHPT may be cured, with normalization of both serum calcium and RIH. Surgery is both safe and effective in experienced hands with surgical success rates typically < 95% (5). In subjects with symptomatic PHPT, surgery is indicated. At the 3rd and, more recently, the 4th International Workshops on the management of asymptomatic PHPT, amended guidelines were developed to identify which patients may be safely followed without surgery. The recommendations from these workshops also provide a set of guidelines for appropriate monitoring and medical follow-up in those who do not meet surgical guidelines as well as those who are unable or unwilling to undergo parathyroidectomy (4, 6). The more recent guidelines now recommend assessment of both serum creatinine and estimated glomerular filtration rate (eGFR) annually (6). Individuals who have persistent or recurrent disease following parathyroidectomy also require ongoing follow-up. Close monitoring and targeted medical therapy that provides skeletal protection and reduced serum calcium levels are of value (4, 6, 7). Therapeutic options to achieve these goals, however, are limited to calcimimetics agents and anti-resorptives (8, 9).
+
+One potential option is a calcimimetic agent capable of activating the calcium-sensing receptor (CaSR) on the surface of parathyroid cells. In addition to parathyroid cells, the CaSR is expressed along the nephron as well as in other tissues, and is the key regulator of PTH synthesis and secretion (10, 11). Cinacalcet (Sensipar®/Mimpara®) is an allosteric modulator of the CaSR. By increasing the sensitivity of the CaSR to extracellular calcium, cinacalcet effects a reduction in PTH and therefore a reduction in serum calcium (12, 13).
+
+Clinical data support the efficacy of cinacalcet in PHPT (13, 14, 15, 16). A pooled analysis of data from three multicenter clinical trials of cinacalcet in patients with inoperable PHPT showed reduction in serum calcium by at least 1 mg/dl in two-thirds of patients treated with cinacalcet (14). An open-label study in patients with intractable PHPT who did not respond to surgery or for whom surgery was contraindicated showed a similar response (15).
+
+This report presents the results of the first multicenter, international, phase 3 randomized, double-blind, placebo-controlled (RCT) trial of cinacalcet in subjects with PHPT who met the criteria for parathyroid surgery but were unable to undergo parathyroidectomy. Its hypothesis is that subjects with PHPT who met the criteria for parathyroid surgery but who were unable to proceed with surgery would respond to cinacalcet with normalization of the corrected total serum calcium to ≤ 10.3 mg/dl (2.575 mmol/l) in a larger proportion of subjects compared with placebo-treated subjects. It should be noted that this study was intended as the registration RCT for cinacalcet in PHPT. However, during the study, cinacalcet received approval in this indication without a phase 3 RCT having been completed. Therefore, the sponsor stopped enrolment into the study prematurely and only those patients already recruited completed the study as originally intended. The results obtained from those patients are reported herein. No patients were withdrawn from the study because the drug was approved. Despite the enrolment of fewer patients, the statistical power was 90% due to the lower than expected drop-out rate.
+
+Cinacalcet has now been approved for the reduction of hypercalcemia in patients with parathyroid carcinoma and those with severe PHPT who are unable to undergo parathyroidectomy (USA and Canada) and in patients with PHPT for whom parathyroidectomy would be indicated on the basis of serum calcium levels (as defined by relevant treatment guidelines), but in whom parathyroidectomy is not clinically appropriate or is contraindicated (Europe). Cinacalcet is also approved for the treatment of secondary HPT in patients with end-stage renal disease on maintenance dialysis therapy (16, 17).
+
+Written informed consent was obtained from each subject before any study-specific procedure was performed. The protocol was approved by the IRB (or ethics committee for each investigative site). This trial was registered as EudraCT number 2009-012943-41.
+
+This phase 3 study consisted of a 30-day screening phase, a 12-week dose-titration phase, and a 16-week efficacy assessment phase. After taking the last dose of blinded study drug (cinacalcet or placebo) at week 28, all subjects entered an open-label extension phase, during which all subjects received open-label cinacalcet (see Fig. 1).
+
+The subjects were administered cinacalcet or placebo orally at a starting dose of 30 mg twice a day on day 1. They were eligible for dose titration once every 3 weeks during the dose-titration phase, based on total corrected serum calcium concentration and investigators’ safety assessments obtained the previous week. Dosages could be sequentially increased to 60 mg twice daily, 90 mg twice daily, or 90 mg three times daily. During the efficacy assessment phase, cinacalcet dosing could be increased or decreased once every 4 weeks as needed to maintain a serum calcium concentration within the normal range.
+
+Placebo was justified as the control because no approved alternative pharmaceutical options were available for these patients.
+
+The subjects who qualified for the study were randomized in a 1:1 ratio to cinacalcet or placebo. Randomization was stratified by bisphosphonate use. The randomization, by permuted blocks, to investigational product and management of each study center’s investigational product supply, using the interactive voice response system, was performed by ICON Clinical Research, Durham, NC 27709, USA on behalf of Amgen.
+
+Subjects met the following criteria: age ≥ 18 years; diagnosis of PHPT based on laboratory measurements of total corrected serum calcium > 11.3 mg/dl (2.83 mmol/l) and ≤ 12.5 mg/dl (3.13 mmol/l) as determined on two separate occasions at least 7 days apart within the last 6 months before entry; plasma PTH > 55 pg/ml (5.8 pmol/l) as determined on two separate occasions at least 7 days apart within the last 6 months and confirmed during screening. In addition, patients had to meet one of the following criteria: failed parathyroidectomy, cardiovascular and other comorbid conditions contraindicating parathyroidectomy or parathyroidectomy not considered appropriate or not feasible by primary physician and/or subject, failure to find the parathyroid gland for removal, and ectopic parathyroid gland.
+
+Exclusion criteria included any one of the following: symptoms attributable to hypercalcemia requiring immediate medical intervention (including acute kidney stones, nausea, and vomiting); unstable medical condition or hospitalization within 30 days before the date of informed consent; administration of thiazide diuretics or lithium or other drugs influencing serum calcium measurements; initiated or changed dose of bisphosphonate within 12 weeks before study randomization; known hypersensitivity to or inability to tolerate cinacalcet; prior treatment with cinacalcet within the last 60 days; family history or diagnosis of familial benign hypocalciuric hypercalcemia; pregnancy or lactation.
+
+The primary endpoint of the study was the achievement of a normal mean corrected total serum calcium concentration of ≤ 10.3 mg/dl (2.58 mmol/l) during the efficacy assessment phase (weeks 16, 20, 24, and 28). The secondary endpoints were as follows: achievement of an ≥ 1 mg/dl (0.25 mmol/l) reduction in mean corrected total serum calcium concentration from baseline to the efficacy assessment phase (mean of weeks 16, 20, 24, and 28), percentage change in corrected total serum calcium concentration from baseline to the efficacy assessment phase, and mean plasma PTH percentage change from baseline to the efficacy assessment phase. Changes in phosphate, alkaline phosphatase activity, and treatment failure were also assessed during the study, and standard laboratory and clinical parameters were monitored. Changes from baseline to the end of week 28 in subject-reported health-related quality of life (HRQOL) measures using three different questionnaires were exploratory endpoints of the study. These were the parathyroid assessment of symptoms (PAS), medical outcome scores – cognitive functioning (MOS-CF), and short form-36 questionnaire (SF-36) (18, 19, 20). The PAS is a disease-specific outcome tool where higher scores indicate greater disease impact on function. Evaluation of HRQOL questionnaires was blinded until data were unblinded for reporting.
+
+The frequency, severity, and relationship of treatment to adverse events (AEs) were also recorded for each group. A central event committee adjudicated all serious cardiovascular AEs and deaths. All other AEs were assessed by study investigators.
+
+Laboratory indices investigated included: serum calcium, intact PTH, phosphorus, alkaline phosphatase activity, and 25-hydroxy vitamin D3. All laboratory indices were assayed at three central facilities run by Covance in the USA, Switzerland, and Singapore using standardized assay protocols. Corrected total serum calcium was calculated according to the following formulae if serum albumin was < 4 g/dl (40 g/l):
+Corrected calcium (mg/dl)=measured total calcium (mg/dl)+0.8(4.0−serum albumin (g/dl)) or
+Corrected calcium (mmol/l)=measured total calcium (mmol/l)+0.02(40−serum albumin (g/l)).
+
+Changes in laboratory indices from baseline to each study time point (day 1 of treatment, weeks 3, 6, 9, 12, 16, 20, 24, and 28) were tabulated by treatment group.
+
+A sample size of 140 subjects (70 in each treatment group) was planned to provide 90% power to detect a difference of 0.27 in the proportion of subjects achieving the primary endpoint. This power calculation took into account an expected attenuation of the treatment effect due to discontinuation of investigational product (assumed rate of 25%). The revised sample size of 66 was sufficient to provide 90% power to detect a difference of 0.39 in the proportion of subjects achieving the primary endpoint, after adjusting for a 15% dropout/treatment crossover rate.
+
+The primary endpoint was analyzed using a Cochran–Mantel–Haenszel χ2 test stratified by bisphosphonate use; statistical significance was based on α = 0.05 (two-sided). A logistic regression model adjusted for the baseline-corrected total serum calcium level and stratified by bisphosphonate use (and possible inclusion of other baseline covariates) was used for a secondary analysis; an adjusted odds ratio (OR) and 95% CI from the model were provided.
+
+A sequential testing procedure was applied to the analysis of the secondary endpoints (order as listed in section ‘Study endpoints’ above) in order to control the experiment-wise type 1 error rate at 0.05 (two-sided) if the primary hypothesis was statistically significant (P value <0.05, two-sided).
+
+Changes in the MOS-CF scale score from baseline to the end of week 28 were compared for the cinacalcet and placebo groups. An analysis of covariance (ANCOVA) model adjusted for the baseline score was applied. Other potentially prognostic covariates such as age, sex, race, and baseline disease characteristics were also considered for inclusion in the ANCOVA model. The subjects who discontinued study before week 28 had their last value carried forward to impute data for missing values at week 28. No control of type 1 error was attempted for the exploratory endpoints; descriptive P values and 95% CIs are provided.
+
+The safety and tolerability of cinacalcet in the study population were evaluated by assessing the nature, frequency, severity, and relationship to treatment of AEs experienced over the course of the study, reported separately by treatment group.
+
+Of the 149 subjects screened, 67 subjects were randomized, 33 to the cinacalcet group and 34 to the placebo group. All randomized subjects received at least one dose of investigational product (cinacalcet or placebo). The study was stopped by the sponsor before meeting enrollment goals because of approval of the drug for specific PHPT populations included in this protocol and of some delays in the projected enrollment timetable. Thus, once the sponsor had been notified of drug approval, only those patients already recruited were allowed to complete the study. No further patients were enrolled. Six (18.2%) subjects in the cinacalcet group and six (17.6%) in the placebo group discontinued the investigational product for reasons unconnected to drug approval (see Fig. 2).
+
+Subject demographics and baseline characteristics (Table 1) were generally well balanced between the treatment groups. Of the 67 subjects, 77.6% (25 and 27 subjects in the cinacalcet and placebo groups respectively) were women and 22.4% (eight and seven subjects) were men. The subjects in the cinacalcet group were younger (mean (s.d.): 69.5 (13.0) years) compared with those in the placebo group (mean (s.d.): 75.0 (8.9) years). Most of the subjects (61 (91.0%)) were white in both treatment groups (28 (84.8%) in the cinacalcet group and 33 (97.1%) in the placebo group). The distribution of subjects with regard to sex and race was similar in both groups. Subjects in the cinacalcet group had lower mean (s.d.) iPTH level at baseline (179.0 (98.0) pg/ml) as compared with the placebo group (238.6 (212.2) pg/ml). The mean (s.d.) corrected serum calcium level at baseline was similar in both groups (11.73 (0.45) mg/dl in the cinacalcet group). Over half the subjects had been diagnosed with PHPT for more than 2 years.
+
+Exposure of subjects to study drug is summarized in Table 2. The median (quartile 1 (Q1), Q3) doses of cinacalcet used were 60.2 (59.1, 110.3) mg/day.
+
+The primary endpoint was met: 25 (75.8%) subjects in the cinacalcet group achieved mean corrected serum calcium ≤ 10.3 mg/dl (2.575 mmol/l) during the efficacy assessment phase, compared with 0 (0.0%) receiving placebo (P<0.001). Figure 3 shows changes in calcium during treatment. Results from a logistic regression model with bisphosphonate stratification as a covariate and adjusted for baseline calcium show an OR (95% CI) of 119.22 (18.20, infinity), P<0.001 comparing cinacalcet with placebo.
+
+The secondary endpoints of the study were also met. Mean corrected calcium (s.d.) values at baseline were 11.73 (0.45) mg/dl in the cinacalcet group and 11.80 (0.48) mg/dl in the placebo group. The mean corrected serum calcium was decreased by ≥ 1.0 mg/dl in 84.8% of cinacalcet-treated subjects compared with 5.9% of placebo-treated subjects (P<0.001). The percentage change in serum calcium from baseline to efficacy assessment phase also favored cinacalcet (least squares (LS) mean (s.e.m.) −15.21% (1.00%) in the cinacalcet group and −1.66% (0.99%) in the placebo group). The treatment difference (95% CI) was −13.55% (−16.23%, −10.88%), P<0.001. Similarly, the LS mean (s.e.m.) percentage change in plasma PTH from baseline during the efficacy assessment phase was −23.80% (4.18%) in the cinacalcet group and −1.01% (4.05%) in the placebo group with a treatment difference (95% CI) of −22.79% (−34.01%, −11.57%), P<0.001. Figure 4 shows percentage change in serum calcium from baseline over time (A) and intact serum PTH over time (B).
+
+The mean serum phosphorus concentration increased from baseline to efficacy assessment phase in the cinacalcet group (mean (s.e.): from 2.66 (0.07) to 3.54 (0.14) mg/dl (0.665 (0.018) to 0.885 (0.035) mmol/l)) with no clinically meaningful changes in phosphorus levels noted in the placebo group (mean (s.e.): from 2.63 (0.07) to 2.84 (0.1) mg/dl (0.658 (0.018) to 0.71 (0.025) mmol/l)). Mean (s.e.) alkaline phosphatase activity rose steadily in both groups from baseline to the efficacy assessment phase: from 85.5 (4.1) to 97.5 (5.7) U/l (cinacalcet) and from 86.9 (6.3) to 95.0(12.4) U/l (placebo). Mean (s.e.) 25-hydroxy vitamin D levels increased slightly in both groups from baseline to the efficacy assessment phase: from 23.76 (2.19) to 25.61 (2.16) ng/ml (cinacalcet) and from 23.03 (1.75) to 24.57 ng/ml (placebo). No clinically significant abnormalities in clinical laboratory parameters, blood pressure, or electrocardiogram (ECG) were noted during the study.
+
+For the HRQOL indices, differences did not reach statistical significance. At baseline, mean (s.d.) values for MOS-CF were 69.6 (23.3) in the cinacalcet group and 79.2 (18.6) in the placebo group. The subjects reported a LS mean change (s.e.m.) between baseline and week 28 of 7.1 (3.4) for cinacalcet compared with −1.6 (3.3) for placebo (P=0.066). Similarly for the SF-36 questionnaire (physical component summary), mean (s.d.) baseline values for SF-36 were 43.4 (9.3) for cinacalcet and 40.8 (8.8) for placebo. The subjects reported a LS mean change (s.e.m.) between baseline and week 28 of 3.3 (1.2) for cinacalcet compared with 0.4 (1.1) for placebo (P=0.071). For the mental component summary, subjects reported a LS mean change (s.e.m.) of 1.6 (1.6) for cinacalcet compared with −2.7 (1.5) for placebo (P=0.047). Both groups showed an improvement in PAS scores over 28 weeks: LS mean change (s.e.m.) was −91.0 (37.1) for cinacalcet compared with −59.0 (35.2) for placebo (P=0.515).
+
+There was also no significant difference between the groups regarding treatment failures as defined by corrected calcium > 12.5 mg/dl (3.125 mmol/l) on two occasions or requirement for parathyroidectomy. This occurred in one subject (3.0%) receiving cinacalcet and two (5.9%) receiving placebo (P = 0.598).
+
+Although the numbers of subjects reporting treatment-associated AEs were similar between groups (27 cinacalcet vs 20 placebo), AEs were different in nature. The numbers of subjects with serious AEs were also similar (three cinacalcet vs four placebo). The most frequent AEs were nausea (30% cinacalcet and 18% placebo) and muscle spasms (18% cinacalcet and 0% placebo) (Supplementary Table 1, see section on supplementary data given at the end of this article). No hypocalcemic events were recorded in either group.
+
+One subject in the cinacalcet group discontinued investigational product owing to accidental medication overdose. The patient took twice the recommended dose for 9 days and experienced mild to moderate gastrointestinal symptoms, which resolved following withdrawal from investigational product. One fatal event in the cinacalcet group was reported by the investigator as due to decreased appetite (anorexia), which the investigator did not consider to be related to the investigational product or to hypercalcemia: this 89-year-old woman with a history of dementia was hospitalized due to a progressive inability to take in fluids (anorexia) and food 2 weeks after cinacalcet had been initiated. The patient had been prescribed multiple concomitant medications, including haloperidol.
+
+This multicenter, international, double-blind, randomized, placebo-controlled phase 3 trial of patients with PHPT unable or unwilling to undergo parathyroidectomy met its primary objective by demonstrating that a significantly higher proportion of subjects randomized to receive cinacalcet (75.8%) had their serum calcium lowered into the normal reference range (≤ 10.3 mg/dl; 2.575 mmol/l) compared with subjects randomized to receive placebo (0%). In addition to the primary effect on the regulation of PTH secretion, some of the effects of cinacalcet on lowering serum calcium may be due to its effects on the CaSR in other tissues including the kidney (21). Cinacalcet may also have an effect on bone (22). Plasma RIH was lowered significantly but did not normalize.
+
+The study subjects were considered to be surgical candidates according to the guidelines for management of asymptomatic PHPT (4) (with serum calcium > 1.0 mg/dl (0.25 mmol/l) above the upper limit of normal) but they were unable or unwilling to undergo parathyroidectomy.
+
+The results of this clinical trial confirm results from previous studies of cinacalcet in subjects with PHPT. The proportion of cinacalcet-treated subjects normalizing serum calcium in this study (76%) is similar to results observed for patients who had failed parathyroidectomy (73%) (23). The proportion of subjects with a > 1.0 mg/dl (0.25 mmol/l) reduction in serum calcium is similar to the results seen in patients with intractable PHPT (88%) (15).
+
+Current international guidelines focus on normalizing serum calcium by surgery and reducing the impact of PHPT on target tissues with preservation of renal and skeletal health (6, 24). The impact of a nonsurgical approach to lowering serum calcium is thus an important consideration in the medical management of PHPT among those individuals with clinically important hypercalcemia who are not candidates for parathyroid surgery. Thus, cinacalcet would be a useful treatment option for subjects who have hypercalcemia and have failed surgery or are unable to proceed with surgery. In addition, in subjects with multiple endocrine neoplasia (MEN), cinacalcet has been shown to be useful in delaying surgery, if necessary, while maintaining normocalcemia (25). The dose regimens of cinacalcet required to lower serum calcium in MEN1-associated PHPT appear to be similar to those required in sporadic PHPT (2, 26).
+
+Medical management in PHPT also includes correction of vitamin D insufficiency with cholecalciferol in order to achieve a 25-hydroxy vitamin D level of at least 50 nmol/l (4). Supplementation requires monitoring of both serum and urine calcium to ensure that hypercalcemia and hypercalciuria do not worsen (27, 28). Bisphosphonates (including alendronate) may provide skeletal protection and are a medical option in the management of PHPT (29, 30). Treatment with alendronate in a 24-month trial for subjects with asymptomatic PHPT resulted in improvements in bone mineral density at the lumbar spine in comparison with placebo. Reductions in bone remodeling were observed. However, serum calcium and RIH remained elevated and were unchanged over the 24-month study period (29). Combination therapy with both alendronate and cinacalcet has been found to both lower serum calcium and provide skeletal protection (30). Vitamin D inadequacy should be corrected in patients with PHPT. Vitamin D inadequacy has been associated with increased weight of parathyroid adenomas and higher levels of serum calcium and PTH. Neither vitamin D nor bisphosphonates are approved to treat hypercalcemia in patients with PHPT.
+
+Recent studies of HRQOL in patients with PHPT concluded that neurological features appear to be related to preoperative levels of serum calcium. Improvements in HRQOL were observed following parathyroidectomy (18, 31, 32). Furthermore, in a randomized study, improvements in two domains on SF-36 and favorable trends on other measures were noted in surgical patients compared with those who did not undergo the operation (33). Perrier et al. (25) further evaluated cognition in asymptomatic PHPT (mean calcium 10.5 mg/dl) and also utilized functional magnetic resonance imaging (fMRI) to assess brain function in a randomized controlled trial comparing parathyroidectomy with observational studies. There were no differences in cognition between the two groups or in fMRI voxel counts. Therefore, the improvements seen in HRQOL from observational studies following parathyroidectomy were not confirmed in this randomized controlled trial.
+
+Our study showed that the patient groups were below the US norms for HRQOL indices (50 for the SF-36 scale). Although a significant reduction in serum calcium was observed, only minor improvements were seen for the mental component scores in the SF-36 and MOS-CF scale for the cinacalcet groups. Similarly, patient-reported outcomes for the SF-36 physical components and PAS only indicated small improvements. These observations are similar to those made in previous studies and may illustrate an important difference in the patient’s attitude to surgical and pharmacological approaches to PHPT management (15). The impact of both surgery and medical intervention on neurocognitive function requires further evaluation utilizing larger randomized controlled trials.
+
+Cinacalcet was generally well tolerated in PHPT. The types of AEs reported in this study are similar to those reported in previous trials across a range of PHPT severities and appear to be limited to nausea, headache, arthralgia, and myalgias (14, 15, 18, 34).
+
+The strengths of our study include the double-blind randomized placebo-controlled design as well as careful follow-up and high subject retention. A limitation is the relatively short duration of study. A longer trial with bone mineral density and fracture data would be of value in assessing the long-term effects of cinacalcet on skeletal health.
+
+In conclusion, this study clearly met its objectives. Cinacalcet may be a valuable treatment option for subjects with PHPT who are unable to undergo parathyroidectomy.


### PR DESCRIPTION
## Summary
- add a serum calcium biochemical readout for the PHPT-associated multiglandular disease context in Parathyroid Hyperplasia
- link the FDA primary hyperparathyroidism serum-calcium surrogate endpoint row to that readout
- add PMID:25637076 via `just fetch-reference` for cinacalcet serum-calcium response evidence

## Notes
- This is curated as a subtype/context mapping, not as a claim that all primary hyperparathyroidism is parathyroid hyperplasia.

## Validation
- `just validate kb/disorders/Parathyroid_Hyperplasia.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`