### PR TITLE
[codex] Link hypokalemia potassium endpoints

### DIFF
--- a/kb/disorders/Bartter_Syndrome.yaml
+++ b/kb/disorders/Bartter_Syndrome.yaml
@@ -1117,6 +1117,7 @@ biochemical:
       downstream of thick-ascending-limb salt wasting.
     evidence:
     - reference: PMID:36993809
+      reference_title: "Long-term outcome of Bartter syndrome in 54 patients: A multicenter study in Korea."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: >-

--- a/kb/disorders/Bartter_Syndrome.yaml
+++ b/kb/disorders/Bartter_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Bartter syndrome
 creation_date: "2026-04-22T00:00:00Z"
-updated_date: "2026-05-09T04:45:11Z"
+updated_date: "2026-05-11T13:39:19Z"
 category: Mendelian
 synonyms:
 - Bartter syndrome
@@ -1103,6 +1103,36 @@ biochemical:
 - name: Serum Potassium
   presence: DECREASED
   notes: Low serum potassium (typically 1.5-3.0 mEq/L)
+  readouts:
+  - target: Compensatory Distal Sodium Reabsorption and Potassium Wasting
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-048
+    - FDA-SE-pediatric-noncancer-035
+    interpretation: >-
+      Higher serum potassium during replacement or potassium-sparing therapy
+      reflects partial correction of the renal potassium-wasting physiology
+      downstream of thick-ascending-limb salt wasting.
+    evidence:
+    - reference: PMID:36993809
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Potassium chloride supplements and potassium-sparing diuretics were
+        administered in 94% and 68% of patients, respectively. The mean dosage
+        of potassium chloride supplements was 5.0 and 2.1 mEq/day/kg for
+        patients younger and older than 18 years, respectively.
+      explanation: >-
+        Multicenter clinical evidence supports potassium chloride replacement
+        and potassium-sparing therapy as routine treatment of the Bartter
+        low-potassium state.
+  biomarker_term:
+    preferred_term: potassium measurement
+    term:
+      id: NCIT:C64853
+      label: Potassium Measurement
   evidence:
   - reference: PMID:19096086
     supports: SUPPORT

--- a/kb/disorders/Gitelman_Syndrome.yaml
+++ b/kb/disorders/Gitelman_Syndrome.yaml
@@ -1,7 +1,7 @@
 name: Gitelman syndrome
 category: Mendelian
 creation_date: '2026-05-03T20:36:52Z'
-updated_date: '2026-05-09T03:15:56Z'
+updated_date: '2026-05-11T13:39:19Z'
 synonyms:
 - Gitelman's syndrome
 - Familial hypokalemia-hypomagnesemia
@@ -681,6 +681,41 @@ biochemical:
 - name: Serum potassium
   presence: DECREASED
   notes: Low serum potassium due to renal potassium wasting downstream of salt wasting and aldosterone activation.
+  readouts:
+  - target: Collecting-duct potassium and hydrogen wasting
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-048
+    - FDA-SE-pediatric-noncancer-035
+    interpretation: >-
+      Higher serum potassium during potassium replacement indicates partial
+      correction of aldosterone-driven renal potassium wasting and the
+      downstream hypokalemic state.
+    evidence:
+    - reference: PMID:28003083
+      reference_title: "Gitelman syndrome: consensus and guidance from a Kidney Disease: Improving Global Outcomes (KDIGO) Controversies Conference."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "oral magnesium and potassium supplements"
+      explanation: >-
+        KDIGO consensus supports potassium supplementation as usual
+        mechanism-directed management of the low-potassium state in Gitelman
+        syndrome.
+    - reference: PMID:41278357
+      reference_title: "Clinical Characteristics, Symptoms, and Long-Term Outcomes in Gitelman Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Potassium-sparing medication (used in 33%) slightly increased blood potassium"
+      explanation: >-
+        Large clinical survey evidence supports blood potassium as a measurable
+        response to potassium-sparing treatment in Gitelman syndrome.
+  biomarker_term:
+    preferred_term: potassium measurement
+    term:
+      id: NCIT:C64853
+      label: Potassium Measurement
   evidence:
   - reference: PMID:28744758
     reference_title: "Gitelman syndrome: an analysis of the underlying pathophysiologic mechanisms of acid-base and electrolyte abnormalities."

--- a/kb/disorders/Hypokalemic_Periodic_Paralysis.yaml
+++ b/kb/disorders/Hypokalemic_Periodic_Paralysis.yaml
@@ -1,6 +1,6 @@
 name: Hypokalemic Periodic Paralysis
 creation_date: '2026-05-09T15:13:09Z'
-updated_date: '2026-05-09T22:35:49Z'
+updated_date: '2026-05-11T13:39:19Z'
 description: >-
   Hypokalemic periodic paralysis is a rare inherited skeletal-muscle
   channelopathy characterized by recurrent attacks of flaccid weakness or
