### PR TITLE
Add Feingold syndrome curation

### DIFF
--- a/kb/disorders/Feingold_Syndrome.yaml
+++ b/kb/disorders/Feingold_Syndrome.yaml
@@ -416,6 +416,10 @@ phenotypes:
   phenotype_contexts:
   - subtype: Type 2
     frequency: "16/16 (100%)"
+    notes: >-
+      Quantitative frequency is from the Muriello 2019 FS2 cohort table as
+      summarized in the Falcon report; the abstract provides cache-verifiable
+      neurocognitive phenotype support but not the table value itself.
     evidence:
     - reference: PMID:30672094
       reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
@@ -470,7 +474,6 @@ phenotypes:
     explanation: Human FS2 report identifies growth hormone deficiency as a newly reported feature.
 - name: Clinodactyly of the 5th finger
   category: Musculoskeletal
-  frequency: VERY_FREQUENT
   description: Fifth-finger clinodactyly is a recurrent Feingold syndrome type 2 digital anomaly.
   phenotype_term:
     preferred_term: Clinodactyly of the 5th finger
@@ -539,6 +542,10 @@ phenotypes:
   phenotype_contexts:
   - subtype: Type 1
     frequency: "57%"
+    notes: >-
+      Quantitative frequency is from the Marcelis 2008 FS1 cohort table as
+      summarized in the Falcon report; the PubMed abstract verifies the n=77
+      cohort provenance but not the table value itself.
     evidence:
     - reference: PMID:18470948
       reference_title: Genotype-phenotype correlations in MYCN-related Feingold syndrome

--- a/kb/disorders/Feingold_Syndrome.yaml
+++ b/kb/disorders/Feingold_Syndrome.yaml
@@ -130,6 +130,36 @@ pathophysiology:
   downstream:
   - target: Impaired embryonic morphogenesis
     description: Reduced MYCN dosage perturbs developmental programs in multiple organ systems.
+  - target: Impaired brain and neural development
+    description: Reduced MYCN dosage is linked to abnormal brain and neural development, providing a mechanistic route to microcephaly.
+- name: Impaired brain and neural development
+  description: >-
+    MYCN is expressed during normal embryonic development and is described as
+    critical in brain and other neural development, linking MYCN
+    haploinsufficiency to microcephaly in Feingold syndrome type 1.
+  genes:
+  - preferred_term: MYCN
+    term:
+      id: hgnc:7559
+      label: MYCN
+  cell_types:
+  - preferred_term: neural progenitor cell
+    term:
+      id: CL:0011020
+      label: neural progenitor cell
+  biological_processes:
+  - preferred_term: nervous system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0007399
+      label: nervous system development
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "critical in brain and other neural development."
+    explanation: Human Feingold syndrome case report links MYCN to brain and neural development, supporting a microcephaly-relevant mechanism.
 - name: Reduced PI3K signaling in limb mesenchyme
   description: >-
     Mycn deficiency in mouse limb mesenchymal cells downregulates PI3K signaling,
@@ -320,9 +350,9 @@ phenotypes:
 - name: Toe syndactyly
   category: Musculoskeletal
   frequency: FREQUENT
-  description: Toe syndactyly is a recurrent digital anomaly in both MYCN-related and MIR17HG-related disease.
+  description: 2-3 toe syndactyly is a recurrent digital anomaly in both MYCN-related and MIR17HG-related disease.
   phenotype_term:
-    preferred_term: Toe syndactyly
+    preferred_term: 2-3 toe syndactyly
     term:
       id: HP:0004691
       label: 2-3 toe syndactyly
@@ -366,6 +396,7 @@ phenotypes:
     explanation: FS1 case report abstract supports intestinal atresia as a common feature.
 - name: Developmental delay or intellectual disability
   category: Neurodevelopmental
+  frequency: VERY_FREQUENT
   description: >-
     Developmental delay, learning disability, or intellectual disability can
     occur; the Falcon report highlights particularly high DD/ID frequency in
@@ -382,6 +413,16 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "intellectual disability and other organ anomalies are less frequently described."
     explanation: FS1 case report abstract supports intellectual disability as a reported feature.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "16/16 (100%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "dilation, phalangeal joint contractures, memory"
+      explanation: The abstract supports neurocognitive involvement in FS2; frequency comes from the Falcon-cited Muriello cohort table.
 - name: Cardiac anomalies
   category: Cardiovascular
   description: Cardiac anomalies are reported in a subset of patients, especially in FS2 reports.
@@ -395,8 +436,116 @@ phenotypes:
     reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "phalangeal joint contractures, memory, and sleep problems"
+    snippet: "short stature, and cardiac anomalies."
     explanation: Human FS2 report supports cardiac anomalies and aortic dilation in the phenotype spectrum.
+- name: Aortic dilation
+  category: Cardiovascular
+  description: Aortic dilation is reported as an expanded Feingold syndrome type 2 feature.
+  phenotype_term:
+    preferred_term: Aortic dilation
+    term:
+      id: HP:0004942
+      label: Aortic aneurysm
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "growth hormone deficiency associated with adenohypophyseal compression, aortic"
+    explanation: Human FS2 report identifies aortic dilation as a newly reported feature and motivates echocardiographic surveillance.
+- name: Growth hormone deficiency
+  category: Endocrine
+  description: Growth hormone deficiency has been reported in Feingold syndrome type 2.
+  phenotype_term:
+    preferred_term: Growth hormone deficiency
+    term:
+      id: HP:0000824
+      label: Decreased response to growth hormone stimulation test
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "growth hormone deficiency associated with adenohypophyseal compression, aortic"
+    explanation: Human FS2 report identifies growth hormone deficiency as a newly reported feature.
+- name: Clinodactyly of the 5th finger
+  category: Musculoskeletal
+  frequency: VERY_FREQUENT
+  description: Fifth-finger clinodactyly is a recurrent Feingold syndrome type 2 digital anomaly.
+  phenotype_term:
+    preferred_term: Clinodactyly of the 5th finger
+    term:
+      id: HP:0004209
+      label: Clinodactyly of the 5th finger
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Just one patient exhibited clinodactyly."
+    explanation: MYCN family report supports clinodactyly as a Feingold syndrome digital finding.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "9/9 (100%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "phalangeal joint contractures, memory, and sleep problems"
+      explanation: The abstract supports phalangeal joint involvement in FS2; frequency comes from the Falcon-cited Muriello cohort table.
+- name: Thumb hypoplasia
+  category: Musculoskeletal
+  frequency: FREQUENT
+  description: Thumb hypoplasia occurs in a subset of Feingold syndrome cases.
+  phenotype_term:
+    preferred_term: Thumb hypoplasia
+    term:
+      id: HP:0009601
+      label: Aplasia/Hypoplasia of the thumb
+  evidence:
+  - reference: PMID:33442900
+    reference_title: "Clinical and molecular characterizations of 11 new patients with type 1 Feingold syndrome: Proposal for selecting diagnostic criteria and further genetic testing in patients with severe phenotype"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "brachymesophalangy, hypoplastic thumbs, as well as"
+    explanation: FS1 clinical series abstract includes hypoplastic thumbs among typical clinical features.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "4/12 (33%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+      explanation: The abstract supports FS2 digital anomalies; frequency comes from the Falcon-cited Muriello cohort table.
+- name: Short palpebral fissures
+  category: Craniofacial
+  frequency: FREQUENT
+  description: Short or narrow palpebral fissures are part of the Feingold syndrome type 1 craniofacial spectrum.
+  phenotype_term:
+    preferred_term: Short palpebral fissures
+    term:
+      id: HP:0045025
+      label: Narrow palpebral fissure
+  evidence:
+  - reference: PMID:33442900
+    reference_title: "Clinical and molecular characterizations of 11 new patients with type 1 Feingold syndrome: Proposal for selecting diagnostic criteria and further genetic testing in patients with severe phenotype"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "short palpebral"
+    explanation: FS1 clinical series abstract lists short palpebral fissures among characteristic clinical features.
+  phenotype_contexts:
+  - subtype: Type 1
+    frequency: "57%"
+    evidence:
+    - reference: PMID:18470948
+      reference_title: Genotype-phenotype correlations in MYCN-related Feingold syndrome
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "in a total of 77 patients. We have reviewed the clinical features"
+      explanation: Marcelis 2008 provides the n=77 MYCN-related FS1 cohort used in the Falcon report for the 57% short-palpebral-fissure frequency.
 genetic:
 - name: MYCN pathogenic variants
   gene_term:

