### PR TITLE
[codex] Link FH LDL-C endpoints

### DIFF
--- a/kb/disorders/Familial_Hypercholesterolemia.yaml
+++ b/kb/disorders/Familial_Hypercholesterolemia.yaml
@@ -684,12 +684,6 @@ biochemical:
       lipid-lowering therapy reports pharmacodynamic suppression of the central
       FH lipid-abnormality node.
     evidence:
-    - reference: PMID:29219151
-      reference_title: "Familial hypercholesterolaemia."
-      supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
-      snippet: "Familial hypercholesterolaemia is a common inherited disorder characterized by abnormally elevated serum levels of low-density lipoprotein (LDL) cholesterol from birth, which in time can lead to cardiovascular disease (CVD)."
-      explanation: Review links serum LDL-C elevation to the central FH disease mechanism and downstream cardiovascular disease.
     - reference: PMID:32197277
       reference_title: "Inclisiran for the Treatment of Heterozygous Familial Hypercholesterolemia."
       supports: SUPPORT

--- a/kb/disorders/Familial_Hypercholesterolemia.yaml
+++ b/kb/disorders/Familial_Hypercholesterolemia.yaml
@@ -1,6 +1,6 @@
 name: Familial Hypercholesterolemia
 creation_date: "2026-03-06T00:00:00Z"
-updated_date: "2026-05-09T19:29:45Z"
+updated_date: "2026-05-11T15:27:00Z"
 description: >
   Familial hypercholesterolemia (FH) is a common autosomal dominant disorder of
   lipid metabolism characterized by significantly elevated serum low-density
@@ -659,6 +659,50 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "Individuals with a more severe phenotype, often as a result of biallelic variants, can present with very significant elevations in LDL-C (>500 mg/dL), early-onset coronary artery disease (CAD; presenting as early as childhood in some), and calcific aortic valve disease."
     explanation: Supports a distinct valvular deposition branch in severe FH.
+biochemical:
+- name: Serum LDL cholesterol
+  presence: Elevated
+  context: Core circulating lipid marker used diagnostically and as a pharmacodynamic endpoint for LDL-lowering therapy in FH.
+  biomarker_term:
+    preferred_term: Low Density Lipoprotein Cholesterol Measurement
+    term:
+      id: NCIT:C105588
+      label: Low Density Lipoprotein Cholesterol Measurement
+  readouts:
+  - target: Elevated Circulating LDL Cholesterol
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-042
+    - FDA-SE-adult-noncancer-043
+    - FDA-SE-pediatric-noncancer-030
+    - FDA-SE-pediatric-noncancer-031
+    interpretation: >-
+      Higher serum LDL-C reflects greater circulating LDL burden; LDL-C
+      reduction during statin, PCSK9-targeted, ANGPTL3-targeted, or other
+      lipid-lowering therapy reports pharmacodynamic suppression of the central
+      FH lipid-abnormality node.
+    evidence:
+    - reference: PMID:29219151
+      reference_title: "Familial hypercholesterolaemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Familial hypercholesterolaemia is a common inherited disorder characterized by abnormally elevated serum levels of low-density lipoprotein (LDL) cholesterol from birth, which in time can lead to cardiovascular disease (CVD)."
+      explanation: Review links serum LDL-C elevation to the central FH disease mechanism and downstream cardiovascular disease.
+    - reference: PMID:32197277
+      reference_title: "Inclisiran for the Treatment of Heterozygous Familial Hypercholesterolemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Among adults with heterozygous familial hypercholesterolemia, those who received inclisiran had significantly lower levels of LDL cholesterol than those who received placebo, with an infrequent dosing regimen and an acceptable safety profile."
+      explanation: Phase 3 data supports LDL-C as a treatment-responsive pharmacodynamic readout in HeFH.
+  evidence:
+  - reference: PMID:29219151
+    reference_title: "Familial hypercholesterolaemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Familial hypercholesterolaemia is a common inherited disorder characterized by abnormally elevated serum levels of low-density lipoprotein (LDL) cholesterol from birth, which in time can lead to cardiovascular disease (CVD)."
+    explanation: Review supports elevated serum LDL cholesterol as the defining circulating biomarker in FH.
 phenotypes:
 - category: Metabolic
   name: Hypercholesterolemia

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1050,7 +1050,7 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with heterozygous familial
     and nonfamilial hypercholesterolemia; endpoint: Serum LDL cholesterol; approval context: traditional;
     drug mechanism: Lipid-lowering.'