@@ -370,6 +370,59 @@ phenotypes:
     explanation: >-
       A single case supports respiratory muscle paralysis as a rare severe
       manifestation rather than a common disease feature.
+biochemical:
+- name: Serum potassium during attacks
+  presence: DECREASED
+  context: Acute paralytic attacks treated with potassium chloride.
+  readouts:
+  - target: Sarcolemmal Depolarization and Sodium-Channel Inactivation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-048
+    - FDA-SE-pediatric-noncancer-035
+    interpretation: >-
+      Higher serum potassium during treatment reflects correction of
+      attack-associated hypokalemia and should reduce low-potassium-driven
+      sarcolemmal depolarization, sodium-channel inactivation, and skeletal
+      muscle inexcitability.
+    evidence:
+    - reference: PMID:18426576
+      reference_title: Practical aspects in the management of hypokalemic periodic paralysis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Potassium chloride is the favored potassium salt given at 0.5-1.0 mEq/kg
+        for acute attacks.
+      explanation: >-
+        Management review evidence supports serum potassium as the
+        pharmacodynamically modified analyte during potassium-salt treatment of
+        acute HypoPP attacks.
+    - reference: PMID:29125635
+      reference_title: Review of the Diagnosis and Treatment of Periodic Paralysis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Monitor ECG and potassium levels.
+      explanation: >-
+        Treatment guidance supports monitoring potassium levels during acute
+        potassium-modifying management.
+  biomarker_term:
+    preferred_term: potassium measurement
+    term:
+      id: NCIT:C64853
+      label: Potassium Measurement
+  evidence:
+  - reference: PMID:29125635
+    reference_title: Review of the Diagnosis and Treatment of Periodic Paralysis.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two or more attacks of muscle weakness with documented serum K <3.5 mEq/L
+    explanation: >-
+      Diagnostic criteria from the review support low serum potassium during
+      HypoPP attacks.
 genetic:
 - name: CACNA1S-related hypokalemic periodic paralysis
   association: Causative

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1184,8 +1184,21 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypokalemia; population: Patients with hypokalemia; endpoint: Serum potassium;
     approval context: traditional; drug mechanism: Potassium salts.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hypokalemic Periodic Paralysis
+  - Gitelman syndrome
+  - Bartter syndrome
+  mapped_disease_files:
+  - kb/disorders/Hypokalemic_Periodic_Paralysis.yaml
+  - kb/disorders/Gitelman_Syndrome.yaml
+  - kb/disorders/Bartter_Syndrome.yaml
+  mapping_notes: >-
+    Partial broad-use mapping: the FDA row covers hypokalemia treated with
+    potassium salts broadly. These DisMech entries are current curated
+    hypokalemia contexts where serum potassium is central and potassium
+    supplementation or salts are biologically relevant; this is not exhaustive
+    for all causes of hypokalemia.
 - row_id: FDA-SE-adult-noncancer-049
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4517,8 +4530,21 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypokalemia; population: Patients with hypokalemia; endpoint: Serum potassium;
     approval context: traditional; drug mechanism: Potassium salts.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hypokalemic Periodic Paralysis
+  - Gitelman syndrome
+  - Bartter syndrome
+  mapped_disease_files:
+  - kb/disorders/Hypokalemic_Periodic_Paralysis.yaml
+  - kb/disorders/Gitelman_Syndrome.yaml
+  - kb/disorders/Bartter_Syndrome.yaml
+  mapping_notes: >-
+    Partial broad-use mapping: the FDA row covers pediatric hypokalemia treated
+    with potassium salts broadly. These DisMech entries are current curated
+    hypokalemia contexts where serum potassium is central and potassium
+    supplementation or salts are biologically relevant; this is not exhaustive
+    for all pediatric causes of hypokalemia.
 - row_id: FDA-SE-pediatric-noncancer-036
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

Links the FDA adult and pediatric hypokalemia serum potassium surrogate endpoint rows into the disease biology model for the currently curated DisMech hypokalemia contexts.

- Adds a serum potassium biochemical readout for Hypokalemic Periodic Paralysis, linked to sarcolemmal depolarization and sodium-channel inactivation during acute attacks.
- Adds potassium measurement terms and pharmacodynamic readouts to Gitelman syndrome and Bartter syndrome, linked to their renal potassium-wasting pathograph nodes.
- Marks `FDA-SE-adult-noncancer-048` and `FDA-SE-pediatric-noncancer-035` as curated partial mappings, with caveats that the FDA hypokalemia rows are broad and these disease mappings are not exhaustive.

## Validation

- `just validate kb/disorders/Hypokalemic_Periodic_Paralysis.yaml`
- `just validate kb/disorders/Gitelman_Syndrome.yaml`
- `just validate kb/disorders/Bartter_Syndrome.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Note: targeted validation normalized unrelated ClinicalTrials cache files locally; those generated changes were restored and are not included in this PR.