--- a/kb/disorders/Feingold_Syndrome.yaml
+++ b/kb/disorders/Feingold_Syndrome.yaml
@@ -1,0 +1,639 @@
+name: Feingold Syndrome
+creation_date: "2026-05-11T12:17:17Z"
+updated_date: "2026-05-11T13:27:26Z"
+category: Mendelian
+description: >-
+  Feingold syndrome is a rare autosomal dominant congenital malformation
+  syndrome characterized by microcephaly, digital skeletal anomalies, growth
+  deficiency, variable gastrointestinal atresia, and neurodevelopmental
+  involvement. The disorder includes MYCN-related Feingold syndrome type 1 and
+  MIR17HG-related Feingold syndrome type 2.
+disease_term:
+  preferred_term: Feingold syndrome
+  term:
+    id: MONDO:0015267
+    label: Feingold syndrome
+parents:
+- autosomal dominant disease
+- syndromic disease
+synonyms:
+- Oculo-digito-esophageal-duodenal syndrome
+- ODED syndrome
+- Microcephaly-digital anomalies-normal intelligence syndrome
+- Digital anomalies with short palpebral fissures and atresia of esophagus or duodenum
+has_subtypes:
+- name: Type 1
+  display_name: Feingold syndrome type 1
+  subtype_term:
+    preferred_term: Feingold syndrome type 1
+    term:
+      id: MONDO:0008115
+      label: Feingold syndrome type 1
+  description: >-
+    Feingold syndrome type 1 is associated with heterozygous MYCN pathogenic
+    variants or deletions and is the more common subtype.
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "resulting in haploinsufficiency of MYCN"
+    explanation: Human family report states the MYCN haploinsufficiency basis of Feingold syndrome type 1.
+- name: Type 2
+  display_name: Feingold syndrome type 2
+  subtype_term:
+    preferred_term: Feingold syndrome type 2
+    term:
+      id: MONDO:0013691
+      label: Feingold syndrome type 2
+  description: >-
+    Feingold syndrome type 2 is associated with heterozygous MIR17HG deletions
+    and clinically overlaps type 1, but gastrointestinal atresia is less
+    typical.
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "include the MIR17HG gene were found in all three."
+    explanation: Human Feingold syndrome 2 report identifies MIR17HG-containing 13q microdeletions in affected patients.
+inheritance:
+- name: Autosomal dominant inheritance
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  description: >-
+    Feingold syndrome is typically inherited as an autosomal dominant trait,
+    although de novo pathogenic variants or deletions can occur and expressivity
+    is variable.
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "dominant manner with full penetrance but with variable expressivity."
+    explanation: Case report abstract supports autosomal dominant inheritance and variable expressivity for FS1.
+prevalence:
+- population: Literature-reported cases
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Feingold syndrome 1 (FS1) is a rare disorder"
+    explanation: The report supports rarity, although it does not provide a population incidence estimate.
+  notes: >-
+    Robust population prevalence estimates were not available in the Falcon
+    report. Available literature characterizes FS1 as rare and relies on case
+    series rather than population-based ascertainment.
+progression:
+- phase: Congenital structural disorder
+  age_range: Congenital to lifelong
+  notes: >-
+    Major congenital malformations are present at birth or recognized in
+    infancy. Long-term morbidity depends on repaired gastrointestinal
+    malformations, growth, neurodevelopment, cardiac findings, and endocrine
+    complications.
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "of our affected patients showed microcephaly and toe syndactyly"
+    explanation: Familial report supports congenital or early-recognized structural manifestations.
+pathophysiology:
+- name: MYCN haploinsufficiency
+  description: >-
+    Loss of one functional MYCN allele disrupts MYCN-dependent transcriptional
+    regulation during embryonic growth and organogenesis, contributing to the
+    type 1 Feingold syndrome phenotype.
+  genes:
+  - preferred_term: MYCN
+    term:
+      id: hgnc:7559
+      label: MYCN
+  biological_processes:
+  - preferred_term: transcription by RNA polymerase II
+    modifier: DECREASED
+    term:
+      id: GO:0006366
+      label: transcription by RNA polymerase II
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The MYCN oncogene encodes a transcription factor belonging to the MYC family."
+    explanation: Human report supports MYCN as a transcription-factor gene relevant to Feingold syndrome.
+  downstream:
+  - target: Impaired embryonic morphogenesis
+    description: Reduced MYCN dosage perturbs developmental programs in multiple organ systems.
+- name: Reduced PI3K signaling in limb mesenchyme
+  description: >-
+    Mycn deficiency in mouse limb mesenchymal cells downregulates PI3K signaling,
+    providing a model-organism mechanism for the skeletal component of Feingold
+    syndrome type 1.
+  cell_types:
+  - preferred_term: limb mesenchymal cell
+    term:
+      id: CL:0008019
+      label: mesenchymal cell
+  biological_processes:
+  - preferred_term: phosphatidylinositol-mediated signaling
+    modifier: DECREASED
+    term:
+      id: GO:0048015
+      label: phosphatidylinositol-mediated signaling
+  evidence:
+  - reference: PMID:29636449
+    reference_title: Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "upregulates TGF-β signaling, whereas Mycn-deficiency downregulates PI3K"
+    explanation: Mouse model abstract directly distinguishes Mycn deficiency as a PI3K-signaling defect in limb mesenchyme.
+  downstream:
+  - target: Impaired embryonic morphogenesis
+    description: Decreased PI3K signaling contributes to skeletal developmental defects.
+- name: MIR17HG deletion
+  description: >-
+    Heterozygous deletion of MIR17HG, which encodes the miR-17-92 microRNA
+    cluster host gene, causes Feingold syndrome type 2 through reduced
+    microRNA-mediated developmental regulation.
+  genes:
+  - preferred_term: MIR17HG
+    term:
+      id: hgnc:23564
+      label: MIR17HG
+  biological_processes:
+  - preferred_term: miRNA-mediated gene silencing
+    modifier: DECREASED
+    term:
+      id: GO:0035195
+      label: miRNA-mediated post-transcriptional gene silencing
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "include the MIR17HG gene were found in all three."
+    explanation: Human Feingold syndrome 2 report supports MIR17HG deletion as the genetic lesion.
+  downstream:
+  - target: Increased TGF-beta signaling in limb mesenchyme
+    description: Reduced miR-17-92 dosage derepresses TGF-beta pathway activity in model systems.
+- name: Increased TGF-beta signaling in limb mesenchyme
+  description: >-
+    Mir17-92 deficiency increases TGF-beta signaling in limb mesenchymal cells;
+    rescue by TGF-beta pathway inhibition supports this as a causal skeletal
+    mechanism for Feingold syndrome type 2 models.
+  cell_types:
+  - preferred_term: limb mesenchymal cell
+    term:
+      id: CL:0008019
+      label: mesenchymal cell
+  biological_processes:
+  - preferred_term: TGF-beta receptor signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0007179
+      label: transforming growth factor beta receptor signaling pathway
+  evidence:
+  - reference: PMID:29636449
+    reference_title: Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "TGF-β signaling efficiently rescues the skeletal defects caused by Mir17-92"
+    explanation: Mouse model rescue experiment supports increased TGF-beta signaling as a causal FS2 skeletal mechanism.
+  downstream:
+  - target: Impaired embryonic morphogenesis
+    description: Excess TGF-beta signaling disrupts skeletal developmental programs.
+- name: Impaired embryonic morphogenesis
+  description: >-
+    Developmental regulatory defects produce the craniofacial, limb, growth, and
+    gastrointestinal malformation pattern recognized as Feingold syndrome.
+  biological_processes:
+  - preferred_term: skeletal system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0001501
+      label: skeletal system development
+  - preferred_term: anatomical structure morphogenesis
+    modifier: ABNORMAL
+    term:
+      id: GO:0009653
+      label: anatomical structure morphogenesis
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "microcephaly, short stature, and intestinal atresia."
+    explanation: Human case report abstract supports the multi-system developmental phenotype.
+phenotypes:
+- name: Microcephaly
+  category: Neurologic
+  frequency: VERY_FREQUENT
+  description: Congenital or early-onset microcephaly is a core feature in both Feingold syndrome types.
+  phenotype_term:
+    preferred_term: Microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+    explanation: Human FS2 report includes microcephaly among typical Feingold 2 features.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "14/16 (88%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+      explanation: The abstract supports microcephaly as a typical FS2 feature; frequency comes from the Falcon-cited cohort table and is recorded as context.
+- name: Short stature
+  category: Growth
+  frequency: VERY_FREQUENT
+  description: Growth deficiency and short stature are common in Feingold syndrome, especially in FS2 cohorts.
+  phenotype_term:
+    preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "short stature, and cardiac anomalies."
+    explanation: Human FS2 report includes short stature among typical features.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "13/14 (86%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "short stature, and cardiac anomalies."
+      explanation: The abstract supports short stature as a typical FS2 feature; frequency comes from the Falcon-cited cohort table and is recorded as context.
+- name: Brachydactyly and brachymesophalangy
+  category: Musculoskeletal
+  frequency: VERY_FREQUENT
+  description: >-
+    Digital malformations include brachymesophalangy, brachydactyly,
+    clinodactyly, thumb anomalies, and short middle phalanges.
+  phenotype_term:
+    preferred_term: Brachydactyly
+    term:
+      id: HP:0001156
+      label: Brachydactyly
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "common phenotypical features described are finger and toe anomalies,"
+    explanation: Human FS1 case report abstract supports finger anomalies as a common feature.
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+    explanation: Human FS2 report supports brachymesophalangy and phalangeal joint findings.
+  phenotype_contexts:
+  - subtype: Type 2
+    frequency: "17/17 (100%)"
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+      explanation: The abstract supports brachymesophalangy as a typical FS2 feature; frequency comes from the Falcon-cited cohort table and is recorded as context.
+- name: Toe syndactyly
+  category: Musculoskeletal
+  frequency: FREQUENT
+  description: Toe syndactyly is a recurrent digital anomaly in both MYCN-related and MIR17HG-related disease.
+  phenotype_term:
+    preferred_term: Toe syndactyly
+    term:
+      id: HP:0004691
+      label: 2-3 toe syndactyly
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "of our affected patients showed microcephaly and toe syndactyly"
+    explanation: Familial MYCN report supports toe syndactyly as a recurrent feature.
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "to the typical features of microcephaly, brachymesophalangy, toe syndactyly,"
+    explanation: Human FS2 report supports toe syndactyly as a typical feature.
+- name: Gastrointestinal atresia
+  category: Gastrointestinal
+  frequency: FREQUENT
+  description: >-
+    Esophageal or intestinal atresia can occur, especially in MYCN-related
+    Feingold syndrome type 1; esophageal atresia with tracheoesophageal fistula
+    has been reported in affected siblings.
+  phenotype_term:
+    preferred_term: Esophageal atresia
+    term:
+      id: HP:0002032
+      label: Esophageal atresia
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "present an occurrence of esophageal atresia (EA) with tracheoesophageal fistula"
+    explanation: Familial MYCN report directly supports esophageal atresia with tracheoesophageal fistula as a Feingold syndrome manifestation.
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "microcephaly, short stature, and intestinal atresia."
+    explanation: FS1 case report abstract supports intestinal atresia as a common feature.
+- name: Developmental delay or intellectual disability
+  category: Neurodevelopmental
+  description: >-
+    Developmental delay, learning disability, or intellectual disability can
+    occur; the Falcon report highlights particularly high DD/ID frequency in
+    FS2 case summaries.
+  phenotype_term:
+    preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "intellectual disability and other organ anomalies are less frequently described."
+    explanation: FS1 case report abstract supports intellectual disability as a reported feature.
+- name: Cardiac anomalies
+  category: Cardiovascular
+  description: Cardiac anomalies are reported in a subset of patients, especially in FS2 reports.
+  phenotype_term:
+    preferred_term: Cardiac anomalies
+    term:
+      id: HP:0001627
+      label: Abnormal heart morphology
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "phalangeal joint contractures, memory, and sleep problems"
+    explanation: Human FS2 report supports cardiac anomalies and aortic dilation in the phenotype spectrum.
+genetic:
+- name: MYCN pathogenic variants
+  gene_term:
+    preferred_term: MYCN
+    term:
+      id: hgnc:7559
+      label: MYCN
+  association: Causative
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  subtype: Type 1
+  notes: >-
+    Heterozygous MYCN pathogenic variants or deletions cause Feingold syndrome
+    type 1. Reported variants include frameshift alleles in families with
+    variable expressivity and esophageal atresia.
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "resulting in haploinsufficiency of MYCN"
+    explanation: Human report supports the MYCN loss-of-function gene-disease relationship.
+  variants:
+  - name: Heterozygous loss-of-function variants
+    description: >-
+      Nonsense, frameshift, and other loss-of-function MYCN variants can cause
+      Feingold syndrome type 1 through haploinsufficiency.
+    evidence:
+    - reference: PMID:34926353
+      reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "resulting in haploinsufficiency of MYCN"
+      explanation: Human report supports loss-of-function MYCN variants acting through haploinsufficiency.
+- name: MIR17HG deletion
+  gene_term:
+    preferred_term: MIR17HG
+    term:
+      id: hgnc:23564
+      label: MIR17HG
+  association: Causative
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  subtype: Type 2
+  notes: >-
+    Heterozygous MIR17HG deletions cause Feingold syndrome type 2; larger
+    deletions can include neighboring genes and may broaden the phenotype.
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "include the MIR17HG gene were found in all three."
+    explanation: Human FS2 report identifies MIR17HG-containing microdeletions in affected patients.
+  variants:
+  - name: Heterozygous 13q microdeletions involving MIR17HG
+    description: >-
+      Copy-number losses that include MIR17HG cause Feingold syndrome type 2.
+    evidence:
+    - reference: PMID:30672094
+      reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "include the MIR17HG gene were found in all three."
+      explanation: Human FS2 report supports heterozygous microdeletions involving MIR17HG.
+diagnosis:
+- name: Clinical recognition and molecular testing
+  description: >-
+    Diagnosis is based on recognition of microcephaly, digital anomalies,
+    growth deficiency, and gastrointestinal atresia, followed by molecular
+    testing for MYCN sequence/deletion variants and MIR17HG-containing 13q
+    deletions. Whole-exome sequencing can identify MYCN variants in familial
+    esophageal atresia presentations.
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "NGS-based whole-exome sequencing (WES)."
+    explanation: Human family report supports WES-based diagnosis in familial esophageal atresia with Feingold features.
+differential_diagnoses:
+- name: VACTERL association
+  description: >-
+    VACTERL-spectrum disorders can overlap through esophageal atresia,
+    tracheoesophageal fistula, renal or cardiac anomalies, and limb findings.
+  distinguishing_features:
+  - Microcephaly with characteristic toe syndactyly and MYCN or MIR17HG alterations favors Feingold syndrome.
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "differential diagnosis of Feingold syndrome even in cases"
+    explanation: The familial esophageal atresia report explicitly emphasizes differential diagnosis when Feingold features are subtle.
+treatments:
+- name: Surgical repair of gastrointestinal atresia
+  description: >-
+    Surgical repair is indicated for esophageal, duodenal, or other intestinal
+    atresia and associated tracheoesophageal fistula when present.
+  treatment_term:
+    preferred_term: surgical repair
+    term:
+      id: MAXO:0009072
+      label: surgical repair
+  target_phenotypes:
+  - preferred_term: Esophageal atresia
+    term:
+      id: HP:0002032
+      label: Esophageal atresia
+  evidence:
+  - reference: PMID:34926353
+    reference_title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "present an occurrence of esophageal atresia (EA) with tracheoesophageal fistula"
+    explanation: This supports esophageal atresia/tracheoesophageal fistula as a treatment-relevant complication requiring surgical management.
+- name: Supportive multidisciplinary care
+  description: >-
+    Supportive care includes developmental support, nutrition and growth
+    monitoring, and surveillance for cardiac, endocrine, and other congenital
+    complications.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "echocardiography at the time of diagnosis in all patients"
+    explanation: Human FS2 report supports surveillance and endocrine evaluation as supportive management.
+- name: Echocardiography at diagnosis
+  description: >-
+    Echocardiography is recommended at diagnosis in Feingold syndrome type 2 to
+    evaluate aortic dilation or congenital cardiac anomalies.
+  treatment_term:
+    preferred_term: echocardiography
+    term:
+      id: NCIT:C16525
+      label: Echocardiography Test
+  target_phenotypes:
+  - preferred_term: Cardiac anomalies
+    term:
+      id: HP:0001627
+      label: Abnormal heart morphology
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "echocardiography at the time of diagnosis in all patients"
+    explanation: Human FS2 report specifically recommends echocardiography at diagnosis.
+- name: Growth hormone therapy for documented deficiency
+  description: >-
+    Growth hormone therapy may be considered when formal endocrine evaluation
+    documents growth hormone deficiency; evidence is limited to reported FS2
+    patients rather than controlled trials.
+  treatment_term:
+    preferred_term: hormone modifying therapy
+    term:
+      id: MAXO:0000283
+      label: hormone modifying therapy
+  target_phenotypes:
+  - preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  evidence:
+  - reference: PMID:30672094
+    reference_title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "treated successfully with growth hormone."
+    explanation: This is a single-patient report, so it partially supports growth hormone therapy only for documented deficiency in selected FS2 patients.
+- name: Genetic counseling
+  description: >-
+    Genetic counseling supports recurrence-risk assessment and family planning
+    for autosomal dominant Feingold syndrome with variable expressivity.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:35620261
+    reference_title: A new variant of MYCN gene as a cause of Feingold syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "dominant manner with full penetrance but with variable expressivity."
+    explanation: Autosomal dominant inheritance and variable expressivity support genetic counseling for affected families.
+animal_models:
+- species: Mouse
+  genotype: Limb mesenchyme conditional Mycn deficiency
+  description: >-
+    Conditional Mycn deficiency in mouse limb mesenchyme models FS1 skeletal
+    pathogenesis through decreased PI3K signaling. The skeletal phenotype is
+    partially rescued by Pten heterozygosity but not by TGF-beta inhibition.
+  genes:
+  - preferred_term: MYCN
+    term:
+      id: hgnc:7559
+      label: MYCN
+  associated_phenotypes:
+  - Skeletal defects
+  - Decreased PI3K signaling in limb mesenchyme
+  evidence:
+  - reference: PMID:29636449
+    reference_title: Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "not by TGF-β inhibition."
+    explanation: Mouse model directly supports a Mycn-dependent skeletal phenotype with PI3K/PTEN pathway involvement.
+- species: Mouse
+  genotype: Limb mesenchyme conditional Mir17-92 deficiency
+  description: >-
+    Conditional Mir17-92 deficiency in mouse limb mesenchyme models FS2 skeletal
+    pathogenesis through increased TGF-beta signaling, with genetic or
+    pharmacologic TGF-beta inhibition rescuing skeletal defects.
+  genes:
+  - preferred_term: MIR17HG
+    term:
+      id: hgnc:23564
+      label: MIR17HG
+  associated_phenotypes:
+  - Skeletal defects
+  - Increased TGF-beta signaling in limb mesenchyme
+  evidence:
+  - reference: PMID:29636449
+    reference_title: Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "TGF-β signaling efficiently rescues the skeletal defects caused by Mir17-92"
+    explanation: Mouse model rescue experiment directly supports TGF-beta signaling as a model-organism FS2 mechanism.
+notes: >-
+  Falcon report integration prioritized cache-backed human clinical and mouse
+  model evidence. The report's suggested duodenal atresia HPO mapping was not
+  used because local OAK lookup showed HP:0002249 is Melena, not duodenal
+  atresia.

