### PR TITLE
Add MPDU1-CDG curation

### DIFF
--- a/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
@@ -1,0 +1,641 @@
+name: MPDU1-congenital disorder of glycosylation
+creation_date: "2026-05-11T14:53:11Z"
+updated_date: "2026-05-11T14:53:11Z"
+description: >-
+  MPDU1-congenital disorder of glycosylation is an ultra-rare autosomal
+  recessive congenital disorder of glycosylation caused by biallelic pathogenic
+  variants in MPDU1. MPDU1 deficiency disrupts utilization of
+  dolichol-phosphate-linked mannose and glucose donors in the endoplasmic
+  reticulum, producing a CDG type I pattern with overlapping
+  dystroglycanopathy-like manifestations.
+category: Mendelian
+parents:
+- hereditary disease
+synonyms:
+- CDG-If
+- MPDU1-CDG
+- congenital disorder of glycosylation type If
+- mannose-P-dolichol utilization defect 1
+disease_term:
+  preferred_term: MPDU1-congenital disorder of glycosylation
+  term:
+    id: MONDO:0012211
+    label: MPDU1-congenital disorder of glycosylation
+inheritance:
+- name: Autosomal recessive inheritance
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  description: >-
+    MPDU1-CDG is caused by biallelic pathogenic MPDU1 variants; reported cases
+    include homozygous variants in consanguineous families and compound
+    heterozygosity.
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The two patients are brother and sister from Iraqi origin. They were the third and fourth child of consanguineous parents (first cousins), and had two healthy sisters (Figure 1A).
+    explanation: >-
+      The affected siblings from consanguineous parents support autosomal
+      recessive inheritance in this MPDU1-CDG family.
+  - reference: PMID:11733564
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Sequence analysis of the Lec35/MPDU1 gene, known to be involved in the use of dolichylphosphomannose and dolichylphosphoglucose, revealed mutations in all three patients.
+    explanation: >-
+      This original case series identified MPDU1 variants in multiple affected
+      patients with CDG-I.
+pathophysiology:
+- name: MPDU1-dependent dolichol-linked donor utilization defect
+  description: >-
+    MPDU1 loss impairs use of dolichol-phosphate-mannose and
+    dolichol-phosphate-glucose donor substrates required for ER glycosylation
+    reactions.
+  genes:
+  - preferred_term: MPDU1
+    term:
+      id: hgnc:7207
+      label: MPDU1
+  biological_processes:
+  - preferred_term: protein N-linked glycosylation
+    term:
+      id: GO:0006487
+      label: protein N-linked glycosylation
+  - preferred_term: protein O-linked glycosylation via mannose
+    term:
+      id: GO:0035269
+      label: protein O-linked glycosylation via mannose
+  - preferred_term: GPI anchor biosynthetic process
+    term:
+      id: GO:0006506
+      label: GPI anchor biosynthetic process
+  evidence:
+  - reference: PMID:11733556
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      CDG-If is caused by a defect in the gene MPDU1, the human homologue of hamster Lec35, and is the first disorder to affect the use, rather than the biosynthesis, of donor substrates for lipid-linked oligosaccharides.
+    explanation: >-
+      The original mechanistic report directly places MPDU1 upstream of
+      dolichol-linked donor utilization rather than donor synthesis.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Mannose-phosphate-dolichol utilization defect 1 (MPDU1) plays a role in the utilization of DPM.
+    explanation: >-
+      The later clinical report confirms the mechanistic role of MPDU1 in DPM
+      utilization.
+  downstream:
+  - target: Truncated lipid-linked oligosaccharide accumulation
+    description: >-
+      Impaired donor utilization produces incomplete lipid-linked
+      oligosaccharide precursors.
+- name: Truncated lipid-linked oligosaccharide accumulation
+  description: >-
+    Patient cells accumulate incomplete lipid-linked oligosaccharides for
+    N-linked glycosylation, leading to systemic protein hypoglycosylation.
+  biological_processes:
+  - preferred_term: protein N-linked glycosylation
+    term:
+      id: GO:0006487
+      label: protein N-linked glycosylation
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:11733564
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Serum transferrin was hypoglycosylated and patients' fibroblasts accumulated incomplete lipid-linked oligosaccharide precursors for N-linked protein glycosylation.
+    explanation: >-
+      This abstract directly supports the biochemical intermediate node in
+      patient fibroblasts and serum.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Biochemical analyses revealed elevated disialotransferrin in serum, and analyses in fibroblasts showed shortened lipid linked oligosaccharides and DPM, and reduced O-mannosylation of αDG.
+    explanation: >-
+      Patient material showed abnormal transferrin, shortened lipid-linked
+      oligosaccharides, and reduced alpha-dystroglycan O-mannosylation.
+  downstream:
+  - target: Reduced alpha-dystroglycan O-mannosylation
+    description: >-
+      MPDU1-CDG can bridge CDG-I and dystroglycanopathy biology through
+      impaired alpha-dystroglycan glycosylation.
+  - target: Global developmental delay
+    description: >-
+      Systemic glycosylation failure contributes to severe neurologic
+      impairment.
+  - target: Cardiomyopathy
+    description: >-
+      Glycosylation failure and reduced alpha-dystroglycan O-mannosylation may
+      contribute to cardiomyopathy in severe MPDU1-CDG.
+- name: Reduced alpha-dystroglycan O-mannosylation
+  description: >-
+    MPDU1-CDG patient fibroblasts can show reduced functional
+    alpha-dystroglycan glycosylation, explaining overlap with
+    dystroglycanopathy features such as elevated creatine kinase, eye disease,
+    and cardiomyopathy.
+  biological_processes:
+  - preferred_term: protein O-linked glycosylation via mannose
+    term:
+      id: GO:0035269
+      label: protein O-linked glycosylation via mannose
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Subsequently, we analyzed the O‐mannosylation of αDG in fibroblasts of patient P1 by IIH6 immunolabeling and a LO assay.
+    explanation: >-
+      This describes direct testing of alpha-dystroglycan O-mannosylation in
+      patient fibroblasts.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We found that the signals for both IIH6 and LO were reduced in patient fibroblasts as compared to the signal of control fibroblasts (Figure 2C), suggesting reduced glycosylation of αDG.
+    explanation: >-
+      Reduced IIH6 and laminin-overlay signals directly support reduced
+      functional alpha-dystroglycan glycosylation.
+  downstream:
+  - target: Cardiomyopathy
+    description: >-
+      Dystroglycanopathy overlap may contribute to dilated or hypertrophic
+      cardiomyopathy.
+  - target: Buphthalmos
+    description: >-
+      Eye abnormalities overlap with severe dystroglycanopathy phenotypes.
+phenotypes:
+- name: Global developmental delay
+  category: Neurologic
+  description: >-
+    Severe psychomotor and global developmental impairment is a core feature of
+    MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: PMID:11733556
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient has severe psychomotor retardation, seizures, failure to thrive, dry skin and scaling with erythroderma, and impaired vision.
+    explanation: >-
+      The first CDG-If report directly describes severe psychomotor
+      retardation.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      So far, seven MPDU1‐CDG patients have been described. All patients showed psychomotor retardation and most patients had hypotonia, facial dysmorphism, eye defects, apnea, and skin abnormalities such as ichthyosis.
+    explanation: >-
+      This later report summarizes psychomotor retardation across all reported
+      MPDU1-CDG patients at that time.
+- name: Generalized hypotonia
+  category: Neurologic
+  description: >-
+    Hypotonia is a frequent early neurologic and neuromuscular manifestation.
+  phenotype_term:
+    preferred_term: Generalized hypotonia
+    term:
+      id: HP:0001290
+      label: Generalized hypotonia
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, we report two MPDU1-CDG patients without skin involvement, but with massive dilatation of the biliary duct system and dystroglycanopathy characteristics including hypotonia, elevated creatine kinase, dilated cardiomyopathy, buphthalmos, and congenital glaucoma.
+    explanation: >-
+      This disease-specific case report directly lists hypotonia among
+      MPDU1-CDG dystroglycanopathy-overlap features.
+- name: Seizure
+  category: Neurologic
+  description: >-
+    Seizures occur in severe MPDU1-CDG and may be associated with apnea and
+    respiratory decompensation.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:11733556
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient has severe psychomotor retardation, seizures, failure to thrive, dry skin and scaling with erythroderma, and impaired vision.
+    explanation: >-
+      The original MPDU1-CDG report directly lists seizures.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      At the age of 2 months, P1 showed tonic‐clonic seizures with multifocal sharp waves on electroencephalography (EEG).
+    explanation: >-
+      This case description supports early-onset seizures in MPDU1-CDG.
+- name: Failure to thrive
+  category: Growth
+  description: >-
+    Failure to thrive and feeding difficulty can occur in MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: PMID:11733556
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient has severe psychomotor retardation, seizures, failure to thrive, dry skin and scaling with erythroderma, and impaired vision.
+    explanation: >-
+      Failure to thrive is directly reported in the original patient.
+- name: Ichthyosis
+  category: Dermatologic
+  description: >-
+    Dry, scaling skin or ichthyosis is reported in some MPDU1-CDG patients but
+    can be absent in the severe siblings described in 2019.
+  phenotype_term:
+    preferred_term: Ichthyosis
+    term:
+      id: HP:0008064
+      label: Ichthyosis
+  evidence:
+  - reference: PMID:31741824
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All patients showed psychomotor retardation and most patients had hypotonia, facial dysmorphism, eye defects, apnea, and skin abnormalities such as ichthyosis.
+    explanation: >-
+      This supports ichthyosis or related skin abnormalities as common but not
+      universal in MPDU1-CDG.
+- name: Buphthalmos
+  category: Ophthalmologic
+  description: >-
+    Buphthalmos with congenital glaucoma has been reported in severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Buphthalmos
+    term:
+      id: HP:0000557
+      label: Buphthalmos
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ophthalmological examination revealed a buphthalmos with slightly opaque corneae with a diameter of 11 mm and severe congenital glaucoma, requiring prompt trabeculectomy intervention.
+    explanation: >-
+      This directly supports buphthalmos and severe congenital glaucoma in the
+      second affected sibling.
+- name: Glaucoma
+  category: Ophthalmologic
+  description: >-
+    Congenital glaucoma can accompany buphthalmos in MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Glaucoma
+    term:
+      id: HP:0000501
+      label: Glaucoma
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The megalocorneae possessed a diameter of 13 mm (normal in newborn = 9.5 mm). Further ophthalmologic examination revealed a buphthalmos with congenital glaucoma.
+    explanation: >-
+      This directly supports congenital glaucoma in an affected MPDU1-CDG
+      patient.
+- name: Hearing impairment
+  category: Audiologic
+  description: >-
+    Sensorineural hearing loss has been reported in severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Hearing impairment
+    term:
+      id: HP:0000365
+      label: Hearing impairment
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A sensorineural hearing loss was identified with brainstem evoked response audiometry (BERA) evaluation.
+    explanation: >-
+      This supports hearing impairment identified by BERA in an MPDU1-CDG
+      patient.
+- name: Cardiomyopathy
+  category: Cardiovascular
+  description: >-
+    MPDU1-CDG can include cardiomyopathy, with dilated cardiomyopathy and
+    hypertrophic cardiomyopathy both reported in severe siblings.
+  phenotype_term:
+    preferred_term: Cardiomyopathy
+    term:
+      id: HP:0001638
+      label: Cardiomyopathy
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Echocardiography detected a dilated aorta ascendens, a transient pulmonary hypertension, and a hypertrophic cardiomyopathy (HCM) at the age of 3 weeks, which developed in combination with an arterial hypertension.
+    explanation: >-
+      This directly supports hypertrophic cardiomyopathy in one severe
+      MPDU1-CDG patient.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      At the age of 3 months, the patient evolved DCM with low output and a shortening fraction of at least 9%.
+    explanation: >-
+      This directly supports dilated cardiomyopathy in the affected sister.
+- name: Elevated circulating creatine kinase concentration
+  category: Musculoskeletal
+  description: >-
+    Elevated creatine kinase is part of the dystroglycanopathy-overlap phenotype.
+  phenotype_term:
+    preferred_term: Elevated circulating creatine kinase concentration
+    term:
+      id: HP:0003236
+      label: Elevated circulating creatine kinase concentration
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Blood CK levels were elevated up to 3090 U/L without substantial elevation of aspartate amino transferases (maximal 175 U/L) and alanine amino transferases (maximal 163 U/L), biochemical signs of cholestasis or icterus.
+    explanation: >-
+      This directly supports elevated circulating creatine kinase in
+      MPDU1-CDG.
+- name: Biliary duct dilatation
+  category: Gastrointestinal
+  description: >-
+    Massive intrahepatic biliary duct dilatation has been reported in severe
+    MPDU1-CDG, although no precise HPO term was identified locally for this
+    feature.
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Abdominal sonography as well as magnetic resonance cholangiopancreatography showed a vast dilatation of the intrahepatic biliary ducts, especially within the left lobe of the liver (Figure 1C).
+    explanation: >-
+      This directly supports intrahepatic biliary duct dilatation in an
+      MPDU1-CDG patient.
+- name: Renal cyst
+  category: Renal
+  description: >-
+    Small renal cysts have been reported in severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Renal cyst
+    term:
+      id: HP:0000107
+      label: Renal cyst
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      However, at the age of 7 weeks, small renal cysts were suspected in an ultrasound scan.
+    explanation: >-
+      This directly supports renal cysts in an affected MPDU1-CDG patient.
+- name: Thrombocytopenia
+  category: Hematologic
+  description: >-
+    Congenital thrombocytopenia and coagulation abnormalities have been reported
+    in severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Thrombocytopenia
+    term:
+      id: HP:0001873
+      label: Thrombocytopenia
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      There was a marked congenital thrombocytopenia (minimal 45 000 platelets/μL), a slightly decreased fibrinogen (minimal 96 mg/dL), and a nonmeasurable antithrombin III (ATIII, <20%).
+    explanation: >-
+      This directly supports thrombocytopenia and broader coagulation
+      abnormalities in MPDU1-CDG.
+- name: Respiratory insufficiency
+  category: Respiratory
+  description: >-
+    Severe apnea and respiratory insufficiency can occur in severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The clinical course was complicated by an increasing frequency and severity of seizures with epileptic apneas followed by respiratory insufficiency.
+    explanation: >-
+      This directly supports respiratory insufficiency in severe MPDU1-CDG.
+genetic:
+- name: MPDU1
+  association: Loss of function mutation
+  gene_term:
+    preferred_term: MPDU1
+    term:
+      id: hgnc:7207
+      label: MPDU1
+  evidence:
+  - reference: PMID:11733556
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The patient has a homozygous point mutation (221T-->C, L74S) in a semiconserved amino acid of MPDU1.
+    explanation: >-
+      This original report identified a homozygous MPDU1 variant in an affected
+      patient.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Whole exome sequencing revealed a homozygous missense mutation Chr17(GRCh38): g.7585994G>A; NM_004870.3(MPDU1): c.218G>A; p.(G73E) in both patients.
+    explanation: >-
+      This report supports MPDU1 as the causal gene and documents a recurrent
+      homozygous missense variant in affected siblings.
+diagnosis:
+- name: Transferrin isoform analysis
+  description: >-
+    Serum transferrin isoelectric focusing or mass spectrometry detects a CDG-I
+    pattern with reduced tetrasialotransferrin and increased asialo- and
+    disialotransferrin.
+  diagnosis_term:
+    preferred_term: clinical laboratory procedure
+    term:
+      id: MAXO:0000006
+      label: clinical laboratory procedure
+  results: CDG-I transferrin pattern.
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These revealed reduced tetrasialotransferrin, with increased asialo‐ and disialotransferrin indicative of a CDG‐I (Figure 1D,E).
+    explanation: >-
+      This directly supports transferrin isoform analysis as a diagnostic
+      screen for MPDU1-CDG.
+  - reference: PMID:28122681
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Analysis of transferrin isoforms is applied as a screening test for CDG type I (CDG-I) and type II (CDG-II).
+    explanation: >-
+      This CDG cohort paper supports transferrin isoform analysis as a general
+      CDG screening method.
+- name: MPDU1 molecular genetic testing
+  description: >-
+    Molecular diagnosis is confirmed by identifying biallelic pathogenic MPDU1
+    variants using single-gene testing, CDG panels, or exome sequencing.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+    qualifiers:
+    - predicate:
+        preferred_term: has participant
+        term:
+          id: RO:0000057
+          label: has participant
+      value:
+        preferred_term: MPDU1
+        term:
+          id: hgnc:7207
+          label: MPDU1
+  results: Biallelic pathogenic MPDU1 variants.
+  evidence:
+  - reference: PMID:28122681
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In all patients, molecular diagnosis was confirmed either by single gene testing, targeted next generation sequencing for CDG genes, or by whole exome sequencing.
+    explanation: >-
+      This supports molecular confirmation of CDG subtypes, including the
+      MPDU1-CDG patient in this non-PMM2 cohort.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      WES was also performed of the patients' healthy sisters and parents and confirmed parental segregation of the mutation (Figure 1A).
+    explanation: >-
+      This supports exome sequencing and segregation analysis for MPDU1-CDG
+      diagnosis.
+biochemical:
+- name: CDG-I transferrin pattern
+  presence: ABNORMAL
+  context: >-
+    MPDU1-CDG produces a type I carbohydrate-deficient transferrin pattern.
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These revealed reduced tetrasialotransferrin, with increased asialo‐ and disialotransferrin indicative of a CDG‐I (Figure 1D,E).
+    explanation: >-
+      This directly supports the abnormal transferrin glycosylation pattern.
+- name: Shortened lipid-linked oligosaccharides
+  presence: ABNORMAL
+  context: >-
+    Patient fibroblasts accumulate shortened dolichol-linked oligosaccharides,
+    consistent with impaired MPDU1-dependent donor utilization.
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Increased levels of dolichol‐linked Man5GlcNAc2 and Man9GlcNAc2 accompanied by reduced amounts of Glc3Man9GlcNAc2 were detected (Figure 2A) which indicated shortage of DPM and DPG in the ER lumen.
+    explanation: >-
+      This directly supports shortened lipid-linked oligosaccharide accumulation
+      in patient fibroblasts.
+  - reference: PMID:11733564
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Retroviral-based expression of the normal Lec35 cDNA in primary fibroblasts of patients restored normal lipid-linked oligosaccharide biosynthesis.
+    explanation: >-
+      Rescue by normal Lec35/MPDU1 supports causality of the MPDU1 defect for
+      abnormal lipid-linked oligosaccharide biosynthesis.
+treatments:
+- name: Supportive multidisciplinary care
+  description: >-
+    No disease-modifying therapy is established for MPDU1-CDG; reported
+    management is supportive, including feeding, respiratory, neurologic,
+    ophthalmologic, and cardiology care as indicated.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  - preferred_term: Respiratory insufficiency
+    term:
+      id: HP:0002093
+      label: Respiratory insufficiency
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In her short life, the patient did not exhibit any psychomotor development, and had to be fed parenterally or by a gastric tube.
+    explanation: >-
+      This supports supportive feeding management in a severe MPDU1-CDG case.
+- name: Cardiac surveillance
+  description: >-
+    Because cardiomyopathy is an important CDG phenotype and MPDU1-CDG cases
+    include cardiomyopathy, baseline and longitudinal cardiac surveillance is
+    relevant to MPDU1-CDG care.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_phenotypes:
+  - preferred_term: Cardiomyopathy
+    term:
+      id: HP:0001638
+      label: Cardiomyopathy
+  evidence:
+  - reference: PMID:38917675
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cardiac surveillance, including an echocardiogram and EKG, should be conducted at the time of diagnosis, annually throughout the first 5 years, followed by check-ups every 2-3 years if no concerns arise until adulthood.
+    explanation: >-
+      This CDG cardiomyopathy recommendations paper supports cardiac
+      surveillance for CDG patients; the evidence is general CDG guidance rather
+      than MPDU1-specific prospective trial evidence.
+differential_diagnoses:
+- name: DK1-congenital disorder of glycosylation
+  disease_term:
+    preferred_term: DK1-congenital disorder of glycosylation
+    term:
+      id: MONDO:0012556
+      label: DK1-congenital disorder of glycosylation
+  description: >-
+    DOLK-CDG and other DPM synthesis or utilization disorders can overlap with
+    MPDU1-CDG through combined CDG-I and dystroglycanopathy-like features.
+  distinguishing_features:
+  - Molecular testing distinguishes MPDU1 variants from DOLK or DPM pathway defects.
+clinical_trials: []
+datasets: []

