### PR TITLE
[codex] Link cystinuria urinary cystine endpoints

### DIFF
--- a/kb/disorders/Cystinuria.yaml
+++ b/kb/disorders/Cystinuria.yaml
@@ -1,7 +1,7 @@
 name: Cystinuria
 category: Mendelian
 creation_date: '2026-05-05T15:29:06Z'
-updated_date: '2026-05-10T06:12:56Z'
+updated_date: '2026-05-11T15:05:00Z'
 synonyms:
 - Cystinuria-lysinuria syndrome
 description: >
@@ -565,6 +565,48 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Up to 70% of patients with cystinuria may develop chronic kidney disease (CKD)"
       explanation: CKD in cystinuria supports the downstream renal insufficiency phenotype link.
+biochemical:
+- name: Urinary cystine
+  presence: Elevated
+  context: Quantitative urinary cystine marker used diagnostically and to monitor cystine-binding thiol pharmacodynamics.
+  mappings_list:
+  - preferred_term: cystine
+    term:
+      id: CHEBI:17376
+      label: cystine
+  readouts:
+  - target: Urinary Cystine Supersaturation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-018
+    - FDA-SE-pediatric-noncancer-012
+    interpretation: >-
+      Higher urinary cystine tracks with the supersaturation state that drives
+      cystine stone formation; reduced or complexed urinary cystine during
+      cystine-binding thiol therapy reports pharmacodynamic suppression of this
+      lithogenic mechanism.
+    evidence:
+    - reference: PMID:36900678
+      reference_title: A Summary of Current Guidelines and Future Directions for Medical Management and Monitoring of Patients with Cystinuria.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "As the result of a genetic defect in proximal tubular reabsorption of filtered cystine, increased urine levels of the poorly soluble amino acid result in recurrent cystine nephrolithiasis."
+      explanation: Guideline review links increased urinary cystine to the stone-forming supersaturation mechanism.
+    - reference: PMID:30515543
+      reference_title: "Cystinuria: genetic aspects, mouse models, and a new approach to therapy."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "These sulfhydryl drugs convert cystine to the more soluble mixed disulfides of cysteine-penicillamine or cysteine-tiopronin, respectively."
+      explanation: Review explains the cystine-binding thiol pharmacodynamic mechanism reflected by urinary cystine endpoints.
+  evidence:
+  - reference: PMID:36900678
+    reference_title: A Summary of Current Guidelines and Future Directions for Medical Management and Monitoring of Patients with Cystinuria.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "As the result of a genetic defect in proximal tubular reabsorption of filtered cystine, increased urine levels of the poorly soluble amino acid result in recurrent cystine nephrolithiasis."
+    explanation: Guideline review supports elevated urinary cystine as the biochemical abnormality that drives cystine stone disease.
 phenotypes:
 - name: Cystinuria
   category: Biochemical

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -467,8 +467,15 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Cystinuria; population: Patients with cystinuria; endpoint: Urinary cystine;
     approval context: traditional; drug mechanism: Reducing and complexing thiol.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystinuria
+  mapped_disease_files:
+  - kb/disorders/Cystinuria.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: urinary cystine is represented as an elevated
+    biochemical marker linked to the urinary cystine supersaturation pathograph
+    node and to cystine-binding thiol pharmacodynamics.
 - row_id: FDA-SE-adult-noncancer-019
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -3947,8 +3954,15 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Cystinuria; population: Patients with cystinuria; endpoint: Urinary/urine
     cystine; approval context: traditional; drug mechanism: Reducing and complexing thiol.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Cystinuria
+  mapped_disease_files:
+  - kb/disorders/Cystinuria.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: urinary/urine cystine is represented as an
+    elevated biochemical marker linked to the urinary cystine supersaturation
+    pathograph node and to cystine-binding thiol pharmacodynamics.
 - row_id: FDA-SE-pediatric-noncancer-013
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- added a Cystinuria `biochemical` marker for elevated urinary cystine with a CHEBI analyte mapping
- linked urinary cystine to the existing `Urinary Cystine Supersaturation` pathograph node as a pharmacodynamic readout
- mapped FDA surrogate endpoint rows `FDA-SE-adult-noncancer-018` and `FDA-SE-pediatric-noncancer-012` to `kb/disorders/Cystinuria.yaml`

I did not add a `biomarker_term` because the schema expects NCIT biomarker terms and the local NCIT search did not return a suitable urinary cystine measurement term; the analyte is represented with `CHEBI:17376` in `mappings_list` instead.

## Validation

- `just validate kb/disorders/Cystinuria.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`