### PR TITLE
[codex] Link alkaptonuria urinary HGA endpoint

### DIFF
--- a/kb/disorders/Alkaptonuria.yaml
+++ b/kb/disorders/Alkaptonuria.yaml
@@ -1,7 +1,7 @@
 name: Alkaptonuria
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-08T00:00:00Z'
+updated_date: '2026-05-11T14:18:00Z'
 synonyms:
 - Hereditary ochronosis
 - Homogentisic acid oxidase deficiency
@@ -765,6 +765,28 @@ biochemical:
   context: >
     Urinary HGA is substantially increased and is the primary biochemical
     diagnostic marker.
+  readouts:
+  - target: Homogentisic acid accumulation and oxidation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-005
+    interpretation: >-
+      Higher urinary homogentisic acid tracks with greater upstream HGA
+      accumulation; large treatment-induced reductions report pharmacodynamic
+      suppression of HGA production by nitisinone.
+    evidence:
+    - reference: PMID:32822600
+      reference_title: "Efficacy and safety of once-daily nitisinone for patients with alkaptonuria (SONIA 2): an international, multicentre, open-label, randomised controlled trial."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        u-HGA24 at 12 months was significantly decreased by 99·7% in the
+        nitisinone group compared with the control group
+      explanation: >-
+        SONIA 2 supports urinary HGA excretion as the pharmacodynamic analyte
+        reduced by nitisinone in adults with alkaptonuria.
   evidence:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -131,8 +131,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Alkaptonuria; population: Adult patients with alkaptonuria; endpoint:
     Reduction (>90%) in urinary homogentisic acid (HGA) levels; approval context: traditional; drug mechanism:
     Competitive inhibitor of 4-hydroxyphenylpyruvate dioxygenase (HPPD).'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Alkaptonuria
+  mapped_disease_files:
+  - kb/disorders/Alkaptonuria.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: urinary homogentisic acid reduction is linked
+    to the alkaptonuria HGA-accumulation pathograph node and to nitisinone's
+    upstream HPPD-inhibition treatment mechanism.
 - row_id: FDA-SE-adult-noncancer-006
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

Links FDA adult non-cancer row `FDA-SE-adult-noncancer-005` into the alkaptonuria disease biology model.

- Adds a pharmacodynamic readout from increased urinary homogentisic acid to the existing `Homogentisic acid accumulation and oxidation` pathograph node.
- Uses SONIA 2 evidence for nitisinone-driven urinary HGA reduction.
- Marks the FDA alkaptonuria urinary HGA row as a curated DisMech mapping back to `kb/disorders/Alkaptonuria.yaml`.

I checked the local NCIT adapter for a suitable homogentisic-acid measurement term and did not find one, so this patch leaves `biomarker_term` absent rather than forcing a broad or mismatched NCIT term.

## Validation

- `just validate kb/disorders/Alkaptonuria.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`

Note: targeted validation normalized unrelated ClinicalTrials cache files locally; those generated changes were restored and are not included in this PR.