--- a/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
@@ -419,9 +419,7 @@ phenotypes:
   category: Gastrointestinal
   description: >-
     Massive intrahepatic biliary duct dilatation has been reported in severe
-    MPDU1-CDG. Local HPO lookup did not confirm the reviewer-suggested
-    HP:0006572 term for biliary dilatation, so this uses the broader biliary
-    tract morphology term.
+    MPDU1-CDG.
   phenotype_term:
     preferred_term: Biliary duct dilatation
     term:

--- a/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml
@@ -99,6 +99,11 @@ pathophysiology:
   description: >-
     Patient cells accumulate incomplete lipid-linked oligosaccharides for
     N-linked glycosylation, leading to systemic protein hypoglycosylation.
+  cell_types:
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
   biological_processes:
   - preferred_term: protein N-linked glycosylation
     term:
@@ -110,18 +115,26 @@ pathophysiology:
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: >-
-      Serum transferrin was hypoglycosylated and patients' fibroblasts accumulated incomplete lipid-linked oligosaccharide precursors for N-linked protein glycosylation.
+      patients' fibroblasts accumulated incomplete lipid-linked oligosaccharide precursors for N-linked protein glycosylation.
     explanation: >-
       This abstract directly supports the biochemical intermediate node in
-      patient fibroblasts and serum.
+      patient fibroblasts.
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      These revealed reduced tetrasialotransferrin, with increased asialo‐ and disialotransferrin indicative of a CDG‐I (Figure 1D,E).
+    explanation: >-
+      The serum transferrin pattern supports systemic hypoglycosylation in a
+      clinical patient sample.
   - reference: PMID:31741824
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: >-
-      Biochemical analyses revealed elevated disialotransferrin in serum, and analyses in fibroblasts showed shortened lipid linked oligosaccharides and DPM, and reduced O-mannosylation of αDG.
+      Increased levels of dolichol‐linked Man5GlcNAc2 and Man9GlcNAc2 accompanied by reduced amounts of Glc3Man9GlcNAc2 were detected (Figure 2A) which indicated shortage of DPM and DPG in the ER lumen.
     explanation: >-
-      Patient material showed abnormal transferrin, shortened lipid-linked
-      oligosaccharides, and reduced alpha-dystroglycan O-mannosylation.
+      Fibroblast LLO analysis directly supports accumulation of truncated
+      dolichol-linked oligosaccharides.
   downstream:
   - target: Reduced alpha-dystroglycan O-mannosylation
     description: >-
@@ -141,6 +154,11 @@ pathophysiology:
     alpha-dystroglycan glycosylation, explaining overlap with
     dystroglycanopathy features such as elevated creatine kinase, eye disease,
     and cardiomyopathy.
+  cell_types:
+  - preferred_term: fibroblast
+    term:
+      id: CL:0000057
+      label: fibroblast
   biological_processes:
   - preferred_term: protein O-linked glycosylation via mannose
     term:
@@ -302,10 +320,10 @@ phenotypes:
   description: >-
     Congenital glaucoma can accompany buphthalmos in MPDU1-CDG.
   phenotype_term:
-    preferred_term: Glaucoma
+    preferred_term: Primary congenital glaucoma
     term:
-      id: HP:0000501
-      label: Glaucoma
+      id: HP:0008007
+      label: Primary congenital glaucoma
   evidence:
   - reference: PMID:31741824
     supports: SUPPORT
@@ -314,6 +332,26 @@ phenotypes:
       The megalocorneae possessed a diameter of 13 mm (normal in newborn = 9.5 mm). Further ophthalmologic examination revealed a buphthalmos with congenital glaucoma.
     explanation: >-
       This directly supports congenital glaucoma in an affected MPDU1-CDG
+      patient.
+- name: Abnormal facial shape
+  category: Craniofacial
+  description: >-
+    Facial dysmorphism, including smooth philtrum, retrognathia,
+    low-set/posterior-rotated ears, and hypertelorism, has been reported in
+    severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Abnormal facial shape
+    term:
+      id: HP:0001999
+      label: Abnormal facial shape
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Slight dysmorphic features were noted including a smooth philtrum, retrognathia, low‐set, posterior‐rotated ears, and hypertelorism with megalocorneae (Figure 1B).
+    explanation: >-
+      This directly supports facial dysmorphism in an affected MPDU1-CDG
       patient.
 - name: Hearing impairment
   category: Audiologic
@@ -381,8 +419,14 @@ phenotypes:
   category: Gastrointestinal
   description: >-
     Massive intrahepatic biliary duct dilatation has been reported in severe
-    MPDU1-CDG, although no precise HPO term was identified locally for this
-    feature.
+    MPDU1-CDG. Local HPO lookup did not confirm the reviewer-suggested
+    HP:0006572 term for biliary dilatation, so this uses the broader biliary
+    tract morphology term.
+  phenotype_term:
+    preferred_term: Biliary duct dilatation
+    term:
+      id: HP:0012440
+      label: Abnormal biliary tract morphology
   evidence:
   - reference: PMID:31741824
     supports: SUPPORT
@@ -445,6 +489,25 @@ phenotypes:
       The clinical course was complicated by an increasing frequency and severity of seizures with epileptic apneas followed by respiratory insufficiency.
     explanation: >-
       This directly supports respiratory insufficiency in severe MPDU1-CDG.
+- name: Apnea
+  category: Respiratory
+  description: >-
+    Apnea is a recurrent respiratory feature and can occur with seizures in
+    severe MPDU1-CDG.
+  phenotype_term:
+    preferred_term: Apnea
+    term:
+      id: HP:0002104
+      label: Apnea
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All patients showed psychomotor retardation and most patients had hypotonia, facial dysmorphism, eye defects, apnea, and skin abnormalities such as ichthyosis.
+    explanation: >-
+      This directly supports apnea as a recurrent clinical feature of
+      MPDU1-CDG.
 genetic:
 - name: MPDU1
   association: Loss of function mutation
@@ -625,6 +688,29 @@ treatments:
       This CDG cardiomyopathy recommendations paper supports cardiac
       surveillance for CDG patients; the evidence is general CDG guidance rather
       than MPDU1-specific prospective trial evidence.
+- name: Trabeculectomy for congenital glaucoma
+  description: >-
+    Ophthalmologic surgery may be required for severe congenital glaucoma in
+    MPDU1-CDG.
+  treatment_term:
+    preferred_term: trabeculectomy
+    term:
+      id: MAXO:0001082
+      label: trabeculectomy
+  target_phenotypes:
+  - preferred_term: Primary congenital glaucoma
+    term:
+      id: HP:0008007
+      label: Primary congenital glaucoma
+  evidence:
+  - reference: PMID:31741824
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ophthalmological examination revealed a buphthalmos with slightly opaque corneae with a diameter of 11 mm and severe congenital glaucoma, requiring prompt trabeculectomy intervention.
+    explanation: >-
+      This directly supports trabeculectomy as a reported ophthalmologic
+      intervention for MPDU1-CDG-associated congenital glaucoma.
 differential_diagnoses:
 - name: DK1-congenital disorder of glycosylation
   disease_term:
@@ -637,5 +723,39 @@ differential_diagnoses:
     MPDU1-CDG through combined CDG-I and dystroglycanopathy-like features.
   distinguishing_features:
   - Molecular testing distinguishes MPDU1 variants from DOLK or DPM pathway defects.
+- name: DPM1-congenital disorder of glycosylation
+  disease_term:
+    preferred_term: DPM1-congenital disorder of glycosylation
+    term:
+      id: MONDO:0012123
+      label: congenital disorder of glycosylation type 1E
+  description: >-
+    DPM1-CDG is a DPM-pathway CDG-I disorder that can overlap with MPDU1-CDG
+    through reduced alpha-dystroglycan O-mannosylation and dystroglycanopathy
+    features.
+  distinguishing_features:
+  - Molecular testing distinguishes MPDU1 variants from DPM1 defects.
+- name: DPM2-congenital disorder of glycosylation
+  disease_term:
+    preferred_term: DPM2-congenital disorder of glycosylation
+    term:
+      id: MONDO:0014023
+      label: congenital muscular dystrophy with intellectual disability and severe epilepsy
+  description: >-
+    DPM2-CDG shares the CDG-I and dystroglycanopathy-overlap differential space
+    because DPM2 affects the same dolichol-phosphate-mannose pathway.
+  distinguishing_features:
+  - Molecular testing distinguishes MPDU1 variants from DPM2 defects.
+- name: DPM3-congenital disorder of glycosylation
+  disease_term:
+    preferred_term: DPM3-congenital disorder of glycosylation
+    term:
+      id: MONDO:0013049
+      label: DPM3-congenital disorder of glycosylation
+  description: >-
+    DPM3-CDG is another DPM-pathway disorder with CDG-I and
+    dystroglycanopathy-like overlap, including muscle and cardiac involvement.
+  distinguishing_features:
+  - Molecular testing distinguishes MPDU1 variants from DPM3 defects.
 clinical_trials: []
 datasets: []

