### PR TITLE
Add urinary bladder small cell neuroendocrine carcinoma curation

### DIFF
--- a/kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml
+++ b/kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml
@@ -1,6 +1,6 @@
 name: Urinary Bladder Small Cell Neuroendocrine Carcinoma
 creation_date: '2026-05-11T14:55:39Z'
-updated_date: '2026-05-11T15:15:45Z'
+updated_date: '2026-05-11T15:52:00Z'
 description: >-
   Urinary bladder small cell neuroendocrine carcinoma is a rare, high-grade
   neuroendocrine carcinoma arising in the urinary bladder. It usually behaves
@@ -19,6 +19,61 @@ disease_term:
     id: MONDO:0004114
     label: urinary bladder small cell neuroendocrine carcinoma
 pathophysiology:
+- name: Recurrent Small Cell Genomic Alterations
+  description: >-
+    Small cell bladder carcinoma tumor cells frequently carry TP53, TERT, and
+    RB1 alterations, placing tumor-suppressor loss and telomerase activation
+    upstream of cell-cycle disruption and aggressive tumor behavior.
+  evidence:
+  - reference: PMID:40209138
+    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common genomic alterations in SCBC were in TP53 (87%), TERT (75%),
+      and RB1 (70%).
+    explanation: >-
+      Large comparative genomic profiling identifies TP53, TERT, and RB1 as the
+      most common genomic alterations in small cell bladder carcinoma.
+  cell_types:
+  - preferred_term: neuroendocrine tumor cell
+    term:
+      id: CL:0000165
+      label: neuroendocrine cell
+  downstream:
+  - target: Cell-Cycle Checkpoint Loss
+    description: TP53 and RB1 alterations disrupt tumor-suppressor control of the cell cycle.
+  - target: Neuroendocrine Tumor Differentiation
+    description: Genomically altered tumor cells co-occur with a small cell neuroendocrine phenotype.
+- name: Cell-Cycle Checkpoint Loss
+  description: >-
+    TP53 and RB1 pathway disruption weakens cell-cycle checkpoint control in
+    small cell bladder carcinoma tumor cells.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Inactivation of the RB1 gene may be implicated in the oncogenesis of
+      bladder SmCC.
+    explanation: >-
+      The clinicopathologic series directly supports RB1 inactivation as an
+      oncogenic alteration in bladder small cell carcinoma.
+  cell_types:
+  - preferred_term: neuroendocrine tumor cell
+    term:
+      id: CL:0000165
+      label: neuroendocrine cell
+  biological_processes:
+  - preferred_term: regulation of cell cycle
+    modifier: ABNORMAL
+    term:
+      id: GO:0051726
+      label: regulation of cell cycle
+  downstream:
+  - target: High-Grade Tumor Proliferation
+    description: Checkpoint loss permits expansion of malignant neuroendocrine tumor cells.
 - name: Neuroendocrine Tumor Differentiation
   description: >-
     Tumor cells show small cell neuroendocrine differentiation in the bladder,
@@ -46,44 +101,37 @@ pathophysiology:
       id: UBERON:0001255
       label: urinary bladder
   downstream:
-  - target: Rapid Urothelial Tumor Proliferation
-    description: Neuroendocrine carcinoma phenotype contributes to clinically aggressive growth.
-- name: Rapid Urothelial Tumor Proliferation
+  - target: High-Grade Tumor Proliferation
+    description: Neuroendocrine carcinoma phenotype co-occurs with clinically aggressive growth.
+- name: High-Grade Tumor Proliferation
   description: >-
-    Recurrent TP53 and RB1 alterations disrupt cell-cycle control in small cell
-    bladder carcinoma, supporting high-grade proliferation, invasion, and
-    metastatic potential.
+    Malignant neuroendocrine tumor cells proliferate rapidly, contributing to
+    aggressive local growth.
   evidence:
-  - reference: PMID:40209138
-    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The most common genomic alterations in SCBC were in TP53 (87%), TERT (75%),
-      and RB1 (70%).
+      bladder SmCC is an aggressive disease that is frequently present at an
+      advanced stage.
     explanation: >-
-      Large comparative genomic profiling identifies frequent TP53 and RB1
-      alterations, supporting tumor-suppressor loss as an upstream proliferative
-      mechanism in SCBC.
+      The 81-case series supports aggressive biology and frequent advanced-stage
+      presentation in bladder small cell carcinoma.
   cell_types:
-  - preferred_term: urothelial cell
+  - preferred_term: neuroendocrine tumor cell
     term:
-      id: CL:0000731
-      label: urothelial cell
+      id: CL:0000165
+      label: neuroendocrine cell
   biological_processes:
-  - preferred_term: regulation of cell cycle
-    modifier: ABNORMAL
-    term:
-      id: GO:0051726
-      label: regulation of cell cycle
-  - preferred_term: positive regulation of urothelial cell proliferation
+  - preferred_term: cell population proliferation
     modifier: INCREASED
     term:
-      id: GO:0050677
-      label: positive regulation of urothelial cell proliferation
+      id: GO:0008283
+      label: cell population proliferation
   downstream:
   - target: Muscle-Invasive Bladder Cancer
-    description: Proliferation and invasion produce deeply invasive bladder tumors.
+    description: Proliferation supports local invasion through the bladder wall.
 - name: Muscle-Invasive Bladder Cancer
   description: >-
     Local invasion through the bladder wall produces advanced bladder cancer and
@@ -170,6 +218,27 @@ phenotypes:
     term:
       id: HP:0100518
       label: Dysuria
+- category: Clinical
+  name: Urinary Frequency
+  description: >-
+    Increased urinary frequency can occur as an irritative voiding symptom in
+    bladder small cell carcinoma.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other presenting symptoms included dysuria, increased urinary frequency,
+      and urinary tract infection
+    explanation: >-
+      The same clinical presentation sentence lists increased urinary frequency
+      among presenting symptoms.
+  phenotype_term:
+    preferred_term: Urinary frequency
+    term:
+      id: HP:0100515
+      label: Pollakisuria
 - category: Neoplastic
   name: Aggressive Bladder Neoplasm
   diagnostic: true
@@ -260,6 +329,31 @@ genetic:
     explanation: >-
       Immunohistochemical analysis supports RB1 loss as a key molecular alteration
       in bladder small cell carcinoma.
+- name: TERT
+  gene_term:
+    preferred_term: TERT
+    term:
+      id: hgnc:11730
+      label: TERT
+  association: Somatic TERT Promoter Mutation
+  frequency: FREQUENT
+  inheritance:
+  - name: Somatic
+  notes: >-
+    TERT promoter alteration is one of the most common genomic alterations in
+    small cell bladder carcinoma and is consistent with replicative immortality
+    as part of the malignant phenotype.
+  evidence:
+  - reference: PMID:40209138
+    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common genomic alterations in SCBC were in TP53 (87%), TERT (75%),
+      and RB1 (70%).
+    explanation: >-
+      Comparative genomic profiling identifies TERT alteration in 75% of SCBC
+      cases, supporting a dedicated genetic entry.
 treatments:
 - name: Radical Cystectomy
   description: >-
@@ -282,6 +376,29 @@ treatments:
     term:
       id: MAXO:0000004
       label: surgical procedure
+- name: Chemoradiotherapy
+  description: >-
+    Bladder-conserving chemoradiotherapy is a definitive local treatment option
+    for localized small cell bladder carcinoma and can be considered alongside
+    radical cystectomy in modern multimodality care.
+  evidence:
+  - reference: PMID:34582342
+    reference_title: "Small cell carcinoma of the bladder: A population-based analysis of long-term outcomes after radical cystectomy and bladder conservation with chemoradiotherapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      RC and chemoRT offer similar CSS and OS for localized SCBC, even when
+      focusing the analysis on patients treated according to the modern consensus
+      guidelines.
+    explanation: >-
+      Population-based outcome analysis supports chemoradiotherapy as a
+      bladder-conserving treatment option with similar survival to radical
+      cystectomy for localized SCBC.
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
 - name: Platinum-Based Chemotherapy
   description: >-
     Systemic chemotherapy, often using platinum-etoposide regimens adapted from

--- a/kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml
+++ b/kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml
@@ -1,0 +1,356 @@
+name: Urinary Bladder Small Cell Neuroendocrine Carcinoma
+creation_date: '2026-05-11T14:55:39Z'
+updated_date: '2026-05-11T15:15:45Z'
+description: >-
+  Urinary bladder small cell neuroendocrine carcinoma is a rare, high-grade
+  neuroendocrine carcinoma arising in the urinary bladder. It usually behaves
+  aggressively, often presenting with hematuria and muscle-invasive or metastatic
+  disease, and is commonly managed with multimodality treatment modeled on small
+  cell carcinoma biology.
+categories:
+- Neuroendocrine Cancer
+- Bladder Cancer
+- Solid Tumor
+parents:
+- urinary bladder carcinoma
+disease_term:
+  preferred_term: urinary bladder small cell neuroendocrine carcinoma
+  term:
+    id: MONDO:0004114
+    label: urinary bladder small cell neuroendocrine carcinoma
+pathophysiology:
+- name: Neuroendocrine Tumor Differentiation
+  description: >-
+    Tumor cells show small cell neuroendocrine differentiation in the bladder,
+    with high-grade cytology and expression of neuroendocrine-lineage markers.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Most SmCC expressed at least one neuroendocrine markers, including
+      synaptophysin (73%, 41/56) (Fig. 2B), chromogranin (47%, 26/55) (Fig 3B),
+      CD56 (95%, 39/41), and NSE (100%, 4/4).
+    explanation: >-
+      Immunohistochemical data from 81 bladder small cell carcinoma cases support
+      neuroendocrine-marker expression as a defining tumor differentiation pattern.
+  cell_types:
+  - preferred_term: neuroendocrine tumor cell
+    term:
+      id: CL:0000165
+      label: neuroendocrine cell
+  locations:
+  - preferred_term: urinary bladder
+    term:
+      id: UBERON:0001255
+      label: urinary bladder
+  downstream:
+  - target: Rapid Urothelial Tumor Proliferation
+    description: Neuroendocrine carcinoma phenotype contributes to clinically aggressive growth.
+- name: Rapid Urothelial Tumor Proliferation
+  description: >-
+    Recurrent TP53 and RB1 alterations disrupt cell-cycle control in small cell
+    bladder carcinoma, supporting high-grade proliferation, invasion, and
+    metastatic potential.
+  evidence:
+  - reference: PMID:40209138
+    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common genomic alterations in SCBC were in TP53 (87%), TERT (75%),
+      and RB1 (70%).
+    explanation: >-
+      Large comparative genomic profiling identifies frequent TP53 and RB1
+      alterations, supporting tumor-suppressor loss as an upstream proliferative
+      mechanism in SCBC.
+  cell_types:
+  - preferred_term: urothelial cell
+    term:
+      id: CL:0000731
+      label: urothelial cell
+  biological_processes:
+  - preferred_term: regulation of cell cycle
+    modifier: ABNORMAL
+    term:
+      id: GO:0051726
+      label: regulation of cell cycle
+  - preferred_term: positive regulation of urothelial cell proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0050677
+      label: positive regulation of urothelial cell proliferation
+  downstream:
+  - target: Muscle-Invasive Bladder Cancer
+    description: Proliferation and invasion produce deeply invasive bladder tumors.
+- name: Muscle-Invasive Bladder Cancer
+  description: >-
+    Local invasion through the bladder wall produces advanced bladder cancer and
+    increases the risk of nodal or distant spread.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      At presentation, over 90% bladder SmCC were at advanced stages with tumors
+      invading the muscularis propria and beyond, and about 1/3 developed
+      metastases to lymph nodes and other organs.
+    explanation: >-
+      The clinicopathologic series supports advanced presentation, muscle invasion,
+      and metastatic potential as downstream disease behavior.
+  locations:
+  - preferred_term: urinary bladder
+    term:
+      id: UBERON:0001255
+      label: urinary bladder
+histopathology:
+- name: Small Cell Neuroendocrine Carcinoma
+  finding_term:
+    preferred_term: Small Cell Neuroendocrine Carcinoma
+    term:
+      id: NCIT:C3915
+      label: Small Cell Neuroendocrine Carcinoma
+  diagnostic: true
+  description: >-
+    Histology shows high-grade small cell neuroendocrine carcinoma, often requiring
+    immunohistochemical confirmation of neuroendocrine differentiation.
+  evidence:
+  - reference: PMID:32381384
+    reference_title: "Expression of novel neuroendocrine marker insulinoma-associated protein 1 (INSM1) in genitourinary high-grade neuroendocrine carcinomas: An immunohistochemical study with specificity analysis and comparison to chromogranin, synaptophysin, and CD56."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Confirmation of genitourinary high-grade neuroendocrine carcinomas
+      (GU-HGNECs) often requires immunohistochemical staining.
+    explanation: >-
+      Immunohistochemistry study supports the diagnostic role of marker staining
+      for genitourinary high-grade neuroendocrine carcinomas.
+phenotypes:
+- category: Clinical
+  name: Hematuria
+  description: >-
+    Visible or microscopic blood in the urine is a common presenting symptom of
+    bladder tumors.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The majority of patients initially presented with gross or microscopic
+      hematuria (n=73).
+    explanation: >-
+      In the 81-case clinicopathologic series, hematuria was the dominant initial
+      presenting symptom.
+  phenotype_term:
+    preferred_term: Hematuria
+    term:
+      id: HP:0000790
+      label: Hematuria
+- category: Clinical
+  name: Dysuria
+  description: >-
+    Irritative voiding symptoms such as painful urination can occur when the
+    bladder mucosa or outlet is involved by tumor.
+  evidence:
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Other presenting symptoms included dysuria, increased urinary frequency,
+      and urinary tract infection
+    explanation: >-
+      The case series lists dysuria among presenting symptoms of bladder small
+      cell carcinoma.
+  phenotype_term:
+    preferred_term: Dysuria
+    term:
+      id: HP:0100518
+      label: Dysuria
+- category: Neoplastic
+  name: Aggressive Bladder Neoplasm
+  diagnostic: true
+  description: >-
+    The defining manifestation is a malignant urinary bladder tumor with small
+    cell neuroendocrine histology and aggressive clinical behavior.
+  evidence:
+  - reference: PMID:39428391
+    reference_title: "Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in China."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Small cell carcinoma of the bladder (SCCB) is a rare, highly malignant
+      neuroendocrine tumor.
+    explanation: >-
+      Multi-institution clinical cohort supports the malignant neuroendocrine
+      bladder tumor phenotype.
+  phenotype_term:
+    preferred_term: Neoplasm
+    term:
+      id: HP:0002664
+      label: Neoplasm
+genetic:
+- name: TP53
+  gene_term:
+    preferred_term: TP53
+    term:
+      id: hgnc:11998
+      label: TP53
+  association: Somatic Mutations
+  frequency: VERY_FREQUENT
+  inheritance:
+  - name: Somatic
+  notes: >-
+    TP53 alterations are frequent in small cell bladder carcinoma and contribute
+    to loss of cell-cycle checkpoint control in this high-grade tumor type.
+  evidence:
+  - reference: PMID:40209138
+    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common genomic alterations in SCBC were in TP53 (87%), TERT (75%),
+      and RB1 (70%).
+    explanation: >-
+      Comparative genomic profiling identifies TP53 as the most common alteration
+      in SCBC.
+  - reference: PMID:35662501
+    reference_title: "Identification of potential biomarkers and novel therapeutic targets through genomic analysis of small cell bladder carcinoma and associated clinical outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common pathogenic gene variants included ARID1A (48%), TP53 (48%)
+      and RB1 (48%).
+    explanation: >-
+      Targeted sequencing in SCBC supports recurrent pathogenic TP53 variants.
+- name: RB1
+  gene_term:
+    preferred_term: RB1
+    term:
+      id: hgnc:9884
+      label: RB1
+  association: Somatic Mutations
+  frequency: FREQUENT
+  inheritance:
+  - name: Somatic
+  notes: >-
+    RB1 pathway inactivation is a common small cell bladder carcinoma mechanism
+    and supports uncontrolled proliferation through loss of cell-cycle control.
+  evidence:
+  - reference: PMID:40209138
+    reference_title: "Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Among SCBC patients with TP53 mutations, RB1 comutations were observed in
+      77% of patients.
+    explanation: >-
+      Comparative genomic profiling supports frequent RB1 co-mutation in SCBC.
+  - reference: PMID:29763719
+    reference_title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In the present study, we found that over 90% of bladder SmCC lacked RB1
+      expression on immunohistochemical analysis, suggesting that inactivation of
+      the RB1 gene is a critical molecular alteration in development of SmCC.
+    explanation: >-
+      Immunohistochemical analysis supports RB1 loss as a key molecular alteration
+      in bladder small cell carcinoma.
+treatments:
+- name: Radical Cystectomy
+  description: >-
+    Surgical removal of the bladder is considered for localized disease, usually
+    as part of multimodality treatment.
+  evidence:
+  - reference: PMID:34582342
+    reference_title: "Small cell carcinoma of the bladder: A population-based analysis of long-term outcomes after radical cystectomy and bladder conservation with chemoradiotherapy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      RC and chemoRT offer similar CSS and OS for localized SCBC, even when
+      focusing the analysis on patients treated according to the modern consensus
+      guidelines.
+    explanation: >-
+      Population-based outcome analysis supports radical cystectomy as a
+      guideline-consistent local treatment option for localized SCBC.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+- name: Platinum-Based Chemotherapy
+  description: >-
+    Systemic chemotherapy, often using platinum-etoposide regimens adapted from
+    small cell carcinoma treatment, is used for localized or advanced disease.
+  evidence:
+  - reference: PMID:39428391
+    reference_title: "Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in China."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Given its metastatic potential, CT remained an essential part of the treatment.
+    explanation: >-
+      Multi-institution cohort supports chemotherapy as an essential component
+      of treatment for non-metastatic SCCB.
+  - reference: PMID:39536751
+    reference_title: "PD-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Small cell neuroendocrine cancers share biologic similarities across tissue
+      types, including transient response to platinum-based chemotherapy with
+      rapid progression of disease.
+    explanation: >-
+      Prospective phase 1b trial background supports platinum-based chemotherapy
+      sensitivity in small cell neuroendocrine cancers including bladder cohort
+      treatment.
+  treatment_term:
+    preferred_term: chemotherapy
+    term:
+      id: MAXO:0000647
+      label: chemotherapy
+    therapeutic_agent:
+    - preferred_term: cisplatin
+      term:
+        id: CHEBI:27899
+        label: cisplatin
+    - preferred_term: etoposide
+      term:
+        id: CHEBI:4911
+        label: etoposide
+- name: Pembrolizumab Plus Platinum-Based Chemotherapy
+  description: >-
+    Early-phase evidence supports investigation of pembrolizumab combined with
+    platinum-based chemotherapy for stage III-IV small cell bladder or related
+    genitourinary neuroendocrine cancers.
+  evidence:
+  - reference: PMID:39536751
+    reference_title: "PD-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We report a phase 1b study of pembrolizumab in combination with
+      platinum-based chemotherapy in 15 patients with stage III-IV small cell
+      bladder (cohort 1) or small cell/neuroendocrine prostate cancers (cohort 2).
+    explanation: >-
+      Phase 1b data directly studied the combination in a small cohort including
+      stage III-IV small cell bladder cancer; support is partial because larger
+      confirmatory studies are still needed.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: pembrolizumab
+      term:
+        id: NCIT:C106432
+        label: Pembrolizumab
+    - preferred_term: cisplatin
+      term:
+        id: CHEBI:27899
+        label: cisplatin