-  mapping_status: CURATED_DISMECH_MAPPING
+  mapping_status: CANDIDATE_DISMECH_MAPPING
   mapped_diseases:
   - Familial Hypercholesterolemia
   mapped_disease_files:

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1050,8 +1050,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with heterozygous familial
     and nonfamilial hypercholesterolemia; endpoint: Serum LDL cholesterol; approval context: traditional;
     drug mechanism: Lipid-lowering.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: >-
+    Curated familial-component mapping: serum LDL cholesterol is linked to the
+    FH elevated circulating LDL cholesterol pathograph node. The FDA population
+    also includes nonfamilial hypercholesterolemia, which can be linked to the
+    broad Hyperlipidemia entry in a separate non-conflicting batch.
 - row_id: FDA-SE-adult-noncancer-043
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1072,8 +1080,15 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with homozygous familial hypercholesterolemia;
     endpoint: Serum LDL cholesterol; approval context: traditional; drug mechanism: Lipid-lowering.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: serum LDL cholesterol is linked to the FH
+    elevated circulating LDL cholesterol pathograph node and lipid-lowering
+    pharmacodynamics in homozygous familial hypercholesterolemia.
 - row_id: FDA-SE-adult-noncancer-044
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4400,8 +4415,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: HeFH- heterozygous familial hypercholesterolemia; population: Patients
     with heterozygous familial hypercholesterolemia; endpoint: Serum LDL-C; approval context: traditional;
     drug mechanism: Lipid-lowering; age range: 12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: pediatric HeFH serum LDL-C is linked to the
+    FH elevated circulating LDL cholesterol pathograph node and lipid-lowering
+    pharmacodynamics.
 - row_id: FDA-SE-pediatric-noncancer-031
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4425,8 +4447,15 @@ surrogate_endpoints:
     homozygous familial hypercholesterolemia; endpoint: Serum LDL-C; approval context: traditional; drug
     mechanism: angiopoietin-like 3 (ANGPTL3) inhibitor; siRNA targeted at PCSK9; age range: 1 to 4 years;
     12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Familial Hypercholesterolemia
+  mapped_disease_files:
+  - kb/disorders/Familial_Hypercholesterolemia.yaml
+  mapping_notes: >-
+    Curated disease-level mapping: pediatric HoFH serum LDL-C is linked to the
+    FH elevated circulating LDL cholesterol pathograph node and ANGPTL3/PCSK9-
+    targeted lipid-lowering pharmacodynamics.
 - row_id: FDA-SE-pediatric-noncancer-032
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- added a Familial Hypercholesterolemia `biochemical` marker for elevated serum LDL cholesterol
- annotated the marker with `NCIT:C105588` and linked it to the existing `Elevated Circulating LDL Cholesterol` pathograph node as a pharmacodynamic readout
- mapped FDA LDL-C endpoint rows `FDA-SE-adult-noncancer-042`, `FDA-SE-adult-noncancer-043`, `FDA-SE-pediatric-noncancer-030`, and `FDA-SE-pediatric-noncancer-031` to `kb/disorders/Familial_Hypercholesterolemia.yaml`

Note: `FDA-SE-adult-noncancer-042` also includes nonfamilial hypercholesterolemia. This PR links the familial component only; I left the broad `Hyperlipidemia.yaml` file untouched to avoid conflicting with the approved hypertriglyceridemia endpoint PR.

## Validation

- `just validate kb/disorders/Familial_Hypercholesterolemia.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`