### PR TITLE
Add North Carolina macular dystrophy curation

### DIFF
--- a/kb/disorders/North_Carolina_Macular_Dystrophy.yaml
+++ b/kb/disorders/North_Carolina_Macular_Dystrophy.yaml
@@ -1,0 +1,486 @@
+name: North Carolina Macular Dystrophy
+creation_date: "2026-05-11T00:00:00Z"
+updated_date: "2026-05-11T00:00:00Z"
+category: Mendelian
+description: >
+  North Carolina macular dystrophy (NCMD; MCDR1) is a rare autosomal dominant
+  congenital macular developmental disorder with variable expressivity. It is
+  caused by noncoding regulatory variants or tandem duplications that disrupt
+  cis-regulatory control of retinal developmental transcription factors,
+  especially PRDM13 and, at the MCDR3 locus, IRX1. Affected individuals show a
+  broad macular phenotype ranging from drusen-like deposits to severe
+  coloboma-like macular malformations, with variably reduced central vision.
+disease_term:
+  preferred_term: North Carolina macular dystrophy
+  term:
+    id: MONDO:0007630
+    label: North Carolina macular dystrophy
+synonyms:
+- NCMD
+- MCDR1
+- CAPE dystrophy
+- CAPED
+- central areolar pigment epithelial dystrophy
+parents:
+- Macular Dystrophy
+- Retinal Dystrophy
+- Ophthalmological Disease
+inheritance:
+- name: Autosomal dominant
+  inheritance_term:
+    preferred_term: Autosomal dominant inheritance
+    term:
+      id: HP:0000006
+      label: Autosomal dominant inheritance
+  description: >
+    NCMD segregates as an autosomal dominant macular dystrophy. Published
+    pedigrees show marked variable expressivity, from grade 1 drusen-like
+    lesions to severe bilateral coloboma-like macular malformations.
+  evidence:
+  - reference: PMID:37008391
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four subjects from 3 generations were found to have macular abnormalities."
+    explanation: >
+      Affected individuals across three generations in this Mexican family
+      support dominant vertical transmission.
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "North Carolina macular dystrophy (NCMD) is a rare autosomal dominant inherited disorder characterized by macular impairment with a variety of phenotypic manifestations."
+    explanation: >
+      This family study explicitly classifies NCMD as autosomal dominant and
+      emphasizes phenotypic variability.
+pathophysiology:
+- name: Cis-Regulatory PRDM13 Dysregulation
+  description: >
+    NCMD-associated noncoding variants cluster in regulatory elements near
+    PRDM13, and tandem duplications can include PRDM13 or nearby DNase I
+    hypersensitive regulatory sites. These variants alter retinal enhancer
+    activity and dysregulate PRDM13 during central retinal development.
+  gene:
+    preferred_term: PRDM13
+    modifier: DYSREGULATED
+    term:
+      id: hgnc:13998
+      label: PRDM13
+  cell_types:
+  - preferred_term: amacrine cell
+    term:
+      id: CL:0000561
+      label: amacrine cell
+  - preferred_term: retinal ganglion cell
+    term:
+      id: CL:0000740
+      label: retinal ganglion cell
+  biological_processes:
+  - preferred_term: regulation of transcription by RNA polymerase II
+    modifier: DYSREGULATED
+    term:
+      id: GO:0006357
+      label: regulation of transcription by RNA polymerase II
+  - preferred_term: amacrine cell differentiation
+    modifier: DYSREGULATED
+    term:
+      id: GO:0035881
+      label: amacrine cell differentiation
+  evidence:
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Four of these strongly implicate the involvement of PRDM13 in macular development, whereas the pathophysiologic mechanism of the fifth remains unknown but may involve the developmental dysregulation of IRX1."
+    explanation: >
+      The discovery study connects NCMD-causing variants to PRDM13-mediated
+      macular development and raises IRX1 dysregulation for the chromosome 5
+      linked form.
+  - reference: PMID:36243009
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Overall, this study provides insight into the cis-regulatory mechanisms of NCMD and supports that this condition is a retinal enhanceropathy."
+    explanation: >
+      This integrated multi-omics and functional assay study frames NCMD as a
+      retinal enhanceropathy.
+  downstream:
+  - target: Congenital Macular Developmental Disruption
+- name: IRX1 Regulatory Dysregulation
+  description: >
+    A distinct MCDR3 locus involves a large duplication including IRX1. The
+    causal mechanism is less resolved than the PRDM13 hotspot mechanism, but
+    current evidence supports developmental dysregulation of IRX1 as a second
+    regulatory route to NCMD-like macular maldevelopment.
+  gene:
+    preferred_term: IRX1
+    modifier: DYSREGULATED
+    term:
+      id: hgnc:14358
+      label: IRX1
+  biological_processes:
+  - preferred_term: regulation of transcription by RNA polymerase II
+    modifier: DYSREGULATED
+    term:
+      id: GO:0006357
+      label: regulation of transcription by RNA polymerase II
+  evidence:
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Next-generation sequencing of 2 individuals with MCDR3-linked NCMD revealed a 900-kb duplication that included the entire IRX1 gene (V5)."
+    explanation: >
+      The original sequencing study identifies a chromosome 5 MCDR3 duplication
+      including IRX1 in individuals with NCMD.
+  downstream:
+  - target: Congenital Macular Developmental Disruption
+- name: Congenital Macular Developmental Disruption
+  description: >
+    Dysregulated retinal developmental transcriptional control arrests or
+    disrupts human macular development. The resulting lesions are congenital or
+    present in early infancy and usually do not progress between clinical grades.
+  cell_types:
+  - preferred_term: retinal pigment epithelial cell
+    term:
+      id: CL:0002586
+      label: retinal pigment epithelial cell
+  - preferred_term: photoreceptor cell
+    term:
+      id: CL:0000210
+      label: photoreceptor cell
+  - preferred_term: amacrine cell
+    term:
+      id: CL:0000561
+      label: amacrine cell
+  biological_processes:
+  - preferred_term: photoreceptor cell development
+    modifier: DYSREGULATED
+    term:
+      id: GO:0042461
+      label: photoreceptor cell development
+  - preferred_term: amacrine cell differentiation
+    modifier: DYSREGULATED
+    term:
+      id: GO:0035881
+      label: amacrine cell differentiation
+  evidence:
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We identified 5 rare mutations, each capable of arresting human macular development."
+    explanation: >
+      The human genetic discovery paper directly supports arrested macular
+      development as the central pathological process.
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All three patients had macular involvement ranging from patchy yellowish-white lesions to big-area thinning, which are typical for NCMD."
+    explanation: >
+      The Chinese family study links the PRDM13-region duplication to the
+      characteristic macular lesion spectrum.
+  downstream:
+  - target: Macular dystrophy
+  - target: Reduced central visual acuity
+  - target: Choroidal neovascularization
+- name: PRDM13-Dependent Amacrine Cell Specification
+  description: >
+    Model-organism data support a developmental role for Prdm13 in amacrine
+    cell subtype specification. This does not by itself model the human macula,
+    but it supports the plausibility that altered PRDM13 regulation disrupts
+    retinal developmental circuitry.
+  cell_types:
+  - preferred_term: glycinergic amacrine cell
+    term:
+      id: CL:4030028
+      label: glycinergic amacrine cell
+  biological_processes:
+  - preferred_term: amacrine cell differentiation
+    modifier: DYSREGULATED
+    term:
+      id: GO:0035881
+      label: amacrine cell differentiation
+  evidence:
+  - reference: DOI:10.1186/s13064-017-0093-2
+    supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
+    snippet: "Conversely, knockdown of prdm13 specifically inhibits glycinergic amacrine cell genesis."
+    explanation: >
+      Xenopus data support PRDM13 involvement in amacrine cell development, but
+      this is model-organism evidence and does not reproduce a human macula.
+phenotypes:
+- name: Macular dystrophy
+  description: >
+    NCMD is a congenital or early-onset macular dystrophy with variable lesion
+    severity. Mild disease can resemble macular drusen, whereas severe disease
+    can present with large coloboma-like macular malformations.
+  phenotype_term:
+    preferred_term: Macular dystrophy
+    term:
+      id: HP:0007754
+      label: Macular dystrophy
+    onset:
+      onset_category: INFANTILE
+  evidence:
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "All three patients had macular involvement ranging from patchy yellowish-white lesions to big-area thinning, which are typical for NCMD."
+    explanation: >
+      The study describes the broad macular lesion spectrum in genetically
+      confirmed NCMD.
+- name: Macular drusen
+  description: >
+    Grade 1 or mild NCMD can present with drusen-like macular lesions.
+  phenotype_term:
+    preferred_term: Macular drusen
+    term:
+      id: HP:0030499
+      label: Macular drusen
+  evidence:
+  - reference: PMID:37008391
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The 80-year-old mother of the proband had drusen-like lesions consistent with grade 1 NCMD."
+    explanation: >
+      This family report directly documents drusen-like lesions as grade 1
+      NCMD.
+- name: Macular atrophy
+  description: >
+    More severe NCMD lesions can show large central thinning or excavation with
+    loss of macular tissue, clinically resembling atrophic or coloboma-like
+    macular malformation.
+  phenotype_term:
+    preferred_term: Macular atrophy
+    term:
+      id: HP:0007401
+      label: Macular atrophy
+  evidence:
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "OCT revealed varying degrees of macular structure disorganization."
+    explanation: >
+      OCT evidence supports structural macular disruption in NCMD.
+- name: Reduced central visual acuity
+  description: >
+    Central visual acuity is variably affected. Some affected individuals have
+    relatively preserved acuity, whereas severe lesions or complications can
+    cause substantial central vision loss.
+  phenotype_term:
+    preferred_term: Reduced visual acuity
+    term:
+      id: HP:0007663
+      label: Reduced visual acuity
+  evidence:
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The BCVA ranged from 20/50 to 20/20."
+    explanation: >
+      Best-corrected visual acuity measurements in this family demonstrate
+      variable visual acuity.
+  - reference: PMID:37008391
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The proband presented with lifelong bilateral vision impairment with bilaterally symmetric vitelliform Best disease-like appearing macular lesions."
+    explanation: >
+      Lifelong bilateral vision impairment supports reduced visual acuity or
+      central visual function as a clinical phenotype.
+- name: Central scotoma
+  description: >
+    Central scotoma can occur when macular lesions affect the fixation point.
+  phenotype_term:
+    preferred_term: Central scotoma
+    term:
+      id: HP:0000603
+      label: Central scotoma
+  evidence:
+  - reference: PMID:37008391
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The proband presented with lifelong bilateral vision impairment with bilaterally symmetric vitelliform Best disease-like appearing macular lesions."
+    explanation: >
+      The abstract supports central macular visual impairment but does not
+      specifically report formal visual-field testing, so this is partial
+      support for central scotoma.
+- name: Choroidal neovascularization
+  description: >
+    Choroidal neovascularization is a vision-threatening complication of NCMD
+    that can present with intraretinal and subretinal fluid and respond to
+    anti-VEGF treatment.
+  phenotype_term:
+    preferred_term: Choroidal neovascularization
+    term:
+      id: HP:0011506
+      label: Choroidal neovascularization
+  evidence:
+  - reference: DOI:10.1097/icb.0000000000000838
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Optical coherence tomography examination showed intraretinal and subretinal fluid consistent with CNV."
+    explanation: >
+      This case report directly documents CNV in an individual with NCMD.
+genetic:
+- name: PRDM13 regulatory variants and duplications
+  gene_term:
+    preferred_term: PRDM13
+    term:
+      id: hgnc:13998
+      label: PRDM13
+  association: Causative
+  notes: >
+    Pathogenic NCMD variants include noncoding SNVs in a DNase I hypersensitive
+    regulatory region upstream of PRDM13 and tandem duplications involving
+    PRDM13 or its regulatory landscape. These variants act through regulatory
+    dysregulation rather than a simple coding loss-of-function mechanism.
+  evidence:
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This variant lies in a DNase 1 hypersensitivity site (DHS) upstream of both the PRDM13 and CCNC genes."
+    explanation: >
+      The discovery paper identifies the original noncoding PRDM13-region
+      regulatory variant.
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A complete duplication of the PRDM13 gene was also discovered in a single family (V4)."
+    explanation: >
+      This supports PRDM13-region structural variation as a causal mechanism.
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A novel 134.6 kb (g.99932464-100067110dup) tandem duplication on chromosome 6 (NC_000006.11) encompassing the entire CCNC and PRDM13 genes and a DNase 1 hypersensitivity site in the MCDR1 locus was identified."
+    explanation: >
+      This family study expands the causal duplication spectrum at the PRDM13
+      MCDR1 locus.
+  - reference: PMID:37008391
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This suggests that this site, chr6:99593030, is a mutational hotspot."
+    explanation: >
+      The 2023 report supports a PRDM13 regulatory mutational hotspot.
+- name: IRX1-region duplication
+  gene_term:
+    preferred_term: IRX1
+    term:
+      id: hgnc:14358
+      label: IRX1
+  association: Causative
+  notes: >
+    MCDR3-linked NCMD has been associated with a tandem duplication including
+    IRX1. The mechanism is interpreted as developmental regulatory
+    dysregulation, but PRDM13-region variants remain the better-established
+    recurrent NCMD mechanism.
+  evidence:
+  - reference: PMID:26507665
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Next-generation sequencing of 2 individuals with MCDR3-linked NCMD revealed a 900-kb duplication that included the entire IRX1 gene (V5)."
+    explanation: >
+      This supports an IRX1-containing structural variant as the genetic lesion
+      at the MCDR3 locus.
+diagnosis:
+- name: Multimodal ophthalmic evaluation
+  description: >
+    Clinical diagnosis is based on characteristic macular lesions assessed with
+    fundus examination and retinal imaging, including OCT, fundus photography,
+    autofluorescence, ERG, and EOG when needed.
+  diagnosis_term:
+    preferred_term: eye examination
+    term:
+      id: MAXO:0001155
+      label: eye examination
+  evidence:
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Detailed ophthalmological examinations were performed, including best corrected visual acuity (BCVA), slit lamp, dilated indirect ophthalmoscopy, fundus photography, optical coherence tomography (OCT), fundus autofluorescence, full-field electroretinography (ERG), and electrooculography (EOG)."
+    explanation: >
+      This describes the multimodal ophthalmic workup used in a genetically
+      confirmed NCMD family.
+- name: Optical coherence tomography
+  description: >
+    OCT helps define macular structure, identify disorganization or thinning,
+    and detect intraretinal or subretinal fluid when CNV complicates NCMD.
+  diagnosis_term:
+    preferred_term: optical coherence tomography
+    term:
+      id: MAXO:0000969
+      label: optical coherence tomography
+  evidence:
+  - reference: PMID:34427740
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "OCT revealed varying degrees of macular structure disorganization."
+    explanation: >
+      OCT directly demonstrated variable macular structural abnormalities in
+      NCMD.
+  - reference: DOI:10.1097/icb.0000000000000838
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Optical coherence tomography examination showed intraretinal and subretinal fluid consistent with CNV."
+    explanation: >
+      OCT detected fluid consistent with CNV, a treatable complication.
+- name: Molecular genetic testing
+  description: >
+    Whole-genome sequencing, copy-number analysis, breakpoint confirmation, or
+    targeted testing of the PRDM13/IRX1 regulatory loci can confirm the
+    molecular diagnosis.
+  diagnosis_term:
+    preferred_term: genetic testing
+    term:
+      id: MAXO:0000127
+      label: genetic testing
+  evidence:
+  - reference: PMID:37008391
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Whole-genome sequencing (WGS) was performed followed by variant filtering and copy number variant analysis."
+    explanation: >
+      The 2023 family report used WGS and CNV analysis to identify the causal
+      noncoding mutation.
+  - reference: DOI:10.1097/icb.0000000000000838
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Genetic testing of the PRDM13 gene can confirm a molecular diagnosis for North Carolina macular dystrophy."
+    explanation: >
+      This case report explicitly supports PRDM13 genetic testing for molecular
+      diagnosis.
+treatments:
+- name: Anti-VEGF therapy for CNV
+  description: >
+    NCMD itself has no established disease-modifying therapy, but choroidal
+    neovascularization can be treated with intravitreal anti-VEGF therapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Choroidal neovascularization
+    term:
+      id: HP:0011506
+      label: Choroidal neovascularization
+  evidence:
+  - reference: DOI:10.1097/icb.0000000000000838
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The visual acuity improved from 20/400 to 20/150 in the right eye and from 20/100 to 20/40 in the left eye after intravitreal bevacizumab treatment for CNV."
+    explanation: >
+      Case evidence supports anti-VEGF treatment for NCMD-associated CNV.
+- name: Genetic counseling
+  description: >
+    Genetic counseling is appropriate for affected families because NCMD is an
+    autosomal dominant disorder with variable expressivity and molecular testing
+    can confirm the causal regulatory variant or duplication.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:34427740
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "North Carolina macular dystrophy (NCMD) is a rare autosomal dominant inherited disorder characterized by macular impairment with a variety of phenotypic manifestations."
+    explanation: >
+      The inheritance pattern and variable phenotype support genetic counseling,
+      although the cited abstract does not directly evaluate counseling outcomes.
+datasets:

--- a/kb/disorders/North_Carolina_Macular_Dystrophy.yaml
+++ b/kb/disorders/North_Carolina_Macular_Dystrophy.yaml
@@ -95,7 +95,7 @@ pathophysiology:
       linked form.
   - reference: PMID:36243009
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: IN_VITRO
     snippet: "Overall, this study provides insight into the cis-regulatory mechanisms of NCMD and supports that this condition is a retinal enhanceropathy."
     explanation: >
       This integrated multi-omics and functional assay study frames NCMD as a
@@ -453,6 +453,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: bevacizumab
+      term:
+        id: NCIT:C2039
+        label: Bevacizumab
   target_phenotypes:
   - preferred_term: Choroidal neovascularization
     term:

--- a/references_cache/DOI_10.1097_icb.0000000000000838.md
+++ b/references_cache/DOI_10.1097_icb.0000000000000838.md
@@ -1,0 +1,35 @@
+---
+reference_id: "DOI:10.1097/icb.0000000000000838"
+title: CHOROIDAL NEOVASCULARIZATION IN NORTH CAROLINA MACULAR DYSTROPHY RESPONSIVE TO ANTI–VASCULAR ENDOTHELIAL GROWTH FACTOR THERAPY
+authors:
+- Benjamin Bakall
+- J. Shepard Bryan
+- Edwin M. Stone
+- Kent W. Small
+journal: "RETINAL Cases &amp; Brief Reports"
+year: '2021'
+doi: 10.1097/icb.0000000000000838
+content_type: abstract_only
+---
+
+# CHOROIDAL NEOVASCULARIZATION IN NORTH CAROLINA MACULAR DYSTROPHY RESPONSIVE TO ANTI–VASCULAR ENDOTHELIAL GROWTH FACTOR THERAPY
+**Authors:** Benjamin Bakall, J. Shepard Bryan, Edwin M. Stone, Kent W. Small
+**Journal:** RETINAL Cases &amp; Brief Reports (2021)
+**DOI:** [10.1097/icb.0000000000000838](https://doi.org/10.1097/icb.0000000000000838)
+
+## Content
+
+Purpose:
+To report a new family with North Carolina macular dystrophy including a patient with choroidal neovascularization (CNV).
+
+
+Methods:
+Diagnostic modalities included fundus imaging, fluorescein angiography, optical coherence tomography, and genetic testing. The CNV was treated with intravitreal anti–vascular endothelial growth factor according to a treat-and-extend protocol in both eyes.
+
+
+Results:
+A 60-year-old man presented with North Carolina macular dystrophy with decreasing vision in the left eye and persistently deceased central vision in the right eye. Optical coherence tomography examination showed intraretinal and subretinal fluid consistent with CNV. Genetic testing was performed. Examination of family members showed no signs of CNV. The visual acuity improved from 20/400 to 20/150 in the right eye and from 20/100 to 20/40 in the left eye after intravitreal bevacizumab treatment for CNV. Molecular analysis of the PRDM13 gene revealed a pathogenic heterozygous point mutation.
+
+
+Conclusion:
+Recognition and treatment of CNV in North Carolina macular dystrophy can result in improved vision. Genetic testing of the PRDM13 gene can confirm a molecular diagnosis for North Carolina macular dystrophy.

--- a/references_cache/DOI_10.1186_s13064-017-0093-2.md
+++ b/references_cache/DOI_10.1186_s13064-017-0093-2.md
@@ -1,0 +1,38 @@
+---
+reference_id: "DOI:10.1186/s13064-017-0093-2"
+title: Prdm13 forms a feedback loop with Ptf1a and is required for glycinergic amacrine cell genesis in the Xenopus Retina
+authors:
+- Nathalie Bessodes
+- Karine Parain
+- Odile Bronchain
+- Eric J. Bellefroid
+- Muriel Perron
+journal: Neural Development
+year: '2017'
+doi: 10.1186/s13064-017-0093-2
+content_type: abstract_only
+---
+
+# Prdm13 forms a feedback loop with Ptf1a and is required for glycinergic amacrine cell genesis in the Xenopus Retina
+**Authors:** Nathalie Bessodes, Karine Parain, Odile Bronchain, Eric J. Bellefroid, Muriel Perron
+**Journal:** Neural Development (2017)
+**DOI:** [10.1186/s13064-017-0093-2](https://doi.org/10.1186/s13064-017-0093-2)
+
+## Content
+
+Abstract
+
+Background
+Amacrine interneurons that modulate synaptic plasticity between bipolar and ganglion cells constitute the most diverse cell type in the retina. Most are inhibitory neurons using either GABA or glycine as neurotransmitters. Although several transcription factors involved in amacrine cell fate determination have been identified, mechanisms underlying amacrine cell subtype specification remain to be further understood. The Prdm13 histone methyltransferase encoding gene is a target of the transcription factor Ptf1a, an essential regulator of inhibitory neuron cell fate in the retina. Here, we have deepened our knowledge on its interaction with Ptf1a and investigated its role in amacrine cell subtype determination in the developing Xenopus retina.
+
+
+Methods
+We performed prdm13 gain and loss of function in Xenopus and assessed the impact on retinal cell fate determination using RT-qPCR, in situ hybridization and immunohistochemistry.
+
+
+Results
+We found that prdm13 in the amphibian Xenopus is expressed in few retinal progenitors and in about 40% of mature amacrine cells, predominantly in glycinergic ones. Clonal analysis in the retina reveals that prdm13 overexpression favours amacrine cell fate determination, with a bias towards glycinergic cells. Conversely, knockdown of prdm13 specifically inhibits glycinergic amacrine cell genesis. We also showed that, as in the neural tube, prdm13 is subjected to a negative autoregulation in the retina. Our data suggest that this is likely due to its ability to repress the expression of its inducer, ptf1a.
+
+
+Conclusions
+Our results demonstrate that Prdm13, downstream of Ptf1a, acts as an important regulator of glycinergic amacrine subtype specification in the Xenopus retina. We also reveal that Prdm13 regulates ptf1a expression through a negative feedback loop.

--- a/references_cache/PMID_26507665.md
+++ b/references_cache/PMID_26507665.md
@@ -1,0 +1,137 @@
+---
+reference_id: "PMID:26507665"
+title: North Carolina Macular Dystrophy Is Caused by Dysregulation of the Retinal Transcription Factor PRDM13.
+authors:
+- Small KW
+- DeLuca AP
+- Whitmore SS
+- Rosenberg T
+- Silva-Garcia R
+- Udar N
+- Puech B
+- Garcia CA
+- Rice TA
+- Fishman GA
+- Héon E
+- Folk JC
+- Streb LM
+- Haas CM
+- Wiley LA
+- Scheetz TE
+- Fingert JH
+- Mullins RF
+- Tucker BA
+- Stone EM
+journal: Ophthalmology
+year: '2016'
+doi: 10.1016/j.ophtha.2015.10.006
+keywords:
+- Adolescent
+- Adult
+- Child
+- "Child, Preschool"
+- "Chromosomes, Human, Pair 6/genetics"
+- "Corneal Dystrophies, Hereditary/diagnosis, genetics, metabolism"
+- "Eye Proteins/genetics, metabolism"
+- Family
+- Female
+- Fluorescein Angiography
+- Fundus Oculi
+- Genetic Linkage
+- Humans
+- Immunohistochemistry
+- Male
+- Pedigree
+- Phenotype
+- "Polymorphism, Genetic"
+- RNA/genetics
+- Reverse Transcriptase Polymerase Chain Reaction
+- "Tomography, Optical Coherence"
+- Young Adult
+content_type: abstract_only
+---
+
+# North Carolina Macular Dystrophy Is Caused by Dysregulation of the Retinal Transcription Factor PRDM13.
+**Authors:** Small KW, DeLuca AP, Whitmore SS, Rosenberg T, Silva-Garcia R, Udar N, Puech B, Garcia CA, Rice TA, Fishman GA, Héon E, Folk JC, Streb LM, Haas CM, Wiley LA, Scheetz TE, Fingert JH, Mullins RF, Tucker BA, Stone EM
+**Journal:** Ophthalmology (2016)
+**DOI:** [10.1016/j.ophtha.2015.10.006](https://doi.org/10.1016/j.ophtha.2015.10.006)
+
+## Content
+
+1. Ophthalmology. 2016 Jan;123(1):9-18. doi: 10.1016/j.ophtha.2015.10.006. Epub 
+2015 Oct 24.
+
+North Carolina Macular Dystrophy Is Caused by Dysregulation of the Retinal 
+Transcription Factor PRDM13.
+
+Small KW(1), DeLuca AP(2), Whitmore SS(2), Rosenberg T(3), Silva-Garcia R(1), 
+Udar N(1), Puech B(4), Garcia CA(5), Rice TA(6), Fishman GA(7), Héon E(8), Folk 
+JC(2), Streb LM(2), Haas CM(2), Wiley LA(2), Scheetz TE(2), Fingert JH(2), 
+Mullins RF(2), Tucker BA(2), Stone EM(9).
+
+Author information:
+(1)Molecular Insight Research Foundation, Glendale, California.
+(2)Department of Ophthalmology and Visual Sciences, Stephen A. Wynn Institute 
+for Vision Research, University of Iowa, Iowa City, Iowa.
+(3)National Eye Clinic, Kennedy Center, Glostrup, Denmark, and Institute of 
+Clinical Medicine, University of Copenhagen, Copenhagen, Denmark.
+(4)Service d'Exploration de la vision et Neuro-ophtalmologie CHRU, Lille, 
+France.
+(5)University of Texas Health Science Center at Houston, Houston, Texas.
+(6)Byers Eye Institute, Stanford University School of Medicine, Palo Alto, 
+California.
+(7)The Pangere Center for Inherited Retinal Diseases, The Chicago Lighthouse for 
+People Who Are Blind or Visually Impaired, Chicago, Illinois.
+(8)Department of Ophthalmology and Vision Sciences, Programme of Genetics and 
+Genomic Medicine, The Hospital for Sick Children, University of Toronto, 
+Toronto, Ontario, Canada.
+(9)Department of Ophthalmology and Visual Sciences, Stephen A. Wynn Institute 
+for Vision Research, University of Iowa, Iowa City, Iowa. Electronic address: 
+edwin-stone@uiowa.edu.
+
+Comment in
+    Ophthalmology. 2016 Jan;123(1):2-4. doi: 10.1016/j.ophtha.2015.11.015.
+
+PURPOSE: To identify specific mutations causing North Carolina macular dystrophy 
+(NCMD).
+DESIGN: Whole-genome sequencing coupled with reverse transcription polymerase 
+chain reaction (RT-PCR) analysis of gene expression in human retinal cells.
+PARTICIPANTS: A total of 141 members of 12 families with NCMD and 261 unrelated 
+control individuals.
+METHODS: Genome sequencing was performed on 8 affected individuals from 3 
+families affected with chromosome 6-linked NCMD (MCDR1) and 2 individuals 
+affected with chromosome 5-linked NCMD (MCDR3). Variants observed in the MCDR1 
+locus with frequencies <1% in published databases were confirmed using Sanger 
+sequencing. Confirmed variants absent from all published databases were sought 
+in 8 additional MCDR1 families and 261 controls. The RT-PCR analysis of selected 
+genes was performed in stem cell-derived human retinal cells.
+MAIN OUTCOME MEASURES: Co-segregation of rare genetic variants with disease 
+phenotype.
+RESULTS: Five sequenced individuals with MCDR1-linked NCMD shared a haplotype of 
+14 rare variants spanning 1 Mb of the disease-causing allele. One of these 
+variants (V1) was absent from all published databases and all 261 controls, but 
+was found in 5 additional NCMD kindreds. This variant lies in a DNase 1 
+hypersensitivity site (DHS) upstream of both the PRDM13 and CCNC genes. Sanger 
+sequencing of 1 kb centered on V1 was performed in the remaining 4 NCMD 
+probands, and 2 additional novel single nucleotide variants (V2 in 3 families 
+and V3 in 1 family) were identified in the DHS within 134 bp of the location of 
+V1. A complete duplication of the PRDM13 gene was also discovered in a single 
+family (V4). The RT-PCR analysis of PRDM13 expression in developing retinal 
+cells revealed marked developmental regulation. Next-generation sequencing of 2 
+individuals with MCDR3-linked NCMD revealed a 900-kb duplication that included 
+the entire IRX1 gene (V5). The 5 mutations V1 to V5 segregated perfectly in the 
+102 affected and 39 unaffected members of the 12 NCMD families.
+CONCLUSIONS: We identified 5 rare mutations, each capable of arresting human 
+macular development. Four of these strongly implicate the involvement of PRDM13 
+in macular development, whereas the pathophysiologic mechanism of the fifth 
+remains unknown but may involve the developmental dysregulation of IRX1.
+
+Copyright © 2016 American Academy of Ophthalmology. Published by Elsevier Inc. 
+All rights reserved.
+
+DOI: 10.1016/j.ophtha.2015.10.006
+PMCID: PMC4695238
+PMID: 26507665 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors have no proprietary/financial 
+interests to disclose.

--- a/references_cache/PMID_34427740.md
+++ b/references_cache/PMID_34427740.md
@@ -1,0 +1,81 @@
+---
+reference_id: "PMID:34427740"
+title: A novel tandem duplication of PRDM13 in a Chinese family with North Carolina macular dystrophy.
+authors:
+- Wu S
+- Yuan Z
+- Sun Z
+- Zhu T
+- Wei X
+- Zou X
+- Sui R
+journal: Graefes Arch Clin Exp Ophthalmol
+year: '2022'
+doi: 10.1007/s00417-021-05376-w
+keywords:
+- China/epidemiology
+- "Corneal Dystrophies, Hereditary"
+- Electroretinography
+- Humans
+- Pedigree
+- "Tomography, Optical Coherence"
+content_type: abstract_only
+---
+
+# A novel tandem duplication of PRDM13 in a Chinese family with North Carolina macular dystrophy.
+**Authors:** Wu S, Yuan Z, Sun Z, Zhu T, Wei X, Zou X, Sui R
+**Journal:** Graefes Arch Clin Exp Ophthalmol (2022)
+**DOI:** [10.1007/s00417-021-05376-w](https://doi.org/10.1007/s00417-021-05376-w)
+
+## Content
+
+1. Graefes Arch Clin Exp Ophthalmol. 2022 Feb;260(2):645-653. doi: 
+10.1007/s00417-021-05376-w. Epub 2021 Aug 24.
+
+A novel tandem duplication of PRDM13 in a Chinese family with North Carolina 
+macular dystrophy.
+
+Wu S(1), Yuan Z(1), Sun Z(1), Zhu T(1), Wei X(1), Zou X(1), Sui R(2).
+
+Author information:
+(1)Department of Ophthalmology, State Key Laboratory of Complex Severe and Rare 
+Diseases, Peking Union Medical College Hospital, Chinese Academy of Medical 
+Sciences and Peking Union Medical College, Beijing, 100730, China.
+(2)Department of Ophthalmology, State Key Laboratory of Complex Severe and Rare 
+Diseases, Peking Union Medical College Hospital, Chinese Academy of Medical 
+Sciences and Peking Union Medical College, Beijing, 100730, China. 
+hrfsui@163.com.
+
+Comment in
+    Graefes Arch Clin Exp Ophthalmol. 2023 Jul;261(7):2093-2095. doi: 
+10.1007/s00417-023-06006-3.
+
+PURPOSES: North Carolina macular dystrophy (NCMD) is a rare autosomal dominant 
+inherited disorder characterized by macular impairment with a variety of 
+phenotypic manifestations. The aims of this study were to assess the clinical 
+features of a Chinese family with NCMD and to identify the underlying genetic 
+cause of the disease.
+METHODS: Three patients from a Chinese family were included in this study. 
+Detailed ophthalmological examinations were performed, including best corrected 
+visual acuity (BCVA), slit lamp, dilated indirect ophthalmoscopy, fundus 
+photography, optical coherence tomography (OCT), fundus autofluorescence, 
+full-field electroretinography (ERG), and electrooculography (EOG). Genomic DNA 
+was extracted from peripheral blood samples. Whole-genome sequencing and 
+long-read genome sequencing were applied to detect the pathogenic variants. 
+Sanger sequencing was performed to confirm the breakpoints.
+RESULTS: All three patients had macular involvement ranging from patchy 
+yellowish-white lesions to big-area thinning, which are typical for NCMD. The 
+BCVA ranged from 20/50 to 20/20. OCT revealed varying degrees of macular 
+structure disorganization. The ERG responses were normal, and the Arden ration 
+of the EOG was reduced. A novel 134.6 kb (g.99932464-100067110dup) tandem 
+duplication on chromosome 6 (NC_000006.11) encompassing the entire CCNC and 
+PRDM13 genes and a DNase 1 hypersensitivity site in the MCDR1 locus was 
+identified.
+CONCLUSION: A novel large tandem duplication in MCDR1 locus was confirmed in a 
+Chinese family with NCMD with a variety of macular phenotypes.
+
+© 2021. The Author(s), under exclusive licence to Springer-Verlag GmbH Germany, 
+part of Springer Nature.
+
+DOI: 10.1007/s00417-021-05376-w
+PMID: 34427740 [Indexed for MEDLINE]

--- a/references_cache/PMID_36243009.md
+++ b/references_cache/PMID_36243009.md
@@ -1,0 +1,149 @@
+---
+reference_id: "PMID:36243009"
+title: "Multi-omics approach dissects cis-regulatory mechanisms underlying North Carolina macular dystrophy, a retinal enhanceropathy."
+authors:
+- Van de Sompele S
+- Small KW
+- Cicekdal MB
+- Soriano VL
+- "D'haene E"
+- Shaya FS
+- Agemy S
+- Van der Snickt T
+- Rey AD
+- Rosseel T
+- Van Heetvelde M
+- Vergult S
+- Balikova I
+- Bergen AA
+- Boon CJF
+- De Zaeytijd J
+- Inglehearn CF
+- Kousal B
+- Leroy BP
+- Rivolta C
+- Vaclavik V
+- van den Ende J
+- van Schooneveld MJ
+- Gómez-Skarmeta JL
+- Tena JJ
+- Martinez-Morales JR
+- Liskova P
+- Vleminckx K
+- De Baere E
+journal: Am J Hum Genet
+year: '2022'
+doi: 10.1016/j.ajhg.2022.09.013
+keywords:
+- Adult
+- Animals
+- Humans
+- Pedigree
+- "Tomography, Optical Coherence"
+- "Corneal Dystrophies, Hereditary"
+- Retina/metabolism
+- Xenopus laevis/genetics
+content_type: abstract_only
+---
+
+# Multi-omics approach dissects cis-regulatory mechanisms underlying North Carolina macular dystrophy, a retinal enhanceropathy.
+**Authors:** Van de Sompele S, Small KW, Cicekdal MB, Soriano VL, D'haene E, Shaya FS, Agemy S, Van der Snickt T, Rey AD, Rosseel T, Van Heetvelde M, Vergult S, Balikova I, Bergen AA, Boon CJF, De Zaeytijd J, Inglehearn CF, Kousal B, Leroy BP, Rivolta C, Vaclavik V, van den Ende J, van Schooneveld MJ, Gómez-Skarmeta JL, Tena JJ, Martinez-Morales JR, Liskova P, Vleminckx K, De Baere E
+**Journal:** Am J Hum Genet (2022)
+**DOI:** [10.1016/j.ajhg.2022.09.013](https://doi.org/10.1016/j.ajhg.2022.09.013)
+
+## Content
+
+1. Am J Hum Genet. 2022 Nov 3;109(11):2029-2048. doi: 10.1016/j.ajhg.2022.09.013.
+ Epub 2022 Oct 14.
+
+Multi-omics approach dissects cis-regulatory mechanisms underlying North 
+Carolina macular dystrophy, a retinal enhanceropathy.
+
+Van de Sompele S(1), Small KW(2), Cicekdal MB(3), Soriano VL(1), D'haene E(1), 
+Shaya FS(2), Agemy S(4), Van der Snickt T(1), Rey AD(1), Rosseel T(1), Van 
+Heetvelde M(1), Vergult S(1), Balikova I(5), Bergen AA(6), Boon CJF(7), De 
+Zaeytijd J(8), Inglehearn CF(9), Kousal B(10), Leroy BP(11), Rivolta C(12), 
+Vaclavik V(13), van den Ende J(14), van Schooneveld MJ(15), Gómez-Skarmeta 
+JL(16), Tena JJ(16), Martinez-Morales JR(16), Liskova P(17), Vleminckx K(18), De 
+Baere E(19).
+
+Author information:
+(1)Department of Biomolecular Medicine, Ghent University, Ghent, Belgium; Center 
+for Medical Genetics, Ghent University Hospital, Ghent, Belgium.
+(2)Macula and Retina Institute, Los Angeles and Glendale, California, USA.
+(3)Department of Biomolecular Medicine, Ghent University, Ghent, Belgium; Center 
+for Medical Genetics, Ghent University Hospital, Ghent, Belgium; Department of 
+Biomedical Molecular Biology, Ghent University, Ghent, Belgium.
+(4)Department of Ophthalmology, SUNY Downstate Medical Center University, 
+Brooklyn, New York, USA.
+(5)Department of Ophthalmology, University Hospitals Leuven, Leuven, Belgium.
+(6)Department of Human Genetics, Amsterdam UMC, Academic Medical Center, 1105 AZ 
+Amsterdam, The Netherlands; Queen Emma Centre of Precision Medicine, Amsterdam 
+University Medical Centre, University of Amsterdam, Amsterdam, The Netherlands.
+(7)Department of Ophthalmology, Amsterdam University Medical Centers, University 
+of Amsterdam, Amsterdam, The Netherlands; Department of Ophthalmology, Leiden 
+University Medical Center, Leiden, The Netherlands.
+(8)Department of Ophthalmology, Ghent University Hospital, Ghent, Belgium.
+(9)Division of Molecular Medicine, Leeds Institute of Medical Research, 
+University of Leeds, Leeds, UK.
+(10)Department of Ophthalmology, First Faculty of Medicine, Charles University 
+and General University Hospital in Prague, Prague, Czech Republic.
+(11)Center for Medical Genetics, Ghent University Hospital, Ghent, Belgium; 
+Department of Ophthalmology, Ghent University Hospital, Ghent, Belgium; 
+Department of Head & Skin, Ghent University, Ghent, Belgium; Division of 
+Ophthalmology & Center for Cellular & Molecular Therapeutics, Children's 
+Hospital of Philadelphia, Philadelphia, PA, USA.
+(12)Institute of Molecular and Clinical Ophthalmology Basel (IOB), Basel, 
+Switzerland; Department of Ophthalmology, University of Basel, Basel, 
+Switzerland; Department of Genetics and Genome Biology, University of Leicester, 
+Leicester, UK.
+(13)University of Lausanne, Jules-Gonin Eye Hospital, Lausanne, Switzerland.
+(14)Center for Medical Genetics, Antwerp University Hospital, Antwerp, Belgium.
+(15)Department of Ophthalmology, Amsterdam University Medical Centers, 
+University of Amsterdam, Amsterdam, The Netherlands; Bartiméus, Diagnostic 
+Center for Complex Visual Disorders, Zeist, The Netherlands.
+(16)Centro Andaluz de Biología del Desarrollo, Consejo Superior de 
+Investigaciones Científicas and Universidad Pablo de Olavide, Sevilla, Spain.
+(17)Department of Ophthalmology, First Faculty of Medicine, Charles University 
+and General University Hospital in Prague, Prague, Czech Republic; Department of 
+Paediatrics and Inherited Metabolic Disorders, First Faculty of Medicine, 
+Charles University and General University Hospital in Prague, Prague, Czech 
+Republic.
+(18)Center for Medical Genetics, Ghent University Hospital, Ghent, Belgium; 
+Department of Biomedical Molecular Biology, Ghent University, Ghent, Belgium.
+(19)Department of Biomolecular Medicine, Ghent University, Ghent, Belgium; 
+Center for Medical Genetics, Ghent University Hospital, Ghent, Belgium. 
+Electronic address: elfride.debaere@ugent.be.
+
+North Carolina macular dystrophy (NCMD) is a rare autosomal-dominant disease 
+affecting macular development. The disease is caused by non-coding 
+single-nucleotide variants (SNVs) in two hotspot regions near PRDM13 and by 
+duplications in two distinct chromosomal loci, overlapping DNase I 
+hypersensitive sites near either PRDM13 or IRX1. To unravel the mechanisms by 
+which these variants cause disease, we first established a genome-wide 
+multi-omics retinal database, RegRet. Integration of UMI-4C profiles we 
+generated on adult human retina then allowed fine-mapping of the interactions of 
+the PRDM13 and IRX1 promoters and the identification of eighteen candidate 
+cis-regulatory elements (cCREs), the activity of which was investigated by 
+luciferase and Xenopus enhancer assays. Next, luciferase assays showed that the 
+non-coding SNVs located in the two hotspot regions of PRDM13 affect cCRE 
+activity, including two NCMD-associated non-coding SNVs that we identified 
+herein. Interestingly, the cCRE containing one of these SNVs was shown to 
+interact with the PRDM13 promoter, demonstrated in vivo activity in Xenopus, and 
+is active at the developmental stage when progenitor cells of the central retina 
+exit mitosis, suggesting that this region is a PRDM13 enhancer. Finally, mining 
+of single-cell transcriptional data of embryonic and adult retina revealed the 
+highest expression of PRDM13 and IRX1 when amacrine cells start to synapse with 
+retinal ganglion cells, supporting the hypothesis that altered PRDM13 or IRX1 
+expression impairs interactions between these cells during retinogenesis. 
+Overall, this study provides insight into the cis-regulatory mechanisms of NCMD 
+and supports that this condition is a retinal enhanceropathy.
+
+Crown Copyright © 2022. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ajhg.2022.09.013
+PMCID: PMC9674966
+PMID: 36243009 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests The authors declare no 
+competing interests.

--- a/references_cache/PMID_37008391.md
+++ b/references_cache/PMID_37008391.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:37008391"
+title: "New Noncoding Base Pair Mutation at the Identical Locus as the Original NCMD/MCDR1 in a Mexican Family, Suggesting a Mutational Hotspot."
+authors:
+- Small KW
+- Van de Sompele S
+- Avetisjan J
+- Udar N
+- Agemy S
+- De Baere E
+- Shaya FS
+journal: J Vitreoretin Dis
+year: '2023'
+doi: 10.1177/24741264221129432
+content_type: abstract_only
+---
+
+# New Noncoding Base Pair Mutation at the Identical Locus as the Original NCMD/MCDR1 in a Mexican Family, Suggesting a Mutational Hotspot.
+**Authors:** Small KW, Van de Sompele S, Avetisjan J, Udar N, Agemy S, De Baere E, Shaya FS
+**Journal:** J Vitreoretin Dis (2023)
+**DOI:** [10.1177/24741264221129432](https://doi.org/10.1177/24741264221129432)
+
+## Content
+
+1. J Vitreoretin Dis. 2023 Jan 2;7(1):33-42. doi: 10.1177/24741264221129432. 
+eCollection 2023 Jan-Feb.
+
+New Noncoding Base Pair Mutation at the Identical Locus as the Original 
+NCMD/MCDR1 in a Mexican Family, Suggesting a Mutational Hotspot.
+
+Small KW(1)(2), Van de Sompele S(3), Avetisjan J(1)(2), Udar N(1)(2), Agemy 
+S(4), De Baere E(3), Shaya FS(1)(2).
+
+Author information:
+(1)Macula and Retina Institute, Glendale and Los Angeles, CA, USA.
+(2)Molecular Insight Research Foundation, Glendale and Los Angeles, CA, USA.
+(3)Center for Medical Genetics Ghent (CMGG), Department of Biomolecular 
+Medicine, Ghent University, and Ghent University Hospital, Ghent, Belgium.
+(4)New York Retina Consultants PLLC, New York, NY, USA.
+
+PURPOSE: To clinically and molecularly study a newly found family with North 
+Carolina macular dystrophy (NCMD/MCDR1) from Mexico.
+METHODS: This retrospective study comprised 6 members of a 3-generation Mexican 
+family with NCMD. Clinical ophthalmic examinations, including fundus imaging, 
+spectral-domain optical coherence tomography, electroretinography, and 
+electrooculography, were performed. Genotyping with polymorphic markers in the 
+MCDR1 region was performed to determine haplotypes. Whole-genome sequencing 
+(WGS) was performed followed by variant filtering and copy number variant 
+analysis.
+RESULTS: Four subjects from 3 generations were found to have macular 
+abnormalities. The proband presented with lifelong bilateral vision impairment 
+with bilaterally symmetric vitelliform Best disease-like appearing macular 
+lesions. Her 2 children had bilateral large macular coloboma-like malformations, 
+consistent with autosomal dominant NCMD. The 80-year-old mother of the proband 
+had drusen-like lesions consistent with grade 1 NCMD. WGS and subsequent Sanger 
+sequencing found a point mutation at chr6:99593030G>C (hg38) in the noncoding 
+region of the DNase I site thought to be a regulatory element of the retinal 
+transcription factor gene PRDM13. This mutation is the identical site/nucleotide 
+as in the original NCMD family (#765) but is a guanine to cytosine change rather 
+than a guanine to thymine mutation, as found in the original NCMD family.
+CONCLUSIONS: We report a new noncoding mutation at the same locus 
+(chr6:99593030G>C) involving the same DNase I site regulating the retinal 
+transcription factor gene PRDM13. This suggests that this site, chr6:99593030, 
+is a mutational hotspot.
+
+© The Author(s) 2023.
+
+DOI: 10.1177/24741264221129432
+PMCID: PMC9954157
+PMID: 37008391
+
+Conflict of interest statement: The author(s) declared the following potential 
+conflicts of interest with respect to the research, authorship, and/or 
+publication of this article. Pending North Carolina Macular Dystrophy 
+(NCMD/MCDR1) patent: Kent Small, MD.

--- a/research/North_Carolina_Macular_Dystrophy-deep-research-falcon.md
+++ b/research/North_Carolina_Macular_Dystrophy-deep-research-falcon.md
@@ -1,0 +1,1310 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:05:31.692728'
+end_time: '2026-05-11T11:22:38.251561'
+duration_seconds: 1026.57
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: North Carolina Macular Dystrophy
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 40
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** North Carolina Macular Dystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **North Carolina Macular Dystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** North Carolina Macular Dystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **North Carolina Macular Dystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# North Carolina Macular Dystrophy (NCMD) — Disease Characteristics Research Report (Mendelian)
+
+## Executive summary (current understanding)
+North Carolina macular dystrophy (NCMD; also referenced as MCDR1) is a rare, autosomal dominant, congenital macular malformation/developmental maculopathy with marked variable expressivity but (reported) complete/fully penetrant inheritance in many families. It is typically described as nonprogressive (i.e., lesions are present at birth/early infancy and do not usually advance in “grade”), although vision-threatening complications such as choroidal neovascularization (CNV) can occur and can be treatable with anti-VEGF therapy. Mechanistically, NCMD is now widely characterized as a “retinal enhanceropathy,” in which noncoding single-nucleotide variants (SNVs) and tandem duplications perturb cis-regulatory elements controlling developmental retinal transcription factors—most prominently PRDM13 (MCDR1, chr6) and IRX1 (MCDR3, chr5)—disrupting developmental programs and macula-centric retinal organization. (small2023newnoncodingbase pages 1-2, sompele2022multiomicsapproachdissects pages 1-3)
+
+---
+
+## 1. Disease information
+
+### 1.1 Concise overview
+NCMD is a congenital macular developmental disorder typically present at birth and usually described as stable/nonprogressive. A recent report states: “NCMD/MCDR1; OMIM #136550” and defines it as “autosomal dominant, fully penetrant, congenital, nonprogressive macular malformation with marked intrafamilial phenotypic variability.” (small2023newnoncodingbase pages 1-2)
+
+A separate cohort paper states directly: “NCMD is present at birth and rarely progresses.” (green2021northcarolinamacular pages 1-6)
+
+### 1.2 Key identifiers (available from retrieved evidence)
+- **OMIM/MIM:** NCMD/MCDR1 **OMIM #136550** / **MIM: 136550** (small2023newnoncodingbase pages 1-2, sompele2022multiomicsprofilingin pages 25-27)
+- **Locus designations (used in the literature):**
+  - **MCDR1** (chr6q16 region; regulatory variants upstream of PRDM13) (small2023newnoncodingbase pages 1-2, small2016northcarolinamacular pages 1-2, wu2022anoveltandem pages 1-3)
+  - **MCDR3** (chr5p15 region; duplications involving/downstream of IRX1) (small2023newnoncodingbase pages 1-2, small2016northcarolinamacular pages 1-2, bakall2021choroidalneovascularizationin pages 5-5)
+- **Gene OMIM identifiers present in evidence:**
+  - **PRDM13 (OMIM 616741)**; **IRX1 (OMIM 606197)**; **CCNC (OMIM 123838)**; **DHS OMIM 616842** referenced for the regulatory site (wu2022anoveltandem pages 1-3)
+
+**Not retrieved in the tool-accessible full-text set:** MONDO ID, Orphanet ID, MeSH term, ICD-10/ICD-11 code. These identifiers likely exist in curated databases, but were not present in the retrieved primary/review texts and therefore cannot be stated with tool-derived evidence here. (wu2022anoveltandem pages 1-3, sompele2022multiomicsprofilingin pages 25-27)
+
+### 1.3 Synonyms / alternative names
+- North Carolina macular dystrophy (NCMD) (small2023newnoncodingbase pages 1-2)
+- Macular developmental disorder / congenital macular malformation / macular hypoplasia/dysplasia framing (expert commentary emphasizing congenital dysplasia rather than “atrophy”) (small2023commentson“the pages 1-2)
+- Locus-based nomenclature: **MCDR1**, **MCDR3** (small2023commentson“the pages 1-2, sompele2022multiomicsprofilingin pages 25-27)
+
+### 1.4 Evidence provenance
+Evidence in this report is derived from peer-reviewed primary studies (human family genetics; functional assays; case reports), a 2023 clinical electrophysiology review, and preprint computational analysis; it is not derived from EHR aggregation. (small2016northcarolinamacular pages 1-2, sompele2022multiomicsapproachdissects pages 13-14, chiang2023electrophysiologicalevaluationof pages 11-12)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Primary cause: inherited noncoding regulatory variation** that dysregulates key retinal developmental transcription factors.
+- The 2022 AJHG multi-omics study summarizes the causal architecture: NCMD is caused by “non-coding single-nucleotide variants (SNVs) in two hotspot regions near PRDM13 and by duplications overlapping DNase I hypersensitive sites near PRDM13 or IRX1,” framing NCMD as a “retinal enhanceropathy.” (sompele2022multiomicsapproachdissects pages 1-3)
+- A 2023 family study reinforces that the phenotype is consistent with a regulatory “mutational hotspot” upstream of PRDM13. (small2023newnoncodingbase pages 1-2)
+
+**Inheritance pattern:** autosomal dominant (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3)
+
+### 2.2 Risk factors
+- **Genetic risk factors (causal):** Heterozygous noncoding SNVs in PRDM13 regulatory regions and heterozygous tandem duplications at PRDM13 (MCDR1) or IRX1-region cCREs (MCDR3) (sompele2022multiomicsapproachdissects pages 13-14, small2016northcarolinamacular pages 1-2)
+- **Environmental/lifestyle risk factors:** No evidence in retrieved sources supports environmental, infectious, or lifestyle risk modifiers for NCMD; it is consistently treated as a congenital Mendelian retinal developmental disorder. (green2021northcarolinamacular pages 1-6, small2023newnoncodingbase pages 1-2)
+
+### 2.3 Protective factors / GxE
+No protective alleles or gene–environment interaction evidence was identified in the retrieved texts. (sompele2022multiomicsapproachdissects pages 1-3)
+
+---
+
+## 3. Phenotypes (clinical spectrum)
+
+### 3.1 Core phenotypic concept and grading
+A 2023 clinical genetics report describes a **three-grade** spectrum and explicitly states approximate frequency distribution: “approximately one-third of affected individuals in each clinical grade.” (small2023newnoncodingbase pages 1-2)
+- **Grade 1:** few central drusen / central drusen-like deposits (small2023newnoncodingbase pages 1-2)
+- **Grade 2:** confluent drusen ± subretinal fibrosis (small2023newnoncodingbase pages 1-2)
+- **Grade 3:** choroidal coloboma-like excavation/large central atrophic excavation with absent RPE/choroidal lacunae and surrounding fibrosis (small2023newnoncodingbase pages 1-2)
+
+### 3.2 Key signs/symptoms and characteristics (with candidate HPO terms)
+Below, phenotype types are indicated and mapped to suggested **HPO** terms (ontology suggestions are not claims of curated mapping).
+
+1) **Macular developmental lesions / drusen-like deposits** (clinical sign)
+- Evidence: range from “central yellowish-white drusen-like deposits” to confluent drusen-like lesions (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3)
+- Suggested HPO: **Macular dystrophy (HP:0000556)**; **Drusen (HP:0001132)**; **Macular coloboma / coloboma-like macular lesion** (candidate: **Coloboma (HP:0000589)** with localization qualifier)
+
+2) **Macular excavation / chorioretinal atrophy-like appearance** (clinical sign)
+- Grade 3 described as coloboma-like excavation with absent RPE/choroidal lacunae (small2023newnoncodingbase pages 1-2)
+- Suggested HPO: **Chorioretinal atrophy (HP:0001130)**; **Abnormality of the macula (HP:0001103)**
+
+3) **Reduced central vision / variable visual acuity** (symptom/function)
+- Quantitative evidence: visual acuity range reported as **0.0–1.6 LogMAR** in one cohort (green2021northcarolinamacular pages 1-6)
+- Suggested HPO: **Decreased visual acuity (HP:0007663)**; **Central scotoma (HP:0000603)** (central scotomata documented in one child) (audere2016geneticlinkagestudies pages 4-6)
+
+4) **Peripheral retinal spots/drusen-like changes** (clinical sign)
+- “Peripheral retinal spots were seen in all study subjects on widefield imaging.” (green2021northcarolinamacular pages 1-6)
+- Suggested HPO: **Peripheral retinal degeneration (HP:0001133)** (approximate); **Retinal deposits** (candidate)
+
+5) **Choroidal neovascularization (CNV/CNVM)** (complication)
+- CNV can occur in childhood: “a 6-year-old patient developed choroidal neovascularization and required treatment with intravitreal bevacizumab injections.” (green2021northcarolinamacular pages 1-6)
+- Suggested HPO: **Choroidal neovascularization (HP:0000559)**; **Subretinal fibrosis (HP:0007897)**
+
+### 3.3 Quality of life impact
+Direct QoL instruments (EQ-5D/SF-36) were not reported in the retrieved texts. Functional impact is inferred via central vision impairment and scotoma when present. (audere2016geneticlinkagestudies pages 4-6, green2021northcarolinamacular pages 1-6)
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes and loci
+- **PRDM13 dysregulation (MCDR1, chr6):** foundational evidence: “North Carolina macular dystrophy is caused by dysregulation of the retinal transcription factor PRDM13.” (Ophthalmology 2016; publication date **2016-01**) (small2016northcarolinamacular pages 4-5)
+- **IRX1 dysregulation (MCDR3, chr5):** disease-associated duplications include a 900 kb duplication including IRX1 (small2016northcarolinamacular pages 4-5)
+
+### 4.2 Pathogenic variant classes and examples
+**Noncoding SNVs (regulatory/DHS) upstream of PRDM13**
+- Example coordinates cited in cohorts/analyses include **chr6:100,040,906G>T**, **chr6:100,040,974A>C**, **chr6:100,040,987G>C**, **chr6:100,041,040C>T**, **chr6:100,046,783A>C** (hg19/GRCh37 as specified in the original sources) (green2021northcarolinamacular pages 28-31)
+- 2023 report notes a new base-pair mutation at the identical locus as the original, supporting a hotspot. (small2023newnoncodingbase pages 1-2)
+
+**Tandem duplications (structural variants)**
+- 2016 Ophthalmology describes duplications including a **123 kb tandem duplication containing PRDM13** and a **900 kb tandem duplication including IRX1** (small2016northcarolinamacular pages 4-5)
+- 2022 Chinese family reports a **134.6 kb tandem duplication** with explicit coordinate interval: **g.99932464-100067110dup** (chr6) encompassing **CCNC, PRDM13, and a DHS** (publication date **2022-08**) (wu2022anoveltandem pages 1-3)
+
+**Functional directionality (cis-regulatory output) — multi-omics 2022 AJHG**
+Luciferase assays (in vitro) systematically showed allele-dependent effects:
+- Hotspot-1 variants increased reporter expression **1.6–3.2-fold** (p<0.001), while hotspot-2 variants decreased expression to **~0.6–0.7-fold** (p<0.001). (sompele2022multiomicsapproachdissects pages 13-14)
+- Tandem duplication constructs produced **~0.5-fold decreased** luciferase activity relative to single-copy constructs. (sompele2022multiomicsapproachdissects pages 13-14)
+
+### 4.3 Modifier genes, epigenetics, chromosomal abnormalities
+No modifier genes or disease-specific epigenetic signatures were identified in the retrieved evidence. Structural variants are tandem duplications rather than aneuploidy/translocations. (sompele2022multiomicsapproachdissects pages 13-14, wu2022anoveltandem pages 1-3)
+
+---
+
+## 5. Environmental information
+No environmental, lifestyle, or infectious contributors were identified in the retrieved literature; NCMD is presented as a congenital genetic developmental malformation. (green2021northcarolinamacular pages 1-6, small2023newnoncodingbase pages 1-2)
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Current mechanistic model: retinal enhanceropathy → transcription-factor dysregulation → macular maldevelopment
+The strongest mechanistic synthesis is from the 2022 AJHG multi-omics study:
+- **Upstream event:** noncoding SNVs in mutational hotspots and duplications spanning candidate cis-regulatory elements (cCREs) near PRDM13 and IRX1 alter enhancer activity and/or gene regulatory landscape. (sompele2022multiomicsapproachdissects pages 1-3, sompele2022multiomicsapproachdissects pages 13-14)
+- **Regulatory wiring:** UMI-4C (adult human retina) plus integrated retina epigenomics nominated **18 cCREs**, and functional assays (luciferase; Xenopus enhancer assays) showed disease-associated variants change enhancer output. (sompele2022multiomicsapproachdissects pages 1-3)
+- **Developmental timing/cell types:** single-nucleus RNA-seq indicates PRDM13 is predominantly expressed in **amacrine cells** (and some retinal progenitors/horizontal/ganglion cells) and IRX1 peaks in **retinal ganglion cells**, with developmental peaks around embryonic timepoints (e.g., e70). This supports the hypothesis that altered PRDM13/IRX1 expression impairs “amacrine–ganglion cell” interactions during retinogenesis. (sompele2022multiomicsapproachdissects pages 13-14, sompele2022multiomicsapproachdissects pages 1-3)
+
+**Suggested ontology mappings (mechanism; non-exhaustive):**
+- GO Biological Process: **retina development**; **neurogenesis**; **amacrine cell differentiation**; **synapse organization**
+- Cell Ontology (CL) candidates: **amacrine cell**, **retinal ganglion cell**, **retinal progenitor cell** (supported by expression localization and developmental claims) (sompele2022multiomicsapproachdissects pages 13-14)
+
+### 6.2 Model organism support (functional developmental biology)
+A Xenopus study provides developmental mechanism support for PRDM13 function:
+- prdm13 is expressed in retinal progenitors and **~40% of amacrine cells**, predominantly glycinergic; knockdown “prevents glycinergic cell genesis,” while overexpression biases toward amacrine fate with glycinergic preference. (publication date **2017-09**) (bessodes2017prdm13formsa pages 1-2, bessodes2017prdm13formsa pages 10-13)
+These developmental roles align with the AJHG study’s cell-type timing (amacrine emergence and synapsing with ganglion cells) and support a plausible causal chain from regulatory dysregulation to disrupted macular/central retinal wiring. (sompele2022multiomicsapproachdissects pages 1-3, sompele2022multiomicsapproachdissects pages 13-14)
+
+---
+
+## 7. Anatomical structures affected
+
+### 7.1 Organ/tissue level
+- Primary: **Eye**, specifically **retina** and **macula/foveal region** (central retina). (green2021northcarolinamacular pages 1-6, small2023newnoncodingbase pages 1-2)
+
+**Suggested UBERON terms (candidates):**
+- **retina**, **macula lutea**, **fovea centralis**, **retinal pigment epithelium (RPE)**
+
+### 7.2 Cell level
+- RPE involvement is suggested by grade 3 descriptions (“absence of RPE”) and abnormal EOG ratios consistent with RPE dysfunction in some cases. (small2023newnoncodingbase pages 1-2, chiang2023electrophysiologicalevaluationof pages 11-12)
+- Inner retinal neuron involvement is suggested by PRDM13/IRX1 developmental expression in amacrine and ganglion cells and mechanistic hypotheses about synaptic interactions. (sompele2022multiomicsapproachdissects pages 13-14)
+
+---
+
+## 8. Temporal development (natural history)
+
+### 8.1 Onset
+- Lesions are “congenital or present in early infancy” (wu2022anoveltandem pages 1-3), and are “present at birth” (green2021northcarolinamacular pages 1-6).
+
+### 8.2 Progression
+- NCMD is generally described as nonprogressive: “present at birth and rarely progresses” (green2021northcarolinamacular pages 1-6).
+- A 2023 report asserts grade is fixed: affected individuals have “a fixed grade at birth and do not progress between grades.” (small2023newnoncodingbase pages 1-2)
+
+### 8.3 Critical complications over time
+- CNV can occur early (childhood) and can drive acute functional loss; multiple independent case-based sources describe CNV and treatment response. (green2021northcarolinamacular pages 1-6, bakall2021choroidalneovascularizationin pages 2-5)
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology (available statistics)
+Formal prevalence/incidence rates were not identified in the retrieved texts.
+
+However, several quantitative or semi-quantitative epidemiology statements are available:
+- “NCMD is rare but reported worldwide in >50 families.” (small2023newnoncodingbase pages 1-2)
+- “More than 2000 patients have been diagnosed worldwide.” (wu2022anoveltandem pages 1-3)
+- Historical founder kindred: original pedigree described as **>500 individuals across seven generations** (green2021northcarolinamacular pages 1-6), and a “very large kindred (~2000 individuals)” is referenced in linkage-era literature (audere2016geneticlinkagestudies pages 1-2).
+
+### 9.2 Inheritance, penetrance, expressivity
+- Autosomal dominant inheritance is repeatedly stated. (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3)
+- Complete/fully penetrant is reported in several sources (small2023newnoncodingbase pages 1-2, green2021northcarolinamacular pages 1-6).
+- Marked intrafamilial variability / variable expressivity is consistent across cohorts. (small2023newnoncodingbase pages 1-2, green2021northcarolinamacular pages 1-6)
+
+### 9.3 Founder effects / geographic distribution
+- Founder effect is described for the original North Carolina pedigree, descended from two Irish brothers who emigrated in the 19th century. (green2021northcarolinamacular pages 1-6, audere2016geneticlinkagestudies pages 1-2)
+- Multiple sources emphasize the “North Carolina” name is a misnomer due to global distribution (United States, Europe, Central America, Australia/New Zealand, Korea, China). (small2023newnoncodingbase pages 1-2, small2023commentson“the pages 1-2)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical/imaging tests (real-world implementation)
+Multimodal ophthalmic evaluation is emphasized, including:
+- **Fundus examination/photography** for drusen-like deposits, confluent changes, or excavation (wu2022anoveltandem pages 1-3)
+- **OCT**: in mild grade 1 lesions can show RPE-level deposits with preserved ellipsoid zone; severe lesions can show “central intrachoroidal fluid-containing space with preserved retinal layers,” and CNV/subretinal fibrosis may be visible in advanced disease. (chiang2023electrophysiologicalevaluationof pages 11-12)
+- **Widefield imaging**: peripheral spots “seen in all study subjects” can support recognition. (green2021northcarolinamacular pages 1-6)
+
+### 10.2 Electrophysiology (ERG/EOG/mfERG)
+The 2023 electrophysiology review provides test interpretation patterns:
+- **Full-field ERG often normal** in NCMD (suggesting absence of generalized photoreceptor dysfunction). (chiang2023electrophysiologicalevaluationof pages 11-12)
+- **mfERG abnormal** (delayed implicit times and reduced amplitudes localized to central lesion), helping detect macular dysfunction when ffERG is normal. (chiang2023electrophysiologicalevaluationof pages 11-12, chiang2023electrophysiologicalevaluationof pages 12-14)
+- **EOG abnormal** with reduced LP:DT (Arden) ratios reported **1.4–1.6**, consistent with RPE dysfunction. (chiang2023electrophysiologicalevaluationof pages 11-12)
+
+### 10.3 Genetic testing strategy
+Evidence-supported approaches include:
+- **Whole genome sequencing (WGS)** and targeted confirmation (Sanger) for noncoding SNVs and breakpoint characterization; CNV analysis for tandem duplications. (small2023newnoncodingbase pages 1-2)
+- Long-read or genome sequencing can validate tandem duplications (reported in the Chinese family study). (wu2022anoveltandem pages 1-3)
+
+### 10.4 Differential diagnosis (high-level)
+- Mild NCMD can be misdiagnosed as early-onset macular drusen (asymptomatic cases identified in adulthood) (green2021northcarolinamacular pages 13-16).
+- Electrophysiology (normal ffERG with abnormal mfERG; abnormal EOG) is used across macular dystrophy differentials and can help localize macular vs generalized retinal disease and indicate RPE involvement. (chiang2023electrophysiologicalevaluationof pages 7-9, chiang2023electrophysiologicalevaluationof pages 11-12)
+
+---
+
+## 11. Outcome / prognosis
+
+### 11.1 Visual prognosis
+- Vision can remain “relatively good” despite striking lesions; multiple sources report unexpectedly preserved acuity in some individuals (e.g., 20/20–20/50 in a Chinese pedigree). (wu2022anoveltandem pages 1-3)
+- Conversely, severe grade 3 is associated with severe central vision loss, and CNV/subretinal fibrosis can worsen outcomes. (chiang2023electrophysiologicalevaluationof pages 11-12)
+
+### 11.2 Prognostic factors
+- **Disease grade** and **presence of CNV/CNVM** appear to be key drivers of visual outcome; CNVM is highlighted as a cause of vision decline and as treatable. (small2023newnoncodingbase pages 1-2, bakall2021choroidalneovascularizationin pages 2-5)
+
+Mortality/survival outcomes are not applicable (ocular-limited disorder) and not reported in retrieved evidence.
+
+---
+
+## 12. Treatment
+
+### 12.1 Pharmacotherapy / advanced therapeutics
+No disease-modifying pharmacotherapy or gene therapy was identified for NCMD in the retrieved evidence. Current care is primarily monitoring and treating complications.
+
+### 12.2 Treatment of CNV (evidence of real-world implementation)
+- **Bevacizumab (anti-VEGF) intravitreal injection**: case-based evidence indicates improved fluid and vision with intravitreal **1.25 mg bevacizumab** in a pediatric case, with reduced cystic fluid after three monthly injections and stopping after stability. (Bakall et al., 2021-09; URL https://doi.org/10.1097/icb.0000000000000838) (bakall2021choroidalneovascularizationin pages 2-5)
+- **Ranibizumab (anti-VEGF) intravitreal injection**: a familial maculopathy resembling NCMD reported type 2 CNV responsive to **three monthly ranibizumab** injections with “significant improvement” and no later CNV activity. (Nekolova et al., 2022-12; URL https://doi.org/10.5507/bp.2021.037) (nekolova2022moderndiagnosticand pages 2-6)
+
+**Suggested MAXO terms (candidates):**
+- **intravitreal injection**; **anti-VEGF therapy**; **optical coherence tomography** (diagnostic procedure); **low vision rehabilitation** (not explicitly described in retrieved texts, but relevant as supportive care)
+
+### 12.3 Clinical trials
+A tool-based clinicaltrials.gov search retrieved trials metadata but no specific, NCMD-targeted interventional clinical trials were identified in the retrieved evidence set.
+
+---
+
+## 13. Prevention
+No primary prevention is described for NCMD (genetic congenital disorder). Secondary prevention is essentially **cascade screening and early ophthalmic monitoring** in affected families to detect CNV early and treat promptly. (small2023newnoncodingbase pages 1-2, green2021northcarolinamacular pages 13-16)
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring NCMD-equivalent disease in companion animals was identified in the retrieved evidence.
+
+---
+
+## 15. Model organisms
+
+### 15.1 Key model systems and relevance
+- **Xenopus retina (developmental model):** prdm13 gain/loss-of-function experiments demonstrate a causal role in amacrine subtype specification, with knockdown preventing glycinergic amacrine cell genesis and overexpression increasing amacrine fate. This supports developmental plausibility for PRDM13 dysregulation in NCMD. (bessodes2017prdm13formsa pages 1-2, bessodes2017prdm13formsa pages 10-13)
+- **Mechanism-focused enhancer assays (in vivo):** AJHG 2022 reports Xenopus enhancer assays validating in vivo activity of an NCMD-associated cCRE that contacts the PRDM13 promoter and is active when central retinal progenitors exit mitosis. (sompele2022multiomicsapproachdissects pages 1-3)
+
+### 15.2 Limitations
+Non-human models do not possess a human-like macula, so they primarily model **retinal developmental circuitry and cis-regulatory logic**, not macula anatomy per se. The macula-predominant phenotype therefore requires careful cross-species interpretation and may be best modeled with human retinal organoids and human multi-omics integration (explicitly proposed as a future direction). (sompele2022multiomicsprofilingin pages 25-27)
+
+---
+
+## Key schematics (visual evidence)
+Genetic schematics of the original variant set (V1–V5) and their locus contexts are shown in the cropped figures retrieved from Small et al. (Ophthalmology, 2016-01). These illustrate the PRDM13-region regulatory SNVs/duplication (V1–V4) and the IRX1-region duplication (V5). (small2016northcarolinamacular media 3981bb1f, small2016northcarolinamacular media deebfcdf)
+
+---
+
+## Curated summary table
+The following evidence-grounded table consolidates identifiers, loci/genes, variant examples, inheritance, and hallmark phenotypes/complications.
+
+| Item type | Detail | Evidence/Notes |
+|---|---|---|
+| Disease identifier | North Carolina macular dystrophy (NCMD); OMIM/MIM #136550 | Reported explicitly as “NCMD [MIM: 136550]” / “NCMD/MCDR1; OMIM #136550” in evidence; rare congenital macular disorder (small2023newnoncodingbase pages 1-2, sompele2022multiomicsprofilingin pages 25-27) |
+| Locus name | MCDR1 | Chromosome 6 locus upstream of PRDM13; commonly used alternative locus-based identifier for NCMD (small2023newnoncodingbase pages 1-2, small2016northcarolinamacular pages 1-2, wu2022anoveltandem pages 1-3, sompele2022multiomicsprofilingin pages 25-27) |
+| Locus name | MCDR3 | Chromosome 5 locus involving/downstream of IRX1; additional NCMD locus (small2023newnoncodingbase pages 1-2, small2016northcarolinamacular pages 1-2, wu2022anoveltandem pages 1-3, bakall2021choroidalneovascularizationin pages 5-5, sompele2022multiomicsprofilingin pages 25-27) |
+| Gene | PRDM13 | Main disease-implicated transcription factor at MCDR1; NCMD is described as caused by dysregulation of PRDM13 rather than coding loss-of-function alone (small2016northcarolinamacular pages 4-5, small2016northcarolinamacular pages 1-2, sompele2022multiomicsapproachdissects pages 1-3) |
+| Gene | IRX1 | Implicated at MCDR3 through downstream duplications or duplication including IRX1; proposed dysregulation mechanism (small2016northcarolinamacular pages 1-2, bakall2021choroidalneovascularizationin pages 5-5, sompele2022multiomicsapproachdissects pages 1-3) |
+| Gene context | CCNC | Present in the MCDR1 region context; a novel chr6 tandem duplication encompassed CCNC, PRDM13, and a DNase I hypersensitive site. CCNC OMIM 123838 given in evidence, but causal role is less established than PRDM13 dysregulation (wu2022anoveltandem pages 1-3) |
+| Inheritance | Autosomal dominant | Consistently described as autosomal dominant in multiple studies/reviews (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3, green2021northcarolinamacular pages 1-6) |
+| Penetrance | Fully penetrant | Explicitly stated in 2023 evidence: “autosomal dominant, fully penetrant, congenital” with marked intrafamilial variability (small2023newnoncodingbase pages 1-2) |
+| Expressivity | Marked intra- and interfamilial variability | Visual acuity and lesion severity vary widely despite shared familial variants; variable expressivity repeatedly emphasized (small2023newnoncodingbase pages 1-2, green2021northcarolinamacular pages 1-6) |
+| Variant type | Noncoding SNV upstream of PRDM13: chr6:100,040,906G>T (hg19) | Original NCMD-associated regulatory variant in DNase hypersensitivity site upstream of PRDM13 (bakall2021choroidalneovascularizationin pages 5-5, green2021northcarolinamacular pages 28-31) |
+| Variant type | Noncoding SNV upstream of PRDM13: chr6:100,040,974A>C (hg19) | Reported disease-associated variant within PRDM13 regulatory enhancer region (green2021northcarolinamacular pages 28-31) |
+| Variant type | Noncoding SNV upstream of PRDM13: chr6:100,040,987G>C (hg19/GRCh37) | Detected in all affected members of one cohort/families; predicted to lie in enhancer interacting with PRDM13 (green2021northcarolinamacular pages 1-6, green2021northcarolinamacular pages 28-31) |
+| Variant type | Noncoding SNV upstream of PRDM13: chr6:100,041,040C>T (hg19) | Additional NCMD-associated variant in same regulatory region (green2021northcarolinamacular pages 28-31) |
+| Variant type | Noncoding SNV near PRDM13 enhancer: chr6:100,046,783A>C (hg19) | Candidate enhancer variant predicted functional in macular/retinal tissue (green2021northcarolinamacular pages 28-31) |
+| Variant type | 123-kb tandem duplication containing PRDM13 | Structural variant reported at MCDR1 in a family; supports dosage/regulatory mechanism (small2016northcarolinamacular pages 4-5, bakall2021choroidalneovascularizationin pages 5-5) |
+| Variant type | 134.6-kb tandem duplication at chr6 g.99932464-100067110dup | Novel duplication in a Chinese family; encompasses CCNC, PRDM13, and a DNase I hypersensitive site in MCDR1 (wu2022anoveltandem pages 1-3) |
+| Variant type | 900-kb tandem duplication including entire IRX1 gene (V5) | Reported at MCDR3 locus on chromosome 5; segregated with disease (small2016northcarolinamacular pages 4-5, small2016northcarolinamacular pages 1-2) |
+| Variant mechanism | Retinal enhanceropathy / cis-regulatory dysregulation | Pathogenic SNVs cluster in PRDM13 mutational hotspots/cCREs; duplications may duplicate one or more CREs or disturb gene regulatory landscape affecting PRDM13 or IRX1 expression (sompele2022multiomicsapproachdissects pages 13-14, sompele2022multiomicsapproachdissects pages 1-3, sompele2022multiomicsprofilingin pages 25-27) |
+| Clinical phenotype | Congenital, usually nonprogressive macular developmental disorder | Present at birth; typically little progression, though phenotype severity is variable (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3, green2021northcarolinamacular pages 1-6) |
+| Clinical phenotype | Grade 1 lesion | Central yellowish-white/drusen-like deposits; early OCT may show RPE-level deposits with intact ellipsoid zone (wu2022anoveltandem pages 1-3, chiang2023electrophysiologicalevaluationof pages 11-12) |
+| Clinical phenotype | Grade 2 lesion | Larger confluent drusen-like/confluent macular changes, sometimes with subretinal fibrosis (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3) |
+| Clinical phenotype | Grade 3 lesion | Large central atrophic excavation / choroidal coloboma-like lesion with absent RPE/choroidal lacunae in severe disease descriptions (small2023newnoncodingbase pages 1-2, wu2022anoveltandem pages 1-3) |
+| Clinical phenotype | Peripheral retinal spots | Widefield imaging can reveal peripheral radial yellow-white/drusen-like spots; useful clinical clue (green2021northcarolinamacular pages 1-6, green2021northcarolinamacular pages 28-31) |
+| Visual function | Visual acuity highly variable | Reported range 0.0 to 1.6 LogMAR in one series; acuity can remain relatively preserved despite large lesions (green2021northcarolinamacular pages 1-6, wu2022anoveltandem pages 1-3) |
+| Complication | Choroidal neovascularization (CNV/CNVM) | Can occur in childhood/early life; one 6-year-old required treatment; advanced disease may show CNV and subretinal fibrosis (green2021northcarolinamacular pages 1-6, bakall2021choroidalneovascularizationin pages 5-5, chiang2023electrophysiologicalevaluationof pages 11-12) |
+| Management note | Anti-VEGF response for CNV | Intravitreal bevacizumab reported beneficial / vision-improving in NCMD-associated CNV (green2021northcarolinamacular pages 1-6, bakall2021choroidalneovascularizationin pages 5-5) |
+
+
+*Table: This table summarizes evidence-supported identifiers, loci, causal genes, variant classes, inheritance, and hallmark clinical features of North Carolina macular dystrophy. It is designed as a compact reference for disease knowledge base curation using only facts present in the retrieved evidence snippets.*
+
+---
+
+## Recent developments (emphasis 2023–2024)
+1) **Expanded mutational spectrum and hotspot concept (2023):** identification of an additional noncoding base change at the same regulatory locus as the original MCDR1 family supports a mutational hotspot model and reiterates “autosomal dominant, fully penetrant, congenital, nonprogressive” disease framing. (Small et al., 2023-01; URL https://doi.org/10.1177/24741264221129432) (small2023newnoncodingbase pages 1-2)
+
+2) **Expert clarification of developmental terminology (2023):** commentary emphasizes NCMD is better described as congenital macular hypoplasia/dysplasia, cautioning against misleading descriptors such as “atrophy” and reinforcing locus nomenclature (MCDR1/MCDR3). (Small, 2023-09; URL https://doi.org/10.1186/s12886-023-03100-2) (small2023commentson“the pages 1-2)
+
+3) **Clinical electrophysiology integration (2023):** contemporary review consolidates the typical pattern (normal ffERG, abnormal mfERG, abnormal EOG with LP:DT ~1.4–1.6) and highlights how electrophysiology localizes dysfunction and supports differential diagnosis among macular dystrophies. (Chiang & Yu, 2023-02; URL https://doi.org/10.3390/jcm12041430) (chiang2023electrophysiologicalevaluationof pages 11-12)
+
+---
+
+## References (tool-retrieved; URLs and publication dates)
+- Small KW et al. *Ophthalmology*. 2016-01. https://doi.org/10.1016/j.ophtha.2015.10.006 (small2016northcarolinamacular pages 1-2)
+- Van de Sompele S et al. *Am J Hum Genet*. 2022-11. https://doi.org/10.1016/j.ajhg.2022.09.013 (sompele2022multiomicsapproachdissects pages 1-3)
+- Small KW et al. *J VitreoRetinal Dis*. 2023-01. https://doi.org/10.1177/24741264221129432 (small2023newnoncodingbase pages 1-2)
+- Chiang T-K, Yu M. *J Clin Med*. 2023-02. https://doi.org/10.3390/jcm12041430 (chiang2023electrophysiologicalevaluationof pages 11-12)
+- Wu S et al. *Graefes Arch Clin Exp Ophthalmol*. 2022-08. https://doi.org/10.1007/s00417-021-05376-w (wu2022anoveltandem pages 1-3)
+- Bakall B et al. *Retinal Cases & Brief Reports*. 2021-09. https://doi.org/10.1097/icb.0000000000000838 (bakall2021choroidalneovascularizationin pages 2-5)
+- Nekolova J et al. *Biomedical Papers*. 2022-12. https://doi.org/10.5507/bp.2021.037 (nekolova2022moderndiagnosticand pages 2-6)
+- Bessodes N et al. *Neural Development*. 2017-09. https://doi.org/10.1186/s13064-017-0093-2 (bessodes2017prdm13formsa pages 1-2)
+
+---
+
+## Notable evidence gaps (from tool-retrieved corpus)
+- MONDO/Orphanet/MeSH/ICD identifiers were not present in retrieved documents.
+- No robust population prevalence/incidence estimates were found.
+- No NCMD-specific interventional clinical trials or disease-modifying therapies were identified.
+- QoL instrument data were not found.
+
+
+References
+
+1. (small2023newnoncodingbase pages 1-2): Kent W. Small, Stijn Van de Sompele, Jessica Avetisjan, Nitin Udar, Steven Agemy, Elfride De Baere, and Fadi S. Shaya. New noncoding base pair mutation at the identical locus as the original ncmd/mcdr1 in a mexican family, suggesting a mutational hotspot. Journal of VitreoRetinal Diseases, 7:33-42, Jan 2023. URL: https://doi.org/10.1177/24741264221129432, doi:10.1177/24741264221129432. This article has 3 citations.
+
+2. (sompele2022multiomicsapproachdissects pages 1-3): Stijn Van de Sompele, Kent W. Small, Munevver Burcu Cicekdal, Víctor López Soriano, Eva D’haene, Fadi S. Shaya, Steven Agemy, Thijs Van der Snickt, Alfredo Dueñas Rey, Toon Rosseel, Mattias Van Heetvelde, Sarah Vergult, Irina Balikova, Arthur A. Bergen, Camiel J.F. Boon, Julie De Zaeytijd, Chris F. Inglehearn, Bohdan Kousal, Bart P. Leroy, Carlo Rivolta, Veronika Vaclavik, Jenneke van den Ende, Mary J. van Schooneveld, José Luis Gómez-Skarmeta, Juan J. Tena, Juan R. Martinez-Morales, Petra Liskova, Kris Vleminckx, and Elfride De Baere. Multi-omics approach dissects cis-regulatory mechanisms underlying north carolina macular dystrophy, a retinal enhanceropathy. The American Journal of Human Genetics, 109:2029-2048, Nov 2022. URL: https://doi.org/10.1016/j.ajhg.2022.09.013, doi:10.1016/j.ajhg.2022.09.013. This article has 27 citations.
+
+3. (green2021northcarolinamacular pages 1-6): David J. Green, Eva Lenassi, Cerys S. Manning, David McGaughey, Vinod Sharma, Graeme C. Black, Jamie M. Ellingford, and Panagiotis I. Sergouniotis. North carolina macular dystrophy: phenotypic variability and computational analysis of disease-implicated non-coding variants. MedRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.05.21252975, doi:10.1101/2021.03.05.21252975. This article has 3 citations.
+
+4. (sompele2022multiomicsprofilingin pages 25-27): Stijn Van de Sompele, Kent W. Small, Munevver Burcu Cicekdal, Víctor López Soriano, Eva D’haene, Fadi S. Shaya, Steven Agemy, Thijs Van der Snickt, Alfredo Dueñas Rey, Toon Rosseel, Mattias Van Heetvelde, Sarah Vergult, Irina Balikova, Arthur A. Bergen, Camiel J. F. Boon, Julie De Zaeytijd, Chris F. Inglehearn, Bohdan Kousal, Bart P. Leroy, Carlo Rivolta, Veronika Vaclavik, Jenneke van den Ende, Mary J. van Schooneveld, José Luis Gómez-Skarmeta, Juan J. Tena, Juan R. Martinez-Morales, Petra Liskova, Kris Vleminckx, and Elfride De Baere. Multi-omics profiling, in vitro and in vivo enhancer assays dissect the cis-regulatory mechanisms underlying north carolina macular dystrophy, a retinal enhanceropathy. bioRxiv, Jul 2022. URL: https://doi.org/10.1101/2022.03.08.481329, doi:10.1101/2022.03.08.481329. This article has 2 citations.
+
+5. (small2016northcarolinamacular pages 1-2): Kent W. Small, Adam P. DeLuca, S. Scott Whitmore, Thomas Rosenberg, Rosemary Silva-Garcia, Nitin Udar, Bernard Puech, Charles A. Garcia, Thomas A. Rice, Gerald A. Fishman, Elise Héon, James C. Folk, Luan M. Streb, Christine M. Haas, Luke A. Wiley, Todd E. Scheetz, John H. Fingert, Robert F. Mullins, Budd A. Tucker, and Edwin M. Stone. North carolina macular dystrophy is caused by dysregulation of the retinal transcription factor prdm13. Ophthalmology, 123 1:9-18, Jan 2016. URL: https://doi.org/10.1016/j.ophtha.2015.10.006, doi:10.1016/j.ophtha.2015.10.006. This article has 143 citations and is from a highest quality peer-reviewed journal.
+
+6. (wu2022anoveltandem pages 1-3): Shijing Wu, Zhisheng Yuan, Zixi Sun, Tian Zhu, Xing Wei, Xuan Zou, and Ruifang Sui. A novel tandem duplication of prdm13 in a chinese family with north carolina macular dystrophy. Graefe's Archive for Clinical and Experimental Ophthalmology, 260:645-653, Aug 2022. URL: https://doi.org/10.1007/s00417-021-05376-w, doi:10.1007/s00417-021-05376-w. This article has 11 citations.
+
+7. (bakall2021choroidalneovascularizationin pages 5-5): MD Benjamin Bakall, †. J. Shepard, MD Bryan III, MD Edwin M. Stone, and MD Kent W. Small. Choroidal neovascularization in north carolina macular dystrophy responsive to anti–vascular endothelial growth factor therapy. RETINAL Cases &amp; Brief Reports, 15:509-513, Sep 2021. URL: https://doi.org/10.1097/icb.0000000000000838, doi:10.1097/icb.0000000000000838. This article has 19 citations and is from a peer-reviewed journal.
+
+8. (small2023commentson“the pages 1-2): Kent W. Small. Comments on “the possible pathogenesis of macular caldera in patients with north carolina macular dystrophy”. BMC Ophthalmology, Sep 2023. URL: https://doi.org/10.1186/s12886-023-03100-2, doi:10.1186/s12886-023-03100-2. This article has 0 citations and is from a peer-reviewed journal.
+
+9. (sompele2022multiomicsapproachdissects pages 13-14): Stijn Van de Sompele, Kent W. Small, Munevver Burcu Cicekdal, Víctor López Soriano, Eva D’haene, Fadi S. Shaya, Steven Agemy, Thijs Van der Snickt, Alfredo Dueñas Rey, Toon Rosseel, Mattias Van Heetvelde, Sarah Vergult, Irina Balikova, Arthur A. Bergen, Camiel J.F. Boon, Julie De Zaeytijd, Chris F. Inglehearn, Bohdan Kousal, Bart P. Leroy, Carlo Rivolta, Veronika Vaclavik, Jenneke van den Ende, Mary J. van Schooneveld, José Luis Gómez-Skarmeta, Juan J. Tena, Juan R. Martinez-Morales, Petra Liskova, Kris Vleminckx, and Elfride De Baere. Multi-omics approach dissects cis-regulatory mechanisms underlying north carolina macular dystrophy, a retinal enhanceropathy. The American Journal of Human Genetics, 109:2029-2048, Nov 2022. URL: https://doi.org/10.1016/j.ajhg.2022.09.013, doi:10.1016/j.ajhg.2022.09.013. This article has 27 citations.
+
+10. (chiang2023electrophysiologicalevaluationof pages 11-12): Tsun-Kang Chiang and Minzhong Yu. Electrophysiological evaluation of macular dystrophies. Journal of Clinical Medicine, 12:1430, Feb 2023. URL: https://doi.org/10.3390/jcm12041430, doi:10.3390/jcm12041430. This article has 7 citations.
+
+11. (audere2016geneticlinkagestudies pages 4-6): Mareta Audere, Katrina Rutka, Inna Inaskina, Raitis Peculis, Svetlana Sepetiene, Sandra Valeina, and Baiba Lāce. Genetic linkage studies of a north carolina macular dystrophy family. Medicina, 52 3:180-6, Jan 2016. URL: https://doi.org/10.1016/j.medici.2016.04.001, doi:10.1016/j.medici.2016.04.001. This article has 10 citations.
+
+12. (small2016northcarolinamacular pages 4-5): Kent W. Small, Adam P. DeLuca, S. Scott Whitmore, Thomas Rosenberg, Rosemary Silva-Garcia, Nitin Udar, Bernard Puech, Charles A. Garcia, Thomas A. Rice, Gerald A. Fishman, Elise Héon, James C. Folk, Luan M. Streb, Christine M. Haas, Luke A. Wiley, Todd E. Scheetz, John H. Fingert, Robert F. Mullins, Budd A. Tucker, and Edwin M. Stone. North carolina macular dystrophy is caused by dysregulation of the retinal transcription factor prdm13. Ophthalmology, 123 1:9-18, Jan 2016. URL: https://doi.org/10.1016/j.ophtha.2015.10.006, doi:10.1016/j.ophtha.2015.10.006. This article has 143 citations and is from a highest quality peer-reviewed journal.
+
+13. (green2021northcarolinamacular pages 28-31): David J. Green, Eva Lenassi, Cerys S. Manning, David McGaughey, Vinod Sharma, Graeme C. Black, Jamie M. Ellingford, and Panagiotis I. Sergouniotis. North carolina macular dystrophy: phenotypic variability and computational analysis of disease-implicated non-coding variants. MedRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.05.21252975, doi:10.1101/2021.03.05.21252975. This article has 3 citations.
+
+14. (bessodes2017prdm13formsa pages 1-2): Nathalie Bessodes, Karine Parain, Odile Bronchain, Eric J. Bellefroid, and Muriel Perron. Prdm13 forms a feedback loop with ptf1a and is required for glycinergic amacrine cell genesis in the xenopus retina. Neural Development, Sep 2017. URL: https://doi.org/10.1186/s13064-017-0093-2, doi:10.1186/s13064-017-0093-2. This article has 26 citations and is from a peer-reviewed journal.
+
+15. (bessodes2017prdm13formsa pages 10-13): Nathalie Bessodes, Karine Parain, Odile Bronchain, Eric J. Bellefroid, and Muriel Perron. Prdm13 forms a feedback loop with ptf1a and is required for glycinergic amacrine cell genesis in the xenopus retina. Neural Development, Sep 2017. URL: https://doi.org/10.1186/s13064-017-0093-2, doi:10.1186/s13064-017-0093-2. This article has 26 citations and is from a peer-reviewed journal.
+
+16. (bakall2021choroidalneovascularizationin pages 2-5): MD Benjamin Bakall, †. J. Shepard, MD Bryan III, MD Edwin M. Stone, and MD Kent W. Small. Choroidal neovascularization in north carolina macular dystrophy responsive to anti–vascular endothelial growth factor therapy. RETINAL Cases &amp; Brief Reports, 15:509-513, Sep 2021. URL: https://doi.org/10.1097/icb.0000000000000838, doi:10.1097/icb.0000000000000838. This article has 19 citations and is from a peer-reviewed journal.
+
+17. (audere2016geneticlinkagestudies pages 1-2): Mareta Audere, Katrina Rutka, Inna Inaskina, Raitis Peculis, Svetlana Sepetiene, Sandra Valeina, and Baiba Lāce. Genetic linkage studies of a north carolina macular dystrophy family. Medicina, 52 3:180-6, Jan 2016. URL: https://doi.org/10.1016/j.medici.2016.04.001, doi:10.1016/j.medici.2016.04.001. This article has 10 citations.
+
+18. (chiang2023electrophysiologicalevaluationof pages 12-14): Tsun-Kang Chiang and Minzhong Yu. Electrophysiological evaluation of macular dystrophies. Journal of Clinical Medicine, 12:1430, Feb 2023. URL: https://doi.org/10.3390/jcm12041430, doi:10.3390/jcm12041430. This article has 7 citations.
+
+19. (green2021northcarolinamacular pages 13-16): David J. Green, Eva Lenassi, Cerys S. Manning, David McGaughey, Vinod Sharma, Graeme C. Black, Jamie M. Ellingford, and Panagiotis I. Sergouniotis. North carolina macular dystrophy: phenotypic variability and computational analysis of disease-implicated non-coding variants. MedRxiv, Mar 2021. URL: https://doi.org/10.1101/2021.03.05.21252975, doi:10.1101/2021.03.05.21252975. This article has 3 citations.
+
+20. (chiang2023electrophysiologicalevaluationof pages 7-9): Tsun-Kang Chiang and Minzhong Yu. Electrophysiological evaluation of macular dystrophies. Journal of Clinical Medicine, 12:1430, Feb 2023. URL: https://doi.org/10.3390/jcm12041430, doi:10.3390/jcm12041430. This article has 7 citations.
+
+21. (nekolova2022moderndiagnosticand pages 2-6): Jana Nekolova, Alexandr Stepanov, Bohdan Kousal, Marketa Stredova, and Nada Jiraskova. Modern diagnostic and therapeutic approaches in familial maculopathy with reference to north carolina macular dystrophy. Biomedical Papers, 166:418-427, Dec 2022. URL: https://doi.org/10.5507/bp.2021.037, doi:10.5507/bp.2021.037. This article has 4 citations.
+
+22. (small2016northcarolinamacular media 3981bb1f): Kent W. Small, Adam P. DeLuca, S. Scott Whitmore, Thomas Rosenberg, Rosemary Silva-Garcia, Nitin Udar, Bernard Puech, Charles A. Garcia, Thomas A. Rice, Gerald A. Fishman, Elise Héon, James C. Folk, Luan M. Streb, Christine M. Haas, Luke A. Wiley, Todd E. Scheetz, John H. Fingert, Robert F. Mullins, Budd A. Tucker, and Edwin M. Stone. North carolina macular dystrophy is caused by dysregulation of the retinal transcription factor prdm13. Ophthalmology, 123 1:9-18, Jan 2016. URL: https://doi.org/10.1016/j.ophtha.2015.10.006, doi:10.1016/j.ophtha.2015.10.006. This article has 143 citations and is from a highest quality peer-reviewed journal.
+
+23. (small2016northcarolinamacular media deebfcdf): Kent W. Small, Adam P. DeLuca, S. Scott Whitmore, Thomas Rosenberg, Rosemary Silva-Garcia, Nitin Udar, Bernard Puech, Charles A. Garcia, Thomas A. Rice, Gerald A. Fishman, Elise Héon, James C. Folk, Luan M. Streb, Christine M. Haas, Luke A. Wiley, Todd E. Scheetz, John H. Fingert, Robert F. Mullins, Budd A. Tucker, and Edwin M. Stone. North carolina macular dystrophy is caused by dysregulation of the retinal transcription factor prdm13. Ophthalmology, 123 1:9-18, Jan 2016. URL: https://doi.org/10.1016/j.ophtha.2015.10.006, doi:10.1016/j.ophtha.2015.10.006. This article has 143 citations and is from a highest quality peer-reviewed journal.

--- a/research/North_Carolina_Macular_Dystrophy-deep-research-falcon.md.citations.md
+++ b/research/North_Carolina_Macular_Dystrophy-deep-research-falcon.md.citations.md
@@ -1,0 +1,491 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** North Carolina Macular Dystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **North Carolina Macular Dystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T11:22:38.251561
+
+1. small2023newnoncodingbase pages 1-2
+2. green2021northcarolinamacular pages 1-6
+3. wu2022anoveltandem pages 1-3
+4. sompele2022multiomicsapproachdissects pages 1-3
+5. audere2016geneticlinkagestudies pages 4-6
+6. small2016northcarolinamacular pages 4-5
+7. green2021northcarolinamacular pages 28-31
+8. sompele2022multiomicsapproachdissects pages 13-14
+9. audere2016geneticlinkagestudies pages 1-2
+10. chiang2023electrophysiologicalevaluationof pages 11-12
+11. green2021northcarolinamacular pages 13-16
+12. bakall2021choroidalneovascularizationin pages 2-5
+13. nekolova2022moderndiagnosticand pages 2-6
+14. sompele2022multiomicsprofilingin pages 25-27
+15. small2016northcarolinamacular pages 1-2
+16. bakall2021choroidalneovascularizationin pages 5-5
+17. chiang2023electrophysiologicalevaluationof pages 12-14
+18. chiang2023electrophysiologicalevaluationof pages 7-9
+19. MIM: 136550
+20. https://doi.org/10.1097/icb.0000000000000838
+21. https://doi.org/10.5507/bp.2021.037
+22. https://doi.org/10.1177/24741264221129432
+23. https://doi.org/10.1186/s12886-023-03100-2
+24. https://doi.org/10.3390/jcm12041430
+25. https://doi.org/10.1016/j.ophtha.2015.10.006
+26. https://doi.org/10.1016/j.ajhg.2022.09.013
+27. https://doi.org/10.1007/s00417-021-05376-w
+28. https://doi.org/10.1186/s13064-017-0093-2
+29. https://doi.org/10.1177/24741264221129432,
+30. https://doi.org/10.1016/j.ajhg.2022.09.013,
+31. https://doi.org/10.1101/2021.03.05.21252975,
+32. https://doi.org/10.1101/2022.03.08.481329,
+33. https://doi.org/10.1016/j.ophtha.2015.10.006,
+34. https://doi.org/10.1007/s00417-021-05376-w,
+35. https://doi.org/10.1097/icb.0000000000000838,
+36. https://doi.org/10.1186/s12886-023-03100-2,
+37. https://doi.org/10.3390/jcm12041430,
+38. https://doi.org/10.1016/j.medici.2016.04.001,
+39. https://doi.org/10.1186/s13064-017-0093-2,
+40. https://doi.org/10.5507/bp.2021.037,


### PR DESCRIPTION
## Summary

- Add a new North Carolina macular dystrophy disorder entry with Falcon-backed curation.
- Model PRDM13/IRX1 cis-regulatory dysregulation, congenital macular developmental disruption, phenotypes, genetics, diagnosis, and CNV treatment.
- Add the Falcon deep-research artifacts and only the reference caches cited by the YAML.

## Validation

- `just validate kb/disorders/North_Carolina_Macular_Dystrophy.yaml`
- `just validate-references kb/disorders/North_Carolina_Macular_Dystrophy.yaml`
- `just validate-terms kb/disorders/North_Carolina_Macular_Dystrophy.yaml`

## Cleanup

Restored generated tracked `cache/*` changes and uncited `references_cache/clinicaltrials_NCT*.md` churn before staging.