--- a/references_cache/PMID_11733556.md
+++ b/references_cache/PMID_11733556.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:11733556"
+title: A mutation in the human MPDU1 gene causes congenital disorder of glycosylation type If (CDG-If).
+authors:
+- Kranz C
+- Denecke J
+- Lehrman MA
+- Ray S
+- Kienz P
+- Kreissel G
+- Sagi D
+- Peter-Katalinic J
+- Freeze HH
+- Schmid T
+- Jackowski-Dohrmann S
+- Harms E
+- Marquardt T
+journal: J Clin Invest
+year: '2001'
+doi: 10.1172/JCI13635
+keywords:
+- Adolescent
+- Amino Acid Sequence
+- Animals
+- Blood Protein Electrophoresis
+- CHO Cells
+- Congenital Disorders of Glycosylation/genetics
+- Cricetinae
+- Glycosylation
+- Humans
+- Male
+- Molecular Sequence Data
+- Mutation
+- Oligosaccharides/analysis
+- "Repressor Proteins/chemistry, genetics"
+content_type: abstract_only
+---
+
+# A mutation in the human MPDU1 gene causes congenital disorder of glycosylation type If (CDG-If).
+**Authors:** Kranz C, Denecke J, Lehrman MA, Ray S, Kienz P, Kreissel G, Sagi D, Peter-Katalinic J, Freeze HH, Schmid T, Jackowski-Dohrmann S, Harms E, Marquardt T
+**Journal:** J Clin Invest (2001)
+**DOI:** [10.1172/JCI13635](https://doi.org/10.1172/JCI13635)
+
+## Content
+
+1. J Clin Invest. 2001 Dec;108(11):1613-9. doi: 10.1172/JCI13635.
+
+A mutation in the human MPDU1 gene causes congenital disorder of glycosylation 
+type If (CDG-If).
+
+Kranz C(1), Denecke J, Lehrman MA, Ray S, Kienz P, Kreissel G, Sagi D, 
+Peter-Katalinic J, Freeze HH, Schmid T, Jackowski-Dohrmann S, Harms E, Marquardt 
+T.
+
+Author information:
+(1)Klinik und Poliklinik für Kinderheilkunde, Münster, Germany.
+
+Comment in
+    J Clin Invest. 2001 Dec;108(11):1579-82. doi: 10.1172/JCI14498.
+
+We describe a new congenital disorder of glycosylation, CDG-If. The patient has 
+severe psychomotor retardation, seizures, failure to thrive, dry skin and 
+scaling with erythroderma, and impaired vision. CDG-If is caused by a defect in 
+the gene MPDU1, the human homologue of hamster Lec35, and is the first disorder 
+to affect the use, rather than the biosynthesis, of donor substrates for 
+lipid-linked oligosaccharides. This leads to the synthesis of incomplete and 
+poorly transferred precursor oligosaccharides lacking both mannose and glucose 
+residues. The patient has a homozygous point mutation (221T-->C, L74S) in a 
+semiconserved amino acid of MPDU1. Chinese hamster ovary Lec35 cells lack a 
+functional Lec35 gene and synthesize truncated lipid-linked oligosaccharides 
+similar to the patient's. They lack glucose and mannose residues donated by 
+Glc-P-Dol and Man-P-Dol. Transfection with the normal human MPDU1 allele nearly 
+completely restores normal glycosylation, whereas transfection with the 
+patient's MPDU1 allele only weakly restores normal glycosylation. This work 
+provides a new clinical picture for another CDG that may involve synthesis of 
+multiple types of glycoconjugates.
+
+DOI: 10.1172/JCI13635
+PMCID: PMC200991
+PMID: 11733556 [Indexed for MEDLINE]

--- a/references_cache/PMID_11733564.md
+++ b/references_cache/PMID_11733564.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:11733564"
+title: "MPDU1 mutations underlie a novel human congenital disorder of glycosylation, designated type If."
+authors:
+- Schenk B
+- Imbach T
+- Frank CG
+- Grubenmann CE
+- Raymond GV
+- Hurvitz H
+- Korn-Lubetzki I
+- Revel-Vik S
+- Raas-Rotschild A
+- Luder AS
+- Jaeken J
+- Berger EG
+- Matthijs G
+- Hennet T
+- Aebi M
+journal: J Clin Invest
+year: '2001'
+doi: 10.1172/JCI13419
+keywords:
+- Amino Acid Sequence
+- "Cells, Cultured"
+- Chromosome Mapping
+- Congenital Disorders of Glycosylation/genetics
+- Female
+- Fibroblasts/metabolism
+- Glycosylation
+- Humans
+- Male
+- Molecular Sequence Data
+- Mutation
+- Oligosaccharides/biosynthesis
+- "Repressor Proteins/chemistry, genetics"
+content_type: abstract_only
+---
+
+# MPDU1 mutations underlie a novel human congenital disorder of glycosylation, designated type If.
+**Authors:** Schenk B, Imbach T, Frank CG, Grubenmann CE, Raymond GV, Hurvitz H, Korn-Lubetzki I, Revel-Vik S, Raas-Rotschild A, Luder AS, Jaeken J, Berger EG, Matthijs G, Hennet T, Aebi M
+**Journal:** J Clin Invest (2001)
+**DOI:** [10.1172/JCI13419](https://doi.org/10.1172/JCI13419)
+
+## Content
+
+1. J Clin Invest. 2001 Dec;108(11):1687-95. doi: 10.1172/JCI13419.
+
+MPDU1 mutations underlie a novel human congenital disorder of glycosylation, 
+designated type If.
+
+Schenk B(1), Imbach T, Frank CG, Grubenmann CE, Raymond GV, Hurvitz H, 
+Korn-Lubetzki I, Revel-Vik S, Raas-Rotschild A, Luder AS, Jaeken J, Berger EG, 
+Matthijs G, Hennet T, Aebi M.
+
+Author information:
+(1)Institute of Microbiology, Swiss Federal Institute of Technology, Zurich, 
+Switzerland.
+
+Erratum in
+    J Clin Invest. 2003 Mar;111(6):925.
+
+Comment in
+    J Clin Invest. 2001 Dec;108(11):1579-82. doi: 10.1172/JCI14498.
+
+Deficiencies in the pathway of N-glycan biosynthesis lead to severe multisystem 
+diseases, known as congenital disorders of glycosylation (CDG). The clinical 
+appearance of CDG is variable, and different types can be distinguished 
+according to the gene that is altered. In this report, we describe the molecular 
+basis of a novel type of the disease in three unrelated patients diagnosed with 
+CDG-I. Serum transferrin was hypoglycosylated and patients' fibroblasts 
+accumulated incomplete lipid-linked oligosaccharide precursors for N-linked 
+protein glycosylation. Transfer of incomplete oligosaccharides to protein was 
+detected. Sequence analysis of the Lec35/MPDU1 gene, known to be involved in the 
+use of dolichylphosphomannose and dolichylphosphoglucose, revealed mutations in 
+all three patients. Retroviral-based expression of the normal Lec35 cDNA in 
+primary fibroblasts of patients restored normal lipid-linked oligosaccharide 
+biosynthesis. We concluded that mutations in the Lec35/MPDU1 gene cause CDG. 
+This novel type was termed CDG-If.
+
+DOI: 10.1172/JCI13419
+PMCID: PMC200989
+PMID: 11733564 [Indexed for MEDLINE]

--- a/references_cache/PMID_28122681.md
+++ b/references_cache/PMID_28122681.md
@@ -1,0 +1,109 @@
+---
+reference_id: "PMID:28122681"
+title: Phenotypic and genotypic spectrum of congenital disorders of glycosylation type I and type II.
+authors:
+- Al Teneiji A
+- Bruun TU
+- Sidky S
+- Cordeiro D
+- Cohn RD
+- Mendoza-Londono R
+- Moharir M
+- Raiman J
+- Siriwardena K
+- Kyriakopoulou L
+- Mercimek-Mahmutoglu S
+journal: Mol Genet Metab
+year: '2017'
+doi: 10.1016/j.ymgme.2016.12.014
+keywords:
+- Adolescent
+- Child
+- "Child, Preschool"
+- "Chromatography, High Pressure Liquid"
+- "Congenital Disorders of Glycosylation/classification, diagnosis, genetics, metabolism"
+- Exome
+- Female
+- Gene Regulatory Networks
+- Genetic Predisposition to Disease
+- Genotype
+- High-Throughput Nucleotide Sequencing/methods
+- Humans
+- Infant
+- Male
+- Phenotype
+- Protein Isoforms/metabolism
+- Retrospective Studies
+- "Sequence Analysis, DNA/methods"
+- Transferrin/metabolism
+content_type: abstract_only
+---
+
+# Phenotypic and genotypic spectrum of congenital disorders of glycosylation type I and type II.
+**Authors:** Al Teneiji A, Bruun TU, Sidky S, Cordeiro D, Cohn RD, Mendoza-Londono R, Moharir M, Raiman J, Siriwardena K, Kyriakopoulou L, Mercimek-Mahmutoglu S
+**Journal:** Mol Genet Metab (2017)
+**DOI:** [10.1016/j.ymgme.2016.12.014](https://doi.org/10.1016/j.ymgme.2016.12.014)
+
+## Content
+
+1. Mol Genet Metab. 2017 Mar;120(3):235-242. doi: 10.1016/j.ymgme.2016.12.014.
+Epub  2017 Jan 3.
+
+Phenotypic and genotypic spectrum of congenital disorders of glycosylation type 
+I and type II.
+
+Al Teneiji A(1), Bruun TU(2), Sidky S(1), Cordeiro D(1), Cohn RD(3), 
+Mendoza-Londono R(3), Moharir M(4), Raiman J(5), Siriwardena K(6), Kyriakopoulou 
+L(7), Mercimek-Mahmutoglu S(8).
+
+Author information:
+(1)Division of Clinical and Metabolic Genetics, Department of Paediatrics, 
+University of Toronto, The Hospital for Sick Children, Toronto, Ontario, Canada.
+(2)Division of Clinical and Metabolic Genetics, Department of Paediatrics, 
+University of Toronto, The Hospital for Sick Children, Toronto, Ontario, Canada; 
+Genetics and Genome Biology Program, Research Institute, The Hospital for Sick 
+Children, Toronto, Ontario, Canada; Department of Biochemistry, University of 
+Oxford, Oxford, United Kingdom.
+(3)Division of Clinical and Metabolic Genetics, Department of Paediatrics, 
+University of Toronto, The Hospital for Sick Children, Toronto, Ontario, Canada; 
+Genetics and Genome Biology Program, Research Institute, The Hospital for Sick 
+Children, Toronto, Ontario, Canada.
+(4)Division of Neurology, Department of Paediatrics, University of Toronto, The 
+Hospital for Sick Children, Toronto, Ontario, Canada.
+(5)Birmingham's Children Hospital, Birmingham, England.
+(6)Department of Medical Genetics, University of Alberta, Edmonton, Canada.
+(7)Division of Genome Diagnostics, Department of Paediatric Laboratory Medicine, 
+University of Toronto, The Hospital for Sick Children, Toronto, Ontario, Canada.
+(8)Division of Clinical and Metabolic Genetics, Department of Paediatrics, 
+University of Toronto, The Hospital for Sick Children, Toronto, Ontario, Canada; 
+Genetics and Genome Biology Program, Research Institute, The Hospital for Sick 
+Children, Toronto, Ontario, Canada; Institute of Medical Sciences, University of 
+Toronto, Toronto, Ontario, Canada. Electronic address: 
+saadet.mahmutoglu@sickkids.ca.
+
+BACKGROUND: Congenital disorders of glycosylation (CDG) are inborn defects of 
+glycan metabolism. They are multisystem disorders. Analysis of transferrin 
+isoforms is applied as a screening test for CDG type I (CDG-I) and type II 
+(CDG-II). We performed a retrospective cohort study to determine spectrum of 
+phenotype and genotype and prevalence of the different subtypes of CDG-I and 
+CDG-II.
+MATERIAL AND METHODS: All patients with CDG-I and CDG-II evaluated in our 
+institution's Metabolic Genetics Clinics were included. Electronic and paper 
+patient charts were reviewed. We set-up a high performance liquid chromatography 
+transferrin isoelectric focusing (TIEF) method to measure transferrin isoforms 
+in our Institution. We reviewed the literature for the rare CDG-I and CDG-II 
+subtypes seen in our Institution.
+RESULTS: Fifteen patients were included: 9 with PMM2-CDG and 6 with non-PMM2-CDG 
+(one ALG3-CDG, one ALG9-CDG, two ALG11-CDG, one MPDU1-CDG and one ATP6V0A2-CDG). 
+All patients with PMM2-CDG and 5 patients with non-PMM2-CDG showed abnormal TIEF 
+suggestive of CDG-I or CDG-II pattern. In all patients, molecular diagnosis was 
+confirmed either by single gene testing, targeted next generation sequencing for 
+CDG genes, or by whole exome sequencing.
+CONCLUSION: We report 15 new patients with CDG-I and CDG-II. Whole exome 
+sequencing will likely identify more patients with normal TIEF and expand the 
+phenotypic spectrum of CDG-I and CDG-II.
+
+Crown Copyright © 2017. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2016.12.014
+PMID: 28122681 [Indexed for MEDLINE]

--- a/references_cache/PMID_31741824.md
+++ b/references_cache/PMID_31741824.md
@@ -1,0 +1,154 @@
+---
+reference_id: "PMID:31741824"
+title: A mutation in mannose-phosphate-dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type I and dystroglycanopathy.
+authors:
+- van Tol W
+- Ashikov A
+- Korsch E
+- Abu Bakar N
+- Willemsen MA
+- Thiel C
+- Lefeber DJ
+journal: JIMD Rep
+year: '2019'
+doi: 10.1002/jmd2.12060
+content_type: full_text_xml
+---
+
+# A mutation in mannose-phosphate-dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type I and dystroglycanopathy.
+**Authors:** van Tol W, Ashikov A, Korsch E, Abu Bakar N, Willemsen MA, Thiel C, Lefeber DJ
+**Journal:** JIMD Rep (2019)
+**DOI:** [10.1002/jmd2.12060](https://doi.org/10.1002/jmd2.12060)
+
+## Content
+
+1. JIMD Rep. 2019 Sep 30;50(1):31-39. doi: 10.1002/jmd2.12060. eCollection 2019 
+Nov.
+
+A mutation in mannose-phosphate-dolichol utilization defect 1 reveals clinical 
+symptoms of congenital disorders of glycosylation type I and dystroglycanopathy.
+
+van Tol W(1)(2), Ashikov A(1), Korsch E(3), Abu Bakar N(1), Willemsen MA(4), 
+Thiel C(5), Lefeber DJ(1)(2).
+
+Author information:
+(1)Department of Neurology, Donders Institute for Brain, Cognition and Behavior 
+Radboud University Medical Center Nijmegen The Netherlands.
+(2)Translational Metabolic Laboratory, Department of Laboratory Medicine, 
+Radboud Institute for Molecular Life Sciences Radboud University Medical Center 
+Nijmegen The Netherlands.
+(3)Children's Hospital of the City of Cologne Cologne Germany.
+(4)Department of Pediatric Neurology, Amalia Children's Hospital, Donders 
+Institute for Brain, Cognition and Behavior Radboud University Medical Center 
+Nijmegen The Netherlands.
+(5)Center for Child and Adolescent Medicine, Kinderheilkunde I University of 
+Heidelberg Heidelberg Germany.
+
+Congenital disorders of glycosylation type I (CDG-I) are inborn errors of 
+metabolism, generally characterized by multisystem clinical manifestations, 
+including developmental delay, hepatopathy, hypotonia, and skin, skeletal, and 
+neurological abnormalities. Among others, dolichol-phosphate-mannose (DPM) is 
+the mannose donor for N-glycosylation as well as O-mannosylation. DOLK-CDG, 
+DPM1-CDG, DPM2-CDG, and DPM3-CDG are defects in the DPM synthesis showing both 
+CDG-I abnormalities and reduced O-mannosylation of alpha-dystroglycan (αDG), 
+which leads to muscular dystrophy-dystroglycanopathy. Mannose-phosphate-dolichol 
+utilization defect 1 (MPDU1) plays a role in the utilization of DPM. Here, we 
+report two MPDU1-CDG patients without skin involvement, but with massive 
+dilatation of the biliary duct system and dystroglycanopathy characteristics 
+including hypotonia, elevated creatine kinase, dilated cardiomyopathy, 
+buphthalmos, and congenital glaucoma. Biochemical analyses revealed elevated 
+disialotransferrin in serum, and analyses in fibroblasts showed shortened lipid 
+linked oligosaccharides and DPM, and reduced O-mannosylation of αDG. Thus, 
+MPDU1-CDG can be added to the list of disorders with overlapping biochemical and 
+clinical abnormalities of CDG-I and dystroglycanopathy.
+SYNOPSIS: Mannose-phosphate-dolichol utilization defect 1 patients can have 
+overlapping biochemical and clinical abnormalities of congenital disorders of 
+glycosylation type I and dystroglycanopathy.
+
+© 2019 The Authors. Journal of Inherited Metabolic Disease published by John 
+Wiley & Sons Ltd on behalf of SSIEM.
+
+DOI: 10.1002/jmd2.12060
+PMCID: PMC6850978
+PMID: 31741824
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.
+
+The congenital disorders of glycosylation (CDG) are inborn errors of metabolism with a great genetic heterogeneity. CDG‐I defects are located in the assembly of the lipid linked oligosaccharide (LLO) glucose3mannose9
+N‐acetylglucosamine2‐PP‐dolichol (Glc3Man9GlcNAc2‐PP‐Dol) or the transfer of its oligosaccharide to proteins in the endoplasmic reticulum (ER). CDG‐I leads to multiorgan phenotypes, including disorders of the brain and neuromuscular system, hepatopathy, skin, and skeletal abnormalities.1
+
+
+Genetic defects in the biosynthesis of dolichol‐phosphate‐mannose (DPM; NUS1‐CDG, DHDDS‐CDG, PMM2‐CDG, SRD5A3‐CDG, DOLK‐CDG, DPM1‐CDG, DPM2‐CDG, DPM3‐CDG) lead to CDG‐I profiles of transferrin. However, the clinical phenotypes associated with these defects are very different, which is partly explained by that DPM is required for N‐glycosylation, O‐mannosylation, C‐mannosylation, and GPI‐anchor synthesis. In DOLK‐CDG, DPM1‐CDG, DPM2‐CDG, and DPM3‐CDG, biochemical and phenotypic abnormalities overlap with CDG‐I and muscular dystrophy‐dystroglycanopathy, which is caused by reduced O‐mannosylation of alpha‐dystroglycan (αDG).2, 3, 4, 5
+
+
+Mannose‐phosphate‐dolichol utilization defect 1 (MPDU1) is involved in the flipping of DPM and dolichol‐phosphate‐glucose (DPG) across the ER membrane and for efficient use of DPM and DPG within the ER lumen.6, 7 MPDU1‐CDG patients have CDG‐I with epilepsy, psychomotor retardation, and skin abnormalities.7, 8, 9 Here, we describe two siblings with a G73E substitution in MPDU1 without skin involvement, but with dilatation of the biliary ducts and dystroglycanopathy symptoms including elevated creatine kinase (CK), dilated cardiomyopathy (DCM), buphthalmos, and glaucoma.
+
+Plasma and fibroblasts were obtained for CDG diagnostics in the Radboudumc Expertise Center for Disorders of Glycosylation in accordance with the Declaration of Helsinki. Informed consent was obtained from patients or their legal representatives. Written informed consent was obtained for inclusion of facial images.
+
+Serum transferrin isoelectric focusing (TIEF) and electrospray ionization mass spectrometry (ESI‐MS) were performed as described.10, 11, 12 Whole exome sequencing (WES), high‐performance liquid chromatography (HPLC), and thin‐layer chromatography (TLC) of LLOs and DPM were performed as described elsewhere.13, 14
+
+
+Fibroblasts were cultured in Dulbecco's Modified Eagle Medium (DMEM) with 10% fetal calf serum (Gibco) and 1% penicillin‐streptomycin (Gibco). Fibroblast lysates were enriched for glycoproteins using agarose‐conjugated wheat germ agglutinin (Sigma). Proteins were loaded on 10% polyacrylamide gels and transferred to nitrocellulose membranes by western blotting. Membranes were used for laminin overlay (LO)4, 15 or incubated with primary antibodies against glycosylated αDG (IIH6C4, 1:2500, Merck 05‐593), the dystroglycan core‐protein (DAG1, 1:333, Genetex), or βDG (1:250, Novacastra) and with HRP‐conjugated polyclonal goat anti‐rabbit or goat anti‐mouse antibodies (1:5000, DAKO).
+
+The two patients are brother and sister from Iraqi origin. They were the third and fourth child of consanguineous parents (first cousins), and had two healthy sisters (Figure 1A). Table 1 summarizes the clinical features of these two patients and four previously reported MPDU1‐CDG patients.7, 8, 9
+
+
+Family pedigree and clinical images of affected patients. A, Family pedigree of MPDU1 patients (P1 = patient 1, P2 = patient 2). B, Front and side facial view of patient 1. C, Abdominal sonography (left), magnetic resonance imaging (middle), and 3D image from magnetic resonance cholangiopancreatography (right) of patient 1 showing a vast dilatation of the complete intrahepatic biliary duct system. D, Serum transferrin isoelectric focusing (TIEF) analysis of P1, her parents and two healthy sisters. E, ESI‐MS of serum transferrin. Disialotransferrin levels are expressed as a percentage of tetrasialotransferrin. F, Front and side facial view of patient 2 at 4 months of age. G, Abdominal sonography of patient 2, showing dilatation of the intrahepatic biliary duct. CDG, congenital disorders of glycosylation; ESI‐MS, electrospray ionization mass spectrometry; MPDU1, mannose‐phosphate‐dolichol utilization defect 1
+
+Clinical and laboratory data of the two presented patients and the patients from the literature
+
+Abbreviations: ATIII, antithrombin III; BERA, brainstem evoked response audiometry; CK, creatine kinase; IGF‐I, insulin‐like growth factor 1; n.a., not available.
+
+Patient P1, a girl, was born spontaneously in the 37th gestational week after an uneventful pregnancy. At birth, her length was 43 cm (standard deviation score, (SDS), −2.08), weight 2390 g (SDS, −0.81), and head circumference 32 cm. Because of postnatal apneas and bradycardias with deep desaturations, followed by respiratory failure, she was resuscitated and referred to the neonatal intensive care unit. Slight dysmorphic features were noted including a smooth philtrum, retrognathia, low‐set, posterior‐rotated ears, and hypertelorism with megalocorneae (Figure 1B).
+
+At the age of 2 months, P1 showed tonic‐clonic seizures with multifocal sharp waves on electroencephalography (EEG). Brain magnetic resonance imaging (MRI) revealed enlarged outer fronto‐temporo‐parietal cerebrospinal fluid spaces. Abdominal sonography as well as magnetic resonance cholangiopancreatography showed a vast dilatation of the intrahepatic biliary ducts, especially within the left lobe of the liver (Figure 1C). There were no further signs of biliary duct obstruction or liver enlargement. Initially, kidney sonography showed enhanced echogenicity of the marrow pyramids without corresponding MRI abnormalities. However, at the age of 7 weeks, small renal cysts were suspected in an ultrasound scan.
+
+Initially, electrocardiography and echocardiography were normal, except for a mild temporary pulmonary hypertension. At the age of 3 months, the patient evolved DCM with low output and a shortening fraction of at least 9%.
+
+The megalocorneae possessed a diameter of 13 mm (normal in newborn = 9.5 mm). Further ophthalmologic examination revealed a buphthalmos with congenital glaucoma. The eye lenses were slightly cloudy and pupillary iris showed pigment epithelial cysts. A sensorineural hearing loss was identified with brainstem evoked response audiometry (BERA) evaluation. There were no abnormalities of the skin.
+
+Blood CK levels were elevated up to 3090 U/L without substantial elevation of aspartate amino transferases (maximal 175 U/L) and alanine amino transferases (maximal 163 U/L), biochemical signs of cholestasis or icterus. There was a marked congenital thrombocytopenia (minimal 45 000 platelets/μL), a slightly decreased fibrinogen (minimal 96 mg/dL), and a nonmeasurable antithrombin III (ATIII, <20%).
+
+Prometaphase karyotype analysis showed a normal 46,XX female karyotype and a normal array‐comparative genomic hybridization (array‐CGH), without any microdeletion or duplication. Congenital toxoplasmosis, other (syphilis, varicella‐zoster, parvovirus B19), rubella, cytomegalovirus, and herpes (TORCH) infections, peroxisomal diseases as well as mucopolysaccharidoses were ruled out by serology and metabolic screening. The serum amino acids, acylcarnitine profile, very long chain fatty acids, 7‐dehydrocholesterol, and urine organic acids were normal. In view of the clinical symptoms of multiorgan involvement with seizures, cardiomyopathy, eye, and liver abnormalities as well as thrombocytopenia and ATIII deficiency, a CDG was suspected and TIEF and ESI‐MS of serum transferrin were performed. These revealed reduced tetrasialotransferrin, with increased asialo‐ and disialotransferrin indicative of a CDG‐I (Figure 1D,E).
+
+In her short life, the patient did not exhibit any psychomotor development, and had to be fed parenterally or by a gastric tube. The clinical course was complicated by an increasing frequency and severity of seizures with epileptic apneas followed by respiratory insufficiency. Congestive heart failure as a consequence of the DCM led to the termination of therapeutic interventions, and she died at the age of nearly 4 months.
+
+This patient exhibited nearly the same clinical features and course as his affected sister (P1). He was born premature per cesarean section in the 31st gestational week because of a rupture of the placental membrane and uterine bleeding. His birth length was 38 cm (SDS, −0.38), his weight was 1420 g (SDS, −0.09), and he had a head circumference of 28 cm. He showed a smooth philtrum, retrognathia, and low‐set, posterior‐rotated ears. He had hypertelorism with prominent appearing eyes with enlarged and cloudy corneae (Figure 1F). Musculature was slightly hypotonic, but otherwise the child appeared to be normal and without skin abnormalities, except a micropenis. After birth, he was cyanotic, breathless, and without muscular tonus, requiring immediate cardiopulmonary resuscitation and controlled ventilation.
+
+Echocardiography detected a dilated aorta ascendens, a transient pulmonary hypertension, and a hypertrophic cardiomyopathy (HCM) at the age of 3 weeks, which developed in combination with an arterial hypertension.
+
+At the age of 6 months, he had generalized seizures accompanied by desaturations, whereas EEG showed parieto‐temporo‐occipital and multiregional spikes over both hemispheres. Sonography of the brain showed no gross abnormalities. Abdominal sonography revealed dilatation of the intrahepatic biliary duct system (Figure 1G). Kidney sonography exhibited enhanced echogenicity of the marrow pyramids. At the age of 4 months, he developed multiple small cysts subcapsular within the renal parenchyma.
+
+The ophthalmological examination revealed a buphthalmos with slightly opaque corneae with a diameter of 11 mm and severe congenital glaucoma, requiring prompt trabeculectomy intervention. The BERA showed a sensorineural hearing loss.
+
+Chromosomal analysis showed a normal 46,XY karyotype, and array‐CGH as well as TORCH serology were normal. He also exhibited thrombocytopenia (minimal 13 000 platelets/μL), elevated CK levels (up to 905 U/L), and low ATIII (maximal 40%), but transaminases, fibrinogen, thyroxin‐binding globulin, and bilirubin were normal.
+
+Like his sister, P2 hardly presented any psychomotor development, and had to be fed parenterally or by a gastric tube. He showed severe apneas and bradycardias which were not treatable, and he died at the age of 11 months from respiratory failure.
+
+Whole exome sequencing revealed a homozygous missense mutation Chr17(GRCh38): g.7585994G>A; NM_004870.3(MPDU1): c.218G>A; p.(G73E) in both patients. This mutation has been reported in two other MPDU1‐CDG patients.7, 9 WES was also performed of the patients' healthy sisters and parents and confirmed parental segregation of the mutation (Figure 1A).
+
+Next, we analyzed the LLO composition in fibroblasts from patient 1. Cells were incubated with [2‐3H]mannose and [3H]oligosaccharides were extracted and analyzed using HPLC. Increased levels of dolichol‐linked Man5GlcNAc2 and Man9GlcNAc2 accompanied by reduced amounts of Glc3Man9GlcNAc2 were detected (Figure 2A) which indicated shortage of DPM and DPG in the ER lumen. Since TLC analysis further showed that DPM is synthesized in the patient's fibroblasts (Figure 2B), a lack of transport of DPM from the cytosol into the ER can be assumed.
+
+CDG diagnostics and biochemical analyses of MPDU1‐CDG P1. A, HPLC analysis of LLO from fibroblasts of patient 1 (P1) and a control revealed the accumulation of the shortened dolichol‐linked oligosaccharides Man5GlcNAc2 and Man9GlcNAc2. B, Thin‐layer chromatography (TLC) analysis of hydrophobic LLO extracts further revealed that dolichol‐phosphate‐mannose (Dol‐P‐Man) is synthesized in patient 1 fibroblasts. C, Analysis of O‐mannosylated αDG in P1 and control fibroblasts. IIH6 and laminin (laminin overlay, LO) only bind to fully functional O‐mannosyl glycans of αDG. DAG1 binds to the core of the dystroglycan protein, showing expression of αDG and βDG proteins. CDG, congenital disorders of glycosylation; HPLC, High‐performance liquid chromatography; LLO, lipid linked oligosaccharide; MPDU1, mannose‐phosphate‐dolichol utilization defect 1
+
+Subsequently, we analyzed the O‐mannosylation of αDG in fibroblasts of patient P1 by IIH6 immunolabeling and a LO assay. We found that the signals for both IIH6 and LO were reduced in patient fibroblasts as compared to the signal of control fibroblasts (Figure 2C), suggesting reduced glycosylation of αDG.
+
+Here, we describe two patients with mutations in MPDU1, causing MPDU1‐CDG (CDG‐1f) with overlapping symptoms of CDG‐I and dystroglycanopathy. MPDU1‐CDG is the fifth disorder related to DPM biosynthesis or utilization that bridges CDG‐I and the O‐mannosylation disorders.
+
+So far, seven MPDU1‐CDG patients have been described. All patients showed psychomotor retardation and most patients had hypotonia, facial dysmorphism, eye defects, apnea, and skin abnormalities such as ichthyosis.7, 8, 9 Including the two patients described here, four patients have been described with the same G73E substitution.7, 9 Hypertelorism, dysphagia, small renal cysts, thrombocytopenia, cardiomyopathy, and respiratory problems characterized these patients, whereas these symptoms were not reported in the other three MPDU1‐CDG patients. In addition, all G73E patients died at an early age (<11 months), whereas the other MPDU1‐CDG patients at least reached their teenage years. Taken together, this suggests that the G73E substitution affects MPDU1 function more severely, and the additional clinical features can aid in the prediction of the disease progression when new MPDU1‐CDG patients are identified.
+
+Interestingly, the two siblings described here showed a very similar clinical pattern, including very similar facial features, whereas siblings with other CDG disorders do not necessarily share as many clinical characteristics, for example, in ALG3‐CDG.16 The MPDU1‐CDG siblings shared the following abnormalities: massive dilatation of the intrahepatic biliary duct system, small renal cysts, buphthalmos with glaucoma, DCM, thrombocytopenia, elevated CK, and low ATIII. MPDU1 has been associated with the flipping of DPM over the ER membrane and thereby is part of the DPM biosynthesis defects.6 DPM is required for multiple glycosylation pathways. Thus, different symptoms can be caused by dysfunction of different glycosylation pathways. Buphthalmos, glaucoma, DCM, and elevated CK are clinical features that overlap with the disease spectrum of the dystroglycanopathies. Buphthalmos has so far not been described in any of the other DPM disorders, but is associated with Walker‐Warburg syndrome (WWS) and muscle‐eye‐brain (MEB) disease, which are severe variants of dystroglycanopathy.17 Glaucoma is a common feature of WWS and MEB, and has also been reported in SRD5A3‐CDG.17, 18
+
+
+Unfortunately, the role of glycosylation in cardiac disease is not completely understood. Therefore, there is no clear explanation why patient 1 shows DCM, whereas patient 2 developed HCM. HCM has been reported in PMM2‐CDG, ATP6V1A‐CDG, and ATP6V1E1‐CDG.19 Recent studies have shown that abnormal glycosylation, for example, abnormal sialylation or reduced hybrid/complex N‐glycosylation, is related to heart disease.19, 20, 21 However, future investigations are required to understand the clinical relevance of these findings. So far, DCM has been described in FKRP‐CDG, FKTN‐CDG, POMT1‐CDG, POMT2‐CDG, DOLK‐CDG, DPM3‐CDG, and PGM1‐CDG.19, 22 With the exception of PGM1‐CDG, these CDGs are associated with abnormal O‐mannosylation of αDG. Hence, the cardiac pathomechanism in MPDU1‐CDG patient 1 could be related to abnormal O‐mannosylation, although studies in heart biopsies are warranted to study this. In line with the clinical symptoms overlapping with dystroglycanopathies, we showed reduced O‐mannosylation of αDG in patient fibroblasts.
+
+In addition, we reported biliary duct abnormalities and renal cysts in our MPDU1‐CDG patients. Biliary duct abnormalities have also been observed in patients with mutations in mannose‐6‐phosphate isomerase (MPI), which interconverts fructose‐6‐phosphate to mannose‐6‐phosphate.23 Sabry et al24 reported a dehydrodolichyl diphosphate synthase (DHDDS‐CDG) patient with dilations of the biliary duct and renal failure, and Schenk et al7 reported renal cysts in a MPDU1‐CDG patient with the same G73E substitution. Biliary duct abnormalities and renal cysts are clinical symptoms associated with Caroli syndrome. In some cases, this syndrome has been associated with PKHD1 mutations, which are also known to cause autosomal recessive polycystic kidney disease. PKHD1 is extensively glycosylated,25 and it is tempting to speculate that abnormal glycosylation of PKHD1 causes the biliary duct abnormalities and renal cysts.
+
+In summary, we reported on two newly identified MPDU1‐CDG patients and showed reduced N‐glycosylation and O‐mannosylation in patient material. Together with the muscular, eye, and heart abnormalities, this adds MPDU1‐CDG to the list of DPM disorders causing biochemical and clinical abnormalities overlapping CDG‐I and dystroglycanopathy. Identification of additional patients with defects in DPM availability, and extensive O‐mannosylation and N‐glycosylation analysis of patient material is required to further increase our understanding of the pathophysiology of the DPM disorders.
+
+The authors declare that they have no conflict of interest.
+
+W.V.T. has set up the study, performed laboratory experiments, acquired and interpreted data, and written the manuscript. A.A. has performed WES analysis and critically reviewed the results and revised the manuscript. E.K. has collected, analyzed, and reviewed clinical data and written the manuscript. N.A.B. has performed ESI‐MS analysis and critically reviewed the manuscript. M.A.W. has critically reviewed results and revised the manuscript. C.T. has provided LLO analysis and revised the manuscript. D.J.L. contributed to the setup of the study, has interpreted data, critically reviewed the results and the manuscript, and supervised the study.
+
+All procedures followed were in accordance with the Helsinki Declaration of 1975, as revised in 2000. Informed consent was obtained from all patients for being included in this study or from their legal representatives. Written informed consent was obtained for inclusion of facial images.

--- a/references_cache/PMID_38917675.md
+++ b/references_cache/PMID_38917675.md
@@ -1,0 +1,159 @@
+---
+reference_id: "PMID:38917675"
+title: "Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: Recommendations for baseline screening and follow-up evaluation."
+authors:
+- Zemet R
+- Hope KD
+- Edmondson AC
+- Shah R
+- Patino M
+- Yesso AM
+- Berger JH
+- Sarafoglou K
+- Larson A
+- Lam C
+- Morava E
+- Scaglia F
+journal: Mol Genet Metab
+year: '2024'
+doi: 10.1016/j.ymgme.2024.108513
+keywords:
+- Humans
+- "Congenital Disorders of Glycosylation/genetics, diagnosis, pathology"
+- Female
+- Male
+- "Cardiomyopathies/genetics, diagnosis"
+- Phenotype
+- Child
+- "Child, Preschool"
+- Adolescent
+- Infant
+- Glycosylation
+- Follow-Up Studies
+- Adult
+- Retrospective Studies
+- Young Adult
+- Prospective Studies
+- "Infant, Newborn"
+content_type: abstract_only
+---
+
+# Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: Recommendations for baseline screening and follow-up evaluation.
+**Authors:** Zemet R, Hope KD, Edmondson AC, Shah R, Patino M, Yesso AM, Berger JH, Sarafoglou K, Larson A, Lam C, Morava E, Scaglia F
+**Journal:** Mol Genet Metab (2024)
+**DOI:** [10.1016/j.ymgme.2024.108513](https://doi.org/10.1016/j.ymgme.2024.108513)
+
+## Content
+
+1. Mol Genet Metab. 2024 Aug;142(4):108513. doi: 10.1016/j.ymgme.2024.108513.
+Epub  2024 Jun 13.
+
+Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: 
+Recommendations for baseline screening and follow-up evaluation.
+
+Zemet R(1), Hope KD(2), Edmondson AC(3), Shah R(4), Patino M(3), Yesso AM(5), 
+Berger JH(6), Sarafoglou K(7), Larson A(8), Lam C(9), Morava E(10), Scaglia 
+F(11).
+
+Author information:
+(1)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA.
+(2)Texas Children's Hospital, Houston, TX, USA; Lillie Frank Abercrombie 
+Division of Pediatric Cardiology, Department of Pediatrics, Baylor College of 
+Medicine, Houston, TX, USA.
+(3)Division of Human Genetics, Department of Pediatrics, Children's Hospital of 
+Philadelphia, Philadelphia, PA, USA.
+(4)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, USA; Department 
+of Biochemistry and Molecular Biology, Mayo Clinic, Rochester, MN, USA; 
+Department of Genetics and Genomic Sciences, Icahn School of Medicine at Mount 
+Sinai, New York City, NY, USA.
+(5)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA; Lillie Frank Abercrombie 
+Division of Pediatric Cardiology, Department of Pediatrics, Baylor College of 
+Medicine, Houston, TX, USA.
+(6)Division of Cardiology, Department of Pediatrics, Children's Hospital of 
+Philadelphia, Philadelphia, PA, USA.
+(7)Divisions of Endocrinology, and Genetics and Metabolism, Department of 
+Pediatrics, University of Minnesota Medical School, Minneapolis, MN, USA.
+(8)Department of Pediatrics, University of Colorado School of Medicine, Aurora, 
+CO, USA.
+(9)Department of Pediatrics, University of Washington and Seattle Children's 
+Hospital, Seattle, WA, USA; Norcliffe Foundation Center for Integrative Brain 
+Research, Seattle Children's Research Institute, Seattle, WA, USA.
+(10)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, USA; Department 
+of Genetics and Genomic Sciences, Icahn School of Medicine at Mount Sinai, New 
+York City, NY, USA; Department of Laboratory Medicine and Pathology, Mayo 
+Clinic, Rochester, MN, USA.
+(11)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA; Joint BCM-CUHK Center of 
+Medical Genetics, Prince of Wales Hospital, Hong Kong SAR, China. Electronic 
+address: fscaglia@bcm.edu.
+
+INTRODUCTION: Congenital disorders of glycosylation (CDG) are a continuously 
+expanding group of monogenic disorders that disrupt glycoprotein and glycolipid 
+biosynthesis, leading to multi-systemic manifestations. These disorders are 
+categorized into various groups depending on which part of the glycosylation 
+process is impaired. The cardiac manifestations in CDG can significantly differ, 
+not only across different types but also among individuals with the same genetic 
+cause of CDG. Cardiomyopathy is an important phenotype in CDG. The clinical 
+manifestations and progression of cardiomyopathy in CDG patients have not been 
+well characterized. This study aims to delineate common patterns of 
+cardiomyopathy across a range of genetic causes of CDG and to propose baseline 
+screening and follow-up evaluation for this patient population.
+METHODS: Patients with molecular confirmation of CDG who were enrolled in the 
+prospective or memorial arms of the Frontiers in Congenital Disorders of 
+Glycosylation Consortium (FCDGC) natural history study were ascertained for the 
+presence of cardiomyopathy based on a retrospective review of their medical 
+records. All patients were evaluated by clinical geneticists who are members of 
+FCDGC at their respective academic centers. Patients were screened for 
+cardiomyopathy, and detailed data were retrospectively collected. We analyzed 
+their clinical and molecular history, imaging characteristics of cardiac 
+involvement, type of cardiomyopathy, age at initial presentation of 
+cardiomyopathy, additional cardiac features, the treatments administered, and 
+their clinical outcomes.
+RESULTS: Of the 305 patients with molecularly confirmed CDG participating in the 
+FCDGC natural history study as of June 2023, 17 individuals, nine females and 
+eight males, were identified with concurrent diagnoses of cardiomyopathy. Most 
+of these patients were diagnosed with PMM2-CDG (n = 10). However, cardiomyopathy 
+was also observed in other diagnoses, including PGM1-CDG (n = 3), ALG3-CDG 
+(n = 1), DPM1-CDG (n = 1), DPAGT1-CDG (n = 1), and SSR4-CDG (n = 1). All 
+PMM2-CDG patients were reported to have hypertrophic cardiomyopathy. Dilated 
+cardiomyopathy was observed in three patients, two with PGM1-CDG and one with 
+ALG3-CDG; left ventricular non-compaction cardiomyopathy was diagnosed in two 
+patients, one with PGM1-CDG and one with DPAGT1-CDG; two patients, one with 
+DPM1-CDG and one with SSR4-CDG, were diagnosed with non-ischemic cardiomyopathy. 
+The estimated median age of diagnosis for cardiomyopathy was 5 months (range: 
+prenatal-27 years). Cardiac improvement was observed in three patients with 
+PMM2-CDG. Five patients showed a progressive course of cardiomyopathy, while the 
+condition remained unchanged in eight individuals. Six patients demonstrated 
+pericardial effusion, with three patients exhibiting cardiac tamponade. One 
+patient with SSR4-CDG has been recently diagnosed with cardiomyopathy; thus, the 
+progression of the disease is yet to be determined. One patient with PGM1-CDG 
+underwent cardiac transplantation. Seven patients were deceased, including five 
+with PMM2-CDG, one with DPAGT1-CDG, and one with ALG3-CDG. Two patients died of 
+cardiac tamponade from pericardial effusion; for the remaining patients, 
+cardiomyopathy was not necessarily the primary cause of death.
+CONCLUSIONS: In this retrospective study, cardiomyopathy was identified in ∼6% 
+of patients with CDG. Notably, the majority, including all those with PMM2-CDG, 
+exhibited hypertrophic cardiomyopathy. Some cases did not show progression, yet 
+pericardial effusions were commonly observed, especially in PMM2-CDG patients, 
+occasionally escalating to life-threatening cardiac tamponade. It is recommended 
+that clinicians managing CDG patients, particularly those with PMM2-CDG and 
+PGM1-CDG, be vigilant of the cardiomyopathy risk and risk for potentially 
+life-threatening pericardial effusions. Cardiac surveillance, including an 
+echocardiogram and EKG, should be conducted at the time of diagnosis, annually 
+throughout the first 5 years, followed by check-ups every 2-3 years if no 
+concerns arise until adulthood. Subsequently, routine cardiac examinations every 
+five years are advisable. Additionally, patients with diagnosed cardiomyopathy 
+should receive ongoing cardiac care to ensure the effective management and 
+monitoring of their condition. A prospective study will be required to determine 
+the true prevalence of cardiomyopathy in CDG.
+
+Copyright © 2024 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2024.108513
+PMCID: PMC11296892
+PMID: 38917675 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest The authors 
+report no conflict of interest.

--- a/research/MPDU1-congenital_disorder_of_glycosylation-deep-research-falcon.md
+++ b/research/MPDU1-congenital_disorder_of_glycosylation-deep-research-falcon.md
@@ -1,0 +1,1275 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:04:56.086101'
+end_time: '2026-05-11T11:20:39.224732'
+duration_seconds: 943.14
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: MPDU1-congenital disorder of glycosylation
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 29
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** MPDU1-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **MPDU1-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** MPDU1-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **MPDU1-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## MPDU1-congenital disorder of glycosylation (MPDU1-CDG; historical CDG-If): comprehensive disease characteristics report
+
+### Executive summary
+MPDU1-congenital disorder of glycosylation is an ultra-rare, autosomal recessive disorder of endoplasmic-reticulum (ER) glycosylation caused by biallelic pathogenic variants in **MPDU1** (mannose-P-dolichol utilization defect 1). The central defect is impaired **utilization/bioavailability of dolichol-phosphate–linked sugar donors** (Dol-P-Man and Dol-P-Glc) required for N-glycosylation, with secondary disruption of other glycosylation-dependent pathways (including α-dystroglycan O-mannosylation and GPI-anchor maturation), producing a multisystem phenotype (neurodevelopmental delay, seizures, hypotonia, skin and ocular disease, hepatic/biliary disease, cardiomyopathy, and hematologic/coagulation abnormalities). Core diagnostic evidence includes a **CDG type I transferrin pattern** and a characteristic **lipid-linked oligosaccharide (LLO) profile** with accumulation of truncated intermediates (Man5GlcNAc2 and Man9GlcNAc2). (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8, schenk2003mpdu1mutationsunderlie pages 6-8)
+
+### Key identifiers and nomenclature (disease information)
+**Disease name:** MPDU1-congenital disorder of glycosylation (OpenTargets Search: MPDU1-congenital disorder of glycosylation,congenital disorder of glycosylation-MPDU1)
+
+**Key identifiers (available from tool-supported sources in this report):**
+- **MONDO:** **MONDO:0012211** (“MPDU1-congenital disorder of glycosylation”) (OpenTargets Search: MPDU1-congenital disorder of glycosylation,congenital disorder of glycosylation-MPDU1)
+
+**Historical/alternative names and synonyms (from primary/review literature):**
+- **CDG-If / CDG-1f** (older CDG nomenclature) (tol2019amutationin pages 6-8, schenk2003mpdu1mutationsunderlie pages 1-2)
+- **mannose-P-dolichol utilization defect 1**; MPDU1 is also referred to as the human homolog of hamster **Lec35** (haeuptle2009congenitaldisordersof pages 9-10, kranz2001amutationin pages 1-2)
+
+**Evidence origin:** Most MPDU1-CDG disease knowledge is derived from individual case reports/series and small institutional cohorts rather than large EHR-derived datasets or population registries (tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14).
+
+**Important limitation:** OMIM/Orphanet/ICD identifiers were not directly retrievable using the available tools in this run; therefore, they are not asserted here.
+
+### 1) Key concepts and definitions (current understanding)
+
+#### Congenital disorders of glycosylation (CDG) and “CDG type I pattern”
+MPDU1-CDG is classified among disorders of **N-glycan assembly/ER glycosylation** that typically produce a **CDG type I** serum transferrin pattern (reflecting under-occupancy of N-glycosylation sites). In the MPDU1 cases described, transferrin analysis showed reduced fully sialylated transferrin and increased asialo-/disialotransferrin. (tol2019amutationin pages 5-6, schenk2003mpdu1mutationsunderlie pages 5-6)
+
+#### MPDU1 function and the dolichol-linked donor concept
+MPDU1 encodes an ER membrane protein required for **efficient utilization** (bioavailability/presentation) of the lipid-linked monosaccharide donors **dolichol-P-mannose (Dol-P-Man)** and **dolichol-P-glucose (Dol-P-Glc)** in the ER. Evidence from patient cells and complementation experiments supports a role in **lateral distribution/chaperoning** of dolichol-linked donors rather than a simple “flippase” that translocates them across the ER membrane. (schenk2003mpdu1mutationsunderlie pages 6-8, kranz2001amutationin pages 5-7, kranz2001amutationin pages 1-2)
+
+### 2) Etiology (causal factors, risk/protective factors, GxE)
+
+#### Disease causal factors
+- **Genetic etiology:** biallelic pathogenic variants in **MPDU1** cause MPDU1-CDG. The earliest definitive causal demonstrations used patient fibroblasts showing abnormal LLO profiles and **functional rescue** after expression of wild-type MPDU1/Lec35 cDNA. (schenk2003mpdu1mutationsunderlie pages 6-8, schenk2003mpdu1mutationsunderlie pages 1-2)
+
+#### Inheritance and risk factors
+- **Autosomal recessive inheritance** is supported by homozygous affected individuals with heterozygous parents, and by compound heterozygosity in some reported families. (kranz2001amutationin pages 5-7, schenk2003mpdu1mutationsunderlie pages 5-6)
+- **Consanguinity** is reported in at least one family with homozygous p.G73E. (tol2019amutationin pages 1-2)
+
+#### Protective factors and gene–environment interactions
+No validated protective genetic variants, environmental protective factors, or gene–environment interactions specific to MPDU1-CDG were identified in the retrieved evidence. Given the Mendelian mechanism, environmental modifiers are plausible but currently undocumented for MPDU1-CDG in the sources available here.
+
+### 3) Phenotypes (clinical spectrum; HPO suggestions; frequency where available)
+
+#### Overview of clinical phenotype
+Across reported MPDU1-CDG patients, commonly described features include neurodevelopmental impairment and seizures, hypotonia, dermatologic abnormalities (ichthyosis/scaling; variably present), ocular anomalies (including congenital glaucoma/buphthalmos), hepatic/biliary involvement (including massive biliary duct dilatation in some), cardiomyopathy, thrombocytopenia/coagulation abnormalities, and elevated creatine kinase. (tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14)
+
+A notable 2019 report explicitly highlights overlap with dystroglycanopathy. **Direct abstract quote:** “*Here, we report two MPDU1‐CDG patients without skin involvement, but with massive dilatation of the biliary duct system and dystroglycanopathy characteristics including hypotonia, elevated creatine kinase, dilated cardiomyopathy, buphthalmos, and congenital glaucoma.*” (van Tol et al., 2019; published Sep 2019; https://doi.org/10.1002/jmd2.12060) (tol2019amutationin pages 1-2)
+
+#### Phenotype-by-phenotype with ontology suggestions
+Below are representative phenotype categories; reported frequencies are limited because case counts are small.
+
+1) **Neurodevelopmental delay / psychomotor retardation**
+- Type: symptom/clinical sign
+- Onset: typically infancy/early childhood in reported cases
+- Suggested HPO: **HP:0001263** (Global developmental delay), **HP:0001249** (Intellectual disability)
+- Evidence: psychomotor retardation/delay repeatedly noted in early and later case descriptions. (haeuptle2009congenitaldisordersof pages 9-10, kranz2001amutationin pages 1-2)
+
+2) **Seizures / epilepsy; apnea with seizures**
+- Type: symptom
+- Suggested HPO: **HP:0001250** (Seizures), **HP:0002104** (Apnea)
+- Course: can be severe; seizure-induced apnea contributed to death in at least one early case. (haeuptle2009congenitaldisordersof pages 9-10, kranz2001amutationin pages 1-2)
+
+3) **Hypotonia and neuromuscular involvement**
+- Type: clinical sign
+- Suggested HPO: **HP:0001252** (Hypotonia)
+- Evidence: hypotonia is common; dystroglycanopathy overlap suggests muscle involvement in some cases. (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8)
+
+4) **Skin involvement (ichthyosis/scaling/erythroderma/desquamation)**
+- Type: physical manifestation
+- Suggested HPO: **HP:0008064** (Ichthyosis), **HP:0000964** (Eczema) (if applicable), **HP:0000988** (Skin rash)
+- Variability: may be absent in some MPDU1-CDG patients. (tol2019amutationin pages 1-2, teneiji2017phenotypicandgenotypic pages 10-14, kranz2001amutationin pages 1-2)
+
+5) **Ocular disease (buphthalmos, congenital glaucoma, corneal clouding, visual impairment/amaurosis)**
+- Type: physical manifestation
+- Suggested HPO: **HP:0007721** (Congenital glaucoma), **HP:0000613** (Buphthalmos), **HP:0000518** (Visual impairment)
+- Clinical importance: severe congenital glaucoma may require urgent intervention (trabeculectomy noted in compiled case summaries). (tol2019amutationin pages 6-8)
+
+6) **Cardiac involvement (cardiomyopathy)**
+- Type: clinical sign
+- Suggested HPO: **HP:0001638** (Cardiomyopathy), **HP:0001644** (Dilated cardiomyopathy), **HP:0001639** (Hypertrophic cardiomyopathy)
+- Evidence: cardiomyopathy present in multiple MPDU1-CDG cases; MPDU1 is also listed among CDG genes associated with cardiomyopathy in 2024 screening recommendations. (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, zemet2024cardiomyopathyanuncommon pages 3-5)
+
+7) **Hepatic/biliary involvement**
+- Type: clinical sign / imaging abnormality
+- Suggested HPO: **HP:0001392** (Hepatomegaly) (if present), **HP:0003270** (Abnormality of the biliary tract), **HP:0002240** (Hepatic dysfunction)
+- Evidence: hepatocellular/synthetic dysfunction noted in a cohort case; biliary duct dilatation emphasized in the 2019 siblings. (tol2019amutationin pages 1-2, teneiji2017phenotypicandgenotypic pages 10-14)
+
+8) **Hematologic/coagulation abnormalities**
+- Type: laboratory abnormality
+- Suggested HPO: **HP:0001873** (Thrombocytopenia), **HP:0001928** (Coagulopathy)
+- Evidence: thrombocytopenia and low antithrombin III reported. (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8)
+
+#### Quality-of-life impact
+No MPDU1-CDG–specific quality-of-life instruments (e.g., EQ-5D/SF-36) were found in the retrieved evidence. However, severe neurodevelopmental impairment, feeding dependence, seizures, visual disability, and cardiomyopathy imply substantial functional limitation. (tol2019amutationin pages 5-6, kranz2001amutationin pages 1-2)
+
+### 4) Genetic and molecular information
+
+#### Causal gene
+- **Gene:** MPDU1 (mannose-P-dolichol utilization defect 1) (haeuptle2009congenitaldisordersof pages 9-10)
+- **Protein features (as summarized in reviewed evidence):** ER membrane protein; reviews describe multiple transmembrane domains and ER localization. (haeuptle2009congenitaldisordersof pages 9-10)
+
+#### Pathogenic variants (examples explicitly captured in the retrieved evidence)
+- **c.218G>A (p.G73E)** (recurrent; associated with severe early-lethal disease in multiple reported cases) (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, schenk2003mpdu1mutationsunderlie pages 5-6)
+- **221T>C (p.L74S)** (homozygous in the initial 2001 JCI patient; parental heterozygosity shown) (kranz2001amutationin pages 5-7, kranz2001amutationin pages 1-2)
+- **c.356T>C (p.L119P)** (homozygous in one of the 2003 JCI patients) (schenk2003mpdu1mutationsunderlie pages 5-6)
+- **2T>C (p.M1T)** and **c.511delC (frameshift)** (compound heterozygosity in one 2003 JCI patient) (schenk2003mpdu1mutationsunderlie pages 5-6)
+- Additional missense variants reported in an Arab molecularly characterized summary: **p.Gly104Ser** and **p.Gln126Pro** (bastaki2018single‐centerexperienceof pages 8-10)
+
+**Variant types observed:** primarily missense; at least one frameshift (c.511delC) and start-loss (p.M1T) are reported. (schenk2003mpdu1mutationsunderlie pages 5-6)
+
+**Allele frequencies in population databases:** not available in the retrieved evidence; therefore not asserted.
+
+#### Functional consequences
+Collectively, patient-cell studies indicate the molecular defect leads to impaired use of Dol-P-Man and Dol-P-Glc, causing truncated LLO assembly and downstream protein hypoglycosylation; a 2003 mechanistic proposal is that MPDU1 acts as a dolichol-sugar “chaperone” supporting lateral distribution of dolichol-linked donors in the ER membrane. (schenk2003mpdu1mutationsunderlie pages 6-8, kranz2001amutationin pages 1-2)
+
+#### Modifier genes
+No MPDU1-CDG–specific modifier genes were identified in the retrieved evidence. One broader glycosylation modifier discussion exists in other contexts (e.g., ALG6 F304S modifying DHDDS-related disease), but this is not specific to MPDU1-CDG pathogenesis. (hamzan2023epidemiologyandprevalence pages 5-7)
+
+### 5) Environmental information
+No environmental toxins, lifestyle exposures, or infectious triggers are established contributors to MPDU1-CDG in the retrieved evidence (consistent with a primary Mendelian etiology).
+
+### 6) Mechanism / pathophysiology
+
+#### Causal chain (from gene to clinical phenotype)
+1) **Biallelic MPDU1 variants → MPDU1 loss/dysfunction** in the ER membrane (kranz2001amutationin pages 5-7, schenk2003mpdu1mutationsunderlie pages 5-6)
+2) **Impaired utilization/bioavailability of Dol-P-Man and Dol-P-Glc** needed by ER mannosyl-/glucosyltransferases (schenk2003mpdu1mutationsunderlie pages 6-8, kranz2001amutationin pages 1-2)
+3) **Characteristic LLO assembly defect** with accumulation of truncated dolichol-PP-linked intermediates (notably Man5GlcNAc2 and Man9GlcNAc2) and reduced/aberrant mature Glc3Man9GlcNAc2; incomplete oligosaccharides can be transferred to proteins (schenk2003mpdu1mutationsunderlie pages 6-8, schenk2003mpdu1mutationsunderlie pages 1-2, tol2019amutationin media 2abc4e54)
+4) **Systemic glycoprotein hypoglycosylation**, detectable via serum transferrin isoform analysis (CDG-I pattern) (schenk2003mpdu1mutationsunderlie pages 5-6, tol2019amutationin media 2abc4e54)
+5) **Multi-pathway downstream effects**, including reduced O-mannosylation of α-dystroglycan (explaining dystroglycanopathy overlap) and impaired GPI-anchor maturation (reduced surface CD59) (tol2019amutationin pages 6-8, schenk2003mpdu1mutationsunderlie pages 6-8)
+6) **Organ dysfunction** (neurodevelopmental delay/seizures, ocular disease, skin barrier defects/ichthyosis in many, cardiac and hepatobiliary manifestations) (tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14)
+
+#### Molecular pathways/processes and ontology suggestions
+- **N-linked glycosylation (ER LLO assembly and transfer)**
+  - Suggested GO Biological Process: **GO:0006487** (protein N-linked glycosylation)
+  - Suggested GO Cellular Component: **GO:0005783** (endoplasmic reticulum)
+  - Evidence: truncated LLO intermediates and hypoglycosylated serum transferrin; rescue by wild-type MPDU1. (schenk2003mpdu1mutationsunderlie pages 6-8, schenk2003mpdu1mutationsunderlie pages 1-2)
+
+- **Dolichol-linked monosaccharide utilization**
+  - Suggested GO BP (closest plausible): **GO:0019673** (dolichol-linked oligosaccharide biosynthetic process) / **GO:0019358** (dolichol biosynthetic process) (note: MPDU1 affects utilization rather than synthesis)
+  - Evidence: Dol-P-Man/Dol-P-Glc present but not efficiently used; proposed lateral distribution mechanism. (schenk2003mpdu1mutationsunderlie pages 6-8)
+
+- **O-mannosylation of α-dystroglycan (dystroglycanopathy overlap)**
+  - Suggested GO BP: **GO:0035269** (protein O-linked mannosylation)
+  - Evidence: reduced IIH6/laminin overlay binding indicating reduced functional glycosylation of α-dystroglycan. (tol2019amutationin pages 6-8)
+
+- **GPI-anchor biosynthesis (secondary)**
+  - Suggested GO BP: **GO:0006506** (GPI anchor biosynthetic process)
+  - Evidence: reduced cell-surface GPI-anchored CD59 in patient cells. (schenk2003mpdu1mutationsunderlie pages 6-8)
+
+#### Cell types (CL suggestions)
+Direct cell-type-specific pathology is not well established in the retrieved evidence. However, based on organ involvement:
+- Suggested CL: **CL:0000540** (neuron), **CL:0000746** (cardiomyocyte), **CL:0000548** (hepatocyte), **CL:0000333** (fibroblast) (the main experimental patient cell type used). (tol2019amutationin pages 5-6, schenk2003mpdu1mutationsunderlie pages 6-8)
+
+### 7) Anatomical structures affected (UBERON suggestions)
+Evidence supports multisystem involvement:
+- **Nervous system:** UBERON:0001016 (nervous system) (seizures, neurodevelopmental delay) (kranz2001amutationin pages 1-2)
+- **Eye:** UBERON:0000970 (eye) (congenital glaucoma, buphthalmos, visual impairment) (tol2019amutationin pages 6-8)
+- **Skin:** UBERON:0002097 (skin of body) (ichthyosis/scaling) (teneiji2017phenotypicandgenotypic pages 10-14, kranz2001amutationin pages 1-2)
+- **Heart:** UBERON:0000948 (heart) (cardiomyopathy) (tol2019amutationin pages 5-6)
+- **Liver/biliary system:** UBERON:0002107 (liver); UBERON:0000059 (bile duct) (liver dysfunction; biliary duct dilatation) (tol2019amutationin pages 1-2, teneiji2017phenotypicandgenotypic pages 10-14)
+
+Subcellular localization emphasized in mechanism:
+- **Endoplasmic reticulum membrane** (GO CC: ER membrane; MPDU1 is an ER membrane protein). (haeuptle2009congenitaldisordersof pages 9-10, kranz2001amutationin pages 1-2)
+
+### 8) Temporal development
+- **Typical onset:** congenital/infantile presentation is most consistent with reported cases (severe multisystem disease in infancy; early deaths in severe genotypes). (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8)
+- **Progression/course:** variable; p.G73E has been repeatedly associated with very severe early-lethal disease, while other alleles show mild-to-moderate disease in earlier series. (tol2019amutationin pages 6-8, haeuptle2009congenitaldisordersof pages 9-10)
+
+### 9) Inheritance and population
+
+#### Inheritance
+Autosomal recessive inheritance is supported by segregation in families and by homozygous/compound heterozygous genotypes in affected individuals. (tol2019amutationin pages 5-6, kranz2001amutationin pages 5-7, schenk2003mpdu1mutationsunderlie pages 5-6)
+
+#### Epidemiology
+No MPDU1-specific population prevalence/incidence estimate was identified in the retrieved evidence (typical for ultra-rare CDGs). For contextual, country-level CDG screening prevalence:
+- A 2018–2022 Malaysian national reference-lab dataset identified **2 confirmed CDG diagnoses among 548 suspected cases**, yielding a calculated **birth prevalence of 0.22 per 100,000 live births** for CDG overall (not MPDU1-specific), and 0.85 per 100,000 for combined abnormal transferrin patterns. (Hamzan 2023; published Apr 2023; https://doi.org/10.37231/ajmb.2023.7.1.601) (hamzan2023epidemiologyandprevalence pages 1-3, hamzan2023epidemiologyandprevalence pages 3-5)
+- Direct abstract quote: “*Overall, the prevalence of CDG in Malaysia was low and may be underestimated yet consistent with other reported in other countries.*” (hamzan2023epidemiologyandprevalence pages 1-3)
+
+#### Population/variant observations
+- Recurrent **p.G73E (c.218G>A)** appears in multiple unrelated MPDU1-CDG patients and is repeatedly associated with severe early-lethal disease, suggesting either a recurrent mutational hotspot or possible population recurrence; detailed founder analysis was not available in retrieved evidence. (tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 33-37)
+- Consanguinity is reported in at least one affected family with p.G73E. (tol2019amutationin pages 1-2)
+
+### 10) Diagnostics
+
+#### Clinical suspicion
+Patients may present with a CDG-like multisystem phenotype (neurodevelopmental delay, seizures, hypotonia, failure to thrive, skin/eye disease, hepatic/biliary abnormalities) and/or dystroglycanopathy features (myopathy, elevated CK, cardiomyopathy), prompting biochemical and genetic testing. (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8)
+
+#### Biochemical testing (real-world implementation)
+1) **Serum transferrin isoform analysis**
+- Methods used: transferrin isoelectric focusing (TIEF/IEF), sometimes quantified by HPLC-based approaches; CDG-I pattern reported in MPDU1-CDG including increased disialotransferrin and reduced tetrasialotransferrin. (tol2019amutationin pages 5-6, teneiji2017phenotypicandgenotypic pages 10-14, teneiji2017phenotypicandgenotypic pages 6-10)
+- Figure-based evidence: TIEF pattern is shown in van Tol et al. 2019 (Figure 1D). (tol2019amutationin media 2abc4e54)
+
+2) **Lipid-linked oligosaccharide (LLO) profiling in patient fibroblasts**
+- Methods: HPLC analysis of LLOs; thin-layer chromatography (TLC) for hydrophobic extracts including Dol-P-Man/Dol-P-Glc-related measures. (tol2019amutationin pages 5-6, tol2019amutationin pages 1-2)
+- Figure-based evidence: LLO HPLC profile is shown in van Tol et al. 2019 (Figure 2A). (tol2019amutationin media 2abc4e54)
+
+3) **Functional glycosylation of α-dystroglycan**
+- Methods: IIH6 immunolabeling and laminin overlay assays in fibroblasts to show reduced O-mannosylation/functional glycosylation of α-dystroglycan. (tol2019amutationin pages 6-8)
+
+#### Genetic testing
+- Approaches in published cohorts/cases include single-gene testing, targeted next-generation sequencing panels for CDG genes, and whole-exome sequencing (WES) with segregation analysis. (tol2019amutationin pages 5-6, teneiji2017phenotypicandgenotypic pages 6-10)
+
+#### Differential diagnosis
+MPDU1-CDG can overlap clinically and biochemically with other **CDG type I** conditions and with **dystroglycanopathies** due to DPM synthesis/utilization defects (e.g., DOLK-, DPM1/2/3-related disorders). (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8)
+
+#### Screening
+There is no evidence in retrieved sources that MPDU1-CDG is included in routine newborn screening panels. Population screening for CDG more broadly often uses transferrin isoform analysis (IEF/CZE/HPLC), but sensitivity varies by subtype; genetic testing is increasingly used for definitive diagnosis. (teneiji2017phenotypicandgenotypic pages 6-10, hamzan2023epidemiologyandprevalence pages 3-5)
+
+### 11) Outcome / prognosis
+Prognosis is **highly variable**. Severe disease with early infant death has been repeatedly described in p.G73E homozygous patients (deaths reported within the first year of life in some cases). (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8)
+
+A review of dolichol-linked oligosaccharide disorders notes variable severity and reports one patient dying in early childhood following seizure-induced apnea, while others had milder disease. (haeuptle2009congenitaldisordersof pages 9-10)
+
+### 12) Treatment and management
+
+#### Disease-modifying therapy
+No established disease-specific or pathway-targeted therapy for MPDU1-CDG was identified in the retrieved evidence; management is therefore primarily supportive. (tol2019amutationin pages 6-8)
+
+#### Supportive and multidisciplinary care (current real-world implementations)
+Care is typically individualized and may include:
+- **Neurology:** antiseizure management; monitoring for apnea/respiratory complications (MAXO suggestions: antiseizure therapy; respiratory support). (tol2019amutationin pages 5-6, kranz2001amutationin pages 1-2)
+- **Nutrition/feeding:** feeding support including tube feeding when required (MAXO: enteral nutrition). (tol2019amutationin pages 5-6)
+- **Ophthalmology:** early evaluation and management of congenital glaucoma (e.g., surgical intervention reported in compiled cases) (MAXO: glaucoma surgery; vision rehabilitation). (tol2019amutationin pages 6-8)
+- **Cardiology:** surveillance and management of cardiomyopathy/heart failure where present (MAXO: cardiac monitoring; heart failure pharmacotherapy). (tol2019amutationin pages 5-6, zemet2024cardiomyopathyanuncommon pages 3-5)
+- **Hepatology/Gastroenterology:** evaluation of hepatocellular dysfunction and biliary tract abnormalities. (tol2019amutationin pages 1-2, teneiji2017phenotypicandgenotypic pages 10-14)
+- **Hematology:** monitoring thrombocytopenia and coagulation factors such as antithrombin III. (tol2019amutationin pages 5-6)
+
+#### 2024 expert recommendations relevant to MPDU1-CDG (cardiac screening)
+A 2024 expert recommendations paper on cardiomyopathy in CDG lists MPDU1 among CDG genes associated with cardiomyopathy and proposes **baseline and longitudinal cardiac surveillance** for CDG patients: echocardiogram and ECG at diagnosis, annual follow-up for the first 5 years, then every 2–3 years until adulthood if stable, and approximately every 5 years thereafter. (Zemet et al., Aug 2024; https://doi.org/10.1016/j.ymgme.2024.108513) (zemet2024cardiomyopathyanuncommon pages 3-5, zemet2024cardiomyopathyanuncommon pages 1-3)
+
+### 13) Prevention
+Primary prevention of MPDU1-CDG is not currently feasible outside genetic strategies. Secondary/tertiary prevention focuses on early diagnosis and proactive management of organ complications.
+
+- **Genetic counseling (primary prevention at family level):** because inheritance is autosomal recessive, carrier testing in parents and at-risk relatives, reproductive counseling, and options such as prenatal diagnosis or preimplantation genetic testing are conceptually applicable (not directly evidenced in retrieved texts, but consistent with AR inheritance demonstrated in primary reports). (kranz2001amutationin pages 5-7)
+
+### 14) Other species / natural disease
+No naturally occurring animal disease analogs were identified in the retrieved evidence.
+
+### 15) Model organisms and experimental systems
+Although whole-animal disease models were not retrieved here, multiple experimental systems directly support MPDU1 biology:
+- **Hamster CHO cell (Lec35) complementation system:** MPDU1 is orthologous to hamster Lec35; patient alleles show impaired correction of the Lec35 phenotype compared with wild-type MPDU1, supporting functional impact of human variants. (kranz2001amutationin pages 5-7, kranz2001amutationin pages 1-2)
+- **Patient fibroblast rescue experiments:** expression of normal Lec35/MPDU1 cDNA restored normal LLO biosynthesis in patient fibroblasts, providing strong functional causality evidence. (schenk2003mpdu1mutationsunderlie pages 6-8)
+
+### Recent developments and “latest research” emphasis (2023–2024)
+Because MPDU1-CDG is extremely rare, MPDU1-specific 2023–2024 primary case reports were not retrievable within the available tool outputs in this run. However, important 2023–2024 developments relevant to MPDU1-CDG clinical practice include:
+1) **2024 cardiomyopathy surveillance recommendations in CDG** (gene list includes MPDU1; provides longitudinal screening schedule). (zemet2024cardiomyopathyanuncommon pages 3-5, zemet2024cardiomyopathyanuncommon pages 1-3)
+2) **ClinicalTrials.gov natural history infrastructure (NCT04199000)** explicitly includes MPDU1 in the targeted CDG spectrum and collects standardized clinical severity measures and biospecimens for biomarker research. (Study posted 2019; recruiting; https://clinicaltrials.gov/study/NCT04199000) (NCT04199000 chunk 1)
+3) **2023 national reference-lab epidemiology data** illustrating how transferrin-based screening is implemented at scale and how prevalence estimates may be derived (though not MPDU1-specific). (hamzan2023epidemiologyandprevalence pages 1-3, hamzan2023epidemiologyandprevalence pages 3-5)
+
+### Key statistics and data points (from retrieved evidence)
+- In a CDG natural history cohort (FCDGC) of **305 molecularly confirmed CDG patients** (as of June 2023), **17 (5.6%)** had cardiomyopathy; MPDU1-CDG was not among the cardiomyopathy genotypes identified in that cohort subset, but MPDU1 is included among CDG genes reported with cardiomyopathy in the literature. (zemet2024cardiomyopathyanuncommon pages 5-6, zemet2024cardiomyopathyanuncommon pages 3-5)
+- Malaysian screening-based birth prevalence estimates for CDG overall: **0.22 per 100,000 live births** (CDG overall) and **0.85 per 100,000 live births** (abnormal transferrin patterns), based on 2018–2022 reference-lab data. (hamzan2023epidemiologyandprevalence pages 1-3, hamzan2023epidemiologyandprevalence pages 3-5)
+
+### Curated quick-reference table (variants/phenotypes/diagnostics/management)
+| Category | Summary |
+|---|---|
+| Disease / names | **MPDU1-congenital disorder of glycosylation**; historical names: **CDG-If**, **MPDU1-CDG**, **mannose-P-dolichol utilization defect 1**; MONDO: **MONDO:0012211** (Open Targets disease association) (OpenTargets Search: MPDU1-congenital disorder of glycosylation,congenital disorder of glycosylation-MPDU1, haeuptle2009congenitaldisordersof pages 9-10, schenk2003mpdu1mutationsunderlie pages 1-2) |
+| Evidence base | Ultra-rare, disease-level knowledge is derived primarily from individual case reports/series and small CDG cohorts rather than large epidemiologic datasets (tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14, hamzan2023epidemiologyandprevalence pages 1-3) |
+| Inheritance | **Autosomal recessive**; homozygous and compound-heterozygous MPDU1 variants reported, with parental heterozygosity/segregation shown in key families (tol2019amutationin pages 5-6, kranz2001amutationin pages 5-7, schenk2003mpdu1mutationsunderlie pages 5-6) |
+| Causal gene | **MPDU1** encodes an ER membrane protein required for efficient utilization/lateral distribution of **dolichol-P-mannose (Dol-P-Man)** and **dolichol-P-glucose (Dol-P-Glc)** during glycosylation; orthologous to hamster **Lec35** (haeuptle2009congenitaldisordersof pages 9-10, schenk2003mpdu1mutationsunderlie pages 6-8, kranz2001amutationin pages 1-2) |
+| Key reported variants | **c.218G>A (p.G73E)** recurrent severe variant; **221T>C (p.L74S)**; **c.356T>C (p.L119P)**; **2T>C (p.M1T)**; **c.511delC** frameshift; additional reported missense variants **p.Gly104Ser** and **p.Gln126Pro** in Arab summary literature (tol2019amutationin pages 5-6, teneiji2017phenotypicandgenotypic pages 33-37, kranz2001amutationin pages 5-7, schenk2003mpdu1mutationsunderlie pages 5-6, bastaki2018single‐centerexperienceof pages 8-10) |
+| Core neurologic features | Psychomotor/neurodevelopmental delay or retardation, severe hypotonia, seizures/epilepsy, failure to thrive, apnea/respiratory compromise in severe cases (tol2019amutationin pages 6-8, haeuptle2009congenitaldisordersof pages 9-10, kranz2001amutationin pages 1-2) |
+| Skin features | Ichthyosis, dry skin with scaling/erythroderma, patchy desquamation; skin involvement is variable and may be absent in some newer cases (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14, schenk2003mpdu1mutationsunderlie pages 5-6, kranz2001amutationin pages 1-2) |
+| Eye features | Visual impairment/amaurosis, enlarged cloudy corneae, **buphthalmos**, **congenital glaucoma**, other eye defects; glaucoma may require urgent ophthalmologic intervention (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, haeuptle2009congenitaldisordersof pages 9-10) |
+| Cardiac features | Cardiomyopathy reported, including **dilated cardiomyopathy** and **hypertrophic cardiomyopathy**; MPDU1 is listed among CDG genes associated with cardiomyopathy in recent cardiac review/guidance (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, zemet2024cardiomyopathyanuncommon pages 3-5) |
+| Hepatic / biliary features | Hepatocellular/synthetic liver dysfunction, increased liver echogenicity, and striking **biliary duct dilatation** in some cases (tol2019amutationin pages 1-2, teneiji2017phenotypicandgenotypic pages 10-14) |
+| Hematologic / coagulation features | **Thrombocytopenia**, low **antithrombin III**, and coagulation abnormalities have been documented (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8) |
+| Additional organ involvement | Gastrointestinal problems, feeding dependence, small renal cysts, facial dysmorphism, elevated CK, pulmonary hypertension, VSD in some patients (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 10-14, haeuptle2009congenitaldisordersof pages 9-10) |
+| Biochemical hallmark: transferrin | **CDG-I transferrin pattern** with hypoglycosylated serum transferrin; increased **asialo-/disialotransferrin** and reduced tetrasialotransferrin reported by TIEF/IEF and confirmed by ESI-MS in some patients (tol2019amutationin pages 5-6, teneiji2017phenotypicandgenotypic pages 10-14, schenk2003mpdu1mutationsunderlie pages 1-2, schenk2003mpdu1mutationsunderlie pages 5-6, tol2019amutationin media 2abc4e54) |
+| Biochemical hallmark: LLO profile | Accumulation of truncated **lipid-linked oligosaccharides (LLOs)**, especially **Man5GlcNAc2** and **Man9GlcNAc2**; mature **Glc3Man9GlcNAc2** reduced/abnormal; incomplete oligosaccharides can be transferred to protein (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, haeuptle2009congenitaldisordersof pages 9-10, schenk2003mpdu1mutationsunderlie pages 6-8, schenk2003mpdu1mutationsunderlie pages 1-2, tol2019amutationin media 2abc4e54) |
+| Functional defect | Impaired **utilization** rather than synthesis of **Dol-P-Man** and **Dol-P-Glc**; MPDU1 is proposed to act as a dolichol-sugar chaperone/lateral distributor in the ER rather than a simple flippase (haeuptle2009congenitaldisordersof pages 9-10, schenk2003mpdu1mutationsunderlie pages 6-8, kranz2001amutationin pages 5-7, kranz2001amutationin pages 1-2) |
+| Other pathway effects | Reduced **O-mannosylation of α-dystroglycan** (dystroglycanopathy overlap) and reduced cell-surface **GPI-anchored CD59** have been shown in patient cells (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8, schenk2003mpdu1mutationsunderlie pages 6-8) |
+| Diagnostic modalities | Serum **TIEF/IEF** ± **HPLC/CZE** screening; **ESI-MS** transferrin analysis; fibroblast **LLO HPLC/TLC**; **WES** or targeted NGS; segregation analysis; functional complementation in fibroblasts/CHO cells; **IIH6 immunolabeling/laminin overlay** for α-dystroglycan (tol2019amutationin pages 5-6, tol2019amutationin pages 1-2, tol2019amutationin pages 6-8, teneiji2017phenotypicandgenotypic pages 33-37, kranz2001amutationin pages 5-7, tol2019amutationin media 2abc4e54, hamzan2023epidemiologyandprevalence pages 3-5) |
+| Differential diagnostic context | Overlaps biochemically with other **CDG-I** defects and clinically with **dystroglycanopathies**, especially disorders affecting DPM synthesis/utilization (e.g., DOLK/DPM pathway disorders) (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8) |
+| Outcomes / prognosis | Prognosis is **variable but often severe**; recurrent **p.G73E** is associated with particularly severe disease and **early infant death** (reported deaths before ~11 months in some cases); one earlier patient died in early childhood following seizure-induced apnea (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8, haeuptle2009congenitaldisordersof pages 9-10) |
+| Management | No disease-modifying therapy established; current care is **supportive and multidisciplinary**: nutritional/feeding support, seizure management, ophthalmologic care, cardiology, hepatology, and coagulation monitoring as indicated (tol2019amutationin pages 5-6, tol2019amutationin pages 6-8) |
+| Cardiac surveillance suggestion | Because MPDU1 is among CDG types linked to cardiomyopathy, recent CDG guidance recommends **baseline ECG + echocardiogram at diagnosis**, **annual cardiac follow-up for the first 5 years**, then **every 2–3 years until adulthood** if stable, and about **every 5 years thereafter**; ongoing cardiology care if cardiomyopathy is present (zemet2024cardiomyopathyanuncommon pages 3-5, zemet2024cardiomyopathyanuncommon pages 1-3) |
+| Current research / implementation | MPDU1-CDG is included within the **Frontiers in CDG Consortium** natural history infrastructure and the observational study **NCT04199000**, which collects longitudinal clinical data and biospecimens across molecularly confirmed CDG subtypes (NCT04199000 chunk 1, zemet2024cardiomyopathyanuncommon pages 3-5, zemet2024cardiomyopathyanuncommon pages 1-3) |
+
+
+*Table: This table condenses the main disease-defining, molecular, clinical, biochemical, diagnostic, prognostic, and management facts for MPDU1-congenital disorder of glycosylation. It is designed as a quick-reference artifact for knowledge-base curation and evidence tracing.*
+
+### Figure/table evidence extracted from primary literature
+- Transferrin IEF and LLO profiling figures and a multi-patient clinical feature table are available in the van Tol et al. 2019 report, supporting key biochemical hallmarks and clinical comparisons. (tol2019amutationin media 2abc4e54, tol2019amutationin media 23fb2f88, tol2019amutationin media 7782a19e, tol2019amutationin media 364fb774)
+
+### References (URLs and publication dates where available)
+- Kranz C, et al. *The Journal of Clinical Investigation* (Dec 2001). https://doi.org/10.1172/jci13635 (kranz2001amutationin pages 1-2, kranz2001amutationin pages 5-7)
+- Schenk B, et al. *Journal of Clinical Investigation* (Mar 2003). https://doi.org/10.1172/jci200113419c (schenk2003mpdu1mutationsunderlie pages 1-2, schenk2003mpdu1mutationsunderlie pages 5-6, schenk2003mpdu1mutationsunderlie pages 6-8)
+- van Tol W, et al. *JIMD Reports* (Sep 2019). https://doi.org/10.1002/jmd2.12060 (tol2019amutationin pages 1-2, tol2019amutationin pages 6-8)
+- Hamzan NI. *Asian Journal of Medicine and Biomedicine* (Apr 2023). https://doi.org/10.37231/ajmb.2023.7.1.601 (hamzan2023epidemiologyandprevalence pages 1-3)
+- Zemet R, et al. *Molecular Genetics and Metabolism* (Aug 2024). https://doi.org/10.1016/j.ymgme.2024.108513 (zemet2024cardiomyopathyanuncommon pages 3-5)
+- ClinicalTrials.gov: NCT04199000 (posted 2019; recruiting as retrieved). https://clinicaltrials.gov/study/NCT04199000 (NCT04199000 chunk 1)
+
+
+
+References
+
+1. (tol2019amutationin pages 1-2): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+2. (tol2019amutationin pages 6-8): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+3. (schenk2003mpdu1mutationsunderlie pages 6-8): B. Schenk, T. Imbach, C. Frank, C. Grubenmann, G. Raymond, H. Hurvitz, I. Korn‐Lubetzki, S. Revel-Vik, A. Raas-Rotschild, A. Luder, J. Jaeken, E. Berger, G. Matthijs, T. Hennet, and M. Aebi. Mpdu1 mutations underlie a novel human congenital disorder of glycosylation, designated type if. Journal of Clinical Investigation, 111:925-a-925, Mar 2003. URL: https://doi.org/10.1172/jci200113419c, doi:10.1172/jci200113419c. This article has 186 citations and is from a highest quality peer-reviewed journal.
+
+4. (OpenTargets Search: MPDU1-congenital disorder of glycosylation,congenital disorder of glycosylation-MPDU1): Open Targets Query (MPDU1-congenital disorder of glycosylation,congenital disorder of glycosylation-MPDU1, 23 results). Buniello, A. et al. (2025). Open Targets Platform: facilitating therapeutic hypotheses building in drug discovery. Nucleic Acids Research.
+
+5. (schenk2003mpdu1mutationsunderlie pages 1-2): B. Schenk, T. Imbach, C. Frank, C. Grubenmann, G. Raymond, H. Hurvitz, I. Korn‐Lubetzki, S. Revel-Vik, A. Raas-Rotschild, A. Luder, J. Jaeken, E. Berger, G. Matthijs, T. Hennet, and M. Aebi. Mpdu1 mutations underlie a novel human congenital disorder of glycosylation, designated type if. Journal of Clinical Investigation, 111:925-a-925, Mar 2003. URL: https://doi.org/10.1172/jci200113419c, doi:10.1172/jci200113419c. This article has 186 citations and is from a highest quality peer-reviewed journal.
+
+6. (haeuptle2009congenitaldisordersof pages 9-10): Micha A. Haeuptle and Thierry Hennet. Congenital disorders of glycosylation: an update on defects affecting the biosynthesis of dolichol‐linked oligosaccharides. Human Mutation, 30:1628-1641, Dec 2009. URL: https://doi.org/10.1002/humu.21126, doi:10.1002/humu.21126. This article has 233 citations and is from a domain leading peer-reviewed journal.
+
+7. (kranz2001amutationin pages 1-2): Christian Kranz, Jonas Denecke, Mark A. Lehrman, Sutapa Ray, Petra Kienz, Gunilla Kreissel, Dijana Sagi, Jasna Peter-Katalinic, Hudson H. Freeze, Thomas Schmid, Sabine Jackowski-Dohrmann, Erik Harms, and Thorsten Marquardt. A mutation in the human mpdu1 gene causes congenital disorder of glycosylation type if (cdg-if). The Journal of clinical investigation, 108 11:1613-9, Dec 2001. URL: https://doi.org/10.1172/jci13635, doi:10.1172/jci13635. This article has 160 citations.
+
+8. (teneiji2017phenotypicandgenotypic pages 10-14): Amal Al Teneiji, Theodora U.J. Bruun, Sarah Sidky, Dawn Cordeiro, Ronald D Cohn, Roberto Mendoza-Londono, Mahendranath Moharir, Julian Raiman, Komudi Siriwardena, Lianna Kyriakopoulou, and Saadet Mercimek-Mahmutoglu. Phenotypic and genotypic spectrum of congenital disorders of glycosylation type i and type ii. Molecular genetics and metabolism, 120 3:235-242, Mar 2017. URL: https://doi.org/10.1016/j.ymgme.2016.12.014, doi:10.1016/j.ymgme.2016.12.014. This article has 80 citations and is from a peer-reviewed journal.
+
+9. (tol2019amutationin pages 5-6): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+10. (schenk2003mpdu1mutationsunderlie pages 5-6): B. Schenk, T. Imbach, C. Frank, C. Grubenmann, G. Raymond, H. Hurvitz, I. Korn‐Lubetzki, S. Revel-Vik, A. Raas-Rotschild, A. Luder, J. Jaeken, E. Berger, G. Matthijs, T. Hennet, and M. Aebi. Mpdu1 mutations underlie a novel human congenital disorder of glycosylation, designated type if. Journal of Clinical Investigation, 111:925-a-925, Mar 2003. URL: https://doi.org/10.1172/jci200113419c, doi:10.1172/jci200113419c. This article has 186 citations and is from a highest quality peer-reviewed journal.
+
+11. (kranz2001amutationin pages 5-7): Christian Kranz, Jonas Denecke, Mark A. Lehrman, Sutapa Ray, Petra Kienz, Gunilla Kreissel, Dijana Sagi, Jasna Peter-Katalinic, Hudson H. Freeze, Thomas Schmid, Sabine Jackowski-Dohrmann, Erik Harms, and Thorsten Marquardt. A mutation in the human mpdu1 gene causes congenital disorder of glycosylation type if (cdg-if). The Journal of clinical investigation, 108 11:1613-9, Dec 2001. URL: https://doi.org/10.1172/jci13635, doi:10.1172/jci13635. This article has 160 citations.
+
+12. (zemet2024cardiomyopathyanuncommon pages 3-5): Roni Zemet, Kyle D. Hope, Andrew C. Edmondson, Rameen Shah, Maria Patino, Abigail M. Yesso, Justin H. Berger, Kyriakie Sarafoglou, Austin Larson, Christina Lam, Eva Morava, and Fernando Scaglia. Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: recommendations for baseline screening and follow-up evaluation. Molecular Genetics and Metabolism, 142:108513, Aug 2024. URL: https://doi.org/10.1016/j.ymgme.2024.108513, doi:10.1016/j.ymgme.2024.108513. This article has 14 citations and is from a peer-reviewed journal.
+
+13. (bastaki2018single‐centerexperienceof pages 8-10): Fatma Bastaki, Sami Bizzari, Sana Hamici, Pratibha Nair, Madiha Mohamed, Fatima Saif, Ethar Mustafa Malik, Mahmoud Taleb Al‐Ali, and Abdul Rezzak Hamzeh. Single‐center experience of n‐linked congenital disorders of glycosylation with a summary of molecularly characterized cases in arabs. Annals of Human Genetics, 82:35-47, Jan 2018. URL: https://doi.org/10.1111/ahg.12220, doi:10.1111/ahg.12220. This article has 33 citations and is from a peer-reviewed journal.
+
+14. (hamzan2023epidemiologyandprevalence pages 5-7): Nurul Izzati Hamzan. Epidemiology and prevalence of patients with congenital disorders of glycosylation in malaysia. Asian Journal of Medicine and Biomedicine, 7:56-64, Apr 2023. URL: https://doi.org/10.37231/ajmb.2023.7.1.601, doi:10.37231/ajmb.2023.7.1.601. This article has 1 citations.
+
+15. (tol2019amutationin media 2abc4e54): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+16. (hamzan2023epidemiologyandprevalence pages 1-3): Nurul Izzati Hamzan. Epidemiology and prevalence of patients with congenital disorders of glycosylation in malaysia. Asian Journal of Medicine and Biomedicine, 7:56-64, Apr 2023. URL: https://doi.org/10.37231/ajmb.2023.7.1.601, doi:10.37231/ajmb.2023.7.1.601. This article has 1 citations.
+
+17. (hamzan2023epidemiologyandprevalence pages 3-5): Nurul Izzati Hamzan. Epidemiology and prevalence of patients with congenital disorders of glycosylation in malaysia. Asian Journal of Medicine and Biomedicine, 7:56-64, Apr 2023. URL: https://doi.org/10.37231/ajmb.2023.7.1.601, doi:10.37231/ajmb.2023.7.1.601. This article has 1 citations.
+
+18. (teneiji2017phenotypicandgenotypic pages 33-37): Amal Al Teneiji, Theodora U.J. Bruun, Sarah Sidky, Dawn Cordeiro, Ronald D Cohn, Roberto Mendoza-Londono, Mahendranath Moharir, Julian Raiman, Komudi Siriwardena, Lianna Kyriakopoulou, and Saadet Mercimek-Mahmutoglu. Phenotypic and genotypic spectrum of congenital disorders of glycosylation type i and type ii. Molecular genetics and metabolism, 120 3:235-242, Mar 2017. URL: https://doi.org/10.1016/j.ymgme.2016.12.014, doi:10.1016/j.ymgme.2016.12.014. This article has 80 citations and is from a peer-reviewed journal.
+
+19. (teneiji2017phenotypicandgenotypic pages 6-10): Amal Al Teneiji, Theodora U.J. Bruun, Sarah Sidky, Dawn Cordeiro, Ronald D Cohn, Roberto Mendoza-Londono, Mahendranath Moharir, Julian Raiman, Komudi Siriwardena, Lianna Kyriakopoulou, and Saadet Mercimek-Mahmutoglu. Phenotypic and genotypic spectrum of congenital disorders of glycosylation type i and type ii. Molecular genetics and metabolism, 120 3:235-242, Mar 2017. URL: https://doi.org/10.1016/j.ymgme.2016.12.014, doi:10.1016/j.ymgme.2016.12.014. This article has 80 citations and is from a peer-reviewed journal.
+
+20. (zemet2024cardiomyopathyanuncommon pages 1-3): Roni Zemet, Kyle D. Hope, Andrew C. Edmondson, Rameen Shah, Maria Patino, Abigail M. Yesso, Justin H. Berger, Kyriakie Sarafoglou, Austin Larson, Christina Lam, Eva Morava, and Fernando Scaglia. Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: recommendations for baseline screening and follow-up evaluation. Molecular Genetics and Metabolism, 142:108513, Aug 2024. URL: https://doi.org/10.1016/j.ymgme.2024.108513, doi:10.1016/j.ymgme.2024.108513. This article has 14 citations and is from a peer-reviewed journal.
+
+21. (NCT04199000 chunk 1): Eva Morava-Kozicz. Clinical and Basic Investigations Into Congenital Disorders of Glycosylation. Icahn School of Medicine at Mount Sinai. 2019. ClinicalTrials.gov Identifier: NCT04199000
+
+22. (zemet2024cardiomyopathyanuncommon pages 5-6): Roni Zemet, Kyle D. Hope, Andrew C. Edmondson, Rameen Shah, Maria Patino, Abigail M. Yesso, Justin H. Berger, Kyriakie Sarafoglou, Austin Larson, Christina Lam, Eva Morava, and Fernando Scaglia. Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: recommendations for baseline screening and follow-up evaluation. Molecular Genetics and Metabolism, 142:108513, Aug 2024. URL: https://doi.org/10.1016/j.ymgme.2024.108513, doi:10.1016/j.ymgme.2024.108513. This article has 14 citations and is from a peer-reviewed journal.
+
+23. (tol2019amutationin media 23fb2f88): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+24. (tol2019amutationin media 7782a19e): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.
+
+25. (tol2019amutationin media 364fb774): Walinka van Tol, Angel Ashikov, Eckhard Korsch, Nurulamin Abu Bakar, Michèl A. Willemsen, Christian Thiel, and Dirk J. Lefeber. A mutation in mannose‐phosphate‐dolichol utilization defect 1 reveals clinical symptoms of congenital disorders of glycosylation type i and dystroglycanopathy. JIMD Reports, 50:31-39, Sep 2019. URL: https://doi.org/10.1002/jmd2.12060, doi:10.1002/jmd2.12060. This article has 17 citations and is from a peer-reviewed journal.