--- a/references_cache/PMID_29763719.md
+++ b/references_cache/PMID_29763719.md
@@ -1,0 +1,129 @@
+---
+reference_id: "PMID:29763719"
+title: "Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases."
+authors:
+- Wang G
+- Xiao L
+- Zhang M
+- Kamat AM
+- Siefker-Radtke A
+- Dinney CP
+- Czerniak B
+- Guo CC
+journal: Hum Pathol
+year: '2018'
+doi: 10.1016/j.humpath.2018.05.005
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- "Biomarkers, Tumor/analysis, genetics"
+- "Carcinoma, Small Cell/chemistry, genetics, mortality, secondary"
+- Female
+- Gene Silencing
+- Humans
+- Immunohistochemistry
+- Male
+- Middle Aged
+- Neoplasm Staging
+- Predictive Value of Tests
+- Retinoblastoma Binding Proteins/genetics
+- Retrospective Studies
+- Texas
+- Ubiquitin-Protein Ligases/genetics
+- "Urinary Bladder Neoplasms/chemistry, genetics, mortality, pathology"
+content_type: full_text_xml
+---
+
+# Small cell carcinoma of the urinary bladder: a clinicopathological and immunohistochemical analysis of 81 cases.
+**Authors:** Wang G, Xiao L, Zhang M, Kamat AM, Siefker-Radtke A, Dinney CP, Czerniak B, Guo CC
+**Journal:** Hum Pathol (2018)
+**DOI:** [10.1016/j.humpath.2018.05.005](https://doi.org/10.1016/j.humpath.2018.05.005)
+
+## Content
+
+1. Hum Pathol. 2018 Sep;79:57-65. doi: 10.1016/j.humpath.2018.05.005. Epub 2018
+May  12.
+
+Small cell carcinoma of the urinary bladder: a clinicopathological and 
+immunohistochemical analysis of 81 cases.
+
+Wang G(1), Xiao L(1), Zhang M(1), Kamat AM(2), Siefker-Radtke A(3), Dinney 
+CP(2), Czerniak B(1), Guo CC(4).
+
+Author information:
+(1)Department of Pathology, The University of Texas MD Anderson Cancer Center, 
+Houston, TX, 77030, USA.
+(2)Department of Urology, The University of Texas MD Anderson Cancer Center, 
+Houston, TX, 77030, USA.
+(3)Department of Genitourinary Medical Oncology, The University of Texas MD 
+Anderson Cancer Center, Houston, TX, 77030, USA.
+(4)Department of Pathology, The University of Texas MD Anderson Cancer Center, 
+Houston, TX, 77030, USA. Electronic address: ccguo@mdanderson.org.
+
+Small cell carcinoma (SmCC) of the bladder is a rare disease. We retrospectively 
+studied a large series of bladder SmCC from a single institution. The patients 
+included 69 men and 12 women with a mean age of 68 years. Most bladder SmCCs 
+were presented at advanced stage, with tumors invading the muscularis propria 
+and beyond (n = 77). SmCC was pure in 27 cases and mixed with other histologic 
+types in 54 cases, including urothelial carcinoma (UC) (n = 32), UC in situ 
+(n = 26), glandular (n = 14), micropapillary (n = 4), sarcomatoid (n = 4), 
+squamous (n = 3), and plasmacytoid (n = 1) features. Most SmCCs expressed 
+neuroendocrine markers synaptophysin (41/56), chromogranin (26/55), and CD56 
+(39/41); however, they did not express UC luminal markers CK20 (0/17), GATA3 
+(1/30), and uroplakin II (1/22). Some SmCCs showed focal expression of CK5/6 
+(9/25), a marker for the basal molecular subtype. Furthermore, expression of the 
+retinoblastoma 1 (RB1) gene protein was lost in most of the bladder SmCCs 
+(2/23). The patients' survival was significantly associated with cancer stage 
+but did not show a significant difference between mixed and pure SmCCs. Compared 
+with conventional UC at similar stages, SmCC had a worse prognosis only when 
+patients developed metastatic diseases. In conclusion, bladder SmCC is an 
+aggressive disease that is frequently present at an advanced stage. A fraction 
+of SmCCs show a basal molecular subtype, which may underlie its good response to 
+chemotherapy. Inactivation of the RB1 gene may be implicated in the oncogenesis 
+of bladder SmCC.
+
+Copyright © 2018 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.humpath.2018.05.005
+PMCID: PMC6133751
+PMID: 29763719 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflicts of Interest The authors have no 
+conflicts of interest to disclose.
+
+Bladder cancer is the sixth most common malignancy in the US, with an estimated incidence of 79,030 new cases in 2017 [1]. Approximately 90% of bladder cancers are composed of urothelial carcinoma (UC), and other histologic types, such as squamous cell carcinoma and adenocarcinoma, are far less common [2]. Although most UC are detected at an early stage, about 25% UC are present at an advanced stage – the tumor invades the muscularis propria and/or metastasizes to lymph nodes and other organs [3]. Invasive UC demonstrates a high tendency to develop divergent differentiation, leading to a number of histologic variants, such as micropapillary, nested, plasmacytoid, and sarcomatoid variants [4,5]. Some aggressive UC variants are associated with poor clinical outcome and may require therapeutic approaches that differ from those used for the conventional UC [6]. In spite of their clinical importance, it may be difficult to recognize UC variants, particularly at metastatic sites, as the morphologic features of histologic variants are not limited to bladder UC and can be seen in other carcinomas. Several recent studies have reported that immunohistochemistry is a useful tool to aid the differential diagnosis of UC variants [7,8].
+
+Small cell carcinoma (SmCC) of the bladder is a rare histologic variant and accounts for less than 1% of all bladder malignancies [9–11]. SmCC belongs to a family of neuroendocrine tumors, which also includes large cell neuroendocrine carcinoma, well-differentiated neuroendocrine tumor, and paragangliomas in the bladder [9]. SmCC is by far the most common neuroendocrine tumor in the bladder. Like its more common counterpart in the lungs, bladder SmCC typically expresses neuroendocrine markers, such as synaptophysin, chromogranin, and neuron-specific enolase (NSE), but a lack of expression of these markers does not exclude the diagnosis of SmCC [9]. There have been limited studies about this rare disease, and most studies have been based on small cohorts of patients. Although several large series of bladder SmCC were previously reported, but they were largely focused on clinical and therapeutic aspects of this rare disease [12–13]. Herein we describe a large series of SmCC from a single institution, providing detailed clinicopathologic and immunohistochemical features of this rare disease.
+
+After the Institutional Review Board at The University of Texas MD Anderson Cancer Center approved the study, we searched our pathology database from 1992 to 2014 and found 81 cases of SmCC of the urinary bladder. All 81 patients underwent transurethral biopsy or resection of bladder tumor, and 48 patients underwent radical cystectomy. The patients’ archived hematoxylin- and eosin (H&E) stained slides were retrieved from our files and reviewed for pathological analysis, including histologic features, other coexistent histologic variants, pathologic stage, and metastasis to lymph nodes and other organs. Clinical data, including patients’ demographics, treatments, and outcomes, were retrieved from their medical records. The primary tumor pathologic stage was evaluated according to the 2010 American Joint Committee on Cancer TNM criteria: I (T1N0M0), II (T2N0M0), III (T3N0M0 and T4aN0M0), and IV (T4bN0M0, TanyN1–3M0 and TanyNanyM1). [14]. In cases in which cystectomy was not performed, clinical stage was determined based on clinical and radiographic findings.
+
+Immunohistochemical staining was performed on routine sections as well as tissue micro array (TMA) sections. TMA consisted of 1-mm SmCC tissue cores (two cores per patient) and was constructed using a manual tissue arrayer (Beecher Instruments, Silver Spring, MD). The following monoclonal antibodies were used for immunostaining: AE1/AE3 (clone AE1/3, 1:100 dilution, Dako, Carpinteria, CA), CAM 5.2 (clone CAM 5.2, 1:50 dilution, BD Biosciences, San Jose, CA), CK7 (clone OV-TL 12/30, 1:100 dilution, Dako), CK5/6 (D5/16B4 clone, 1:50 dilution, Dako), CK14 (LL002 clone, 1:50 dilution; BioGenex, Fremont, CA), CK20 (clone Ks20.8, 1:4000 dilution, Dako), CK903 (clone 34βE12, 1:100 dilution, Dako), synaptophysin (clone 27G12, dilution 1:600, Leica Biosystems, Buffalo Grove, IL), chromogranin (clone LKZH10, 1:4000 dilution, Millipore, San Diego, CA), CD56 (clone 123C3, 1:100 dilution, Life Technologies, Carlsbad, CA), neuron-specific enolase (NSE; clone E-27, 1:3 dilution, Cell Marque, Rocklin, CA), GATA-3 (clone HG3-31, 1:100 dilution, Santa Cruz Biotechnology, Santa Cruz, CA), p63 (clone 4A4, 1:1000 dilution, Santa Cruz Biotechnology), RB1(clone LM95.1, 1:30 dilution; Millipore), thrombomodulin (clone 1009, dilution 1:10, Dako), and uroplakin II (clone BC-21, 1:00 dilution; Biocare, Concord, CA). Briefly, 4-μm-thick sections were deparaffinized in xylene and hydrated in graded alcohol. Immunostaining was performed using a BOND-MAX autostainer (Leica Biosystems, Buffalo Grove, IL). Slides were incubated with the primary antibody and then with a visualization reagent (secondary goat anti-mouse immunoglobulin and horseradish peroxidase linked to a dextran polymer backbone). The slides were then rinsed with distilled water, incubated with a 3,3-diaminobenzidine substrate-chromogen solution, and subjected to Mayer hematoxylin counterstaining. The immunohistochemical slides were evaluated by two pathologists (G.W. and C.C.G.) blinded to patient identity and reported as either positive or negative.
+
+The cancer specific survivals for patients with SmCC at different stages were compared using the Kaplan-Meier method with the Prism 6 software program (GraphPad Software, La Jolla, CA). The cancer specific survivals of bladder SmCC were also compared with a cohort of 89 cases of conventional UC at similar stages that were treated in our institute. The Fisher exact test was used to calculate two-tailed P values. P values less than 0.05 were considered statistically significant.
+
+The patients included 69 men and 12 women (Table 1). The median age of patients was 68 years (range, 34–90 years). The majority of patients initially presented with gross or microscopic hematuria (n=73). Other presenting symptoms included dysuria, increased urinary frequency, and urinary tract infection (Table 1). Cystoscopic examination typically demonstrated ulcerated or fungating lesions. The tumors were most commonly located at the lateral (n=30) and posterior wall (n=20). Nonetheless, the tumors were observed at other locations as well. In 3 cases, the tumors were found in diverticula.
+
+Microscopically, the tumors showed sheets and large nests of malignant cells with round-to-oval nuclei, scant cytoplasm, and a high nuclear/cytoplasmic ratio (Fig. 1A), resembling SmCC of the lung. The nuclei showed finely stippled chromatin and numerous mitotic figures but lacked prominent nucleoli. Coagulative necrosis and nuclear molding were commonly seen. Only 1/3 of SmCC were pure (n=27), and the majority was mixed with other histologic types (n=54). Overall, the SmCC component accounted for a mean of 34% (range 5–90%) of the mixed tumor. The most common coexistent histologic types were conventional UC (n=32) (Fig. 1B) and UC in situ (n=26) (Fig. 2A). Other histologic types included adenocarcinoma (n=14) (Fig. 3A), micropapillary (n=4), sarcomatous (n=4) (Fig. 1C), squamous cell carcinoma (n=3) (Fig. 1D), and plasmacytoid (n=1) variants.
+
+Immunohistochemical studies were performed in most cases (Table 2). Most SmCC expressed at least one neuroendocrine markers, including synaptophysin (73%, 41/56) (Fig. 2B), chromogranin (47%, 26/55) (Fig 3B), CD56 (95%, 39/41), and NSE (100%, 4/4). SmCC also expressed various cytokeratins, such as pan-CK (89%, 8/9), CK7 (47%, 9/19), HMWCK (60%, 3/5), and CAM5.2 (100%, 6/6), but the staining signals were often focal and weak. SmCC generally did not express urothelial luminal markers, including CK20 (0/17) (Fig. 2C), GATA3 (1/30) (Fig. 2D), and uroplakin II (1/22). A fraction of SmCC expressed a basal marker CK5/6 (9/25). In addition, only two cases showed nuclear expression of the RB1 gene protein (2/23), indicating the important role of this tumor suppressor gene in the development of SmCC (Fig 4).
+
+Pathologic staging was evaluated on 48 patients who underwent radical cystectomy. The primary tumor invaded the lamina propria (pT1) (n=2), muscularis propria (pT2) (n=28) and perivesical soft tissue (pT3) (n=18). To aid the clinical staging, patients underwent a variety of radiographic imaging evaluations, including computed tomography (CT), positron emission tomography, bone scan scintigraphy, and magnetic resonance imaging (MRI). 55 patents had diseases localized to the bladder, including stage I (n=4), II (n=40), and III (n=11). 26 patients had stage IV diseases with metastases to lymph nodes (n=16) and/or other organs (n=11). The most frequent metastasis organ was the liver (n=7), followed by the bone (n=4), lung (n=2) and brain (n=1). Treatment information was available for 72 patients. Patients received chemotherapy (n=63), cystectomy (n=48), radiation (n=11), and immunotherapy (n=2). Among the patients who underwent cystectomy, 43 patients also had received neoadjuvant chemotherapy before surgery.
+
+Clinical followup was available for 77 patients, and the mean follow-up time was 36 months (range, 1–166 months). 38 patients died in a mean of 16 months (range, 1–96 months), and 39 patients were alive in a mean of 55 months (range, 1–166 months). The cancer specific survival time was significantly associated with the clinical stage (p=0.0017) (Fig. 5A). The outcome of SmCC was also compared with 89 cases of conventional UCa at similar stages that were treated at our institute (Fig. 5B). The median survival time did not show any significant difference between SmCC and UC (29 months vs 24 months) (p=0.2224) in stage I, II, and III patients. However, when the disease developed metastasis (stage IV), SmCC had a significantly poorer median survival time than that of UC (15 months vs 24 months) (p=0.0194). The median survival time did not show any significant difference between pure and mixed SmCC (Fig. 5C) (p=0.8734). The median survival time for the patients who underwent neoadjuvant chemotherapy before cystectomy was 38 months, but the median survival time for patients who did not received neoadjuvant chemotherapy was only 12 months (Fig. 5D). Long-term survival (> 60 months) was observed in 17 patients, who had disease localized to the bladder and received neoadjuvant chemotherapy.
+
+We retrospectively analyzed a large cohort of bladder SmCC from a single institution and found that bladder SmCC demonstrated distinct clinicopathologic features from the conventional UC. At presentation, over 90% bladder SmCC were at advanced stages with tumors invading the muscularis propria and beyond, and about 1/3 developed metastases to lymph nodes and other organs. The patients’ cancer specific survival showed significant association with cancer stage. About 2/3 bladder SmCC were mixed with other histologic type, most commonly UC or UCIS; however, the patients’ survival did not show a significant difference between pure or mixed SmCC. We also compared the survivals of bladder SmCC and UC at similar stages. Patients with SmCC limited to the bladder achieved a long-term survival after neoadjuvant chemotherapy and radical cystectomy. However, when the disease developed metastasis, bladder SmCC showed a significantly worse survival than conventional UC at similar stages, as the widespread disease could not be eradicated by surgery alone. Our immunohistochemical analysis not only supported the neuroendocrine nature of bladder SmCC but also suggested that a fraction of bladder SmCC belonged to a basal molecular subtype, which might underlie its good response to chemotherapy. We also found that the inactivation of the RB1 gene was highly prevalent in SmCC, indicating an important role in the oncogenesis of bladder SmCC.
+
+Although the origin of bladder SmCC remains uncertain, there have been several hypotheses about its pathogenesis [15–19]. It has been postulated that bladder SmCC may develop from malignant transformation of Kulchitsky-type neuroendocrine cells in the bladder mucosa, as immunohistochemistry and electromicroscopy have demonstrated the presence of sporadic neuroendocrine cells in the normal urothelial urothelium [15]. Another theory has suggested that bladder SmCC may result from transdifferentiation of conventional UC. Indeed, a recent study demonstrated that microRNA-145 transformed conventional UC cells to pluripotent stem cells with subsequent differentiation into neuroendocrine, glandular, squamous lineages [16]. A third theory proposed that bladder SmCC and UC may share a common clonal origin - a multipotential, undifferentiated cell (or cancer stem cell) based on the fact that most SmCC coexist with conventional UC in the bladder [18]. In the current study, 66% of bladder SmCC were mixed with other carcinomas, most commonly UC (40%) and UCIS (32%), suggestive a close relationship between SmCC and UC. Furthermore, Cheng et al. compared patterns of loss of heterozygosity between SmCC and corresponding UC and found that they shared almost identical patterns of allelic loss, supporting SmCC and UC originate from a common, clonal precursor [19]. Nonetheless, more genetic and molecular studies are needed to explore the oncogenesis of bladder SmCC.
+
+Recent genomic analyses of bladder UC have demonstrated two intrinsic molecular subtypes, luminal and basal, and each subtype is associated with distinct clinical behavior and sensitivity to chemotherapy [20,21]. Basal UC is more aggressive with shorter survival in a chemotherapy-naive setting when compared to luminal UC. However, basal UC is more sensitive to cisplatinum-based chemotherapy and thus the patients with basal UC appeared to benefit more from chemotherapy when compared to luminal UC [22]. Using a small panel of immunohistochemical markers, we successfully separated bladder UC into luminal and basal subtypes, which demonstrated over 90% consistence with the molecular subtypes based on the genomic analysis [23]. In the current study, most SmCC (64%) did not express luminal or basal markers, largely reflecting the dedifferentiated nature of this disease. Among the 10 cases of SmCC that expressed basal or luminal markers, 9 cases expressed the basal marker CK5/6 and only 1 case expressed the luminal marker GATA-3, suggesting that SmCC is likely to evolve from a basal subtype UC. In addition, our limited genomic analysis also supported that most SmCC demonstrated a gene expression profile of the basal subtype (data not shown), which may underlie its good response to chemotherapy.
+
+The RB1 gene encodes a tumor suppressor protein that regulates cell-cycle regulation, senescence, and cell apoptosis [24]. Recent genomic analysis of 110 lung SmCC revealed inactivation of the RB1 gene in nearly all the tumors, sometimes by complex genomic rearrangements [25]. Only two lung SmCC had the wild-type RB1, but they both showed evidence of chromothripsis, leading to overexpression of cyclin D1, revealing an alternative mechanism of RB1 deregulation. Thus, loss of the tumour suppressors RB1 is considered an essential molecular event for the development of lung SmCC. In bladder UC, RB1 mutations were found in 21% of non-muscle-invasive UC and 36% of muscle-invasive UC, suggesting that RB1 mutations are associated with an invasive disease [26,27]. A recent study demonstrated that patients with bladder UC lacking RB1 expression may benefit from forced expression of the RB1 protein using tumor-targeted liposomal delivery method [28]. In the present study, we found that over 90% of bladder SmCC lacked RB1 expression on immunohistochemical analysis, suggesting that inactivation of the RB1 gene is a critical molecular alteration in development of SmCC. Patients with bladder SmCC may be suitable candidates for the RB1-targeted therapy.
+
+Our study demonstrated that the survival of patients with bladder SmCC was significantly associated with cancer stage. Studies have reported that pure SmCC was associated with a worse prognosis than SmCC mixed with other histology [29,30]. In the current study, we did not find any significant difference between pure SmCC and those with mixed histology. We also compared SmCC with conventional UCa at similar stages and found that they had a similar outcome, when the tumors were localized to the bladder and thus likely to be completely resected. However, SmCC had a worse outcome than UC, when the tumors developed metastasis, as they were unlikely to be completely resected. SmCC demonstrated a high sensitivity to cisplatin-based chemotherapy. A previous study from our institute by Lynch et al found neoadjuvant chemotherapy was associated with pathologic downstaging and significantly improved the patient’s survival [12]. In the current study, a long-term survival (> 5 years) was achieved in 16 patients including 7 patients with > 10 years of survival. All these patients had disease localized to the bladder and underwent neoadjuvant chemotherapy followed by radical cystectomy. Although limited by their retrospective nature, our study supports that neoadjuvant chemotherapy followed by radical cystectomy is an effective approach in treating patients with SmCC localized to the bladder.
+
+It is important to differentiate SmCC from other malignant neoplasms in the bladder. Poorly differentiated UC may show solid sheets of immature cells with large nuclei and scant cytoplasm, mimicking SmCC, but it shows a distinct immunohistochemical profile from SmCC. As demonstrated in the current study, bladder most SmCC express neuroendocrine markers, such as chromogranin, synaptophysin, and CD56, but not urothelial markers, such as uroplakin II, GATA-3, and CK20. In contrast, UC usually expressed urothelial markers but not neuroendocrine markers. Metastatic SmCC from other organs, particularly those from the prostate, may also involve the bladder. Bladder SmCC frequently co-exists with other malignant histologies, particularly UC and UCIS. In our study, 66% of bladder SmCC were accompanied by other histologic types of carcinoma, most frequently UC (40%) and UCIS (32%). However, prostatic SmCC often arise in the setting of prostatic adenocarcinoma with an elevated level of prostatic specific antigen (PSA). Our previous study found that prostatic SmCC frequently demonstrated the TMPRSS2-ERG fusion while this gene fusion was not detected in bladder SmCC [31]. Another recent study reported that bladder SmCC often showed mutations in the TERT promoter but these mutations were not present in SmCC or neuroendocrine carcinomas of other organs [32]. Lymphoma and melanoma occasionally involves the bladder but they express lymphocytic and melanocytic markers. Additionally they lack expressions of either epithelial or neuroendocrine markers.
+
+Although we reported a large series of bladder SmCC with detailed clinicopathologic and immunohistochemical analysis, there were some limitations in our study. First, there was a high variability in the number of cases that were analyzed with each immunostain, as a large number of cases in our study were referral and consultation cases from different hospitals, where immunohistochemistry was not uniformly performed. There might be a potential bias in selection of immunohistochemistry, as the cases were not stained with the same antibodies. Second, only a limited number of the immunohistochemical markers for the molecular classification were tested in our study. However, our recent study found that the immunohistochemical expressions of only two markers, luminal (GATA3) and basal (CK5/6), were sufficient to identify the molecular subtypes of bladder cancer with over 90% accuracy [23]. Finally, our immunohistochemical methods were not uniform, as they were performed on routine histologic sections as well as on TMAs. As TMAs examine only a small fraction of the tumor that is analyzed using routine sections, it has been questioned whether TMA cores could adequately assess biomarkers that exhibited tissue heterogeneity. However, several groups have demonstrated strong correlations between TMA and routine sections. In most instances, two 0.6-mm cores could adequately represent the staining that is observed on routine sections [33,34]. Nonetheless, additional independent immunohistochemical study may be needed to verify the findings of our study.
+
+In conclusion, SmCC of the bladder is an aggressive disease which usually presents at an advanced stage with frequent metastases. Most bladder SmCC are mixed with UC and other histologic types, suggestive that they might share a common clonal origin. When the disease is localized to the bladder, SmCC does not have a significantly different clinical outcome from conventional UCa. Indeed, neoadjuvant chemotherapy followed by radical cystectomy can lead to a long-term survival in patients who have SmCC limited to the bladder. However, when the disease develops metastasis, SmCC shows a significantly worse prognosis than UC. Although most SmCC do not express luminal or basal markers, a small fraction shows a basal molecular subtype, which may underlie its good response to chemotherapy. The prevalence of the RB1 gene dysfunction in bladder SmCC suggests that it plays an important role in its oncogenesis and may be a potential therapeutic target for this aggressive disease.

--- a/references_cache/PMID_32381384.md
+++ b/references_cache/PMID_32381384.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:32381384"
+title: "Expression of novel neuroendocrine marker insulinoma-associated protein 1 (INSM1) in genitourinary high-grade neuroendocrine carcinomas: An immunohistochemical study with specificity analysis and comparison to chromogranin, synaptophysin, and CD56."
+authors:
+- Chen JF
+- Yang C
+- Sun Y
+- Cao D
+journal: Pathol Res Pract
+year: '2020'
+doi: 10.1016/j.prp.2020.152993
+keywords:
+- "Biomarkers, Tumor/analysis"
+- "CD56 Antigen/analysis, biosynthesis"
+- "Carcinoma, Neuroendocrine/pathology"
+- "Chromogranins/analysis, biosynthesis"
+- Female
+- Humans
+- Immunohistochemistry
+- Male
+- "Repressor Proteins/analysis, biosynthesis"
+- Sensitivity and Specificity
+- "Synaptophysin/analysis, biosynthesis"
+- Urogenital Neoplasms/pathology
+content_type: abstract_only
+---
+
+# Expression of novel neuroendocrine marker insulinoma-associated protein 1 (INSM1) in genitourinary high-grade neuroendocrine carcinomas: An immunohistochemical study with specificity analysis and comparison to chromogranin, synaptophysin, and CD56.
+**Authors:** Chen JF, Yang C, Sun Y, Cao D
+**Journal:** Pathol Res Pract (2020)
+**DOI:** [10.1016/j.prp.2020.152993](https://doi.org/10.1016/j.prp.2020.152993)
+
+## Content
+
+1. Pathol Res Pract. 2020 Jun;216(6):152993. doi: 10.1016/j.prp.2020.152993. Epub
+ 2020 Apr 26.
+
+Expression of novel neuroendocrine marker insulinoma-associated protein 1 
+(INSM1) in genitourinary high-grade neuroendocrine carcinomas: An 
+immunohistochemical study with specificity analysis and comparison to 
+chromogranin, synaptophysin, and CD56.
+
+Chen JF(1), Yang C(2), Sun Y(3), Cao D(4).
+
+Author information:
+(1)Department of Pathology and Immunology, Washington University School of 
+Medicine, Saint Louis, MO, USA.
+(2)Department of Pathology, Memorial Sloan Kettering Cancer Center, New York, 
+NY, USA.
+(3)Department of Pathology, Beth Israel Deaconess Medical Center and Harvard 
+Medical School, Boston, MA, USA.
+(4)Department of Pathology and Immunology, Washington University School of 
+Medicine, Saint Louis, MO, USA. Electronic address: dengfengcao@wustl.edu.
+
+Confirmation of genitourinary high-grade neuroendocrine carcinomas (GU-HGNECs) 
+often requires immunohistochemical staining. Here we evaluated a novel 
+neuroendocrine marker, insulinoma-associated protein 1 (INSM1), in GU-HGNECs 
+with comparison to chromogranin, synaptophysin and CD56. Immunohistochemical 
+expression of INSM1, chromogranin, synaptophysin, and CD56 was evaluated in 39 
+GU-HGNECs using full tissue sections [4 in kidney, 28 in urinary bladder, and 7 
+in prostate; 31 small cell carcinomas (SmCCs), 6 large cell neuroendocrine 
+carcinomas (LCNECs), 2 mixed SmCC-LCNECs]. In 33 SmCCs/components, INSM1 showed 
+similar sensitivity (93.9 %) to chromogranin (87.8 %), synaptophysin (93.9 %) 
+and CD56 (87.8 %), and stained a similar percentage of tumor cells (52 %) to 
+chromogranin (49 %) and CD56 (52 %), but lower than synaptophysin (87 %) 
+(p < 0.0001). In 8 LCNECs/components, INSM1 is similar to chromogranin, 
+synaptophysin or CD56 in sensitivity (62.5 %, 62.5 %, 75 %, 62.5 %, 
+respectively) and the mean percentage of positively stained tumor cells (21 %, 
+44 %, 48 %, 37 %, respectively). INSM1 is more sensitive for SmCCs than LCNECs 
+(93.9 % vs. 62.5 %, p = 0.015). INSM1 showed 97.4 % specificity upon analyzing 
+273 genitourinary non-neuroendocrine tumors on tissue microarrays. Our study 
+indicates that INSM1 is a sensitive marker for genitourinary HGNECs with high 
+specificity. For genitourinary SmCCs, INSM1 shows similar sensitivity to 
+chromogranin, synaptophysin and CD56 but stains a lower percentage of tumor 
+cells than synaptophysin. For genitourinary LCNECs, INSM1 showed similar 
+sensitivity to chromogranin, synaptophysin and CD56. INSM1 is more sensitive for 
+genitourinary SmCCs than LCNECs. Our result and literature review indicate that 
+whether INSM1 is more sensitive than conventional neuroendocrine markers for 
+HGNECs depends on the tumor primary sites.
+
+Copyright © 2020 Elsevier GmbH. All rights reserved.
+
+DOI: 10.1016/j.prp.2020.152993
+PMID: 32381384 [Indexed for MEDLINE]

--- a/references_cache/PMID_34582342.md
+++ b/references_cache/PMID_34582342.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:34582342"
+title: "Small cell carcinoma of the bladder: A population-based analysis of long-term outcomes after radical cystectomy and bladder conservation with chemoradiotherapy."
+authors:
+- Oh J
+- Eigl B
+- Black PC
+- Pickles T
+- Villamil C
+- Sunderland K
+- Tyldesley S
+journal: Can Urol Assoc J
+year: '2022'
+doi: 10.5489/cuaj.7411
+content_type: abstract_only
+---
+
+# Small cell carcinoma of the bladder: A population-based analysis of long-term outcomes after radical cystectomy and bladder conservation with chemoradiotherapy.
+**Authors:** Oh J, Eigl B, Black PC, Pickles T, Villamil C, Sunderland K, Tyldesley S
+**Journal:** Can Urol Assoc J (2022)
+**DOI:** [10.5489/cuaj.7411](https://doi.org/10.5489/cuaj.7411)
+
+## Content
+
+1. Can Urol Assoc J. 2022 Feb;16(2):55-62. doi: 10.5489/cuaj.7411.
+
+Small cell carcinoma of the bladder: A population-based analysis of long-term 
+outcomes after radical cystectomy and bladder conservation with 
+chemoradiotherapy.
+
+Oh J(1)(2), Eigl B(3), Black PC(4), Pickles T(1)(2), Villamil C(5), Sunderland 
+K(6), Tyldesley S(1)(2).
+
+Author information:
+(1)Department of Surgery, Faculty of Medicine, University of British Columbia, 
+Vancouver, BC, Canada.
+(2)Department of Radiation Oncology, British Columbia Cancer - Vancouver Centre, 
+Vancouver, BC, Canada.
+(3)Department of Medical Oncology, Faculty of Medicine, University of British 
+Columbia, Vancouver, BC, Canada.
+(4)Department of Urologic Sciences, University of British Columbia, Vancouver, 
+BC, Canada.
+(5)Department of Pathology and Laboratory Medicine, British Columbia Cancer - 
+Vancouver Centre, Vancouver, BC, Canada.
+(6)Cancer Surveillance and Outcomes, Population Oncology, British Columbia 
+Cancer.
+
+INTRODUCTION: We aimed to describe the oncological outcomes after radical 
+cystectomy and chemo-radiation for localized small cell bladder cancer (SCBC).
+METHODS: This population-based analysis of localized SCBC from 1985-2018 in 
+British Columbia included an analysis (analysis 1) of cancer-specific survival 
+(CSS) and overall survival (OS) of patients treated with curative-intent radical 
+cystectomy (RC) and radiation (RT), and an analysis (analysis 2) of CSS and OS 
+in patients treated with RC and chemoRT consistent with the SCBC Canadian 
+consensus guideline.
+RESULTS: Seventy-seven patients who were treated with curative intent were 
+identified: 33 patients had RC and 44 had RT. For analysis 1, five-year OS was 
+29% and 39% for RC and RT, respectively (p=0.51), and five-year CSS was 35% and 
+52% for RC and RT, respectively (p=0.29). On multivariable analysis, higher 
+Charlson comorbidity index (CCI) and the lack of neoadjuvant chemotherapy (NAC) 
+were associated with worse OS, while higher CCI and Eastern Cooperative Oncology 
+Group (ECOG) were associated with worse CSS. For analysis 2, five-year OS was 
+56% and 58% for the RC and chemoRT groups, respectively (p=0.90), and five-year 
+CSS was 56% for RC and 71% for chemoRT (p=0.71). Four of 42 (9.5%) chemoRT 
+patients had RC at relapse.
+CONCLUSIONS: SCBC is a rare entity with a poor prognosis. RC and chemoRT offer 
+similar CSS and OS for localized SCBC, even when focusing the analysis on 
+patients treated according to the modern consensus guidelines. NAC should be 
+considered for eligible patients. Both chemoRT and RC treatment options should 
+be discussed with patients with SCBC.
+
+DOI: 10.5489/cuaj.7411
+PMCID: PMC8932431
+PMID: 34582342
+
+Conflict of interest statement: Competing interests: The authors do not report 
+any competing personal or financial interests related to this work.

--- a/references_cache/PMID_35662501.md
+++ b/references_cache/PMID_35662501.md
@@ -1,0 +1,102 @@
+---
+reference_id: "PMID:35662501"
+title: Identification of potential biomarkers and novel therapeutic targets through genomic analysis of small cell bladder carcinoma and associated clinical outcomes.
+authors:
+- Burgess EF
+- Sanders JA
+- Livasy C
+- Symanowski J
+- Gatalica Z
+- Steuerwald NM
+- Arguello D
+- Brouwer CR
+- Korn WM
+- Grigg CM
+- Zhu J
+- Matulay JT
+- Clark PE
+- Heath EI
+- Raghavan D
+journal: Urol Oncol
+year: '2022'
+doi: 10.1016/j.urolonc.2022.04.019
+keywords:
+- "Biomarkers, Tumor/genetics"
+- Carcinoma
+- Genomics
+- Humans
+- Mutation
+- "Neoplasm Recurrence, Local/genetics"
+- Prognosis
+- Urinary Bladder/pathology
+- "Urinary Bladder Neoplasms/genetics, pathology"
+- Xeroderma Pigmentosum Group D Protein/genetics
+content_type: abstract_only
+---
+
+# Identification of potential biomarkers and novel therapeutic targets through genomic analysis of small cell bladder carcinoma and associated clinical outcomes.
+**Authors:** Burgess EF, Sanders JA, Livasy C, Symanowski J, Gatalica Z, Steuerwald NM, Arguello D, Brouwer CR, Korn WM, Grigg CM, Zhu J, Matulay JT, Clark PE, Heath EI, Raghavan D
+**Journal:** Urol Oncol (2022)
+**DOI:** [10.1016/j.urolonc.2022.04.019](https://doi.org/10.1016/j.urolonc.2022.04.019)
+
+## Content
+
+1. Urol Oncol. 2022 Aug;40(8):383.e1-383.e10. doi: 10.1016/j.urolonc.2022.04.019.
+ Epub 2022 May 31.
+
+Identification of potential biomarkers and novel therapeutic targets through 
+genomic analysis of small cell bladder carcinoma and associated clinical 
+outcomes.
+
+Burgess EF(1), Sanders JA(2), Livasy C(3), Symanowski J(4), Gatalica Z(5), 
+Steuerwald NM(4), Arguello D(6), Brouwer CR(2), Korn WM(6), Grigg CM(4), Zhu 
+J(4), Matulay JT(4), Clark PE(4), Heath EI(7), Raghavan D(4).
+
+Author information:
+(1)Levine Cancer Institute, Atrium Health, Charlotte, NC. Electronic address: 
+earle.burgess@atriumhealth.org.
+(2)Department of Bioinformatics and Genomics, University of North Carolina at 
+Charlotte, Charlotte, NC.
+(3)Carolinas Pathology Group, Charlotte, NC.
+(4)Levine Cancer Institute, Atrium Health, Charlotte, NC.
+(5)Department of Pathology, University of Oklahoma Health Sciences Center, 
+Oklahoma City, OK.
+(6)Caris Life Sciences, Irving, TX.
+(7)Karmanos Cancer Institute, Wayne State University, Detroit, MI.
+
+OBJECTIVES: Small cell bladder carcinoma (SCBC) represents a rare histologic 
+variant with a poor prognosis and for which no routine biomarkers exist. Limited 
+reports of genomic sequencing in SCBC have demonstrated a high prevalence of 
+TP53 and RB1 gene mutations, though the prognostic value of these and other gene 
+variants in SCBC remains undefined. In this study, we performed targeted genomic 
+sequencing on a cohort of SCBC patients and correlated genomic findings with 
+clinical outcomes to identify potential novel biomarkers.
+MATERIALS AND METHODS: Thirty-one patients with SCBC and available 
+treatment-naïve tumor specimens were identified from an institutional database 
+(23 limited stage [LS], 8 extensive stage [ES]). Small cell carcinoma specimens 
+were microdissected and subjected to tumor next-generation whole-exon sequencing 
+with a 592 gene panel. Kaplan-Meier techniques and Cox proportional hazards 
+models were used to evaluate genomic aberration association with relapse-free 
+survival (RFS) and overall survival (OS) in the limited stage cohort.
+RESULTS: The most common pathogenic gene variants included ARID1A (48%), TP53 
+(48%) and RB1 (48%). Mutations in genes with potential therapeutic targets not 
+routinely evaluated in SCBC included BRCA1/2 (16%), POLE (13%), JAK2 (13%), 
+PDGFB (13%) and FGFR3 (3%). Multiple novel biomarker candidates showed trends 
+for improvements in OS in the LS subset including ERCC2 (HR 0.322, P = 0.122) 
+and RB1 (HR 0.481, P = 0.182), while LS patients with TP53 mutations (HR 2.730, 
+P = 0.056), and MCL1 gene amplification (HR 4.183, P = 0.018) suggested inferior 
+OS. Additionally, gene or copy number variants with potential prognostic benefit 
+included UBR5 and DAXX (P = 0.02, [hazard ratios nonestimable due to zero events 
+in biomarker positive groups]).
+CONCLUSIONS: These results support the role for tumor genomic profiling in SCBC 
+and identify multiple potential novel biomarkers and therapeutic targets in this 
+rare disease. Efforts to validate these findings should lead to improved 
+decision-making and treatment outcomes in SCBC.
+
+Copyright © 2022 The Author(s). Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.urolonc.2022.04.019
+PMID: 35662501 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflict of interest The authors declare no 
+conflicts of interest.

--- a/references_cache/PMID_39428391.md
+++ b/references_cache/PMID_39428391.md
@@ -1,0 +1,96 @@
+---
+reference_id: "PMID:39428391"
+title: Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in China.
+authors:
+- Lu J
+- Zhou J
+- Liu Y
+- Li Y
+- Tang Y
+- Li N
+- Wang S
+- Song Y
+- Zhang W
+- Xiang X
+- Jin J
+journal: Sci Rep
+year: '2024'
+doi: 10.1038/s41598-024-75512-z
+keywords:
+- Humans
+- "Urinary Bladder Neoplasms/mortality, pathology, therapy"
+- Male
+- Female
+- Middle Aged
+- "Carcinoma, Small Cell/therapy, mortality, pathology"
+- China/epidemiology
+- Aged
+- Retrospective Studies
+- Cystectomy
+- Adult
+- Treatment Outcome
+- Kaplan-Meier Estimate
+- Combined Modality Therapy
+content_type: abstract_only
+---
+
+# Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in China.
+**Authors:** Lu J, Zhou J, Liu Y, Li Y, Tang Y, Li N, Wang S, Song Y, Zhang W, Xiang X, Jin J
+**Journal:** Sci Rep (2024)
+**DOI:** [10.1038/s41598-024-75512-z](https://doi.org/10.1038/s41598-024-75512-z)
+
+## Content
+
+1. Sci Rep. 2024 Oct 20;14(1):24652. doi: 10.1038/s41598-024-75512-z.
+
+Treatment and survival of non-metastatic small cell carcinoma of the bladder 
+from multiple centers in China.
+
+Lu J(1), Zhou J(1), Liu Y(2), Li Y(2), Tang Y(2), Li N(2), Wang S(2), Song Y(2), 
+Zhang W(1), Xiang X(1), Jin J(3).
+
+Author information:
+(1)Department of Radiation Oncology, National Cancer Center, National Clinical 
+Research Center for Cancer/Cancer Hospital & Shenzhen Hospital, Chinese Academy 
+of Medical Sciences and Peking Union Medical College, 113 Baohe Avenue, Longgang 
+District, Shenzhen, 518172, Guangdong, China.
+(2)State Key Laboratory of Molecular Oncology, Department of Radiation Oncology, 
+National Clinical Research Center for Cancer/Cancer Hospital, National Cancer 
+Center, Chinese Academy of Medical Sciences and Peking Union Medical College, 
+Beijing, 100021, China.
+(3)Department of Radiation Oncology, National Cancer Center, National Clinical 
+Research Center for Cancer/Cancer Hospital & Shenzhen Hospital, Chinese Academy 
+of Medical Sciences and Peking Union Medical College, 113 Baohe Avenue, Longgang 
+District, Shenzhen, 518172, Guangdong, China. jinjing@csco.org.cn.
+
+Small cell carcinoma of the bladder (SCCB) is a rare, highly malignant 
+neuroendocrine tumor. This study attempted to analyze tumor characteristics, 
+treatments and clinical outcomes in China. We conducted a retrospective analysis 
+of patients diagnosed with non-metastatic SCCB at multi-institutions between 
+January 2007 and January 2022. The Kaplan-Meier method was used to calculate 
+survival. A total of 20 patients were included. 10 had localized disease 
+(T1-2N0), and 10 had locally advanced disease (≥ T3 or N+). 13 received local 
+treatment (partial cystectomy or transurethral resection of the bladder tumor) 
+and 7 received radical treatment (radical cystectomy or radiotherapy). A total 
+of 18 patients (90%) received chemotherapy (CT), either neoadjuvant CT (n = 5) 
+or adjuvant CT (n = 13). The median OS for the receiving local treatment was 
+65.3 months (95% CI 0 to 138 months) and the corresponding 1-year, 2-year, and 
+3-year OS was 77%, 54%, and 54%, respectively. The median OS for the receiving 
+radical treatment was not reached and the corresponding 1-year, 2-year, and 
+3-year OS was 100%, 100%, and 75%, respectively. The median PFS for receiving 
+local treatment was 13.8 months (95% CI 9.3 to 18.3 months) and the 
+corresponding 1-year, 2-year, and 3-year PFS was 46%, 31%, and 31%, 
+respectively. The median PFS for the receiving radical treatment was not reached 
+and the corresponding 1-year, 2-year, and 3-year PFS was 83%, 56%, and 56%, 
+respectively. This study reported the largest cohort of non-metastatic SCCB 
+among Chinese population. Given its metastatic potential, CT remained an 
+essential part of the treatment. The survival outcomes of radical cystectomy and 
+RT in non-metastatic SCCB were encouraging.
+
+© 2024. The Author(s).
+
+DOI: 10.1038/s41598-024-75512-z
+PMCID: PMC11491447
+PMID: 39428391 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_39536751.md
+++ b/references_cache/PMID_39536751.md
@@ -1,0 +1,117 @@
+---
+reference_id: "PMID:39536751"
+title: PD-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers.
+authors:
+- Gu Y
+- Ly A
+- Rodriguez S
+- Zhang H
+- Kim J
+- Mao Z
+- Sachdeva A
+- Zomorodian N
+- Pellegrini M
+- Li G
+- Liu S
+- Drakaki A
+- Rettig MB
+- Chin AI
+journal: Cell Rep Med
+year: '2024'
+doi: 10.1016/j.xcrm.2024.101824
+keywords:
+- Humans
+- Male
+- "Prostatic Neoplasms/drug therapy, pathology"
+- "Urinary Bladder Neoplasms/drug therapy, pathology"
+- Cisplatin/therapeutic use
+- Aged
+- Middle Aged
+- "Programmed Cell Death 1 Receptor/antagonists & inhibitors"
+- Antineoplastic Combined Chemotherapy Protocols/therapeutic use
+- "Antibodies, Monoclonal, Humanized/therapeutic use"
+- Female
+- "Carcinoma, Small Cell/drug therapy, pathology"
+- "Carcinoma, Neuroendocrine/drug therapy, pathology, mortality"
+- Immune Checkpoint Inhibitors/therapeutic use
+- Adult
+content_type: abstract_only
+---
+
+# PD-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers.
+**Authors:** Gu Y, Ly A, Rodriguez S, Zhang H, Kim J, Mao Z, Sachdeva A, Zomorodian N, Pellegrini M, Li G, Liu S, Drakaki A, Rettig MB, Chin AI
+**Journal:** Cell Rep Med (2024)
+**DOI:** [10.1016/j.xcrm.2024.101824](https://doi.org/10.1016/j.xcrm.2024.101824)
+
+## Content
+
+1. Cell Rep Med. 2024 Nov 19;5(11):101824. doi: 10.1016/j.xcrm.2024.101824. Epub 
+2024 Nov 12.
+
+PD-1 blockade plus cisplatin-based chemotherapy in patients with small 
+cell/neuroendocrine bladder and prostate cancers.
+
+Gu Y(1), Ly A(2), Rodriguez S(2), Zhang H(2), Kim J(3), Mao Z(4), Sachdeva A(2), 
+Zomorodian N(2), Pellegrini M(5), Li G(6), Liu S(7), Drakaki A(8), Rettig MB(9), 
+Chin AI(10).
+
+Author information:
+(1)Department of Molecular, Cellular and Developmental Biology, University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(2)Department of Urology, David Geffen School of Medicine, University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(3)Department of Biostatistics, Fielding School of Public Health, University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(4)Department of Microbiology, Immunology and Molecular Genetics, University of 
+California, Los Angeles, Los Angeles, CA, USA.
+(5)Department of Molecular, Cellular and Developmental Biology, University of 
+California, Los Angeles, Los Angeles, CA, USA; Jonsson Comprehensive Cancer 
+Center, David Geffen School of Medicine, University of California, Los Angeles, 
+Los Angeles, CA, USA; Eli and Edythe Broad Center of Regenerative Medicine and 
+Stem Cell Research, University of California, Los Angeles, Los Angeles, CA, USA.
+(6)Department of Biostatistics, Fielding School of Public Health, University of 
+California, Los Angeles, Los Angeles, CA, USA; Jonsson Comprehensive Cancer 
+Center, David Geffen School of Medicine, University of California, Los Angeles, 
+Los Angeles, CA, USA.
+(7)Department of Medicine, Division of Hematology and Oncology, David Geffen 
+School of Medicine, University of California Los Angeles, Los Angeles, CA, USA.
+(8)Jonsson Comprehensive Cancer Center, David Geffen School of Medicine, 
+University of California, Los Angeles, Los Angeles, CA, USA; Department of 
+Medicine, Division of Hematology and Oncology, David Geffen School of Medicine, 
+University of California Los Angeles, Los Angeles, CA, USA.
+(9)Jonsson Comprehensive Cancer Center, David Geffen School of Medicine, 
+University of California, Los Angeles, Los Angeles, CA, USA; Department of 
+Medicine, Division of Hematology and Oncology, David Geffen School of Medicine, 
+University of California Los Angeles, Los Angeles, CA, USA; The VA Greater Los 
+Angeles Healthcare System, Los Angeles, CA, USA.
+(10)Department of Urology, David Geffen School of Medicine, University of 
+California, Los Angeles, Los Angeles, CA, USA; Jonsson Comprehensive Cancer 
+Center, David Geffen School of Medicine, University of California, Los Angeles, 
+Los Angeles, CA, USA; Eli and Edythe Broad Center of Regenerative Medicine and 
+Stem Cell Research, University of California, Los Angeles, Los Angeles, CA, USA. 
+Electronic address: arnoldchin@mednet.ucla.edu.
+
+Small cell neuroendocrine cancers share biologic similarities across tissue 
+types, including transient response to platinum-based chemotherapy with rapid 
+progression of disease. We report a phase 1b study of pembrolizumab in 
+combination with platinum-based chemotherapy in 15 patients with stage III-IV 
+small cell bladder (cohort 1) or small cell/neuroendocrine prostate cancers 
+(cohort 2). Overall response rate (ORR) is 43% with two-year overall survival 
+(OS) rate of 86% (95% confidence interval [CI]: 0.63, 1.00) for cohort 1 and 57% 
+(95% CI: 0.30, 1.00) for cohort 2. Treatment is tolerated well with grade 3 or 
+higher adverse events occurring in 40% of patients with no deaths or treatment 
+cessation secondary to toxicity. Single-cell and T cell receptor sequencing of 
+serial peripheral blood samples reveals clonal expansion of diverse T cell 
+repertoire correlating with progression-free survival. Our results demonstrate 
+promising efficacy and safety of this treatment combination and support future 
+investigation of this biomarker. This study was registered at ClinicalTrials.gov 
+(NCT03582475).
+
+Copyright © 2024 The Author(s). Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.xcrm.2024.101824
+PMCID: PMC11604497
+PMID: 39536751 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests The authors declare no 
+competing interests.

--- a/references_cache/PMID_40209138.md
+++ b/references_cache/PMID_40209138.md
@@ -1,0 +1,102 @@
+---
+reference_id: "PMID:40209138"
+title: Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma.
+authors:
+- Jaime-Casas S
+- Chawla NS
+- Salgia NJ
+- Mercier B
+- Govindarajan A
+- Li X
+- Castro DV
+- Ebrahimi H
+- Barragan-Carrillo R
+- Zang PD
+- LeVee A
+- Zugman M
+- Dizman N
+- Hsu J
+- Meza L
+- Zengin Z
+- Chehrazi-Raffle A
+- Dorff T
+- Pal SK
+- Tripathi A
+journal: JCO Precis Oncol
+year: '2025'
+doi: 10.1200/PO-24-00947
+keywords:
+- Humans
+- "Small Cell Lung Carcinoma/genetics, pathology"
+- "Urinary Bladder Neoplasms/genetics, pathology"
+- Male
+- Female
+- "Lung Neoplasms/genetics, pathology"
+- Aged
+- Middle Aged
+- "Carcinoma, Small Cell/genetics, pathology"
+- Genomics
+- "Carcinoma, Transitional Cell/genetics, pathology"
+- Mutation
+- "Aged, 80 and over"
+content_type: abstract_only
+---
+
+# Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma.
+**Authors:** Jaime-Casas S, Chawla NS, Salgia NJ, Mercier B, Govindarajan A, Li X, Castro DV, Ebrahimi H, Barragan-Carrillo R, Zang PD, LeVee A, Zugman M, Dizman N, Hsu J, Meza L, Zengin Z, Chehrazi-Raffle A, Dorff T, Pal SK, Tripathi A
+**Journal:** JCO Precis Oncol (2025)
+**DOI:** [10.1200/PO-24-00947](https://doi.org/10.1200/PO-24-00947)
+
+## Content
+
+1. JCO Precis Oncol. 2025 Apr;9:e2400947. doi: 10.1200/PO-24-00947. Epub 2025 Apr
+ 10.
+
+Comparative Genomic Characterization of Small Cell Carcinoma of the Bladder 
+Compared With Urothelial Carcinoma and Small Cell Lung Carcinoma.
+
+Jaime-Casas S(1), Chawla NS(1), Salgia NJ(2), Mercier B(1), Govindarajan A(3), 
+Li X(1), Castro DV(1), Ebrahimi H(1), Barragan-Carrillo R(1), Zang PD(1), LeVee 
+A(1), Zugman M(1), Dizman N(4), Hsu J(1), Meza L(5), Zengin Z(5), 
+Chehrazi-Raffle A(1), Dorff T(1), Pal SK(1), Tripathi A(1).
+
+Author information:
+(1)Department of Medical Oncology & Experimental Therapeutics, City of Hope 
+Comprehensive Cancer Center, Duarte, CA.
+(2)Department of Immunology, Roswell Park Comprehensive Cancer Center, Buffalo, 
+NY.
+(3)Department of Medicine, Memorial Sloan Kettering Cancer Center, New York 
+City, NY.
+(4)M.D. Anderson Cancer Center, Houston, TX.
+(5)Department of Internal Medicine, Yale University School of Medicine, New 
+Haven, CT.
+
+PURPOSE: Small cell bladder cancer (SCBC) is a rare histologic variant of 
+bladder cancer with an aggressive disease course and poor outcomes. Given its 
+uncommon nature, there is a paucity of high-quality data characterizing genomic 
+drivers of this disease, and most patients are treated with approaches mirroring 
+small cell lung cancer (SCLC). Leveraging the Tempus Lens deidentified 
+clinically annotated genomic data set, we sought to evaluate the mutational 
+landscape of SCBC relative to urothelial carcinoma (UC) and SCLC.
+METHODS: Somatic pathogenic genomic alterations in patients with SCBC, UC, and 
+SCLC of any stage who underwent blood- or tissue-based genomic profiling through 
+the Tempus assay were cataloged. Baseline clinical and demographic features were 
+compared across histologic groups. Alterations were collated and summarized 
+using descriptive statistics. Pairwise comparisons were performed to assess 
+differences in mutation frequency across pathologic cohorts.
+RESULTS: In total, 149 SCBC, 4,350 UC, and 1,697 SCLC patients were included in 
+the study. The most common genomic alterations in SCBC were in TP53 (87%), TERT 
+(75%), and RB1 (70%). Among SCBC patients with TP53 mutations, RB1 comutations 
+were observed in 77% of patients. Compared with UC, SCBC patients were 
+significantly enriched for TP53, RB1, KMT2D, and KDM6A mutations. Compared with 
+SCLC, SCBC patients were enriched for TERT, ARID1A, and CREBBP mutations, among 
+others (P < .05). Multiple clinically targetable mutations were observed in 
+SCBC, including PIK3CA (19%), ERBB2/3 (13%), and ALK (10%). Limitations of this 
+study include its retrospective nature.
+CONCLUSION: This study represents one of the most extensive efforts to 
+characterize SCBC to date, providing a novel understanding of the genomic 
+alterations underlying the disease and revealing actionable mutations that could 
+serve as potential targets for improved clinical outcomes.
+
+DOI: 10.1200/PO-24-00947
+PMID: 40209138 [Indexed for MEDLINE]

--- a/research/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma-deep-research-falcon.md
+++ b/research/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma-deep-research-falcon.md
@@ -1,0 +1,1266 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:01:05.799622'
+end_time: '2026-05-11T11:09:25.434112'
+duration_seconds: 499.63
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Urinary Bladder Small Cell Neuroendocrine Carcinoma
+  mondo_id: ''
+  category: ''
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 30
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Urinary Bladder Small Cell Neuroendocrine Carcinoma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Urinary Bladder Small Cell Neuroendocrine Carcinoma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Urinary Bladder Small Cell Neuroendocrine Carcinoma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Urinary Bladder Small Cell Neuroendocrine Carcinoma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Comprehensive Research Report: Urinary Bladder Small Cell Neuroendocrine Carcinoma (SCCNEC)
+
+## Target Disease
+- **Disease name:** Urinary bladder small cell neuroendocrine carcinoma
+- **Common abbreviations:** SCCB, SCBC, bladder small cell carcinoma
+- **Category:** High-grade neuroendocrine carcinoma (extrapulmonary small cell carcinoma)
+- **MONDO / Orphanet / OMIM / MeSH / ICD-10/ICD-11 identifiers:** Not explicitly available in the retrieved primary texts for this run; therefore, specific codes cannot be asserted with evidence-grade citations here.
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview (what is the disease?)
+Urinary bladder small cell neuroendocrine carcinoma (often termed **small cell carcinoma of the bladder**, SCCB/SCBC) is a **rare, aggressive, poorly differentiated, high-grade neuroendocrine carcinoma** of the urinary bladder that is histomorphologically similar to small cell carcinomas arising in other organs (notably lung). (akbulut2024updatesonurinary pages 1-3, simon2025smallcellcarcinoma pages 4-5)
+
+It comprises **<1% of bladder malignancies/cancers** in multiple authoritative sources. (akbulut2024updatesonurinary pages 1-3, gu2024pd1blockadeplus pages 1-3, simon2025smallcellcarcinoma pages 1-2)
+
+### 1.2 Synonyms / alternative names
+- Small cell carcinoma of the bladder (SCCB) (lu2024treatmentandsurvival pages 1-2, gu2024pd1blockadeplus pages 1-3)
+- Small cell bladder cancer (SCBC) (oh2021smallcellcarcinoma pages 1-2, gu2024pd1blockadeplus pages 1-3)
+- Small cell neuroendocrine carcinoma of the bladder / urinary bladder (NCT05312671 chunk 1, NCT06091124 chunk 1)
+- High-grade neuroendocrine carcinoma (urinary tract), when grouped with LCNEC (NCT06228066 chunk 1)
+
+### 1.3 Aggregated vs individual-patient sources
+The evidence base for SCCB is **predominantly aggregated/retrospective** (population registries, retrospective cohorts, pathology reviews) because of rarity, with relatively few prospective trials. For example, SEER-based incidence analyses (dores2015apopulationbasedstudy pages 1-2) and population-based outcomes cohorts (British Columbia registry) (oh2021smallcellcarcinoma pages 1-2) contrast with smaller multi-center retrospective cohorts (n=20) (lu2024treatmentandsurvival pages 1-2) and early-phase prospective immunotherapy-combination trials (n=15) (gu2024pd1blockadeplus pages 1-3).
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (mechanistic/biologic)
+SCCB is frequently **mixed with urothelial carcinoma (UC)** and is widely interpreted as arising via **divergent differentiation/transdifferentiation from a urothelial precursor**, supported by overlap in genomic features with UC. (akbulut2024updatesonurinary pages 1-3, akbulut2024updatesonurinary pages 3-4)
+
+Genetically, SCCB commonly shows **inactivation of tumor suppressors TP53 and RB1**, a recurring hallmark of small cell carcinomas. (gu2024pd1blockadeplus pages 1-3, akbulut2024updatesonurinary pages 3-4)
+
+### 2.2 Risk factors
+- **Tobacco exposure:** A 2025 review summarizes smoking as the **principal modifiable risk factor**, with **50%–79%** of SCCB patients being current/former smokers. (simon2025smallcellcarcinoma pages 1-2)
+- **Sex/age:** SCCB disproportionately affects **older men**, which functions as a demographic risk correlate. (simon2025smallcellcarcinoma pages 1-2, lu2024treatmentandsurvival pages 1-2)
+
+> Evidence note: SEER-based epidemiology also notes marked male predominance for urinary bladder extrapulmonary small cell carcinoma (male/female IRR 4.91). (dores2015apopulationbasedstudy pages 1-2)
+
+### 2.3 Protective factors
+No evidence for genetic or environmental protective factors specific to SCCB was identified in the retrieved sources.
+
+### 2.4 Gene–environment interactions
+No explicit gene–environment interaction analyses for SCCB (e.g., specific variants interacting with smoking exposure) were identified in the retrieved sources.
+
+---
+
+## 3. Phenotypes (clinical presentation)
+
+### 3.1 Common presenting features
+SCCB often presents similarly to urothelial carcinoma, with hematuria as the dominant symptom.
+- The 2025 review reports **gross or microscopic hematuria in 68%–90%** of patients. (simon2025smallcellcarcinoma pages 4-5)
+- Additional urinary symptoms include **dysuria and frequency**; UTIs and suprapubic discomfort are also noted. (simon2025smallcellcarcinoma pages 4-5)
+- Many patients present with **nodal or metastatic involvement** at diagnosis in some series/reviews. (liao2024emerginginsightsin pages 1-2, simon2025smallcellcarcinoma pages 4-5)
+
+### 3.2 Phenotype characteristics (onset, severity, progression)
+- **Typical onset:** adult/older adult (median age ~73 in SEER-referenced cohorts/reviews). (simon2025smallcellcarcinoma pages 1-2, lu2024treatmentandsurvival pages 1-2)
+- **Severity/progression:** clinically aggressive with early metastasis and relapse after initial chemotherapy response (modeled after SCLC behavior). (gu2024pd1blockadeplus pages 1-3, liao2024emerginginsightsin pages 1-2)
+
+### 3.3 HPO term suggestions (non-exhaustive)
+*(Ontology IDs are provided as standard mappings; the retrieved sources did not themselves provide HPO codes.)*
+- Hematuria — **HP:0000790** (supported by clinical presentation evidence) (simon2025smallcellcarcinoma pages 4-5)
+- Dysuria — **HP:0100584** (simon2025smallcellcarcinoma pages 4-5)
+- Urinary frequency — **HP:0000010** (simon2025smallcellcarcinoma pages 4-5)
+- Recurrent urinary tract infections — **HP:0002719** (simon2025smallcellcarcinoma pages 4-5)
+- Bone pain (via bone metastasis) — **HP:0002653** (metastatic patterns discussed) (lu2024treatmentandsurvival pages 1-2)
+
+### 3.4 Quality-of-life impact
+Specific validated HRQoL instruments (e.g., EQ-5D/SF-36) for SCCB were not found in the retrieved sources. Given frequent hematuria, urinary symptoms, and need for multimodal therapy (cystectomy/chemoradiation), significant QoL impact is expected, but this inference is not quantified in the evidence set.
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes (germline)
+No germline causal genes or Mendelian inheritance patterns are established for SCCB in the retrieved evidence; SCCB is primarily characterized as a **somatic, acquired malignancy**.
+
+### 4.2 Somatic genomic alterations (pathogenic variants in tumors)
+A 2024 pathology review summarizes SCCB genomic features including:
+- **Frequent inactivating TP53 and RB1 mutations** (tumor suppressor loss) (akbulut2024updatesonurinary pages 3-4)
+- **TERT promoter mutations** (akbulut2024updatesonurinary pages 3-4, simon2025smallcellcarcinoma pages 15-16)
+- **Absence of FGFR3 alterations** (contrasting with subsets of urothelial carcinoma) (akbulut2024updatesonurinary pages 3-4)
+- **APOBEC mutational signature** (akbulut2024updatesonurinary pages 3-4)
+- Alterations in epigenetic regulators **ARID1A, KDM6A, CREBBP, EP300** (akbulut2024updatesonurinary pages 3-4)
+- Potentially targetable alterations: **PIK3CA hotspot mutations** and occasional **ERBB2 amplification** (akbulut2024updatesonurinary pages 3-4)
+
+A mechanistic/biologic convergence across small cell carcinomas is also emphasized: the 2024 clinical trial report states small cell carcinomas across tissues share high rates of **TP53 and RB1 inactivation**. (gu2024pd1blockadeplus pages 1-3)
+
+### 4.3 Epigenetic information
+The 2024 pathology review reports that RB protein loss can sometimes reflect **epigenetic RB1 silencing** and highlights alterations in epigenetic regulators (ARID1A, KDM6A, CREBBP, EP300). (akbulut2024updatesonurinary pages 3-4)
+
+### 4.4 Transcriptomic / expression programs
+RNA/miRNA findings summarized in the pathology review include **loss of urothelial differentiation**, **activation of neural/neuroendocrine programs**, dysregulated EMT, and immune-suppressive/pro-metastatic expression profiles. (akbulut2024updatesonurinary pages 3-4)
+
+### 4.5 Molecular subtypes (transcription-factor-defined)
+SCCB heterogeneity has been stratified using transcription factors **ASCL1, NEUROD1, POU2F3**, with reported subgroup frequencies (ASCL1+ 34%, NEUROD1+ 23%, ASCL1+/NEUROD1+ 16%, POU2F3+ 21%, double-negative 6%). (akbulut2024updatesonurinary pages 3-4)
+
+### 4.6 GO (biological process) and CL (cell type) term suggestions
+*(Not explicitly enumerated in the retrieved sources; provided as standard structured suggestions aligned to the evidence.)*
+- GO: neuroendocrine differentiation (general); cell cycle dysregulation (TP53/RB1 loss); epithelial-to-mesenchymal transition (EMT) (akbulut2024updatesonurinary pages 3-4)
+- CL: epithelial cell (urothelial lineage) and neuroendocrine-like tumor cell state (akbulut2024updatesonurinary pages 3-4, akbulut2024updatesonurinary pages 1-3)
+
+---
+
+## 5. Environmental Information
+
+### 5.1 Environmental/lifestyle factors
+Smoking is repeatedly identified as a major modifiable risk factor for SCCB in contemporary reviews. (simon2025smallcellcarcinoma pages 1-2)
+
+No specific occupational toxins, radiation exposures, or infectious triggers were identified in the retrieved SCCB-specific evidence.
+
+---
+
+## 6. Mechanism / Pathophysiology (causal chain)
+
+### 6.1 High-level causal chain (evidence-supported)
+1. **Urothelial precursor tumor** (often conventional urothelial carcinoma component) (akbulut2024updatesonurinary pages 1-3)
+2. Acquisition/selection of a **small-cell neuroendocrine differentiation program** with characteristic morphology and neuroendocrine marker expression (CD56/synaptophysin/chromogranin/INSM1) (akbulut2024updatesonurinary pages 1-3)
+3. Underlying genomic drivers frequently include **TP53/RB1 inactivation** (cell-cycle checkpoint loss) and **TERT promoter mutation** (replicative immortality), plus epigenetic regulator alterations and APOBEC mutagenesis (akbulut2024updatesonurinary pages 3-4, gu2024pd1blockadeplus pages 1-3)
+4. Clinical consequence: **rapid progression, early metastasis, transient chemosensitivity with relapse**, and poor survival in advanced/extensive disease (gu2024pd1blockadeplus pages 1-3, liao2024emerginginsightsin pages 1-2)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/tissue level
+- Primary site: **urinary bladder** (urothelial mucosa and bladder wall). (akbulut2024updatesonurinary pages 1-3)
+- Common metastatic sites noted in SCCB literature synthesized in the 2024 cohort paper include **pelvic/retroperitoneal lymph nodes, liver, and bone**. (lu2024treatmentandsurvival pages 1-2)
+
+### 7.2 UBERON term suggestions
+- Urinary bladder — **UBERON:0001255**
+- Pelvic lymph node (regional nodes) — mapped generally to lymph node structures
+- Liver — **UBERON:0002107**
+- Bone tissue — **UBERON:0001474**
+
+---
+
+## 8. Temporal Development (natural history)
+
+### 8.1 Onset pattern
+Typically presents in older adults (median age ~73 in SEER-referenced cohorts). (simon2025smallcellcarcinoma pages 1-2, lu2024treatmentandsurvival pages 1-2)
+
+### 8.2 Progression and staging concepts
+SCCB is clinically staged using standard bladder cancer staging systems (AJCC TNM), and many expert sources also use a **two-tier limited vs extensive** framework analogous to small cell lung cancer for treatment planning. (lu2024treatmentandsurvival pages 1-2)
+
+The disease often demonstrates initial chemotherapy responses but frequent relapse/progression, motivating multimodal therapy in non-metastatic disease. (gu2024pd1blockadeplus pages 1-3, oh2021smallcellcarcinoma pages 1-2)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology and incidence
+- **Rarity:** SCCB is repeatedly described as <1% of bladder cancers. (akbulut2024updatesonurinary pages 1-3, gu2024pd1blockadeplus pages 1-3, simon2025smallcellcarcinoma pages 1-2)
+- **SEER extrapulmonary small cell carcinoma incidence:** urinary bladder is among the highest-incidence EPSCC sites, **IR 0.7–0.8 per million person-years** in SEER 1992–2010. (dores2015apopulationbasedstudy pages 1-2)
+- **Incidence trend:** SEER-based analysis found the incidence of **small cell carcinoma of the urinary bladder increased** during 1992–2010 with **APC 6.75**. (dores2015apopulationbasedstudy pages 1-2)
+- **Demographics:** male predominance is strong (male/female IRR 4.91 in SEER EPSCC analysis; and male:female ~3:1 in SEER-referenced SCCB cohort summaries). (dores2015apopulationbasedstudy pages 1-2, lu2024treatmentandsurvival pages 1-2)
+
+### 9.2 Inheritance
+SCCB is not described as an inherited disorder in the retrieved evidence; the molecular data emphasize **somatic** alterations (TP53, RB1, TERT promoter, etc.). (akbulut2024updatesonurinary pages 3-4, gu2024pd1blockadeplus pages 1-3)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Biopsy and histopathology
+Diagnosis is based on **histology** showing classic small cell morphology and supported by neuroendocrine-marker immunohistochemistry. (akbulut2024updatesonurinary pages 1-3)
+
+### 10.2 Immunohistochemistry (IHC)
+Typical neuroendocrine markers include **CD56, synaptophysin, chromogranin, and INSM1**. (akbulut2024updatesonurinary pages 1-3)
+
+RB loss by IHC and abnormal p53 staining patterns consistent with TP53 alteration are frequent supportive findings. (akbulut2024updatesonurinary pages 1-3)
+
+### 10.3 Imaging
+Staging commonly uses **contrast-enhanced CT and/or MRI**. A consensus approach described in the 2024 cohort paper includes gadolinium-enhanced MRI or contrast-enhanced CT as part of staging and a limited vs extensive system analogous to SCLC. (lu2024treatmentandsurvival pages 1-2)
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Survival statistics (population-based and cohort)
+- In a British Columbia population-based analysis of localized SCBC (1985–2018; n=77), **5-year OS was 29% (radical cystectomy) vs 39% (radiation)** (p=0.51). (oh2021smallcellcarcinoma pages 1-2)
+- In the same study, among guideline-concordant patients, **5-year OS was 56% (RC) vs 58% (chemoRT)** (p=0.90), and 5-year CSS was 56% vs 71% (p=0.71). (oh2021smallcellcarcinoma pages 1-2)
+- In a 2024 multi-center Chinese non-metastatic SCCB cohort (n=20), reported outcomes were more favorable for radical local treatment: local treatment median OS **65.3 months** vs radical treatment median OS not reached; 3-year OS 54% vs 75%. (lu2024treatmentandsurvival pages 1-2)
+- In extensive disease, the 2024 phase 1b trial background summarizes historical outcomes: **median OS 7–13 months** despite initial 40%–60% responses to etoposide/platinum. (gu2024pd1blockadeplus pages 1-3)
+
+### 11.2 Prognostic factors
+- In localized SCBC, lack of neoadjuvant chemotherapy was associated with worse OS in multivariable modeling in the population cohort. (oh2021smallcellcarcinoma pages 1-2)
+- Molecular subgrouping (e.g., POU2F3/PLCG2 expression) has been associated with poorer PFS/OS in summarized molecular studies. (akbulut2024updatesonurinary pages 3-4)
+
+---
+
+## 12. Treatment
+
+### 12.1 Standard systemic therapy (real-world implementation)
+Because of rarity, SCCB regimens are commonly **extrapolated from small cell lung cancer**, centered on **platinum (cisplatin/carboplatin) + etoposide**, used either as definitive systemic therapy in extensive disease or perioperatively/with chemoradiation in limited disease. (lu2024treatmentandsurvival pages 1-2, gu2024pd1blockadeplus pages 1-3, liao2024emerginginsightsin pages 1-2)
+
+### 12.2 Multimodal local therapy (localized disease)
+Authoritative population-based evidence indicates **radical cystectomy and bladder-conserving chemoradiotherapy can yield comparable long-term outcomes** in localized disease when delivered in guideline-consistent multimodal frameworks. (oh2021smallcellcarcinoma pages 1-2)
+
+### 12.3 Immunotherapy and emerging combinations (recent developments, 2024)
+A notable 2024 development is prospective evidence for adding PD-1 blockade to platinum chemotherapy:
+- **Direct abstract quote:** “We report a phase 1b study of pembrolizumab in combination with platinum-based chemotherapy in 15 patients with stage III-IV small cell bladder (cohort 1) or small cell/neuroendocrine prostate cancers (cohort 2). Overall response rate (ORR) is 43% with two-year overall survival (OS) rate of 86% (95% confidence interval [CI]: 0.63, 1.00) for cohort 1 and 57% (95% CI: 0.30, 1.00) for cohort 2.” (gu2024pd1blockadeplus pages 1-3)
+This trial also reported grade ≥3 adverse events in 40% with no treatment-related deaths and included extensive immune correlative analyses. (gu2024pd1blockadeplus pages 1-3)
+
+### 12.4 Active clinical trials (real-world pipeline)
+Evidence from ClinicalTrials.gov records in this run includes:
+- **NCT05312671**: Atezolizumab + platinum/etoposide followed by cystectomy (localized small cell/neuroendocrine bladder cancer). (NCT05312671 chunk 1)
+- **NCT06091124 (NEOBLAST)**: Neoadjuvant adebrelimab + etoposide/cisplatin followed by radical cystectomy. (NCT06091124 chunk 1)
+- **NCT06228066 (LASER)**: Lurbinectedin ± avelumab in metastatic SCCB/high-grade neuroendocrine urinary tract tumors after platinum/etoposide. (NCT06228066 chunk 1)
+- **NCT06161532 (SMART)**: Sacituzumab govitecan ± atezolizumab in rare metastatic GU tumors including high-grade neuroendocrine carcinomas. (NCT06161532 chunk 1)
+- **NCT00756639**: Prophylactic cranial irradiation (PCI) in small cell carcinoma of the urothelium. (NCT00756639 chunk 1)
+
+### 12.5 MAXO term suggestions (non-exhaustive)
+- Platinum-based chemotherapy (cisplatin/carboplatin + etoposide)
+- Radical cystectomy
+- Radiotherapy / chemoradiotherapy
+- Immune checkpoint inhibitor therapy (PD-1/PD-L1 blockade)
+
+---
+
+## 13. Prevention
+
+### 13.1 Primary prevention
+Given smoking is a major modifiable risk factor, tobacco cessation is the most evidence-supported preventive strategy referenced in SCCB-focused reviews. (simon2025smallcellcarcinoma pages 1-2)
+
+No SCCB-specific screening or chemoprevention strategies were identified in the retrieved sources.
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring SCCB analogs in non-human species were identified in the retrieved evidence.
+
+---
+
+## 15. Model Organisms
+No SCCB-specific animal models or dedicated model organism resources were identified in the retrieved evidence set for this run.
+
+---
+
+## Recent (2023–2024) and Foundational Evidence Summary Tables
+The following evidence-map tables consolidate the most relevant studies and actionable diagnostic/treatment details available in this run.
+
+| Citation (first author, year) | Publication date/month | Study type/data source | Population (n; stage) | Key findings (include incidence/survival/genomics) | URL/DOI | PMID |
+|---|---|---|---|---|---|---|
+| Dores, 2015 | Mar 2015 | Population-based SEER-13 epidemiology/survival study | Small cell carcinoma cases in SEER 1992–2010; EPSCC n=2,438 overall; urinary bladder site-specific analyses; limited vs distant stage | Urinary bladder was among the highest-incidence extrapulmonary small cell carcinoma sites (IR 0.7–0.8 per million person-years); bladder had strong male predominance (male/female IRR 4.91); incidence of urinary bladder small cell carcinoma increased with APC 6.75 during 1992–2010; distant-to-limited stage IRR for bladder was decreased (0.32–0.46); for nearly all sites with distant stage disease, 3-year relative survival was <10% (dores2015apopulationbasedstudy pages 1-2) | https://doi.org/10.1186/s12885-015-1188-y |  |
+| Oh, 2021 | Sep 2021 online; Can Urol Assoc J 2022 | Population-based cohort from British Columbia | Localized SCBC treated with curative intent, n=77; RC n=33, RT n=44; analysis 2 compared RC vs chemoRT per consensus-guideline treatment | Five-year OS was 29% (RC) vs 39% (RT), p=0.51; five-year CSS 35% (RC) vs 52% (RT), p=0.29. In guideline-concordant analysis, 5-year OS was 56% (RC) vs 58% (chemoRT), p=0.90; 5-year CSS 56% vs 71%, p=0.71. Lack of neoadjuvant chemotherapy was associated with worse OS; authors conclude RC and chemoRT offer similar outcomes and NAC should be considered (oh2021smallcellcarcinoma pages 1-2) | https://doi.org/10.5489/cuaj.7411 |  |
+| Akbulut, 2024 | Mar 2024 | Narrative pathology/genomics review | Urinary bladder neuroendocrine tumors; summarizes bladder SMC/LCNEC literature and molecular subgroup data | Reviews that bladder SMC/LCNEC comprise <1% of bladder malignancies; most SMCs are pure or mixed with urothelial carcinoma. Histology: small cells with nuclear molding, high mitoses, necrosis/crush artifact. IHC: CD56, synaptophysin, chromogranin, INSM1; frequent RB loss and mutant-pattern p53. Molecularly, bladder SMC shows higher TMB than conventional urothelial carcinoma, frequent TP53/RB1 inactivation, TERT promoter mutations, APOBEC signature, no FGFR3 alterations, and alterations in ARID1A, KDM6A, CREBBP, EP300; potential targetable events include PIK3CA hotspots and occasional ERBB2 amplifications. Molecular subgroups reported using ASCL1/NEUROD1/POU2F3, with POU2F3 and PLCG2 associated with poorer PFS/OS (akbulut2024updatesonurinary pages 1-3, akbulut2024updatesonurinary pages 3-4) | https://doi.org/10.1097/pap.0000000000000433 |  |
+| Liao, 2024 | Jan 2024 | ASCO Educational Book review/expert synthesis | GU small-cell carcinomas; bladder-focused review drawing on retrospective series and guidelines | States bladder SCC accounts for ~0.48%–2% of bladder cancers; usually presents with gross hematuria and in the majority with nodal/metastatic involvement (~70%). Pathology/IHC parallels SCLC with epithelial and neuroendocrine markers (chromogranin, synaptophysin, INSM1, CD56). Management is multimodal and extrapolated from SCLC, using platinum-based chemotherapy with surgery and/or radiation; untreated 5-year OS is reported as <10%, and advanced disease remains highly lethal (liao2024emerginginsightsin pages 1-2) | https://doi.org/10.1200/edbk_430336 |  |
+| Gu, 2024 | Nov 2024 | Phase 1b clinical trial with correlative biomarker analyses | 15 patients with stage III–IV small cell bladder (cohort 1) or small cell/neuroendocrine prostate cancer (cohort 2) receiving pembrolizumab + platinum chemotherapy | In this mixed bladder/prostate neuroendocrine trial, ORR was 43%; 2-year OS was 86% in cohort 1 and 57% in cohort 2; grade ≥3 adverse events occurred in 40% with no treatment-related deaths. Introductory data summarize SCBC as <1% of bladder cancers, often mixed with urothelial carcinoma (up to 70%), with initial 40%–60% response to etoposide/platinum but median OS 7–13 months in extensive disease. Genomically, SCCs share high rates of TP53 and RB1 inactivation; correlative analyses included PD-L1, TMB, MSI, and targeted 648-gene somatic testing (gu2024pd1blockadeplus pages 1-3, gu2024pd1blockadeplus pages 6-9) | https://doi.org/10.1016/j.xcrm.2024.101824 |  |
+| Lu, 2024 | Oct 2024 | Multi-institution retrospective cohort from China | Non-metastatic SCCB, n=20; localized T1–2N0 n=10, locally advanced ≥T3 or N+ n=10 | SCCB accounts for 0.5%–1.0% of bladder cancers; cites SEER trend from 0.3% to 0.6%, male:female 3:1, median age 73. In the cohort, 90% received chemotherapy (neoadjuvant n=5, adjuvant n=13). Median OS was 65.3 months for local treatment and not reached for radical treatment; 3-year OS 54% vs 75%, respectively. Median PFS was 13.8 months for local treatment and not reached for radical treatment. Review within paper notes historical large series with median OS 11–20.7 months and 3-year OS 33%–37% for all stages; common metastases are pelvic/retroperitoneal nodes, liver, and bone; guidelines recommend platinum/etoposide-based multimodality therapy (lu2024treatmentandsurvival pages 1-2, lu2024treatmentandsurvival pages 7-7) | https://doi.org/10.1038/s41598-024-75512-z |  |
+| Simon, 2025 | Jun 2025 | Comprehensive review of pathogenesis, presentation, and management | Review of SCCB literature; includes institutional/series summaries rather than a single cohort | Defines SCCB as a rare aggressive neuroendocrine malignancy accounting for <1% of bladder cancers; incidence rose from 0.05 to 0.14 per 100,000 between the 1990s and 2000s. Predominantly affects older men (77.8% male; median age 73). Smoking is the principal modifiable risk factor (50%–79% current/former smokers). Common presentation includes gross/microscopic hematuria (68%–90%), dysuria, frequency, suprapubic discomfort; paraneoplastic syndromes are rare. Pure SCCB represents about one-third of cases; most are mixed with urothelial carcinoma. Shared clonal origin with UC is supported by concordant TP53 mutations; review also notes frequent TP53/RB mutations, high TMB, and frequent TERT promoter mutation in SCCB (simon2025smallcellcarcinoma pages 1-2, simon2025smallcellcarcinoma pages 4-5, simon2025smallcellcarcinoma pages 15-16) | https://doi.org/10.1177/23523735251370956 |  |
+
+
+*Table: This table compiles major recent and foundational studies/resources on urinary bladder small cell neuroendocrine carcinoma, emphasizing epidemiology, pathology/genomics, treatment, and survival. It is useful as a quick evidence map for building a disease knowledge base entry and identifying where recent advances complement older population-based outcome data.*
+
+| Domain | Item (test/marker/therapy) | Details | Evidence type | Key quantitative data | Source (first author/year or NCT) | URL/DOI |
+|---|---|---|---|---|---|---|
+| Diagnostic | Histopathology | Small-cell morphology: cells smaller than ~3 lymphocytes, high nuclear-to-cytoplasmic ratio, scant cytoplasm, inconspicuous nucleoli, vesicular chromatin, nuclear molding, frequent mitoses, geographic/single-cell necrosis, crush artifact; growth in solid sheets, trabeculae, acinar patterns (akbulut2024updatesonurinary pages 1-3) | Review | No single performance metric reported | Akbulut 2024 | https://doi.org/10.1097/pap.0000000000000433 |
+| Diagnostic | Immunohistochemistry panel | Typical neuroendocrine markers: CD56, synaptophysin, chromogranin, INSM1; keratin often limited/dot-like perinuclear in SMC; frequent RB loss by IHC and abnormal p53 staining supporting TP53 alteration (akbulut2024updatesonurinary pages 1-3) | Review | No sensitivity/specificity stated; Ki-67 described as high in SMC/LCNEC (akbulut2024updatesonurinary pages 1-3) | Akbulut 2024 | https://doi.org/10.1097/pap.0000000000000433 |
+| Diagnostic | Expanded marker panel | SCCB can express synaptophysin, chromogranin, INSM1, neuron-specific enolase, CD56, pancytokeratin, CK8, CK19; up to 40% may stain TTF-1; electron microscopy may show dense-core neurosecretory granules and desmosomes (simon2025smallcellcarcinoma pages 4-5, gu2024pd1blockadeplus pages 1-3) | Review + trial background | TTF-1 positivity up to 40% (simon2025smallcellcarcinoma pages 4-5) | Simon 2025; Gu 2024 | https://doi.org/10.1177/23523735251370956 ; https://doi.org/10.1016/j.xcrm.2024.101824 |
+| Diagnostic | Molecular/IHC subtype markers | Novel transcription-factor markers NEUROD1, ASCL1, POU2F3 identify subgroups; reported groups: ASCL1+ 34%, NEUROD1+ 23%, ASCL1+/NEUROD1+ 16%, POU2F3+ 21%, double-negative 6%; POU2F3 and PLCG2 associated with worse PFS/OS (akbulut2024updatesonurinary pages 3-4, akbulut2024updatesonurinary pages 1-3) | Review | Subtype proportions: 34%, 23%, 16%, 21%, 6%; PLCG2 expressed in 32% (akbulut2024updatesonurinary pages 3-4) | Akbulut 2024 | https://doi.org/10.1097/pap.0000000000000433 |
+| Diagnostic | Imaging for staging | Recommended staging includes gadolinium-enhanced MRI or contrast-enhanced CT; CT urography commonly used; whole-body FDG PET/CT mentioned for metastatic detection (lu2024treatmentandsurvival pages 1-2, simon2025smallcellcarcinoma pages 15-16) | Cohort/review | CT urography accuracy cited in review: 40%–92% for perivesical invasion and 40%–85% for nodal metastasis (simon2025smallcellcarcinoma pages 4-5) | Lu 2024; Simon 2025 | https://doi.org/10.1038/s41598-024-75512-z ; https://doi.org/10.1177/23523735251370956 |
+| Diagnostic | Genomic profiling | Frequent inactivating TP53 and RB1 mutations, TERT promoter mutations, higher tumor mutation burden than conventional urothelial carcinoma, APOBEC signature; additional alterations in ARID1A, KDM6A, CREBBP, EP300; occasional PIK3CA hotspot mutations and ERBB2 amplification (akbulut2024updatesonurinary pages 3-4, simon2025smallcellcarcinoma pages 15-16) | Review | No test performance metric reported | Akbulut 2024; Simon 2025 | https://doi.org/10.1097/pap.0000000000000433 ; https://doi.org/10.1177/23523735251370956 |
+| Treatment | Platinum-etoposide systemic therapy | Standard frontline approach extrapolated from SCLC: cisplatin or carboplatin plus etoposide for extensive disease; also used neoadjuvantly/adjuvantly in limited disease (lu2024treatmentandsurvival pages 1-2, liao2024emerginginsightsin pages 1-2, gu2024pd1blockadeplus pages 1-3) | Guideline-informed review + cohort + trial background | Initial response rate 40%–60% in SCBC; median OS 7–13 months in extensive disease (gu2024pd1blockadeplus pages 1-3) | Liao 2024; Lu 2024; Gu 2024 | https://doi.org/10.1200/edbk_430336 ; https://doi.org/10.1038/s41598-024-75512-z ; https://doi.org/10.1016/j.xcrm.2024.101824 |
+| Treatment | Multimodal local therapy | For limited/localized disease, reviews/guidelines support concurrent chemoradiotherapy or neoadjuvant chemotherapy followed by local treatment (radical cystectomy or radiotherapy) (lu2024treatmentandsurvival pages 1-2, oh2021smallcellcarcinoma pages 1-2) | Cohort + guideline-informed review | In BC population study, lack of neoadjuvant chemotherapy associated with worse OS; 5-year OS 56% RC vs 58% chemoRT in guideline-concordant patients (oh2021smallcellcarcinoma pages 1-2) | Lu 2024; Oh 2021 | https://doi.org/10.1038/s41598-024-75512-z ; https://doi.org/10.5489/cuaj.7411 |
+| Treatment | Radical cystectomy (RC) | Used after neoadjuvant chemotherapy or as radical local treatment in selected non-metastatic patients (lu2024treatmentandsurvival pages 1-2, oh2021smallcellcarcinoma pages 1-2) | Cohort | Five-year OS 29% and CSS 35% in all curative-intent RC patients; in guideline-concordant subgroup, 5-year OS 56% and CSS 56% (oh2021smallcellcarcinoma pages 1-2) | Oh 2021 | https://doi.org/10.5489/cuaj.7411 |
+| Treatment | Definitive chemoradiotherapy / radiotherapy | Curative-intent RT used with platinum-based chemotherapy for localized disease; consensus-guideline analysis used ~60 Gy EQD2; hypofractionated 45 Gy/15 fractions over 3 weeks and conventional 60–66 Gy regimens referenced; RT dose ≥54 Gy associated with improved OS in cited series (oh2021smallcellcarcinoma pages 1-2, lu2024treatmentandsurvival pages 7-7) | Population cohort + retrospective synthesis | Five-year OS 39% and CSS 52% for all RT patients; in guideline-concordant chemoRT subgroup, 5-year OS 58% and CSS 71% (oh2021smallcellcarcinoma pages 1-2); no OS difference between RC and RT in organ-confined disease in pooled data (26.7 vs 30.0 months) (lu2024treatmentandsurvival pages 7-7) | Oh 2021; Lu 2024 | https://doi.org/10.5489/cuaj.7411 ; https://doi.org/10.1038/s41598-024-75512-z |
+| Treatment | Chinese multi-center real-world treatment | In non-metastatic SCCB, 90% received chemotherapy; 13 had local treatment (PC/TURBT), 7 radical treatment (RC/RT) (lu2024treatmentandsurvival pages 1-2) | Cohort | Local-treatment median OS 65.3 months; radical-treatment median OS not reached; 3-year OS 54% vs 75%; local-treatment median PFS 13.8 months; radical-treatment median PFS not reached (lu2024treatmentandsurvival pages 1-2) | Lu 2024 | https://doi.org/10.1038/s41598-024-75512-z |
+| Treatment | Pembrolizumab + platinum-based chemotherapy | Phase 1b regimen for stage III-IV small cell bladder/prostate neuroendocrine cancers (trial registered NCT03582475); explored immunologic correlates with serial single-cell PBMC analyses (gu2024pd1blockadeplus pages 1-3, gu2024pd1blockadeplus pages 6-9) | Prospective phase 1b trial | ORR 43%; 2-year OS 86% in bladder cohort and 57% in prostate cohort; grade ≥3 adverse events 40%; no treatment-related deaths or cessation due to toxicity (gu2024pd1blockadeplus pages 1-3) | Gu 2024 | https://doi.org/10.1016/j.xcrm.2024.101824 |
+| Treatment | Atezolizumab + platinum + etoposide followed by cystectomy | Ongoing phase II trial in localized small cell/neuroendocrine bladder cancer; atezolizumab 1200 mg day 1 + etoposide 100 mg/m2 days 1–3 + cisplatin 70 mg/m2 day 1 or carboplatin AUC 5 day 1, every 21 days ×4; then cystectomy and atezolizumab maintenance up to 1 year (NCT05312671 chunk 1) | ClinicalTrials.gov | Enrollment 63 planned; primary endpoint pathologic complete response at cystectomy (NCT05312671 chunk 1) | NCT05312671 | https://clinicaltrials.gov/study/NCT05312671 |
+| Treatment | Neoadjuvant adebrelimab + etoposide + cisplatin followed by radical cystectomy | Ongoing phase II single-arm study for neuroendocrine bladder carcinoma; adebrelimab 1200 mg day 1 + etoposide 0.1 g days 1–3 + cisplatin 35 mg/m2 days 1–2 every 21 days for up to 4 cycles, then RC (NCT06091124 chunk 1) | ClinicalTrials.gov | Enrollment 22 planned; primary endpoints: ypCR and safety/tolerability (NCT06091124 chunk 1) | NCT06091124 | https://clinicaltrials.gov/study/NCT06091124 |
+| Treatment | Lurbinectedin ± avelumab (LASER) | Ongoing phase II study in metastatic SCCB/HGNET after prior platinum/etoposide or ineligible/refused; lurbinectedin 3.2 mg/m2 IV q21d ± avelumab 800 mg IV q21d (NCT06228066 chunk 1) | ClinicalTrials.gov | Enrollment 45 planned; primary endpoint ORR; background notes average survival about 1 year and lurbinectedin ORR 35% in second-line SCLC (NCT06228066 chunk 1) | NCT06228066 | https://clinicaltrials.gov/study/NCT06228066 |
+| Treatment | Sacituzumab govitecan ± atezolizumab (SMART) | Ongoing phase II in rare metastatic GU tumors including high-grade neuroendocrine bladder/urinary tract cancers; sacituzumab govitecan 10 mg/kg IV days 1 and 8 q21d ± atezolizumab 1200 mg day 1 q21d (NCT06161532 chunk 1) | ClinicalTrials.gov | Enrollment 60 planned; primary endpoint ORR (NCT06161532 chunk 1) | NCT06161532 | https://clinicaltrials.gov/study/NCT06161532 |
+| Treatment | Prophylactic cranial irradiation (PCI) | Phase II MD Anderson study of whole-brain RT after chemotherapy/surgery in locally advanced/metastatic small cell carcinoma of the urothelium; PCI 30 Gy in 2 Gy fractions over 3 weeks (NCT00756639 chunk 1) | ClinicalTrials.gov | Enrollment 31 actual; primary endpoint brain-metastasis-free survival at 1 year (NCT00756639 chunk 1) | NCT00756639 | https://clinicaltrials.gov/study/NCT00756639 |
+
+
+*Table: This table summarizes evidence-supported diagnostic modalities and current treatment approaches for urinary bladder small cell neuroendocrine carcinoma, including marker panels, staging tools, standard multimodal therapy, and active clinical trials. It is useful as a compact evidence map for clinical and knowledge-base curation.*
+
+---
+
+## Abstract-Supported Key Statistics and Direct Quotes (selected)
+
+1. **SEER EPSCC incidence and trends (direct abstract quote):** “Of the EPSCC sites, urinary bladder, prostate, and uterine cervix had the highest incidence (IRs = 0.7-0.8)… During 1992–2010, significant changes in IRs were observed for… small cell carcinoma of the urinary bladder (APC = 6.75).” (dores2015apopulationbasedstudy pages 1-2)
+
+2. **Prospective immunotherapy + chemotherapy signal (direct abstract quote):** “Overall response rate (ORR) is 43% with two-year overall survival (OS) rate of 86%… for cohort 1…” (pembrolizumab + platinum; SCBC cohort). (gu2024pd1blockadeplus pages 1-3)
+
+3. **Non-metastatic multi-center China cohort (direct abstract quote):** “A total of 20 patients were included… A total of 18 patients (90%) received chemotherapy… The median OS for the receiving local treatment was 65.3 months… The median OS for the receiving radical treatment was not reached…” (lu2024treatmentandsurvival pages 1-2)
+
+---
+
+## Expert synthesis / analysis (evidence-based)
+Across recent authoritative pathology and oncology sources, SCCB is best conceptualized as a **urothelial-lineage malignancy that adopts a small-cell neuroendocrine state**, driven by recurrent **TP53/RB1 loss** and associated molecular programs (loss of urothelial differentiation and activation of neural/neuroendocrine transcriptional programs). (akbulut2024updatesonurinary pages 3-4, akbulut2024updatesonurinary pages 1-3, gu2024pd1blockadeplus pages 1-3)
+
+Clinically, the strongest real-world management pattern is **multimodal therapy** (platinum-etoposide-based systemic therapy integrated with cystectomy or chemoradiation), with population-based evidence showing **comparable long-term survival** for guideline-concordant cystectomy-based vs chemoRT-based strategies in localized disease. (oh2021smallcellcarcinoma pages 1-2)
+
+The most notable 2024 therapeutic development in the retrieved evidence is early-phase prospective support for **checkpoint blockade combined with platinum chemotherapy**, which—if validated—could shift frontline systemic therapy for advanced SCCB toward immunochemotherapy paradigms similar to small cell lung cancer. (gu2024pd1blockadeplus pages 1-3)
+
+
+References
+
+1. (akbulut2024updatesonurinary pages 1-3): Dilara Akbulut and Hikmat Al-Ahmadie. Updates on urinary bladder tumors with neuroendocrine features. Advances In Anatomic Pathology, 31:169-177, Mar 2024. URL: https://doi.org/10.1097/pap.0000000000000433, doi:10.1097/pap.0000000000000433. This article has 12 citations and is from a domain leading peer-reviewed journal.
+
+2. (simon2025smallcellcarcinoma pages 4-5): Nicholas I Simon, Andre R Kydd, Dilara Akbulut, David Takeda, Jaydira Del Rivero, Maria Merino, Bernadette Redd, Liza Lindenberg, Esther Mena, Elias Chandran, Sandeep Gurram, Salah Boudjadi, Scot Niglio, Parth Sharma, Anish Thomas, and Andrea B Apolo. Small cell carcinoma of the bladder: review of pathogenesis, presentation, and management. Bladder Cancer, Jun 2025. URL: https://doi.org/10.1177/23523735251370956, doi:10.1177/23523735251370956. This article has 1 citations.
+
+3. (gu2024pd1blockadeplus pages 1-3): Yiqian Gu, Ann Ly, Sara Rodriguez, Hanwei Zhang, Jiyoon Kim, Zhiyuan Mao, Ankush Sachdeva, Nazy Zomorodian, Matteo Pellegrini, Gang Li, Sandy Liu, Alexandra Drakaki, Matthew B. Rettig, and Arnold I. Chin. Pd-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers. Cell Reports Medicine, 5:101824, Nov 2024. URL: https://doi.org/10.1016/j.xcrm.2024.101824, doi:10.1016/j.xcrm.2024.101824. This article has 16 citations and is from a peer-reviewed journal.
+
+4. (simon2025smallcellcarcinoma pages 1-2): Nicholas I Simon, Andre R Kydd, Dilara Akbulut, David Takeda, Jaydira Del Rivero, Maria Merino, Bernadette Redd, Liza Lindenberg, Esther Mena, Elias Chandran, Sandeep Gurram, Salah Boudjadi, Scot Niglio, Parth Sharma, Anish Thomas, and Andrea B Apolo. Small cell carcinoma of the bladder: review of pathogenesis, presentation, and management. Bladder Cancer, Jun 2025. URL: https://doi.org/10.1177/23523735251370956, doi:10.1177/23523735251370956. This article has 1 citations.
+
+5. (lu2024treatmentandsurvival pages 1-2): Jiawei Lu, Jiaomei Zhou, Yueping Liu, Yexiong Li, Yuan Tang, Ning Li, Shulian Wang, Yongwen Song, Wenjue Zhang, Xiaoyong Xiang, and Jing Jin. Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in china. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-75512-z, doi:10.1038/s41598-024-75512-z. This article has 3 citations and is from a peer-reviewed journal.
+
+6. (oh2021smallcellcarcinoma pages 1-2): Justin Oh, Bernhard Eigl, Peter C. Black, Tom Pickles, Carlos Villamil, Katherine Sunderland, and Scott Tyldesley. Small cell carcinoma of the bladder: a population-based analysis of long-term outcomes after radical cystectomy and bladder conservation with chemoradiotherapy. Canadian Urological Association Journal, Jul 2021. URL: https://doi.org/10.5489/cuaj.7411, doi:10.5489/cuaj.7411. This article has 0 citations.
+
+7. (NCT05312671 chunk 1):  Atezolizumab Plus Etoposide and Platinum in Small Cell Bladder Cancer. Sidney Kimmel Comprehensive Cancer Center at Johns Hopkins. 2022. ClinicalTrials.gov Identifier: NCT05312671
+
+8. (NCT06091124 chunk 1):  Neoadjuvant Adebrelimab Plus Etoposide and Cisplatin in Neuroendocrine Bladder Carcinoma. RenJi Hospital. 2023. ClinicalTrials.gov Identifier: NCT06091124
+
+9. (NCT06228066 chunk 1):  Lurbinectedin With or Without Avelumab in Small Cell Carcinoma of the Bladder (LASER). National Cancer Institute (NCI). 2024. ClinicalTrials.gov Identifier: NCT06228066
+
+10. (dores2015apopulationbasedstudy pages 1-2): Graça M Dores, Osama Qubaiah, Ankur Mody, Bassam Ghabach, and Susan S Devesa. A population-based study of incidence and patient survival of small cell carcinoma in the united states, 1992–2010. BMC Cancer, Mar 2015. URL: https://doi.org/10.1186/s12885-015-1188-y, doi:10.1186/s12885-015-1188-y. This article has 54 citations and is from a peer-reviewed journal.
+
+11. (akbulut2024updatesonurinary pages 3-4): Dilara Akbulut and Hikmat Al-Ahmadie. Updates on urinary bladder tumors with neuroendocrine features. Advances In Anatomic Pathology, 31:169-177, Mar 2024. URL: https://doi.org/10.1097/pap.0000000000000433, doi:10.1097/pap.0000000000000433. This article has 12 citations and is from a domain leading peer-reviewed journal.
+
+12. (liao2024emerginginsightsin pages 1-2): Ross S. Liao, Hui Ting Ruan, Albert Jang, Melissa Huynh, Rosa Nadal Rios, Jean H. Hoffman-Censits, Shuanzeng Wei, Omar Y. Mian, and Pedro C. Barata. Emerging insights in small-cell carcinoma of the genitourinary tract: from diagnosis to novel therapeutic horizons. American Society of Clinical Oncology educational book. American Society of Clinical Oncology. Annual Meeting, 44:e430336, Jan 2024. URL: https://doi.org/10.1200/edbk\_430336, doi:10.1200/edbk\_430336. This article has 12 citations.
+
+13. (simon2025smallcellcarcinoma pages 15-16): Nicholas I Simon, Andre R Kydd, Dilara Akbulut, David Takeda, Jaydira Del Rivero, Maria Merino, Bernadette Redd, Liza Lindenberg, Esther Mena, Elias Chandran, Sandeep Gurram, Salah Boudjadi, Scot Niglio, Parth Sharma, Anish Thomas, and Andrea B Apolo. Small cell carcinoma of the bladder: review of pathogenesis, presentation, and management. Bladder Cancer, Jun 2025. URL: https://doi.org/10.1177/23523735251370956, doi:10.1177/23523735251370956. This article has 1 citations.
+
+14. (NCT06161532 chunk 1):  Sacituzumab Govitecan With or Without Atezolizumab Immunotherapy in Rare Genitourinary Tumors (SMART) Such as High Grade Neuroendocrine Carcinomas, Adenocarcinoma, and Squamous Cell Bladder/Urinary Tract Cancer, Renal Medullary Carcinoma and Penile C.... National Cancer Institute (NCI). 2024. ClinicalTrials.gov Identifier: NCT06161532
+
+15. (NCT00756639 chunk 1):  Prophylactic Cranial Irradiation (PCI) for Small Cell Carcinoma of the Urothelium. M.D. Anderson Cancer Center. 2008. ClinicalTrials.gov Identifier: NCT00756639
+
+16. (gu2024pd1blockadeplus pages 6-9): Yiqian Gu, Ann Ly, Sara Rodriguez, Hanwei Zhang, Jiyoon Kim, Zhiyuan Mao, Ankush Sachdeva, Nazy Zomorodian, Matteo Pellegrini, Gang Li, Sandy Liu, Alexandra Drakaki, Matthew B. Rettig, and Arnold I. Chin. Pd-1 blockade plus cisplatin-based chemotherapy in patients with small cell/neuroendocrine bladder and prostate cancers. Cell Reports Medicine, 5:101824, Nov 2024. URL: https://doi.org/10.1016/j.xcrm.2024.101824, doi:10.1016/j.xcrm.2024.101824. This article has 16 citations and is from a peer-reviewed journal.
+
+17. (lu2024treatmentandsurvival pages 7-7): Jiawei Lu, Jiaomei Zhou, Yueping Liu, Yexiong Li, Yuan Tang, Ning Li, Shulian Wang, Yongwen Song, Wenjue Zhang, Xiaoyong Xiang, and Jing Jin. Treatment and survival of non-metastatic small cell carcinoma of the bladder from multiple centers in china. Scientific Reports, Oct 2024. URL: https://doi.org/10.1038/s41598-024-75512-z, doi:10.1038/s41598-024-75512-z. This article has 3 citations and is from a peer-reviewed journal.

--- a/research/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma-deep-research-falcon.md.citations.md
+++ b/research/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma-deep-research-falcon.md.citations.md
@@ -1,0 +1,481 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Urinary Bladder Small Cell Neuroendocrine Carcinoma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Urinary Bladder Small Cell Neuroendocrine Carcinoma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T11:09:25.434112
+
+1. dores2015apopulationbasedstudy pages 1-2
+2. oh2021smallcellcarcinoma pages 1-2
+3. lu2024treatmentandsurvival pages 1-2
+4. simon2025smallcellcarcinoma pages 1-2
+5. simon2025smallcellcarcinoma pages 4-5
+6. akbulut2024updatesonurinary pages 3-4
+7. akbulut2024updatesonurinary pages 1-3
+8. liao2024emerginginsightsin pages 1-2
+9. lu2024treatmentandsurvival pages 7-7
+10. simon2025smallcellcarcinoma pages 15-16
+11. CI
+12. https://doi.org/10.1186/s12885-015-1188-y
+13. https://doi.org/10.5489/cuaj.7411
+14. https://doi.org/10.1097/pap.0000000000000433
+15. https://doi.org/10.1200/edbk_430336
+16. https://doi.org/10.1016/j.xcrm.2024.101824
+17. https://doi.org/10.1038/s41598-024-75512-z
+18. https://doi.org/10.1177/23523735251370956
+19. https://clinicaltrials.gov/study/NCT05312671
+20. https://clinicaltrials.gov/study/NCT06091124
+21. https://clinicaltrials.gov/study/NCT06228066
+22. https://clinicaltrials.gov/study/NCT06161532
+23. https://clinicaltrials.gov/study/NCT00756639
+24. https://doi.org/10.1097/pap.0000000000000433,
+25. https://doi.org/10.1177/23523735251370956,
+26. https://doi.org/10.1016/j.xcrm.2024.101824,
+27. https://doi.org/10.1038/s41598-024-75512-z,
+28. https://doi.org/10.5489/cuaj.7411,
+29. https://doi.org/10.1186/s12885-015-1188-y,
+30. https://doi.org/10.1200/edbk\_430336,


### PR DESCRIPTION
## Summary

- Adds a new DISMECH page for urinary bladder small cell neuroendocrine carcinoma (MONDO:0004114).
- Integrates Falcon deep research findings on neuroendocrine histology, TP53/RB1 alterations, clinical presentation, and multimodality treatment.
- Adds fetched PubMed reference caches for every cited PMID and includes the Falcon report artifacts.

## Validation

- `just validate kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml`
- `just validate-references kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml`
- `just validate-terms kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml`
- `just compliance kb/disorders/Urinary_Bladder_Small_Cell_Neuroendocrine_Carcinoma.yaml` (weighted compliance 92.0%)

## Notes

- Restored tracked generated `cache/*` churn and unrelated `references_cache/clinicaltrials_NCT*.md` churn before staging.
- Staged only the disorder YAML, Falcon research artifacts, and cited PMID cache files.