### PR TITLE
[codex] Link hypothyroidism TSH endpoints

### DIFF
--- a/kb/disorders/Hashimotos_Thyroiditis.yaml
+++ b/kb/disorders/Hashimotos_Thyroiditis.yaml
@@ -1,6 +1,6 @@
 name: Hashimoto's Thyroiditis
 creation_date: '2025-12-18T17:01:35Z'
-updated_date: '2026-03-02T21:29:00Z'
+updated_date: '2026-05-11T12:59:41Z'
 category: Complex
 parents:
 - Autoimmune Disease
@@ -250,6 +250,29 @@ biochemical:
 - name: TSH
   presence: Elevated
   context: Primary hypothyroidism
+  readouts:
+  - target: Thyroid Hormone Deficiency
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-051
+    - FDA-SE-pediatric-noncancer-037
+    interpretation: >-
+      In primary Hashimoto-related hypothyroidism, higher TSH reflects stronger
+      pituitary feedback to deficient thyroid hormone production; thyroid
+      hormone replacement should reduce TSH toward the therapeutic goal range.
+    evidence:
+    - reference: PMID:35235282
+      reference_title: "Thyroid and Parathyroid Conditions: Hypothyroidism."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Thyroid hormone should be titrated based on goal TSH values, symptoms,
+        and potential treatment adverse effects.
+      explanation: >-
+        Supports TSH as a pharmacodynamic treatment-adjustment readout for
+        thyroid hormone replacement in hypothyroidism.
   evidence:
   - reference: PMID:35235282
     reference_title: "Thyroid and Parathyroid Conditions: Hypothyroidism."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1252,8 +1252,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hypothyroidism; population: Patients with hypothyroidism; endpoint: Serum
     thyroid-stimulating hormone (TSH); approval context: traditional; drug mechanism: Thyroid hormone
     analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hashimoto's Thyroiditis
+  mapped_disease_files:
+  - kb/disorders/Hashimotos_Thyroiditis.yaml
+  mapping_notes: >-
+    Partial disease-context mapping: the FDA row covers hypothyroidism broadly,
+    while this DisMech page models Hashimoto's thyroiditis as a primary
+    autoimmune hypothyroidism context with elevated TSH and levothyroxine
+    monitoring. Central congenital hypothyroidism is not mapped here because
+    TSH may be low, normal, or only mildly elevated and is not a reliable sole
+    endpoint in that biology.
 - row_id: FDA-SE-adult-noncancer-052
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4561,8 +4571,18 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypothyroidism; population: Patients with hypothyroidism; endpoint: Thyroid-stimulating
     hormone (TSH); approval context: traditional; drug mechanism: Thyroid hormone analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hashimoto's Thyroiditis
+  mapped_disease_files:
+  - kb/disorders/Hashimotos_Thyroiditis.yaml
+  mapping_notes: >-
+    Partial disease-context mapping: the FDA row covers hypothyroidism broadly,
+    while this DisMech page models Hashimoto's thyroiditis as a primary
+    autoimmune hypothyroidism context with elevated TSH and levothyroxine
+    monitoring. Central congenital hypothyroidism is not mapped here because
+    TSH may be low, normal, or only mildly elevated and is not a reliable sole
+    endpoint in that biology.
 - row_id: FDA-SE-pediatric-noncancer-038
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Add a TSH biomarker readout in Hashimoto's thyroiditis linked to the thyroid hormone deficiency pathograph node.
- Bridge adult and pediatric FDA hypothyroidism TSH endpoint rows to the Hashimoto primary hypothyroidism context.
- Caveat the source-table mapping as broad hypothyroidism and explicitly avoid mapping central congenital hypothyroidism where TSH is unreliable.

## Validation
- `just validate kb/disorders/Hashimotos_Thyroiditis.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Note: committed with `SKIP=yamlfix` because that formatter reflowed unrelated pre-existing content in this file; the actual diff is limited to the TSH readout and FDA row mappings.