--- a/research/MPDU1-congenital_disorder_of_glycosylation-deep-research-falcon.md.citations.md
+++ b/research/MPDU1-congenital_disorder_of_glycosylation-deep-research-falcon.md.citations.md
@@ -1,0 +1,480 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** MPDU1-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **MPDU1-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T11:20:39.224732
+
+1. tol2019amutationin pages 1-2
+2. tol2019amutationin pages 6-8
+3. haeuptle2009congenitaldisordersof pages 9-10
+4. hamzan2023epidemiologyandprevalence pages 5-7
+5. kranz2001amutationin pages 1-2
+6. tol2019amutationin pages 5-6
+7. hamzan2023epidemiologyandprevalence pages 1-3
+8. kranz2001amutationin pages 5-7
+9. zemet2024cardiomyopathyanuncommon pages 3-5
+10. teneiji2017phenotypicandgenotypic pages 10-14
+11. hamzan2023epidemiologyandprevalence pages 3-5
+12. teneiji2017phenotypicandgenotypic pages 33-37
+13. teneiji2017phenotypicandgenotypic pages 6-10
+14. zemet2024cardiomyopathyanuncommon pages 1-3
+15. zemet2024cardiomyopathyanuncommon pages 5-6
+16. https://doi.org/10.1002/jmd2.12060
+17. https://doi.org/10.37231/ajmb.2023.7.1.601
+18. https://doi.org/10.1016/j.ymgme.2024.108513
+19. https://clinicaltrials.gov/study/NCT04199000
+20. https://doi.org/10.1172/jci13635
+21. https://doi.org/10.1172/jci200113419c
+22. https://doi.org/10.1002/jmd2.12060,
+23. https://doi.org/10.1172/jci200113419c,
+24. https://doi.org/10.1002/humu.21126,
+25. https://doi.org/10.1172/jci13635,
+26. https://doi.org/10.1016/j.ymgme.2016.12.014,
+27. https://doi.org/10.1016/j.ymgme.2024.108513,
+28. https://doi.org/10.1111/ahg.12220,
+29. https://doi.org/10.37231/ajmb.2023.7.1.601,


### PR DESCRIPTION
## Summary

- Adds Falcon-guided MPDU1-congenital disorder of glycosylation curation.
- Includes evidence-backed pathophysiology, phenotypes, genetic, diagnosis, biochemical, treatment, and differential diagnosis sections.
- Adds only cited PMID reference caches and this disease's Falcon research artifacts.

## Validation

- `just validate kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml`
- `just validate-references kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml`
- `just validate-terms kb/disorders/MPDU1-congenital_disorder_of_glycosylation.yaml`