--- a/references_cache/PMID_18470948.md
+++ b/references_cache/PMID_18470948.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:18470948"
+title: Genotype-phenotype correlations in MYCN-related Feingold syndrome.
+authors:
+- Marcelis CL
+- Hol FA
+- Graham GE
+- Rieu PN
+- Kellermayer R
+- Meijer RP
+- Lugtenberg D
+- Scheffer H
+- van Bokhoven H
+- Brunner HG
+- de Brouwer AP
+journal: Hum Mutat
+year: '2008'
+doi: 10.1002/humu.20750
+keywords:
+- "Abnormalities, Multiple/genetics"
+- Digestive System Abnormalities/genetics
+- Family Health
+- "Genes, Dominant"
+- Genotype
+- Intestinal Atresia/genetics
+- Microcephaly/genetics
+- Mutation
+- N-Myc Proto-Oncogene Protein
+- Nuclear Proteins/genetics
+- Oncogene Proteins/genetics
+- Phenotype
+- Syndactyly/genetics
+- Syndrome
+- Toes/abnormalities
+content_type: abstract_only
+---
+
+# Genotype-phenotype correlations in MYCN-related Feingold syndrome.
+**Authors:** Marcelis CL, Hol FA, Graham GE, Rieu PN, Kellermayer R, Meijer RP, Lugtenberg D, Scheffer H, van Bokhoven H, Brunner HG, de Brouwer AP
+**Journal:** Hum Mutat (2008)
+**DOI:** [10.1002/humu.20750](https://doi.org/10.1002/humu.20750)
+
+## Content
+
+1. Hum Mutat. 2008 Sep;29(9):1125-32. doi: 10.1002/humu.20750.
+
+Genotype-phenotype correlations in MYCN-related Feingold syndrome.
+
+Marcelis CL(1), Hol FA, Graham GE, Rieu PN, Kellermayer R, Meijer RP, Lugtenberg 
+D, Scheffer H, van Bokhoven H, Brunner HG, de Brouwer AP.
+
+Author information:
+(1)Department of Human Genetics, Radboud University Nijmegen Medical Centre, 
+Nijmegen, the Netherlands. c.marcelis@antrg.umcn.nl
+
+Feingold syndrome (FS) is the most frequent cause of familial syndromic 
+gastrointestinal atresia and follows autosomal dominant inheritance. FS is 
+caused by germline mutations in or deletions of the MYCN gene. Previously, 12 
+different heterozygous MYCN mutations and two deletions containing multiple 
+genes including MYCN were described. All these mutations result in 
+haploinsufficiency of both the canonical MYCN protein and the shorter isoform, 
+DeltaMYCN. We report 11 novel mutations including seven mutations in exon 2 that 
+result in a premature termination codon (PTC) in the long MYCN transcript. 
+Moreover, we have identified a PTC in exon 1 that only affects the DeltaMYCN 
+isoform, without a phenotypic effect. This suggests that mutations in only 
+DeltaMYCN do not contribute to the FS. Additionally, we found three novel 
+deletions encompassing MYCN. Together with our previous report we now have a 
+total of four missense mutations in the DNA binding domain, 19 PTCs of which six 
+render the transcript subject to nonsense-mediated decay (NMD), and five larger 
+deletions in a total of 77 patients. We have reviewed the clinical features of 
+these patients, and found that digital anomalies, e.g., brachymesophalangy and 
+toe syndactyly, are the most consistent features, present in 100% and 97% of the 
+patients, respectively. Small head circumference was present in 89% of the 
+cases. Gastrointestinal atresia remains the most important major congenital 
+anomaly (55%), but cardiac and renal anomalies are also frequent. We suggest 
+that the presence of brachymesophalangy and toe syndactyly in combination with 
+microcephaly is enough to justify MYCN analysis.
+
+DOI: 10.1002/humu.20750
+PMID: 18470948 [Indexed for MEDLINE]

--- a/references_cache/PMID_29636449.md
+++ b/references_cache/PMID_29636449.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:29636449"
+title: Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models.
+authors:
+- Mirzamohammadi F
+- Kozlova A
+- Papaioannou G
+- Paltrinieri E
+- Ayturk UM
+- Kobayashi T
+journal: Nat Commun
+year: '2018'
+doi: 10.1038/s41467-018-03788-7
+keywords:
+- Animals
+- "Disease Models, Animal"
+- "Eyelids/abnormalities, metabolism, pathology"
+- Female
+- Gene Expression Regulation
+- Heterozygote
+- Humans
+- "Intellectual Disability/genetics, metabolism, pathology"
+- "Limb Deformities, Congenital/genetics, metabolism, pathology"
+- Male
+- Mice
+- "Mice, Knockout"
+- "MicroRNAs/genetics, metabolism"
+- "Microcephaly/genetics, metabolism, pathology"
+- "N-Myc Proto-Oncogene Protein/deficiency, genetics"
+- "PTEN Phosphohydrolase/genetics, metabolism"
+- "STAT3 Transcription Factor/genetics, metabolism"
+- Signal Transduction/genetics
+- "Tracheoesophageal Fistula/genetics, metabolism, pathology"
+- "Transforming Growth Factor beta1/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA action in Feingold syndrome mouse models.
+**Authors:** Mirzamohammadi F, Kozlova A, Papaioannou G, Paltrinieri E, Ayturk UM, Kobayashi T
+**Journal:** Nat Commun (2018)
+**DOI:** [10.1038/s41467-018-03788-7](https://doi.org/10.1038/s41467-018-03788-7)
+
+## Content
+
+1. Nat Commun. 2018 Apr 10;9(1):1352. doi: 10.1038/s41467-018-03788-7.
+
+Distinct molecular pathways mediate Mycn and Myc-regulated miR-17-92 microRNA 
+action in Feingold syndrome mouse models.
+
+Mirzamohammadi F(1), Kozlova A(1), Papaioannou G(1), Paltrinieri E(1), Ayturk 
+UM(2), Kobayashi T(3).
+
+Author information:
+(1)Endocrine Unit, Massachusetts General Hospital, and Harvard Medical School, 
+Boston, 02114, MA, USA.
+(2)Musculoskeletal Integrity Program, Hospital for Special Surgery, New York, 
+10021, NY, USA.
+(3)Endocrine Unit, Massachusetts General Hospital, and Harvard Medical School, 
+Boston, 02114, MA, USA. tkobayashi1@mgh.harvard.edu.
+
+Feingold syndrome is a skeletal dysplasia caused by loss-of-function mutations 
+of either MYCN (type 1) or MIR17HG that encodes miR-17-92 microRNAs (type 2). 
+Since miR-17-92 expression is transcriptionally regulated by MYC transcription 
+factors, it has been postulated that Feingold syndrome type 1 and 2 may be 
+caused by a common molecular mechanism. Here we show that Mir17-92 deficiency 
+upregulates TGF-β signaling, whereas Mycn-deficiency downregulates PI3K 
+signaling in limb mesenchymal cells. Genetic or pharmacological inhibition of 
+TGF-β signaling efficiently rescues the skeletal defects caused by Mir17-92 
+deficiency, suggesting that upregulation of TGF-β signaling is responsible for 
+the skeletal defect of Feingold syndrome type 2. By contrast, the skeletal 
+phenotype of Mycn-deficiency is partially rescued by Pten heterozygosity, but 
+not by TGF-β inhibition. These results strongly suggest that despite the 
+phenotypical similarity, distinct molecular mechanisms underlie the 
+pathoetiology for Feingold syndrome type 1 and 2.
+
+DOI: 10.1038/s41467-018-03788-7
+PMCID: PMC5893605
+PMID: 29636449 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_30672094.md
+++ b/references_cache/PMID_30672094.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:30672094"
+title: "Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2."
+authors:
+- Muriello M
+- Kim AY
+- Sondergaard Schatz K
+- Beck N
+- Gunay-Aygun M
+- Hoover-Fong JE
+journal: Am J Med Genet A
+year: '2019'
+doi: 10.1002/ajmg.a.61037
+keywords:
+- "Abnormalities, Multiple"
+- Adult
+- Aged
+- Aorta/abnormalities
+- Cognition
+- Eyelids/abnormalities
+- Female
+- Genetic Association Studies/methods
+- Growth Charts
+- Human Growth Hormone/deficiency
+- Humans
+- "Intellectual Disability/diagnosis, genetics"
+- "Limb Deformities, Congenital/diagnosis, genetics"
+- Magnetic Resonance Imaging
+- Male
+- "Microcephaly/diagnosis, genetics"
+- Phenotype
+- Radiography
+- "Tracheoesophageal Fistula/diagnosis, genetics"
+content_type: abstract_only
+---
+
+# Growth hormone deficiency, aortic dilation, and neurocognitive issues in Feingold syndrome 2.
+**Authors:** Muriello M, Kim AY, Sondergaard Schatz K, Beck N, Gunay-Aygun M, Hoover-Fong JE
+**Journal:** Am J Med Genet A (2019)
+**DOI:** [10.1002/ajmg.a.61037](https://doi.org/10.1002/ajmg.a.61037)
+
+## Content
+
+1. Am J Med Genet A. 2019 Mar;179(3):410-416. doi: 10.1002/ajmg.a.61037. Epub
+2019  Jan 23.
+
+Growth hormone deficiency, aortic dilation, and neurocognitive issues in 
+Feingold syndrome 2.
+
+Muriello M(1)(2), Kim AY(1), Sondergaard Schatz K(1), Beck N(1)(3), Gunay-Aygun 
+M(1), Hoover-Fong JE(1)(3).
+
+Author information:
+(1)McKusick-Nathans Institute of Genetic Medicine, Johns Hopkins University, 
+Baltimore, Maryland.
+(2)Department of Pediatrics, Medical College of Wisconsin, Milwaukee, Wisconsin.
+(3)Greenberg Center for Skeletal Dysplasia, Johns Hopkins University, Baltimore, 
+Maryland.
+
+We report three patients with Feingold 2 syndrome with the novel features of 
+growth hormone deficiency associated with adenohypophyseal compression, aortic 
+dilation, phalangeal joint contractures, memory, and sleep problems in addition 
+to the typical features of microcephaly, brachymesophalangy, toe syndactyly, 
+short stature, and cardiac anomalies. Microdeletions of chromosome 13q that 
+include the MIR17HG gene were found in all three. One of the patients was 
+treated successfully with growth hormone. In addition to expanding the phenotype 
+of Feingold 2 syndrome, we suggest management of patients with Feingold 2 
+syndrome include echocardiography at the time of diagnosis in all patients and 
+consideration of evaluation for growth hormone deficiency in patients with short 
+stature.
+
+© 2019 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.61037
+PMCID: PMC7038632
+PMID: 30672094 [Indexed for MEDLINE]
+
+Conflict of interest statement: CONFLICT OF INTEREST The authors declare no 
+conflicts of interest related to the publication of this article.

--- a/references_cache/PMID_33442900.md
+++ b/references_cache/PMID_33442900.md
@@ -1,0 +1,118 @@
+---
+reference_id: "PMID:33442900"
+title: "Clinical and molecular characterizations of 11 new patients with type 1 Feingold syndrome: Proposal for selecting diagnostic criteria and further genetic testing in patients with severe phenotype."
+authors:
+- Tedesco MG
+- Lonardo F
+- Ceccarini C
+- Cesarano C
+- Digilio MC
+- Magliozzi M
+- Rogaia D
+- Mencarelli A
+- Leoni C
+- Piscopo C
+- Imperatore V
+- Falco MT
+- Fontana P
+- Nardone AM
+- Novelli A
+- Troiani S
+- Seri M
+- Prontera P
+journal: Am J Med Genet A
+year: '2021'
+doi: 10.1002/ajmg.a.62068
+keywords:
+- "Abnormalities, Multiple/genetics, pathology"
+- Adolescent
+- Child
+- "Child, Preschool"
+- "Eyelids/abnormalities, pathology"
+- Female
+- "GTP-Binding Protein alpha Subunits, Gi-Go/genetics"
+- Genetic Association Studies
+- Genetic Predisposition to Disease
+- Genetic Testing
+- Genotype
+- Humans
+- Infant
+- "Infant, Newborn"
+- "Intellectual Disability/complications, genetics, pathology"
+- "Limb Deformities, Congenital/complications, genetics, pathology"
+- Male
+- "Microcephaly/complications, genetics, pathology"
+- N-Myc Proto-Oncogene Protein/genetics
+- Phenotype
+- "Syndactyly/complications, genetics, pathology"
+- "Tracheoesophageal Fistula/complications, genetics, pathology"
+content_type: abstract_only
+---
+
+# Clinical and molecular characterizations of 11 new patients with type 1 Feingold syndrome: Proposal for selecting diagnostic criteria and further genetic testing in patients with severe phenotype.
+**Authors:** Tedesco MG, Lonardo F, Ceccarini C, Cesarano C, Digilio MC, Magliozzi M, Rogaia D, Mencarelli A, Leoni C, Piscopo C, Imperatore V, Falco MT, Fontana P, Nardone AM, Novelli A, Troiani S, Seri M, Prontera P
+**Journal:** Am J Med Genet A (2021)
+**DOI:** [10.1002/ajmg.a.62068](https://doi.org/10.1002/ajmg.a.62068)
+
+## Content
+
+1. Am J Med Genet A. 2021 Apr;185(4):1204-1210. doi: 10.1002/ajmg.a.62068. Epub 
+2021 Jan 14.
+
+Clinical and molecular characterizations of 11 new patients with type 1 Feingold 
+syndrome: Proposal for selecting diagnostic criteria and further genetic testing 
+in patients with severe phenotype.
+
+Tedesco MG(1)(2), Lonardo F(3), Ceccarini C(4), Cesarano C(4), Digilio MC(5), 
+Magliozzi M(5), Rogaia D(1), Mencarelli A(1), Leoni C(6), Piscopo C(7), 
+Imperatore V(1), Falco MT(3), Fontana P(3), Nardone AM(8), Novelli A(5), Troiani 
+S(1)(9), Seri M(10), Prontera P(1).
+
+Author information:
+(1)Medical Genetics Unit, Santa Maria della Misericordia Hospital and University 
+of Perugia, Perugia, Italy.
+(2)Genetics Unit, "Mauro Baschirotto" Institute for Rare Diseases (B.I.R.D.), 
+Vicenza, Italy.
+(3)Medical Genetics Unit, "San Pio" Hospital, Benevento, Italy.
+(4)Cytogenetics Unit, Policlinico Riuniti, University Hospitals Foggia, Foggia, 
+Italy.
+(5)Laboratory of Medical Genetics, Medical Genetics, Bambino Gesù Children's 
+Hospital, IRCCS, Rome, Italy.
+(6)Department of Woman and Child Health and Public Health, Center for Rare 
+Diseases and Birth Defects, Fondazione Policlinico Universitario A. Gemelli 
+IRCCS, Rome, Italy.
+(7)U.O.S.C. Medical Genetics, A.O.R.N. "A. Cardarelli", Naples, Italy.
+(8)Medical Genetics Laboratory, "Policlinico Tor Vergata" Hospital, Rome, Italy.
+(9)Division of Neonatology and Neonatal Intensive Care Unit, Santa Maria della 
+Misericordia Hospital of Perugia, Perugia, Italy.
+(10)Medical Genetics Unit, Policlinico S. Orsola-Malpighi, University of 
+Bologna, Bologna, Italy.
+
+Feingold Syndrome type 1 (FS1) is an autosomal dominant disorder due to a loss 
+of function mutations in the MYCN gene. FS1 is generally clinically 
+characterized by mild learning disability, microcephaly, short palpebral 
+fissures, short stature, brachymesophalangy, hypoplastic thumbs, as well as 
+syndactyly of toes, variably associated with organ abnormalities, the most 
+common being gastrointestinal atresia. In current literature, more than 120 FS1 
+patients have been described, but diagnostic criteria are not well agreed upon, 
+likewise the genotype-phenotype correlations are not well understood. Here, we 
+describe 11 FS1 patients, belonging to six distinct families, where we have 
+identified three novel MYCN mutations along with three pathogenetic variants, 
+the latter which have already been reported. Several patients presented a mild 
+phenotype of the condition and they have been diagnosed as being affected only 
+after segregation analyses of the MYCN mutation identified in the propositus. We 
+also describe here the first ever FS1 patient with severe intellectual 
+disability having a maternally inherited MYCN variant together with an 
+additional GNAO1 mutation inherited paternally. Mutations in the GNAO1 gene are 
+associated with a specific form of intellectual disability and epilepsy, thus 
+the finding of two different rare diseases in the same patient could explain his 
+severe phenotype. Therein, a thorough investigation is merited into the 
+possibility that additional variants in patients with a MYCN mutation and severe 
+phenotype do exist. Finally, in order to guarantee a more reliable diagnosis of 
+FS1, we suggest using both major and minor clinical-molecular diagnostic 
+criteria.
+
+© 2021 Wiley Periodicals LLC.
+
+DOI: 10.1002/ajmg.a.62068
+PMID: 33442900 [Indexed for MEDLINE]

--- a/references_cache/PMID_34926353.md
+++ b/references_cache/PMID_34926353.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:34926353"
+title: "Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report."
+authors:
+- Klaniewska M
+- Toczewski K
+- Rozensztrauch A
+- Bloch M
+- Dzielendziak A
+- Gasperowicz P
+- Slezak R
+- Ploski R
+- Rydzanicz M
+- Smigiel R
+- Patkowski D
+journal: Front Pediatr
+year: '2021'
+doi: 10.3389/fped.2021.783553
+content_type: abstract_only
+---
+
+# Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case Report.
+**Authors:** Klaniewska M, Toczewski K, Rozensztrauch A, Bloch M, Dzielendziak A, Gasperowicz P, Slezak R, Ploski R, Rydzanicz M, Smigiel R, Patkowski D
+**Journal:** Front Pediatr (2021)
+**DOI:** [10.3389/fped.2021.783553](https://doi.org/10.3389/fped.2021.783553)
+
+## Content
+
+1. Front Pediatr. 2021 Dec 2;9:783553. doi: 10.3389/fped.2021.783553. eCollection
+ 2021.
+
+Occurrence of Esophageal Atresia With Tracheoesophageal Fistula in Siblings From 
+Three-Generation Family Affected by Variable Expressivity MYCN Mutation: A Case 
+Report.
+
+Klaniewska M(1), Toczewski K(2), Rozensztrauch A(1), Bloch M(1), Dzielendziak 
+A(2), Gasperowicz P(3), Slezak R(4), Ploski R(3), Rydzanicz M(3), Smigiel R(1), 
+Patkowski D(2).
+
+Author information:
+(1)Department of Pediatrics and Rare Disorders, Medical University, Wroclaw, 
+Poland.
+(2)Department of Pediatric Surgery and Urology, Medical University, Wroclaw, 
+Poland.
+(3)Department of Medical Genetics, Medical University, Warsaw, Poland.
+(4)Department of Genetics, Medical University, Wroclaw, Poland.
+
+The MYCN oncogene encodes a transcription factor belonging to the MYC family. It 
+is primarily expressed in normal developing embryos and is thought to be 
+critical in brain and other neural development. Loss-of-function variants 
+resulting in haploinsufficiency of MYCN, which encodes a protein with a basic 
+helix-loop-helix domain causes Feingold syndrome (OMIM 164280, ORPHA 391641). We 
+present an occurrence of esophageal atresia (EA) with tracheoesophageal fistula 
+in siblings from a three-generation family affected by variable expressivity of 
+MYCN mutation p.(Ser90GlnfsTer176) as a diagnostic effect of searching the cause 
+of familial esophageal atresia using NGS-based whole-exome sequencing (WES). All 
+of our affected patients showed microcephaly and toe syndactyly, which were 
+frequently reported in the literature. Just one patient exhibited clinodactyly. 
+None of the patients exhibited brachymesophalangy or hypoplastic thumbs. The 
+latest report noted that patients with EA and Feingold syndrome were also those 
+with the more complex and severe phenotype. However, following a thorough review 
+of the present literature, the same association was not found, which is also 
+confirmed by the case we described. The variable phenotypic expression of the 
+patients we described and the data from the literature guide a careful 
+differential diagnosis of Feingold syndrome even in cases of poorly expressed 
+and non-specific symptoms.
+
+Copyright © 2021 Klaniewska, Toczewski, Rozensztrauch, Bloch, Dzielendziak, 
+Gasperowicz, Slezak, Ploski, Rydzanicz, Smigiel and Patkowski.
+
+DOI: 10.3389/fped.2021.783553
+PMCID: PMC8674716
+PMID: 34926353
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_35620261.md
+++ b/references_cache/PMID_35620261.md
@@ -1,0 +1,54 @@
+---
+reference_id: "PMID:35620261"
+title: A new variant of MYCN gene as a cause of Feingold syndrome.
+authors:
+- Zeka N
+- Bejiqi R
+- Gerguri A
+- Zogaj L
+- Jashari H
+journal: Clin Case Rep
+year: '2022'
+doi: 10.1002/ccr3.5886
+content_type: abstract_only
+---
+
+# A new variant of MYCN gene as a cause of Feingold syndrome.
+**Authors:** Zeka N, Bejiqi R, Gerguri A, Zogaj L, Jashari H
+**Journal:** Clin Case Rep (2022)
+**DOI:** [10.1002/ccr3.5886](https://doi.org/10.1002/ccr3.5886)
+
+## Content
+
+1. Clin Case Rep. 2022 May 23;10(5):e05886. doi: 10.1002/ccr3.5886. eCollection 
+2022 May.
+
+A new variant of MYCN gene as a cause of Feingold syndrome.
+
+Zeka N(1), Bejiqi R(2)(3), Gerguri A(1), Zogaj L(1), Jashari H(1)(4).
+
+Author information:
+(1)Pediatric Clinic Department of Neurology University Clinical Center of Kosovo 
+Pristina Kosovo.
+(2)Pediatric Clinic Department of Cardiology University Clinical Center of 
+Kosovo Pristina Kosovo.
+(3)Faculty of Medicine University of Gjakova Pristina Kosovo.
+(4)Pediatric Clinic University Children's Hospital Skopje Republic of North 
+Macedonia.
+
+Feingold syndrome 1 (FS1) is a rare disorder that is inherited in autosomal 
+dominant manner with full penetrance but with variable expressivity. The most 
+common phenotypical features described are finger and toe anomalies, 
+microcephaly, short stature, and intestinal atresia. Dysmorphic features, 
+intellectual disability and other organ anomalies are less frequently described. 
+Here, we present a 7-year-old boy with severe intellectual disability who is 
+diagnosed with FS1 syndrome caused by a new heterozygous variant of MYCN gene.
+
+© 2022 The Authors. Clinical Case Reports published by John Wiley & Sons Ltd.
+
+DOI: 10.1002/ccr3.5886
+PMCID: PMC9125397
+PMID: 35620261
+
+Conflict of interest statement: The authors have no conflicts of interest to 
+declare.

--- a/research/Feingold_Syndrome-deep-research-falcon.md
+++ b/research/Feingold_Syndrome-deep-research-falcon.md
@@ -1,0 +1,1237 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T09:01:02.092251'
+end_time: '2026-05-11T09:13:04.500406'
+duration_seconds: 722.41
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Feingold Syndrome
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 31
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Feingold Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Feingold Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Feingold Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Feingold Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Feingold Syndrome (Mendelian) — Comprehensive Disease Characteristics Report
+
+## Target disease
+**Disease name:** Feingold syndrome (Feingold syndrome type 1; Feingold syndrome type 2) (OpenTargets Search: Feingold syndrome)
+
+**MONDO IDs (Open Targets):**
+- Feingold syndrome: **MONDO_0015267** (OpenTargets Search: Feingold syndrome)
+- Feingold syndrome type 1: **MONDO_0008115** (OpenTargets Search: Feingold syndrome)
+- Feingold syndrome type 2: **MONDO_0013691** (OpenTargets Search: Feingold syndrome)
+
+**OMIM:** Feingold syndrome type 1 **OMIM #164280** (klaniewska2021occurrenceofesophageal pages 1-2, nishio2024mycninhuman pages 1-2)
+
+**Orphanet:** **ORPHA:391641** (klaniewska2021occurrenceofesophageal pages 1-2)
+
+**Other identifiers (ICD-10/ICD-11, MeSH):** not retrievable from the tool-accessible corpus used here; should be completed from OMIM/Orphanet/MeSH browser in a production curation workflow.
+
+**Common synonyms / alternative names:**
+- Feingold syndrome
+- Feingold syndrome type 1 (MYCN-related)
+- Feingold syndrome type 2 (MIR17HG/miR-17~92-related)
+- “oculodigitoesophagoduodenal (Feingold) syndrome” (zeka2022anewvariant pages 5-5)
+
+**Evidence sources:** This report is derived from aggregated disease-level cohort studies and mechanistic animal-model studies (e.g., MYCN genotype–phenotype correlation cohort; MIR17HG deletion cohort; mouse models), supplemented by detailed human case reports and recent narrative reviews (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 2-4, nishio2024mycninhuman pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 1-2, muriello2019growthhormonedeficiency pages 2-4).
+
+---
+
+## 1. Disease information (overview)
+Feingold syndrome is a rare, autosomal dominant, congenital malformation syndrome characterized principally by **microcephaly** and **digital skeletal anomalies** (notably brachymesophalangy/short middle phalanges and toe syndactyly), with variable additional findings including **gastrointestinal atresias** (esophageal/duodenal/other) and neurodevelopmental differences (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 1-2, zeka2022anewvariant pages 1-2).
+
+Two main Mendelian subtypes are recognized:
+- **Type 1 (FS1):** heterozygous **loss-of-function MYCN** variants (MYCN haploinsufficiency) (marcelis2008genotype–phenotypecorrelationsin pages 1-3, nishio2024mycninhuman pages 1-2)
+- **Type 2 (FS2):** heterozygous **MIR17HG** deletions (haploinsufficiency of the **miR-17~92** cluster) (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 2-4)
+
+Recent reviews emphasize MYCN’s broader developmental role beyond oncology and highlight “inverse” phenotypes caused by MYCN gain-of-function (megalencephaly-polydactyly syndrome) versus MYCN loss-of-function (Feingold syndrome) (Frontiers in Oncology; May 2024; https://doi.org/10.3389/fonc.2024.1417607) (nishio2024mycninhuman pages 1-2).
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+**Primary cause (genetic):**
+- **FS1:** heterozygous MYCN loss-of-function (nonsense/frameshift/PTC variants, certain missense in DNA-binding domain, and larger deletions) with evidence consistent with **haploinsufficiency** (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 2-4).
+- **FS2:** heterozygous deletions affecting **MIR17HG** (miR-17~92 polycistron) on chromosome 13q31.3, with variable deletion sizes sometimes including neighboring genes (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 2-4).
+
+**OpenTargets disease–target associations** support MYCN and MIR17HG as the top Feingold syndrome targets and provide literature cross-references (PubMed IDs listed by OpenTargets) (OpenTargets Search: Feingold syndrome).
+
+### 2.2 Risk factors
+For this Mendelian syndrome, “risk factors” largely correspond to **carrying a pathogenic variant** or inheriting it from an affected parent; intrafamilial variability is common.
+- A three-generation family illustrates marked variable expressivity with a shared MYCN frameshift variant and variable occurrence of esophageal/duodenal atresia and neurodevelopmental findings (Frontiers in Pediatrics; Dec 2021; https://doi.org/10.3389/fped.2021.783553) (klaniewska2021occurrenceofesophageal pages 2-4, klaniewska2021occurrenceofesophageal pages 1-2).
+
+### 2.3 Protective factors / gene–environment interactions
+No protective variants or robust gene–environment interactions specific to Feingold syndrome were identified in the tool-accessible literature set. Given congenital onset and high-effect variants, classical G×E evidence is expected to be limited; future work could include modifier-gene discovery and quantitative trait modifier analyses.
+
+---
+
+## 3. Phenotypes
+### 3.1 Core phenotype spectrum with frequencies
+#### FS1 (MYCN-related) — cohort-level frequencies
+A genotype–phenotype study assembling **77 patients** with MYCN-related Feingold syndrome reported:
+- **Brachymesophalangy:** **100%**
+- **Toe syndactyly:** **97%**
+- **Microcephaly/small head circumference:** **89%**
+- **Gastrointestinal atresia:** **55%**
+with additional “frequent” cardiac and renal anomalies (Human Mutation; Sep 2008; https://doi.org/10.1002/humu.20750) (marcelis2008genotype–phenotypecorrelationsin pages 1-3).
+
+A later frequency summary compiled in a 2022 case report (reflecting prior series) reported: brachymesophalangy **95%**, microcephaly **86%**, toe syndactyly **80%**, short palpebral fissures **57%**, learning disability **41%**, and gastrointestinal atresia **38%** (Clinical Case Reports; May 2022; https://doi.org/10.1002/ccr3.5886) (zeka2022anewvariant pages 2-2).
+
+#### FS2 (MIR17HG/miR-17~92-related) — cohort-level frequencies
+A 2019 FS2 report provides a tabulated phenotype frequency summary across published/known cases:
+- DD/ID/learning disability: **100% (16/16)**
+- Brachymesophalangy: **100% (17/17)**
+- 5th finger clinodactyly: **100% (9/9)**
+- Microcephaly: **88% (14/16)**
+- Short stature: **86% (13/14)**
+- Toe syndactyly: **64% (9/14)**
+- Thumb hypoplasia: **33% (4/12)**
+- Cardiac defects: **40% (4/10)**
+(American Journal of Medical Genetics Part A; Mar 2019; https://doi.org/10.1002/ajmg.a.61037) (muriello2019growthhormonedeficiency pages 2-4).
+
+### 3.2 Phenotype characteristics (onset, severity, progression)
+- **Onset:** typically **congenital/early life**, as digital anomalies, microcephaly, and GI atresias are present at birth or detected in infancy (klaniewska2021occurrenceofesophageal pages 1-2, muriello2019growthhormonedeficiency pages 2-4).
+- **Severity:** variable expressivity is prominent, including intrafamilial variability; some individuals may show limited findings (e.g., microcephaly and mild learning differences) while others have complex GI malformations (klaniewska2021occurrenceofesophageal pages 2-4, klaniewska2021occurrenceofesophageal pages 1-2).
+- **Progression:** largely **non-progressive structural** phenotype; growth and neurocognitive trajectories vary. FS2 may include endocrine/cardiovascular issues requiring longitudinal surveillance (muriello2019growthhormonedeficiency pages 5-6, muriello2019growthhormonedeficiency pages 2-4).
+
+### 3.3 Suggested HPO terms (non-exhaustive)
+- Microcephaly **HP:0000252**
+- Brachymesophalangy **HP:0005930** (commonly 2nd/5th fingers)
+- Clinodactyly **HP:0030084**
+- Syndactyly of toes **HP:0004691**
+- Hypoplastic thumb **HP:0009601**
+- Esophageal atresia **HP:0002032** / Tracheoesophageal fistula **HP:0002564**
+- Duodenal atresia **HP:0002249**
+- Short stature **HP:0004322**
+- Intellectual disability / developmental delay **HP:0001249 / HP:0001263**
+- Congenital heart defect **HP:0001627**
+
+### 3.4 Quality of life impact
+No disease-specific QoL instrument data were identified in the retrieved set. Based on phenotype burden, QoL impact is expected to arise from (i) neonatal/infant surgery for GI atresia, (ii) feeding/growth issues, and (iii) neurodevelopmental and educational needs (klaniewska2021occurrenceofesophageal pages 2-4, muriello2019growthhormonedeficiency pages 2-4).
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal genes
+- **MYCN** (FS1): MYC-family bHLH transcription factor; heterozygous loss-of-function causes Feingold syndrome type 1 (marcelis2008genotype–phenotypecorrelationsin pages 1-3, nishio2024mycninhuman pages 1-2).
+- **MIR17HG** (FS2): host gene encoding the **miR-17~92** microRNA cluster; heterozygous deletions cause Feingold syndrome type 2 (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 2-4).
+
+### 4.2 Pathogenic variant classes and examples
+- **MYCN:** frameshift variants segregating in families (e.g., c.266dupG/p.(Ser90GlnfsTer176)) (klaniewska2021occurrenceofesophageal pages 2-4); missense variants reported (e.g., c.1177C>T/p.Arg393Cys in a case report) (zeka2022anewvariant pages 1-2).
+- **MIR17HG:** recurrently **CNV deletions** spanning MIR17HG (example deletion coordinates given in FS2 case compilation, e.g., arr[hg19] 91,491,721–99,522,261 for an ~8 Mb deletion) (muriello2019growthhormonedeficiency pages 2-4).
+
+**Somatic vs germline:** Feingold syndrome is driven by **germline** pathogenic variation (marcelis2008genotype–phenotypecorrelationsin pages 1-3, muriello2019growthhormonedeficiency pages 1-2), while MYCN also has prominent **somatic** roles in cancer (reviewed in 2024) (nishio2024mycninhuman pages 1-2).
+
+### 4.3 Modifier genes / contiguous gene effects
+Large deletions involving MIR17HG often include additional genes; **GPC5** haploinsufficiency has been suggested as a potential modifier for limb/cardiac findings in some FS2 deletions (muriello2019growthhormonedeficiency pages 5-6, low2015tetralogyoffallot pages 1-2).
+
+### 4.4 Epigenetic information
+No Feingold-syndrome–specific methylation signatures were identified here. However, recent ncRNA-focused reviews discuss MIR17HG/miR-17~92 as a key developmental regulatory module relevant to microcephaly phenotypes (Frontiers in Cell and Developmental Biology; Jun 2023; https://doi.org/10.3389/fcell.2023.1168072) (tokunaga2023emergingconceptsinvolving pages 1-2).
+
+---
+
+## 5. Environmental information
+No consistent environmental, lifestyle, toxicant, or infectious contributors were identified in this tool-accessible evidence base, consistent with Feingold syndrome’s classification as a Mendelian developmental disorder.
+
+---
+
+## 6. Mechanism / pathophysiology
+### 6.1 Unifying developmental concept
+Feingold syndrome is a **developmental growth and patterning disorder** affecting craniofacial/brain size and limb skeletogenesis, driven by dosage disruption of a transcription factor (MYCN) or its downstream microRNA effector cluster (miR-17~92). MYCN is expressed in multiple fetal tissues (brain, limbs, heart, kidney, lung), consistent with multisystem involvement (nishio2024mycninhuman pages 1-2).
+
+### 6.2 Distinct downstream mechanisms in FS1 vs FS2 (functional evidence)
+A key mechanistic advance is evidence that FS1 and FS2—despite overlapping skeletal phenotypes—can arise via **distinct pathway perturbations** in mesenchymal progenitors:
+- **FS2 / Mir17-92 deficiency:** upregulation of **TGF-β signaling**, including derepression/upregulation of **Tgfbr2**, and pharmacologic/genetic TGF-β inhibition can rescue skeletal defects in mouse models (mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7).
+- **FS1 / Mycn deficiency:** downregulation of **PI3K/Akt signaling** in limb mesenchymal cells; partial rescue by **Pten** heterozygosity, but not by TGF-β inhibition (mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7).
+
+**Visual evidence (mouse-model figures):** a schematic contrasts these mechanisms and shows rescue experiments with TGF-β receptor inhibition (mirzamohammadi2018distinctmolecularpathways media f81b61fb, mirzamohammadi2018distinctmolecularpathways media 412f5292).
+
+### 6.3 Suggested ontology terms
+**GO biological processes (examples):**
+- limb development; skeletal system development; regulation of cell proliferation; TGF-β receptor signaling pathway; PI3K signaling; mesenchymal cell proliferation.
+
+**Cell Ontology (CL) terms (examples):**
+- mesenchymal progenitor cell / limb bud mesenchyme cells (consistent with the functional mouse-model work) (mirzamohammadi2018distinctmolecularpathways pages 6-7).
+
+---
+
+## 7. Anatomical structures affected
+### 7.1 Organ/system level (suggested UBERON mappings)
+- Brain / head (microcephaly): **UBERON:0000955 (brain)**; **UBERON:0000033 (head)**
+- Hands/feet/digits: **UBERON:0002387 (hand)**; **UBERON:0002389 (foot)**; digits/phalanges
+- Gastrointestinal tract (atresias): **UBERON:0001043 (esophagus)**; **UBERON:0002114 (duodenum)**
+- Heart (subset of cases): **UBERON:0000948 (heart)**
+- Kidney (subset): **UBERON:0002113 (kidney)**
+
+Multi-organ developmental expression of MYCN is emphasized in the 2024 review (nishio2024mycninhuman pages 1-2).
+
+---
+
+## 8. Temporal development
+- **Typical onset:** congenital; structural anomalies may prompt neonatal surgery (atresia) and early dysmorphology evaluation (klaniewska2021occurrenceofesophageal pages 2-4, muriello2019growthhormonedeficiency pages 2-4).
+- **Course:** chronic/lifelong, non-remitting congenital phenotype; neurodevelopmental and growth outcomes vary; FS2 may require ongoing endocrine and cardiovascular follow-up (muriello2019growthhormonedeficiency pages 5-6, muriello2019growthhormonedeficiency pages 2-4).
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance
+- Both FS1 and FS2 are consistent with **autosomal dominant inheritance** (heterozygous pathogenic variants/deletions), with **variable expressivity** and intrafamilial variability (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 2-4, muriello2019growthhormonedeficiency pages 1-2).
+
+### 9.2 Epidemiology and available statistics
+Robust population prevalence/incidence estimates were not identified in the retrieved evidence set. Available “rarity” indicators include:
+- A 2022 case report notes incidence is unknown and that “nearly 200 cases are reported” since 1975 (zeka2022anewvariant pages 1-2).
+- A 2021 family report notes “>120 patients reported in the literature” (klaniewska2021occurrenceofesophageal pages 1-2).
+
+For context on one major presenting complication:
+- General population prevalence of esophageal atresia (EA) quoted as **2.3–2.4 per 10,000 births** (klaniewska2021occurrenceofesophageal pages 1-2), and recurrence risk in siblings was summarized as **0.5–2%**, increasing up to **~20%** when another sibling is affected (as quoted in the Feingold-family EA report) (klaniewska2021occurrenceofesophageal pages 2-4).
+
+---
+
+## 10. Diagnostics
+### 10.1 Clinical recognition
+A large MYCN cohort analysis recommends **MYCN testing** when the combination of **brachymesophalangy + toe syndactyly + microcephaly** is present (marcelis2008genotype–phenotypecorrelationsin pages 1-3). Clinical suspicion increases with GI atresia or tracheoesophageal fistula and characteristic digital findings (klaniewska2021occurrenceofesophageal pages 1-2).
+
+### 10.2 Genetic testing approaches (real-world implementation)
+- **Single-gene MYCN testing** can be justified by classic digital patterning plus microcephaly (marcelis2008genotype–phenotypecorrelationsin pages 1-3).
+- **Chromosomal microarray / CNV analysis** is important when a contiguous deletion is suspected (e.g., 2p24 deletions encompassing MYCN; 13q31 deletions involving MIR17HG) (zeka2022anewvariant pages 3-4, muriello2019growthhormonedeficiency pages 2-4).
+- **Whole-exome sequencing (WES):** used to solve familial esophageal atresia and identify MYCN frameshift variants (klaniewska2021occurrenceofesophageal pages 2-4).
+- **Genome sequencing (GS):** can identify multiple variant classes simultaneously (SNVs, CNVs, mosaic variants) and may be valuable in complex phenotypes with multiple diagnoses (zeka2022anewvariant pages 5-5).
+
+### 10.3 Differential diagnosis (examples)
+Differential considerations for microcephaly + limb anomalies + GI malformations include other syndromic microcephaly disorders and VACTERL-spectrum conditions; Feingold should remain on the differential even when some classic features are absent because variable expressivity is common (klaniewska2021occurrenceofesophageal pages 2-4, klaniewska2021occurrenceofesophageal pages 1-2).
+
+---
+
+## 11. Outcome / prognosis
+No population-based survival statistics were identified. Prognosis appears driven by:
+- severity and timing of repair of GI atresias (including complications such as postoperative strictures) (klaniewska2021occurrenceofesophageal pages 2-4),
+- neurodevelopmental profile and learning support needs (muriello2019growthhormonedeficiency pages 2-4), and
+- cardiac/endocrine complications in FS2 (recommendations below) (muriello2019growthhormonedeficiency pages 5-6).
+
+---
+
+## 12. Treatment
+Feingold syndrome has no established disease-modifying molecular therapy in humans; management is **supportive**, multidisciplinary, and complication-directed.
+
+### 12.1 Surgical and interventional
+- **Surgical repair of esophageal/duodenal atresia / tracheoesophageal fistula** is a key real-world intervention when present; family case reports describe EA with TEF and postoperative complications such as anastomotic stricture (klaniewska2021occurrenceofesophageal pages 2-4).
+
+**Suggested MAXO terms:** surgical repair of congenital gastrointestinal atresia; esophageal atresia repair.
+
+### 12.2 Supportive, rehabilitative, and surveillance
+- FS2 management recommendations include **echocardiography at diagnosis** for all patients and consideration of **growth hormone deficiency evaluation** in short stature (muriello2019growthhormonedeficiency pages 1-2).
+- A FS2 patient was “treated successfully with growth hormone” (muriello2019growthhormonedeficiency pages 1-2).
+
+**Suggested MAXO terms:** echocardiographic monitoring; endocrine evaluation; growth hormone therapy.
+
+### 12.3 Experimental therapies / clinical trials
+A ClinicalTrials.gov search using the disease name retrieved no Feingold-syndrome–specific interventional trials in this tool run (clinical trials tool state indicated 1 trial found but none were returned as relevant records), consistent with the current supportive-care paradigm.
+
+---
+
+## 13. Prevention
+### 13.1 Genetic counseling (primary prevention)
+Because Feingold syndrome is autosomal dominant, prevention focuses on **genetic counseling** for affected individuals and at-risk families, including discussion of variable expressivity (klaniewska2021occurrenceofesophageal pages 2-4, klaniewska2021occurrenceofesophageal pages 1-2).
+
+**Suggested MAXO terms:** genetic counseling; cascade genetic testing.
+
+### 13.2 Secondary/tertiary prevention
+- Early diagnosis enables anticipatory guidance for GI surgery planning (when prenatal anomalies are detected) and early developmental intervention.
+- For FS2, early cardiac and endocrine screening may prevent complications (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 5-6).
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring veterinary Feingold-syndrome analogs were identified in the retrieved set.
+
+---
+
+## 15. Model organisms
+### 15.1 Mouse models (in vivo)
+A high-impact mechanistic study used conditional deletions in mouse limb mesenchyme to model FS2 (Mir17-92 deficiency) and FS1 (Mycn deficiency), demonstrating both phenotypic overlap (skeletal defects, microcephaly-like cranial defects) and distinct downstream pathway signatures (TGF-β vs PI3K) (Nature Communications; Apr 2018; https://doi.org/10.1038/s41467-018-03788-7) (mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7). Rescue of FS2-like skeletal defects by TGF-β inhibition supports a causal chain for miR-17~92 haploinsufficiency (mirzamohammadi2018distinctmolecularpathways media f81b61fb, mirzamohammadi2018distinctmolecularpathways media 412f5292).
+
+### 15.2 Model limitations
+These models robustly recapitulate limb and cranial skeletal findings, but congenital GI atresias and full neurodevelopmental phenotypes may be incompletely represented depending on tissue specificity and timing of gene deletion.
+
+---
+
+## Recent developments and expert synthesis (prioritizing 2023–2024)
+1. **MYCN’s developmental role and “inverse phenotype” paradigm (2024):** A 2024 review synthesizes evidence that MYCN loss-of-function causes FS1, while specific MYCN gain-of-function variants cause an opposite brain-growth phenotype (megalencephaly-polydactyly syndrome), helping refine MYCN dosage/function models in human development (Frontiers in Oncology; May 2024; https://doi.org/10.3389/fonc.2024.1417607) (nishio2024mycninhuman pages 1-2).
+2. **ncRNA framing of Feingold microcephaly (2023):** A 2023 review places Feingold syndrome within broader ncRNA biology of microcephaly and highlights MIR17HG/miR-17~92 composition and apoptosis-related mechanisms (e.g., BIM derepression), reinforcing noncoding RNA dosage as a key developmental determinant (Frontiers in Cell and Developmental Biology; Jun 2023; https://doi.org/10.3389/fcell.2023.1168072) (tokunaga2023emergingconceptsinvolving pages 1-2).
+3. **Mechanism-to-rescue logic (translational potential):** Although still preclinical, mouse-model rescue of FS2 skeletal defects via TGF-β inhibition provides a concrete pathway-based hypothesis for future therapeutics, while concurrently showing FS1 may require PI3K/Akt-directed strategies rather than TGF-β inhibition (mirzamohammadi2018distinctmolecularpathways pages 6-7, mirzamohammadi2018distinctmolecularpathways media f81b61fb).
+
+---
+
+## Structured summary table (FS1 vs FS2)
+| Type | Causal gene/locus | Typical variant class | Inheritance | Core features | Key quantitative phenotype frequencies reported | Mechanistic/pathway notes | Key references with year/DOI/PMID if available |
+|---|---|---|---|---|---|---|---|
+| Feingold syndrome type 1 | **MYCN** (2p24.3); MONDO also maps Feingold syndrome to MYCN associations (OpenTargets Search: Feingold syndrome, marcelis2008genotype–phenotypecorrelationsin pages 1-3) | Predominantly heterozygous loss-of-function variants: nonsense, frameshift, splice/PTC variants; missense variants in DNA-binding domain; larger 2p24 deletions including **MYCN** also reported (marcelis2008genotype–phenotypecorrelationsin pages 1-3, zeka2022anewvariant pages 3-4, klaniewska2021occurrenceofesophageal pages 1-2, zeka2022anewvariant pages 1-2) | Autosomal dominant with variable expressivity; familial and de novo cases reported (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 2-4, zeka2022anewvariant pages 1-2) | Microcephaly, digital anomalies (especially brachymesophalangy of 2nd/5th fingers, toe syndactyly), short stature, gastrointestinal atresia; additional learning/developmental issues and occasional cardiac/renal/hearing anomalies (marcelis2008genotype–phenotypecorrelationsin pages 1-3, klaniewska2021occurrenceofesophageal pages 1-2, zeka2022anewvariant pages 1-2, zeka2022anewvariant pages 2-2) | **MYCN cohort, n=77 (Marcelis 2008):** brachymesophalangy **100%**, toe syndactyly **97%**, microcephaly/small head circumference **89%**, gastrointestinal atresia **55%**; cardiac and renal anomalies described as frequent (marcelis2008genotype–phenotypecorrelationsin pages 1-3). Another summarized review/case source reports brachymesophalangy **95%**, microcephaly **86%**, toe syndactyly **80%**, short palpebral fissures **57%**, learning disability **41%**, gastrointestinal atresia **38%**, cardiac **14%**, renal **5%**, hearing loss **7%** (zeka2022anewvariant pages 2-2). | Human and mouse data support haploinsufficiency. In limb mesenchyme, **Mycn** deficiency is linked mainly to **downregulated PI3K/Akt signaling**; skeletal phenotype was partially rescued by **Pten** heterozygosity, but not by TGF-β inhibition, indicating a pathway distinct from type 2 (mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7). | Marcelis et al., **2008**, *Human Mutation*, DOI: **10.1002/humu.20750** (marcelis2008genotype–phenotypecorrelationsin pages 1-3); Klaniewska et al., **2021**, DOI: **10.3389/fped.2021.783553** (klaniewska2021occurrenceofesophageal pages 2-4, klaniewska2021occurrenceofesophageal pages 1-2); Zeka et al., **2022**, DOI: **10.1002/ccr3.5886** (zeka2022anewvariant pages 1-2, zeka2022anewvariant pages 2-2); Nishio et al., **2024**, DOI: **10.3389/fonc.2024.1417607** (nishio2024mycninhuman pages 1-2) |
+| Feingold syndrome type 2 | **MIR17HG** / miR-17~92 cluster (13q31.3); Open Targets also links Feingold syndrome type 2 to MIR17HG (OpenTargets Search: Feingold syndrome, muriello2019growthhormonedeficiency pages 1-2) | Usually heterozygous germline deletions/CNV losses involving **MIR17HG** (sometimes with neighboring genes such as **GPC5**); pathogenic mechanism is miR-17~92 haploinsufficiency (muriello2019growthhormonedeficiency pages 1-2, low2015tetralogyoffallot pages 1-2, muriello2019growthhormonedeficiency pages 2-4) | Autosomal dominant / dominant transmission of hemizygous loss; familial segregation reported in some families (muriello2019growthhormonedeficiency pages 1-2, low2015tetralogyoffallot pages 1-2) | Microcephaly, short stature, brachymesophalangy/digital anomalies, toe syndactyly, learning or developmental problems; variable cardiac anomalies; reported expansions include growth hormone deficiency, aortic dilation, joint contractures, memory/sleep issues (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 5-6, muriello2019growthhormonedeficiency pages 2-4) | **MIR17HG deletion cohort frequencies (Muriello 2019):** DD/ID/learning disability **100% (16/16)**, brachymesophalangy **100% (17/17)**, 5th finger clinodactyly **100% (9/9)**, microcephaly **88% (14/16)**, short stature **86% (13/14)**, toe syndactyly **64% (9/14)**, thumb hypoplasia **33% (4/12)**, cardiac defects **40% (4/10)** (muriello2019growthhormonedeficiency pages 2-4). Earlier diagnostic series found **MIR17HG deletions in 2/10** tested suspected Feingold cases (low2015tetralogyoffallot pages 1-2). | Mouse and functional data indicate **Mir17-92 deficiency upregulates TGF-β signaling**, including derepression of **Tgfbr2**; genetic or pharmacologic **TGF-β inhibition** rescued skeletal defects. This contrasts with FS1, where the dominant perturbation is PI3K/Akt downregulation (mirzamohammadi2018distinctmolecularpathways pages 2-3, mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7, tokunaga2023emergingconceptsinvolving pages 1-2). | de Pontual et al., **2011**, *Nature Genetics*, DOI: **10.1038/ng.915** (low2015tetralogyoffallot pages 1-2); Muriello et al., **2019**, *Am J Med Genet A*, DOI: **10.1002/ajmg.a.61037** (muriello2019growthhormonedeficiency pages 1-2, muriello2019growthhormonedeficiency pages 2-4); Mirzamohammadi et al., **2018**, *Nature Communications*, DOI: **10.1038/s41467-018-03788-7** (mirzamohammadi2018distinctmolecularpathways pages 2-3, mirzamohammadi2018distinctmolecularpathways pages 1-2, mirzamohammadi2018distinctmolecularpathways pages 6-7) |
+
+
+*Table: This table compares Feingold syndrome types 1 and 2 across causal loci, variant classes, inheritance, hallmark phenotypes, quantitative frequencies, and mechanistic distinctions. It is useful for quickly contrasting MYCN-associated and MIR17HG-associated disease for diagnostic and knowledge-base curation.*
+
+---
+
+## Evidence limitations and curation gaps
+- ICD-10/ICD-11 and MeSH identifiers were not available in the tool-retrieved evidence set and should be added from authoritative terminologies.
+- Many statements about penetrance, genotype-specific outcomes, and population prevalence remain incompletely quantified in accessible cohort data; most statistics are cohort-derived rather than population-based.
+- For PMID-preferred citations: OpenTargets lists PubMed IDs for key gene–disease associations, but PMIDs were not directly extracted from full-text in this run; future curation should add PMIDs by cross-referencing DOIs to PubMed (OpenTargets Search: Feingold syndrome).
+
+References
+
+1. (OpenTargets Search: Feingold syndrome): Open Targets Query (Feingold syndrome, 6 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+2. (klaniewska2021occurrenceofesophageal pages 1-2): Magdalena Klaniewska, Krystian Toczewski, Anna Rozensztrauch, Michal Bloch, Agata Dzielendziak, Piotr Gasperowicz, Ryszard Slezak, Rafał Ploski, Małgorzata Rydzanicz, Robert Smigiel, and Dariusz Patkowski. Occurrence of esophageal atresia with tracheoesophageal fistula in siblings from three-generation family affected by variable expressivity mycn mutation: a case report. Frontiers in Pediatrics, Dec 2021. URL: https://doi.org/10.3389/fped.2021.783553, doi:10.3389/fped.2021.783553. This article has 6 citations.
+
+3. (nishio2024mycninhuman pages 1-2): Yosuke Nishio, Kohji Kato, Hisashi Oishi, Yoshiyuki Takahashi, and Shinji Saitoh. Mycn in human development and diseases. Frontiers in Oncology, May 2024. URL: https://doi.org/10.3389/fonc.2024.1417607, doi:10.3389/fonc.2024.1417607. This article has 8 citations.
+
+4. (zeka2022anewvariant pages 5-5): Naim Zeka, Ramush Bejiqi, Abdurrahim Gerguri, Leonore Zogaj, and Haki Jashari. A new variant of mycn gene as a cause of feingold syndrome. Clinical Case Reports, May 2022. URL: https://doi.org/10.1002/ccr3.5886, doi:10.1002/ccr3.5886. This article has 4 citations.
+
+5. (marcelis2008genotype–phenotypecorrelationsin pages 1-3): Carlo L.M. Marcelis, Frans A. Hol, Gail E. Graham, Paul N.M.A. Rieu, Richard Kellermayer, Rowdy P.P. Meijer, Dorien Lugtenberg, Hans Scheffer, Hans van Bokhoven, Han G. Brunner, and Arjan P.M. de Brouwer. Genotype–phenotype correlations in mycn‐related feingold syndrome. Human Mutation, 29:1125-1132, Sep 2008. URL: https://doi.org/10.1002/humu.20750, doi:10.1002/humu.20750. This article has 105 citations and is from a domain leading peer-reviewed journal.
+
+6. (klaniewska2021occurrenceofesophageal pages 2-4): Magdalena Klaniewska, Krystian Toczewski, Anna Rozensztrauch, Michal Bloch, Agata Dzielendziak, Piotr Gasperowicz, Ryszard Slezak, Rafał Ploski, Małgorzata Rydzanicz, Robert Smigiel, and Dariusz Patkowski. Occurrence of esophageal atresia with tracheoesophageal fistula in siblings from three-generation family affected by variable expressivity mycn mutation: a case report. Frontiers in Pediatrics, Dec 2021. URL: https://doi.org/10.3389/fped.2021.783553, doi:10.3389/fped.2021.783553. This article has 6 citations.
+
+7. (mirzamohammadi2018distinctmolecularpathways pages 1-2): Fatemeh Mirzamohammadi, Anastasia Kozlova, Garyfallia Papaioannou, Elena Paltrinieri, Ugur M. Ayturk, and Tatsuya Kobayashi. Distinct molecular pathways mediate mycn and myc-regulated mir-17-92 microrna action in feingold syndrome mouse models. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03788-7, doi:10.1038/s41467-018-03788-7. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+8. (muriello2019growthhormonedeficiency pages 2-4): Michael Muriello, Alexander Y. Kim, Krista Sondergaard Schatz, Natalie Beck, Meral Gunay‐Aygun, and Julie E. Hoover‐Fong. Growth hormone deficiency, aortic dilation, and neurocognitive issues in feingold syndrome 2. American Journal of Medical Genetics Part A, 179:410-416, Mar 2019. URL: https://doi.org/10.1002/ajmg.a.61037, doi:10.1002/ajmg.a.61037. This article has 16 citations.
+
+9. (zeka2022anewvariant pages 1-2): Naim Zeka, Ramush Bejiqi, Abdurrahim Gerguri, Leonore Zogaj, and Haki Jashari. A new variant of mycn gene as a cause of feingold syndrome. Clinical Case Reports, May 2022. URL: https://doi.org/10.1002/ccr3.5886, doi:10.1002/ccr3.5886. This article has 4 citations.
+
+10. (muriello2019growthhormonedeficiency pages 1-2): Michael Muriello, Alexander Y. Kim, Krista Sondergaard Schatz, Natalie Beck, Meral Gunay‐Aygun, and Julie E. Hoover‐Fong. Growth hormone deficiency, aortic dilation, and neurocognitive issues in feingold syndrome 2. American Journal of Medical Genetics Part A, 179:410-416, Mar 2019. URL: https://doi.org/10.1002/ajmg.a.61037, doi:10.1002/ajmg.a.61037. This article has 16 citations.
+
+11. (zeka2022anewvariant pages 2-2): Naim Zeka, Ramush Bejiqi, Abdurrahim Gerguri, Leonore Zogaj, and Haki Jashari. A new variant of mycn gene as a cause of feingold syndrome. Clinical Case Reports, May 2022. URL: https://doi.org/10.1002/ccr3.5886, doi:10.1002/ccr3.5886. This article has 4 citations.
+
+12. (muriello2019growthhormonedeficiency pages 5-6): Michael Muriello, Alexander Y. Kim, Krista Sondergaard Schatz, Natalie Beck, Meral Gunay‐Aygun, and Julie E. Hoover‐Fong. Growth hormone deficiency, aortic dilation, and neurocognitive issues in feingold syndrome 2. American Journal of Medical Genetics Part A, 179:410-416, Mar 2019. URL: https://doi.org/10.1002/ajmg.a.61037, doi:10.1002/ajmg.a.61037. This article has 16 citations.
+
+13. (low2015tetralogyoffallot pages 1-2): Karen J. Low, Chris C. Buxton, and Ruth A. Newbury-Ecob. Tetralogy of fallot, microcephaly, short stature and brachymesophalangy is associated with hemizygous loss of noncoding mir17hg and coding gpc5. Clinical dysmorphology, 24 3:113-4, Jul 2015. URL: https://doi.org/10.1097/mcd.0000000000000069, doi:10.1097/mcd.0000000000000069. This article has 9 citations and is from a peer-reviewed journal.
+
+14. (tokunaga2023emergingconceptsinvolving pages 1-2): Mayuri Tokunaga and Takuya Imamura. Emerging concepts involving inhibitory and activating rna functionalization towards the understanding of microcephaly phenotypes and brain diseases in humans. Frontiers in Cell and Developmental Biology, Jun 2023. URL: https://doi.org/10.3389/fcell.2023.1168072, doi:10.3389/fcell.2023.1168072. This article has 0 citations.
+
+15. (mirzamohammadi2018distinctmolecularpathways pages 6-7): Fatemeh Mirzamohammadi, Anastasia Kozlova, Garyfallia Papaioannou, Elena Paltrinieri, Ugur M. Ayturk, and Tatsuya Kobayashi. Distinct molecular pathways mediate mycn and myc-regulated mir-17-92 microrna action in feingold syndrome mouse models. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03788-7, doi:10.1038/s41467-018-03788-7. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+16. (mirzamohammadi2018distinctmolecularpathways media f81b61fb): Fatemeh Mirzamohammadi, Anastasia Kozlova, Garyfallia Papaioannou, Elena Paltrinieri, Ugur M. Ayturk, and Tatsuya Kobayashi. Distinct molecular pathways mediate mycn and myc-regulated mir-17-92 microrna action in feingold syndrome mouse models. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03788-7, doi:10.1038/s41467-018-03788-7. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+17. (mirzamohammadi2018distinctmolecularpathways media 412f5292): Fatemeh Mirzamohammadi, Anastasia Kozlova, Garyfallia Papaioannou, Elena Paltrinieri, Ugur M. Ayturk, and Tatsuya Kobayashi. Distinct molecular pathways mediate mycn and myc-regulated mir-17-92 microrna action in feingold syndrome mouse models. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03788-7, doi:10.1038/s41467-018-03788-7. This article has 25 citations and is from a highest quality peer-reviewed journal.
+
+18. (zeka2022anewvariant pages 3-4): Naim Zeka, Ramush Bejiqi, Abdurrahim Gerguri, Leonore Zogaj, and Haki Jashari. A new variant of mycn gene as a cause of feingold syndrome. Clinical Case Reports, May 2022. URL: https://doi.org/10.1002/ccr3.5886, doi:10.1002/ccr3.5886. This article has 4 citations.
+
+19. (mirzamohammadi2018distinctmolecularpathways pages 2-3): Fatemeh Mirzamohammadi, Anastasia Kozlova, Garyfallia Papaioannou, Elena Paltrinieri, Ugur M. Ayturk, and Tatsuya Kobayashi. Distinct molecular pathways mediate mycn and myc-regulated mir-17-92 microrna action in feingold syndrome mouse models. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03788-7, doi:10.1038/s41467-018-03788-7. This article has 25 citations and is from a highest quality peer-reviewed journal.

--- a/research/Feingold_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/Feingold_Syndrome-deep-research-falcon.md.citations.md
@@ -1,0 +1,482 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Feingold Syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Feingold Syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T09:13:04.500406
+
+1. klaniewska2021occurrenceofesophageal pages 1-2
+2. zeka2022anewvariant pages 5-5
+3. nishio2024mycninhuman pages 1-2
+4. zeka2022anewvariant pages 2-2
+5. muriello2019growthhormonedeficiency pages 2-4
+6. klaniewska2021occurrenceofesophageal pages 2-4
+7. zeka2022anewvariant pages 1-2
+8. tokunaga2023emergingconceptsinvolving pages 1-2
+9. mirzamohammadi2018distinctmolecularpathways pages 6-7
+10. muriello2019growthhormonedeficiency pages 5-6
+11. muriello2019growthhormonedeficiency pages 1-2
+12. low2015tetralogyoffallot pages 1-2
+13. mirzamohammadi2018distinctmolecularpathways pages 1-2
+14. zeka2022anewvariant pages 3-4
+15. mirzamohammadi2018distinctmolecularpathways pages 2-3
+16. hg19
+17. https://doi.org/10.3389/fonc.2024.1417607
+18. https://doi.org/10.3389/fped.2021.783553
+19. https://doi.org/10.1002/humu.20750
+20. https://doi.org/10.1002/ccr3.5886
+21. https://doi.org/10.1002/ajmg.a.61037
+22. https://doi.org/10.3389/fcell.2023.1168072
+23. https://doi.org/10.1038/s41467-018-03788-7
+24. https://doi.org/10.3389/fped.2021.783553,
+25. https://doi.org/10.3389/fonc.2024.1417607,
+26. https://doi.org/10.1002/ccr3.5886,
+27. https://doi.org/10.1002/humu.20750,
+28. https://doi.org/10.1038/s41467-018-03788-7,
+29. https://doi.org/10.1002/ajmg.a.61037,
+30. https://doi.org/10.1097/mcd.0000000000000069,
+31. https://doi.org/10.3389/fcell.2023.1168072,


### PR DESCRIPTION
## Summary
- Add a curated Feingold syndrome disorder entry from the completed Falcon report.
- Model MYCN-related type 1 and MIR17HG-related type 2 subtypes, core phenotypes, mechanisms, genetics, diagnosis, treatments, and mouse models.
- Add only the four PMID caches cited in the YAML plus the Falcon report artifacts.

## Validation
- `just validate kb/disorders/Feingold_Syndrome.yaml`
- `just validate-references kb/disorders/Feingold_Syndrome.yaml`
- `just compliance kb/disorders/Feingold_Syndrome.yaml`

## Notes
- Restored unrelated tracked `cache/` and `references_cache/clinicaltrials_NCT*.md` churn before commit.
- Did not use the Falcon-suggested duodenal atresia HPO mapping because local OAK lookup showed `HP:0002249` is Melena.