### PR TITLE
[codex] Link CTX plasma cholestanol endpoint

### DIFF
--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-09T05:50:50Z'
+updated_date: '2026-05-11T14:43:00Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -711,6 +711,26 @@ biochemical:
 - name: Plasma and tissue cholestanol
   presence: Elevated
   context: Defining biochemical abnormality used diagnostically and for monitoring response.
+  readouts:
+  - target: Cholestanol and bile alcohol accumulation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-011
+    interpretation: >-
+      Higher plasma cholestanol tracks with greater sterol and bile-alcohol
+      accumulation; reduction during primary bile acid therapy reports
+      pharmacodynamic suppression of the accumulated CTX sterol signature.
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Long-term treatment with chenodeoxycholic acid (CDCA) normalizes plasma and cerebrospinal fluid concentration of cholestanol"
+      explanation: >-
+        GeneReviews supports plasma cholestanol as the treatment-responsive
+        biochemical marker normalized by primary bile acid therapy.
   evidence:
   - reference: PMID:20301583
     reference_title: "Cerebrotendinous Xanthomatosis."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -280,8 +280,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cerebrotendinous xanthomatosis (CTX); population: Adults with confirmed
     molecular diagnosis of CTX; endpoint: Reduction in plasma cholestanol; approval context: traditional;
     drug mechanism: Primary bile acid.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cerebrotendinous xanthomatosis
+  mapped_disease_files:
+  - kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: plasma cholestanol reduction is linked to
+    the CTX cholestanol and bile-alcohol accumulation pathograph node and to
+    primary bile acid replacement/suppression therapy.
 - row_id: FDA-SE-adult-noncancer-012
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- linked the CTX plasma/tissue cholestanol biochemical entry to the existing `Cholestanol and bile alcohol accumulation` pathograph node via a pharmacodynamic readout
- mapped FDA surrogate endpoint row `FDA-SE-adult-noncancer-011` to `kb/disorders/Cerebrotendinous_Xanthomatosis.yaml`
- kept the FDA source table as regulatory context while using the existing GeneReviews evidence for the biology and treatment-responsive cholestanol marker

No suitable local NCIT measurement term was found for cholestanol, so this does not add a `biomarker_term`.

## Validation

- `just validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`