### PR TITLE
[codex] Link glomerular proteinuria endpoints

### DIFF
--- a/kb/disorders/IgA_Nephropathy.yaml
+++ b/kb/disorders/IgA_Nephropathy.yaml
@@ -1,6 +1,6 @@
 name: IgA Nephropathy
 creation_date: '2025-12-19T01:12:52Z'
-updated_date: '2026-04-30T20:00:00Z'
+updated_date: '2026-05-11T12:14:04Z'
 category: Autoimmune
 parents:
 - Autoimmune Disease
@@ -850,6 +850,65 @@ biochemical:
       Lower C3 and higher C4 levels were associated with poorer prognosis,
       highlighting a more 'Complement-Pathic' subset of patients.
     explanation: Supports prognostically relevant complement biomarker variation in IgAN.
+- name: Urine protein-to-creatinine ratio
+  presence: Elevated
+  context: >-
+    Quantitative urine proteinuria marker used to monitor glomerular filtration
+    barrier injury and treatment response in proteinuric IgAN.
+  readouts:
+  - target: Podocyte damage and filtration barrier failure
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-093
+    - FDA-SE-pediatric-noncancer-061
+    interpretation: >-
+      Higher urine protein-to-creatinine ratio reflects greater protein leakage
+      from IgAN-related filtration-barrier injury; effective antiproteinuric
+      therapy should lower the ratio.
+    evidence:
+    - reference: PMID:37015244
+      reference_title: "Sparsentan in patients with IgA nephropathy: a prespecified interim analysis from a randomised, double-blind, active-controlled clinical trial."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        At week 36, the geometric least squares mean percent change from
+        baseline in urine protein-creatinine ratio was statistically
+        significantly greater in the sparsentan group (-49·8%) than the
+        irbesartan group (-15·1%).
+      explanation: >-
+        Randomized IgAN trial directly supports urine protein-creatinine ratio
+        as a pharmacodynamic readout of antiproteinuric treatment response.
+    - reference: PMID:39188719
+      reference_title: "Contemporary review of IgA nephropathy."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Acceptable surrogate endpoints for therapeutic trials include ongoing
+        proteinuria and rate of eGFR decline.
+      explanation: >-
+        Contemporary review supports proteinuria as an accepted therapeutic
+        trial endpoint in IgAN.
+  mappings_list:
+  - preferred_term: Protein/Creatinine [Mass Ratio] in Urine
+    term:
+      id: LOINC:2890-2
+      label: Protein/Creatinine [Mass Ratio] in Urine
+  synonyms:
+  - UPCR
+  - urinary protein/creatinine ratio
+  evidence:
+  - reference: PMID:39188719
+    reference_title: "Contemporary review of IgA nephropathy."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Biomarkers predicting adverse outcomes include proteinuria, reduced GFR,
+      hypertension, and pathology.
+    explanation: >-
+      Supports proteinuria as a clinically meaningful biomarker and outcome
+      predictor in IgAN.
 genetic:
 - name: HLA-DQB1
   gene_term:

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2331,8 +2331,17 @@ surrogate_endpoints:
     Patients with primary glomerular disease associated with significant proteinuria (includining immunoglobulin
     A nephropathy (IgAN) and complement 3 glomerulopathy (C3G)); endpoint: Change in urine protein-to-creatinine
     ratio (UPCR); approval context: accelerated or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - IgA Nephropathy
+  mapped_disease_files:
+  - kb/disorders/IgA_Nephropathy.yaml
+  mapping_notes: >-
+    Partial disease-category mapping: the FDA disease/use is broader than IgA
+    nephropathy, but the row explicitly includes IgAN among primary glomerular
+    diseases with significant proteinuria. Complement 3 glomerulopathy and
+    other primary glomerular diseases are not mapped unless corresponding
+    disease pages exist.
 - row_id: FDA-SE-adult-noncancer-094
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5199,8 +5208,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Primary glomerular diseases associated with significant proteinuria; population:
     Patients with primary glomerular disease associated with significant proteinuria; endpoint: Proteinuria
     (urinary protein/creatinine ratio) ˟; approval context: accelerated; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - IgA Nephropathy
+  mapped_disease_files:
+  - kb/disorders/IgA_Nephropathy.yaml
+  mapping_notes: >-
+    Partial disease-category mapping to IgAN as a primary glomerular disease
+    with significant proteinuria. The FDA row remains broader than this single
+    disease page and is not interpreted as covering every primary glomerular
+    disease until additional disease pages are curated.
 - row_id: FDA-SE-pediatric-noncancer-062
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Add urine protein-to-creatinine ratio (UPCR) as an IgA nephropathy biomarker readout linked to the filtration-barrier pathograph node.
- Bridge the adult and pediatric FDA primary glomerular disease proteinuria rows to IgA nephropathy with partial disease-category mapping notes.
- Keep regulatory context in `kb/surrogate_endpoints/fda_surrogate_endpoints.yaml` and biology/evidence in `kb/disorders/IgA_Nephropathy.yaml`.

## Validation
- `just validate kb/disorders/IgA_Nephropathy.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`