### PR TITLE
Add myeloproliferative neoplasm, unclassifiable curation

### DIFF
--- a/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
+++ b/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
@@ -1,6 +1,6 @@
 name: Myeloproliferative Neoplasm, Unclassifiable
 creation_date: "2026-05-11T14:55:10Z"
-updated_date: "2026-05-11T14:55:10Z"
+updated_date: "2026-05-11T16:17:05Z"
 description: >-
   Myeloproliferative neoplasm, unclassifiable (MPN-U) is a clonal myeloid
   neoplasm assigned when a case has myeloproliferative features but does not

--- a/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
+++ b/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
@@ -1,0 +1,446 @@
+name: Myeloproliferative Neoplasm, Unclassifiable
+creation_date: "2026-05-11T14:55:10Z"
+updated_date: "2026-05-11T14:55:10Z"
+description: >-
+  Myeloproliferative neoplasm, unclassifiable (MPN-U) is a clonal myeloid
+  neoplasm assigned when a case has myeloproliferative features but does not
+  satisfy the full diagnostic criteria for a defined myeloproliferative
+  neoplasm, or shows overlapping features across multiple MPN categories. The
+  category is heterogeneous and can include early/prodromal MPNs, advanced
+  fibrotic MPNs, and cases where inflammatory or neoplastic comorbidity obscures
+  the clinicopathologic picture.
+categories:
+- Hematologic Malignancy
+- Myeloproliferative Neoplasm
+parents:
+- myeloproliferative neoplasm
+synonyms:
+- MPN-U
+- MPN, unclassifiable
+- MPN not otherwise specified
+- MPN-NOS
+- chronic myeloproliferative disease, unclassifiable
+disease_term:
+  preferred_term: myeloproliferative neoplasm, unclassifiable
+  term:
+    id: MONDO:0019452
+    label: myeloproliferative neoplasm, unclassifiable
+pathophysiology:
+- name: Clonal Myeloid Proliferation
+  description: >-
+    MPN-U arises from a clonal hematopoietic stem or progenitor population with
+    myeloproliferative behavior, increased production of one or more myeloid
+    lineages, and insufficient integrated clinicopathologic features for
+    assignment to a more specific MPN subtype at diagnosis.
+  evidence:
+  - reference: PMID:34830822
+    reference_title: "The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Myeloproliferative neoplasms (MPNs) are a heterogeneous group of clonal
+      hematopoietic stem cell disorders, characterized by increased
+      proliferation of one or more myeloid lineages in the bone marrow.
+    explanation: >-
+      This review defines the parent MPN biology as clonal hematopoietic stem
+      cell disease with increased myeloid-lineage proliferation in marrow.
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Myeloproliferative neoplasm-unclassifiable (MPN-U) presents an MPN-type
+      phenotype that fails to meet diagnostic criteria for other MPN variants.
+    explanation: >-
+      This cohort abstract supports MPN-U as MPN-type disease that remains
+      unassignable to a defined MPN variant.
+  cell_types:
+  - preferred_term: hematopoietic stem cell
+    term:
+      id: CL:0000037
+      label: hematopoietic stem cell
+  - preferred_term: myeloid cell
+    term:
+      id: CL:0000763
+      label: myeloid cell
+  biological_processes:
+  - preferred_term: myeloid cell differentiation
+    modifier: ABNORMAL
+    term:
+      id: GO:0030099
+      label: myeloid cell differentiation
+  locations:
+  - preferred_term: bone marrow
+    term:
+      id: UBERON:0002371
+      label: bone marrow
+- name: Clinicopathologic Diagnostic Ambiguity
+  description: >-
+    The defining mechanism-level feature of MPN-U is not a unique pathway but
+    the combination of myeloproliferative biology with clinicopathologic,
+    morphologic, molecular, or confounding clinical features that prevent
+    confident classification as CML, PV, ET, PMF, chronic neutrophilic leukemia,
+    chronic eosinophilic leukemia, or another defined MPN at the time of
+    evaluation.
+  evidence:
+  - reference: PMID:34830822
+    reference_title: "The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The latter are currently defined as MPNs with clinical-pathological
+      findings not fulfilling the diagnostic criteria for any other entity.
+    explanation: >-
+      This classification review states the defining exclusionary nature of
+      MPN-U.
+  - reference: PMID:36580136
+    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this regard, high sensitive single target (RT-qPCR, ddPCR) or
+      multi-target next-generation sequencing assays with a minimal sensitivity
+      of VAF 1% are now important for a proper diagnostic identification of MPN
+      cases with low allelic frequencies at initial presentation.
+    explanation: >-
+      The ICC review supports sensitive molecular testing as part of resolving
+      early or low-allele-fraction MPN presentations.
+- name: Thrombotic Complication Biology
+  description: >-
+    MPN-U carries clinically important thrombotic risk, reflecting the
+    prothrombotic behavior seen across myeloproliferative neoplasms and requiring
+    vigilance even though management is not standardized specifically for MPN-U.
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thrombosis was common (21%), necessitating vigilance.
+    explanation: >-
+      The retrospective MPN-U cohort directly reports thrombosis as a common
+      complication.
+  biological_processes:
+  - preferred_term: blood coagulation
+    modifier: ABNORMAL
+    term:
+      id: GO:0007596
+      label: blood coagulation
+phenotypes:
+- category: Hematologic
+  name: Thrombocytosis
+  description: >-
+    Increased platelet count can be present when the unclassifiable neoplasm
+    overlaps essential thrombocythemia-like biology.
+  phenotype_term:
+    preferred_term: Thrombocytosis
+    term:
+      id: HP:0001894
+      label: Thrombocytosis
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Albeit heterogeneous, common presentation features included raised lactate
+      dehydrogenase, thrombocytosis and clustered/pleomorphic megakaryocytes on
+      trephine biopsy.
+    explanation: >-
+      The cohort abstract identifies thrombocytosis as a common presentation
+      feature of MPN-U.
+- category: Hematologic
+  name: Leukocytosis
+  description: >-
+    Increased leukocyte count can occur as part of the myeloproliferative
+    blood-count pattern.
+  phenotype_term:
+    preferred_term: Leukocytosis
+    term:
+      id: HP:0001974
+      label: Increased total leukocyte count
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      significantly shortened in cases with lower platelet counts (<500 × 109
+      /l) and a leucocytosis (≥12 × 109 /l) at presentation.
+    explanation: >-
+      The cohort abstract identifies leukocytosis at presentation as an adverse
+      clinical feature in MPN-U.
+- category: Abdominal
+  name: Splenomegaly
+  description: >-
+    Splenic enlargement may reflect extramedullary hematopoiesis or disease
+    burden in myeloproliferative neoplasms.
+  phenotype_term:
+    preferred_term: Splenomegaly
+    term:
+      id: HP:0001744
+      label: Splenomegaly
+  evidence:
+  - reference: PMID:35217310
+    reference_title: "Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      significant risk of thrombosis, bulky splenomegaly, and debilitating
+      symptom burden.
+    explanation: >-
+      The international practice survey abstract highlights bulky splenomegaly
+      as a clinically important manifestation.
+- category: Dermatologic
+  name: Pruritus
+  description: >-
+    Itching can occur as part of the symptom burden seen in MPN-U and other
+    Philadelphia-negative myeloproliferative neoplasms.
+  phenotype_term:
+    preferred_term: Pruritus
+    term:
+      id: HP:0000989
+      label: Pruritus
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Variability in the clinicopathological phenotypes presents many
+      challenges.
+    explanation: >-
+      The abstract emphasizes variable clinical phenotypes; Falcon surfaced
+      pruritus as a cohort phenotype, but the fetched abstract does not give the
+      exact pruritus frequency, so this evidence is partial.
+- category: Cardiovascular
+  name: Thrombosis
+  frequency: OCCASIONAL
+  description: >-
+    Arterial or venous thrombosis, including atypical-site thrombosis, is a major
+    complication and may be present at or near diagnosis.
+  phenotype_term:
+    preferred_term: Thrombosis
+    term:
+      id: HP:0001977
+      label: Abnormal thrombosis
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thrombosis was common (21%), necessitating vigilance.
+    explanation: >-
+      The 21% cohort frequency supports thrombosis as an occasional-to-common
+      clinical complication.
+- category: Constitutional
+  name: Fatigue
+  description: >-
+    Fatigue is included as a representative constitutional symptom contributing
+    to the debilitating symptom burden described in MPN-U.
+  phenotype_term:
+    preferred_term: Fatigue
+    term:
+      id: HP:0012378
+      label: Fatigue
+  evidence:
+  - reference: PMID:35217310
+    reference_title: "Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      significant risk of thrombosis, bulky splenomegaly, and debilitating
+      symptom burden.
+    explanation: >-
+      The survey abstract supports debilitating symptom burden but does not name
+      fatigue specifically, so this evidence is partial.
+histopathology:
+- name: Clustered Pleomorphic Megakaryocytes
+  description: >-
+    Bone marrow trephine biopsy may show clustered or pleomorphic
+    megakaryocytes, supporting an MPN-type marrow morphology even when the case
+    cannot be classified as a defined MPN subtype.
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Albeit heterogeneous, common presentation features included raised lactate
+      dehydrogenase, thrombocytosis and clustered/pleomorphic megakaryocytes on
+      trephine biopsy.
+    explanation: >-
+      This cohort abstract directly reports clustered or pleomorphic
+      megakaryocytes on trephine biopsy.
+biochemical:
+- name: Raised Lactate Dehydrogenase
+  notes: >-
+    Elevated serum lactate dehydrogenase can accompany the proliferative disease
+    burden in MPN-U.
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Albeit heterogeneous, common presentation features included raised lactate
+      dehydrogenase, thrombocytosis and clustered/pleomorphic megakaryocytes on
+      trephine biopsy.
+    explanation: >-
+      The cohort abstract identifies raised lactate dehydrogenase as a common
+      presentation feature.
+genetic:
+- name: JAK2
+  gene_term:
+    preferred_term: JAK2
+    term:
+      id: hgnc:6192
+      label: JAK2
+  association: Somatic activating variants
+  notes: >-
+    Somatic JAK2 variants may be present in MPN-U, particularly in cases with
+    polycythemia vera-like or thrombocythemia-like features.
+  evidence:
+  - reference: PMID:36580136
+    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      high sensitive single target (RT-qPCR, ddPCR) or multi-target
+      next-generation sequencing assays with a minimal sensitivity of VAF 1% are
+      now important for a proper diagnostic identification of MPN cases with low
+      allelic frequencies at initial presentation.
+    explanation: >-
+      The ICC review supports sensitive molecular testing for low-allele-fraction
+      MPN driver lesions; Falcon identified JAK2 among the recurrent MPN-U
+      drivers, but the fetched abstract does not provide JAK2-specific MPN-U
+      frequencies.
+- name: CALR
+  gene_term:
+    preferred_term: CALR
+    term:
+      id: hgnc:1455
+      label: CALR
+  association: Somatic driver variants
+  notes: >-
+    Somatic CALR variants may occur in MPN-U, especially in cases with
+    thrombocythemia-like or prefibrotic myelofibrosis-like features.
+  evidence:
+  - reference: PMID:36580136
+    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      high sensitive single target (RT-qPCR, ddPCR) or multi-target
+      next-generation sequencing assays with a minimal sensitivity of VAF 1% are
+      now important for a proper diagnostic identification of MPN cases with low
+      allelic frequencies at initial presentation.
+    explanation: >-
+      The ICC review supports sensitive molecular testing for MPN driver lesions;
+      CALR-specific MPN-U frequency is documented in the Falcon report but not in
+      this fetched abstract.
+- name: MPL
+  gene_term:
+    preferred_term: MPL
+    term:
+      id: hgnc:7217
+      label: MPL
+  association: Somatic driver variants
+  notes: >-
+    Somatic MPL variants may occur in MPN-U and implicate thrombopoietin receptor
+    signaling in a subset of cases.
+  evidence:
+  - reference: PMID:36580136
+    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      high sensitive single target (RT-qPCR, ddPCR) or multi-target
+      next-generation sequencing assays with a minimal sensitivity of VAF 1% are
+      now important for a proper diagnostic identification of MPN cases with low
+      allelic frequencies at initial presentation.
+    explanation: >-
+      The ICC review supports sensitive molecular testing for MPN driver lesions;
+      MPL-specific MPN-U frequency is documented in the Falcon report but not in
+      this fetched abstract.
+environmental:
+- name: Smoking
+  effect: Risk factor
+  notes: >-
+    Smoking has been associated with increased risk of MPN development in a
+    Danish population-based cohort, with the strongest subtype-specific signal
+    reported for MPN-U; the association should be interpreted cautiously because
+    MPNs are rare and diagnosis-code misclassification is possible.
+  evidence:
+  - reference: PMID:30318865
+    reference_title: "Smoking is associated with increased risk of myeloproliferative neoplasms: A general population-based cohort study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      For essential thrombocytosis, polycythemia vera, myelofibrosis, and
+      MPN-unclassified, the HRs were 1.8 (95% CI: 0.5-5.8), 1.7 (95% CI:
+      0.5-5.8), 4.3 (95% CI: 0.9-19), and 6.2 (95% CI: 1.5-25), respectively.
+    explanation: >-
+      This population-based cohort found increased hazard for MPN-unclassified
+      among daily smokers compared with never-smokers.
+treatments:
+- name: Phenotype-Directed Pharmacotherapy
+  description: >-
+    Management is individualized and phenotype-driven, addressing cytoses,
+    splenomegaly, thrombosis risk, and symptom burden by extrapolation from
+    related MPNs because MPN-U-specific treatment guidelines and trial evidence
+    are limited.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  evidence:
+  - reference: PMID:35217310
+    reference_title: "Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinicians frequently manage these conditions according to the clinical
+      concerns e.g. splenomegaly akin to the phenotype, but no evidence base
+      exists.
+    explanation: >-
+      The survey abstract supports phenotype-driven pharmacologic management
+      and emphasizes the lack of an MPN-U-specific evidence base.
+diagnosis:
+- name: Exclusionary Clinicopathologic Classification
+  description: >-
+    Diagnosis requires an MPN phenotype that fails to satisfy diagnostic criteria
+    for other classical or non-classical MPNs, with molecular and morphologic
+    workup used to improve specificity and exclude defined entities.
+  evidence:
+  - reference: PMID:35217310
+    reference_title: "Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Myeloproliferative Neoplasm-Unclassifiable (MPN-U) is defined as an MPN
+      that fails to meet the diagnostic criteria for any of the other defined
+      classical or 'non-classical' MPNs.
+    explanation: >-
+      The survey abstract gives the operational diagnostic definition.
+progression:
+- phase: Variable clinical course
+  notes: >-
+    Event-free survival is variable and is shortened by low platelet count and
+    leukocytosis at presentation in the largest contemporary cohort surfaced by
+    the Falcon report.
+  evidence:
+  - reference: PMID:33751548
+    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median event-free survival was 11·25 years (95% confidence interval
+      9·3-not reached), significantly shortened in cases with lower platelet
+      counts (<500 × 109 /l) and a leucocytosis (≥12 × 109 /l) at presentation.
+    explanation: >-
+      The cohort abstract directly reports median event-free survival and
+      adverse presentation features.
+datasets:

--- a/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
+++ b/kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml
@@ -20,6 +20,11 @@ synonyms:
 - MPN not otherwise specified
 - MPN-NOS
 - chronic myeloproliferative disease, unclassifiable
+notes: >-
+  Falcon deep research surfaced pruritus as a cohort phenotype from the
+  full-text UK series, but the fetched PubMed abstract for the cohort does not
+  contain a direct quotable pruritus statement, so pruritus is retained here as
+  report-derived context rather than modeled as evidence-backed phenotype data.
 disease_term:
   preferred_term: myeloproliferative neoplasm, unclassifiable
   term:
@@ -74,37 +79,21 @@ pathophysiology:
     term:
       id: UBERON:0002371
       label: bone marrow
-- name: Clinicopathologic Diagnostic Ambiguity
-  description: >-
-    The defining mechanism-level feature of MPN-U is not a unique pathway but
-    the combination of myeloproliferative biology with clinicopathologic,
-    morphologic, molecular, or confounding clinical features that prevent
-    confident classification as CML, PV, ET, PMF, chronic neutrophilic leukemia,
-    chronic eosinophilic leukemia, or another defined MPN at the time of
-    evaluation.
-  evidence:
-  - reference: PMID:34830822
-    reference_title: "The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      The latter are currently defined as MPNs with clinical-pathological
-      findings not fulfilling the diagnostic criteria for any other entity.
-    explanation: >-
-      This classification review states the defining exclusionary nature of
-      MPN-U.
-  - reference: PMID:36580136
-    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
-    supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      In this regard, high sensitive single target (RT-qPCR, ddPCR) or
-      multi-target next-generation sequencing assays with a minimal sensitivity
-      of VAF 1% are now important for a proper diagnostic identification of MPN
-      cases with low allelic frequencies at initial presentation.
-    explanation: >-
-      The ICC review supports sensitive molecular testing as part of resolving
-      early or low-allele-fraction MPN presentations.
+  downstream:
+  - target: Thrombotic Complication Biology
+    description: >-
+      Clonal myeloproliferation creates a prothrombotic clinical phenotype in a
+      subset of MPN-U patients.
+    evidence:
+    - reference: PMID:33751548
+      reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Thrombosis was common (21%), necessitating vigilance.
+      explanation: >-
+        This cohort abstract supports thrombosis as a common downstream clinical
+        complication of MPN-U.
 - name: Thrombotic Complication Biology
   description: >-
     MPN-U carries clinically important thrombotic risk, reflecting the
@@ -191,28 +180,6 @@ phenotypes:
     explanation: >-
       The international practice survey abstract highlights bulky splenomegaly
       as a clinically important manifestation.
-- category: Dermatologic
-  name: Pruritus
-  description: >-
-    Itching can occur as part of the symptom burden seen in MPN-U and other
-    Philadelphia-negative myeloproliferative neoplasms.
-  phenotype_term:
-    preferred_term: Pruritus
-    term:
-      id: HP:0000989
-      label: Pruritus
-  evidence:
-  - reference: PMID:33751548
-    reference_title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
-    supports: PARTIAL
-    evidence_source: HUMAN_CLINICAL
-    snippet: >-
-      Variability in the clinicopathological phenotypes presents many
-      challenges.
-    explanation: >-
-      The abstract emphasizes variable clinical phenotypes; Falcon surfaced
-      pruritus as a cohort phenotype, but the fetched abstract does not give the
-      exact pruritus frequency, so this evidence is partial.
 - category: Cardiovascular
   name: Thrombosis
   frequency: OCCASIONAL
@@ -300,7 +267,10 @@ genetic:
   association: Somatic activating variants
   notes: >-
     Somatic JAK2 variants may be present in MPN-U, particularly in cases with
-    polycythemia vera-like or thrombocythemia-like features.
+    polycythemia vera-like or thrombocythemia-like features. Falcon deep
+    research reports full-text UK cohort frequencies of JAK2 V617F in 53.7%
+    and JAK2 exon 12 mutations in 2.4% of patients; these frequency data are not
+    present in the fetched PubMed abstract.
   evidence:
   - reference: PMID:36580136
     reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
@@ -325,7 +295,10 @@ genetic:
   association: Somatic driver variants
   notes: >-
     Somatic CALR variants may occur in MPN-U, especially in cases with
-    thrombocythemia-like or prefibrotic myelofibrosis-like features.
+    thrombocythemia-like or prefibrotic myelofibrosis-like features. Falcon
+    deep research reports full-text UK cohort frequencies of CALR type 1 in
+    8.5% and CALR type 2 in 4.8% of patients; these frequency data are not
+    present in the fetched PubMed abstract.
   evidence:
   - reference: PMID:36580136
     reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
@@ -349,7 +322,9 @@ genetic:
   association: Somatic driver variants
   notes: >-
     Somatic MPL variants may occur in MPN-U and implicate thrombopoietin receptor
-    signaling in a subset of cases.
+    signaling in a subset of cases. Falcon deep research reports a full-text UK
+    cohort frequency of MPL mutations in 6.1% of patients; these frequency data
+    are not present in the fetched PubMed abstract.
   evidence:
   - reference: PMID:36580136
     reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
@@ -408,6 +383,88 @@ treatments:
     explanation: >-
       The survey abstract supports phenotype-driven pharmacologic management
       and emphasizes the lack of an MPN-U-specific evidence base.
+- name: Hydroxyurea Cytoreduction
+  description: >-
+    Hydroxyurea/hydroxycarbamide is used for cytoreduction in patients with
+    proliferative blood-count phenotypes, although MPN-U-specific evidence and
+    standardized thresholds remain limited.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: hydroxyurea
+      term:
+        id: CHEBI:44423
+        label: hydroxyurea
+  evidence:
+  - reference: PMID:35191542
+    reference_title: "How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A diagnosis of MPN-U leads to many challenges for both the patient and
+      physician alike including lack of agreed monitoring and therapeutic
+      guidelines, validated prognostic markers and licenced therapies coupled
+      with exclusion from clinical trials.
+    explanation: >-
+      This review supports the lack of licensed MPN-U-specific therapies; Falcon
+      full-text synthesis identifies hydroxycarbamide as the most common
+      cytoreductive agent in the UK cohort.
+- name: Ruxolitinib
+  description: >-
+    Off-label JAK inhibition with ruxolitinib may be considered for selected
+    patients with symptomatic splenomegaly or high symptom burden, extrapolating
+    from related myeloproliferative neoplasms.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: ruxolitinib
+      term:
+        id: CHEBI:66919
+        label: ruxolitinib
+  evidence:
+  - reference: PMID:35191542
+    reference_title: "How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      MPN-U has an inherent risk of an aggressive clinical course and
+      transformation in some but who, and when to treat in the chronic phase,
+      including identifying who may require more aggressive therapy at an earlier
+      stage, remains elusive.
+    explanation: >-
+      The review supports individualized treatment escalation in MPN-U; Falcon
+      full-text synthesis identifies off-label ruxolitinib/JAK-inhibitor use for
+      splenomegaly or symptoms.
+- name: Allogeneic Hematopoietic Stem Cell Transplantation
+  description: >-
+    Allogeneic hematopoietic stem cell transplantation is considered only for
+    selected aggressive, accelerated/blast-phase, or fibrotic presentations
+    because most MPN-U care is individualized and evidence-limited.
+  treatment_term:
+    preferred_term: hematopoietic stem cell transplantation
+    term:
+      id: MAXO:0000747
+      label: hematopoietic stem cell transplantation
+  evidence:
+  - reference: PMID:35191542
+    reference_title: "How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      MPN-U has an inherent risk of an aggressive clinical course and
+      transformation in some but who, and when to treat in the chronic phase,
+      including identifying who may require more aggressive therapy at an earlier
+      stage, remains elusive.
+    explanation: >-
+      The review supports the need to identify patients requiring aggressive
+      therapy; Falcon full-text synthesis identifies allogeneic transplantation
+      as an advanced-disease strategy.
 diagnosis:
 - name: Exclusionary Clinicopathologic Classification
   description: >-
@@ -425,6 +482,28 @@ diagnosis:
       classical or 'non-classical' MPNs.
     explanation: >-
       The survey abstract gives the operational diagnostic definition.
+  - reference: PMID:34830822
+    reference_title: "The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The latter are currently defined as MPNs with clinical-pathological
+      findings not fulfilling the diagnostic criteria for any other entity.
+    explanation: >-
+      This classification review states the defining exclusionary nature of
+      MPN-U.
+  - reference: PMID:36580136
+    reference_title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this regard, high sensitive single target (RT-qPCR, ddPCR) or
+      multi-target next-generation sequencing assays with a minimal sensitivity
+      of VAF 1% are now important for a proper diagnostic identification of MPN
+      cases with low allelic frequencies at initial presentation.
+    explanation: >-
+      The ICC review supports sensitive molecular testing as part of resolving
+      early or low-allele-fraction MPN presentations.
 progression:
 - phase: Variable clinical course
   notes: >-

--- a/references_cache/PMID_30318865.md
+++ b/references_cache/PMID_30318865.md
@@ -1,0 +1,145 @@
+---
+reference_id: "PMID:30318865"
+title: "Smoking is associated with increased risk of myeloproliferative neoplasms: A general population-based cohort study."
+authors:
+- Pedersen KM
+- Bak M
+- Sørensen AL
+- Zwisler AD
+- Ellervik C
+- Larsen MK
+- Hasselbalch HC
+- Tolstrup JS
+journal: Cancer Med
+year: '2018'
+doi: 10.1002/cam4.1815
+keywords:
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Cohort Studies
+- Denmark/epidemiology
+- Female
+- Humans
+- Male
+- Middle Aged
+- "Myeloproliferative Disorders/chemically induced, epidemiology"
+- Proportional Hazards Models
+- Registries
+- Risk Factors
+- "Smoking/adverse effects, epidemiology"
+- Young Adult
+content_type: full_text_xml
+---
+
+# Smoking is associated with increased risk of myeloproliferative neoplasms: A general population-based cohort study.
+**Authors:** Pedersen KM, Bak M, Sørensen AL, Zwisler AD, Ellervik C, Larsen MK, Hasselbalch HC, Tolstrup JS
+**Journal:** Cancer Med (2018)
+**DOI:** [10.1002/cam4.1815](https://doi.org/10.1002/cam4.1815)
+
+## Content
+
+1. Cancer Med. 2018 Nov;7(11):5796-5802. doi: 10.1002/cam4.1815. Epub 2018 Oct
+14.
+
+Smoking is associated with increased risk of myeloproliferative neoplasms: A 
+general population-based cohort study.
+
+Pedersen KM(1), Bak M(1), Sørensen AL(1)(2), Zwisler AD(3), Ellervik C(4)(5), 
+Larsen MK(1)(6), Hasselbalch HC(1), Tolstrup JS(7).
+
+Author information:
+(1)Department of Hematology, Zealand University Hospital, University of 
+Copenhagen, Roskilde, Denmark.
+(2)Institute for Inflammation Research, Centre for Rheumatology and Spine 
+Diseases, Rigshospitalet, Copenhagen University Hospital, Copenhagen, Denmark.
+(3)REHPA, Danish Knowledge Centre for Rehabilitation and Palliative Care, 
+University of Southern Denmark and Odense University Hospital, Nyborg, Denmark.
+(4)Division of Clinical Medicine, Faculty of Health and Medical Sciences, 
+University of Copenhagen, Copenhagen, Denmark.
+(5)Department of Laboratory Medicine, Boston Children's Hospital & Harvard 
+Medical School, Boston, Massachusetts, USA.
+(6)Department of Science and Environment, University of Roskilde, Roskilde, 
+Denmark.
+(7)National Institute of Public Health, University of Southern Denmark, 
+Copenhagen, Denmark.
+
+BACKGROUND: Former studies on smoking as a risk factor for Philadelphia-negative 
+myeloproliferative neoplasms (MPNs) have mainly been carried out in women's 
+cohorts and studies with various definitions of MPNs. Herein, we conducted a 
+cohort study with register-based follow-up of a general population from Denmark, 
+to validate and substantiate prior observations.
+METHODS: In the Danish Health Examination Survey cohort, we used the Cox 
+proportional-hazards model adjusted for age, sex, body mass index, and level of 
+education, to calculate hazard ratios (HRs), to investigate, whether daily 
+smokers or occasional/ex-smokers had an increased risk of MPNs compared to 
+never-smokers.
+RESULTS: From the time of data collection (September 2007 to October 2008) until 
+1 January 2015, 70 individuals were diagnosed with MPNs among 75 896 study 
+participants. Similar results were observed in both the age and sex adjusted 
+analysis and the multivariable analysis. The multivariable HR of any MPN 
+diagnosis for daily smokers was 2.5 (95% CI: 1.3-5.0). For essential 
+thrombocytosis, polycythemia vera, myelofibrosis, and MPN-unclassified, the HRs 
+were 1.8 (95% CI: 0.5-5.8), 1.7 (95% CI: 0.5-5.8), 4.3 (95% CI: 0.9-19), and 6.2 
+(95% CI: 1.5-25), respectively. Among occasional/ex-smokers the corresponding 
+HRs were 1.9 (95% CI: 1.1-3.3), 1.5 (95% CI: 0.6-3.7), 0.8 (95% CI: 0.3-2.4), 
+0.9 (95% CI: 0.2-4.4), and 6.2 (95% CI: 1.8-21). Participants, who smoked 
+>15 g/day, had an overall HR of 3.4 (95% CI: 1.4-8.2) for any MPN diagnosis, 
+while participants who smoked ≤15 g/day, had an overall HR of 2.1 (95% CI: 
+0.9-4.7).
+CONCLUSION: Smoking was associated with MPN development when comparing smokers 
+and never-smokers. Further studies investigating smoking in MPNs are warranted 
+to substantiate our findings.
+
+© 2018 The Authors. Cancer Medicine published by John Wiley & Sons Ltd.
+
+DOI: 10.1002/cam4.1815
+PMCID: PMC6246929
+PMID: 30318865 [Indexed for MEDLINE]
+
+Smoking is associated with a chronic low‐grade inflammatory state as evidenced by increased levels of several pro‐inflammatory cytokines, in vivo activation of leukocytes and platelets, endothelial dysfunction, and systemic oxidative stress.1 Additionally, smoking is associated with a pattern of persistent chronic hypoxic hyperstimulation of myeloid cells assessed by elevated levels of the hematocrit, leukocytosis, monocytosis, and occasionally thrombocytosis.1 Interestingly, these inflammatory components and blood cell indices are also a typical presentation of the Philadelphia‐negative chronic myeloproliferative neoplasms (MPNs), encompassing essential thrombocythemia (ET), polycythemia vera (PV), myelofibrosis (MF), and unclassifiable MPNs (MPN‐U).2
+
+
+The biological continuum of MPNs—from ET through PV to the advanced myelofibrosis state—has been proposed to constitute “A Human Inflammation Model for Cancer Development.”3 According to this model, chronic inflammation, which is also generated by the neoplastic cells themselves, may be an important driver of clonal evolution, premature atherosclerosis, and development of second cancers.4, 5 The perspectives of smoking as a contributing factor for MPNs have most recently been thoroughly described by Hasselbalch,3 including previous important epidemiological studies demonstrating an association of smoking and MPNs.6, 7, 8 Consequently, it has been highlighted that smokers and patients with MPNs share features of an increased inflammatory burden, including, upregulation of important molecular pathways and transcriptions factors3, 9 These shared factors, all of which are vigorously amplified,10, 11, 12, 13 are known to be involved in tumorigenesis and cancer progression.14 Owing to these similarities and the model of chronic inflammation and its role in the clonal evolution and progression of MPNs, it is tempting to suggest smoking as one of several potent inflammatory stimuli potentially triggering and driving the MPN‐clone.
+
+This cohort study with register‐based follow‐up of selected individuals from the general population in Denmark, aimed to investigate whether smokers had an increased risk of MPNs compared to never‐smokers.
+
+We used data from the population‐based study “The Danish Health Examination Survey” (DANHES).15 DANHES conformed to the principles of the Declaration of Helsinki and written informed consent was obtained from all participants. The National Institute of Public Health, University of Southern Denmark, and the Danish Data Protection Agency gave their permission to carry out this specific study (J.nr 2007‐54‐0017). An approval from the Danish Health Authority and the National Committee on Health Research Ethics was not needed, as registry‐based studies are exempted.
+
+In DANHES, all citizens between 18 and 99 years of age from 13 of the 98 municipalities in Denmark (n = 538 497) were invited by letter to fill out two internet‐based questionnaires; a basic questionnaire containing questions on sociodemographic, health behavior including smoking status, self‐reported health, and living conditions plus a supplementary questionnaire concerning diet. A total of 76 484 citizens, corresponding to 14% of the general population in the respective municipalities, filled out the questionnaires. Data were collected between September 2007 and October 2008.
+
+Smoking status was reported as never, daily, current but not daily (reported in categories of at least once per week but not daily, once per month, or rarer than once per month), and former smoking. Participants were categorized as never‐smokers, occasional smokers (ie current non‐daily) combining ex‐smokers, and daily smokers. Occasional and ex‐smokers were combined due to a relatively low number of cases in the two categories. Amount of smoking was reported separately for cigarettes, cheroots and cigars (in numbers per day), and pipe tobacco (in grams per week). Assuming 1 cigarette to be equivalent to 1 g of tobacco, 1 cheroot to 3 g of tobacco, 1 cigar to 5 g of tobacco, and dividing the reported grams of weekly pipe tobacco with 7, a measure of daily amount of smoking in g/day was calculated as a sum of the tobacco from the individual types. Cumulative smoking was calculated in pack‐years based on information on duration of smoking and amount of consumed tobacco: one pack‐year was 20 g smoked daily for one year. Participants with no available data on smoking status were excluded from the analyses. Level of education as well as body mass index (BMI) was categorized into three groups (<10, 10‐12, and ≥12 years and <25, 25‐30, and >30 kg per square meter, respectively).
+
+Participants’ unique civil registration number enabled individual level linkage of data with national registries.16 The civil registration numbers given at birth or immigration to all Danish citizens ensured that different longitudinal measures for all participants could be obtained, including information on all in and out hospital visits and associated diagnosis codes from the Danish National Patient Registry,17 including information on MPN diagnosis, as well as information on vital status and emigration recorded in the Danish Civil Registration System.18 We used the following codes from the International Classification of Diseases to identify patients with MPNs; ET: 8th revision = 287.29, 10th revision = D47.3, D75.2, PV: 8th revision = 208.99, 10th revision = D45, MF: 8th revision = 209, 10th revision = D47.4, C94.4, C94.5, and MPN‐U: 10th revision = D47.1. Participants, who had any MPN diagnosis prior to baseline, were excluded. Any records of either ET, PV, MF, or MPN‐U from baseline until end of follow‐up were defined as MPN events in this study. We followed everyone from baseline to either time of MPN diagnosis, loss to follow‐up, death, or end of follow‐up at 1 January 2015. To increase the accuracy of newly recorded MPNs, participants who were subsequently diagnosed with “cytosis by other causes” (secondary polycythemia; 10th revision: D75.1) were excluded to avoid possible misclassification bias; a method previously described.19
+
+
+We calculated hazard ratios (HR) and 95% confidence intervals (95% CI) using Cox proportional‐hazards models with delayed entry. Age (in days) was used as the underlying time axis to ensure maximal adjustment for confounding by age.20 We examined the Cox proportional‐hazards assumption by plots of log(−time) against log(−log(survival probability)) and by introducing interaction terms between age and alcohol intake in the model, with no violations detected. We performed both an age and sex adjusted analysis comparing daily smokers and occasional/ex‐smokers with never‐smokers and a multivariable analysis adjusted for age, sex, and level of education as well as BMI, as studies have shown that obesity is independently associated with inflammation and MPNs.21, 22, 23 Information on height or weight (and thus BMI) was missing for four percent of the participants. To avoid reducing the sample size, a dummy variable indicating missing BMI value was constructed and used in analyses. Former studies have not been able to show an association with alcohol, why we refrained from adjusting for this.6, 7 Daily smokers were further divided in two groups based on daily amount of smoking (>15 g/day and ≤15 g/day) and compared with never‐smokers, to look at the effect of amount of daily smoking on the risk estimates. Similarly, we examined the risk estimate per 10 pack‐years of smoking to investigate the effect of cumulative smoking in ever‐smokers. Descriptive statistics were presented as medians for continuous variables and as frequencies and percentages for categorical variables. Results were considered statistically significant at the P < 0.05 level. All analyses were performed using SAS 9.4 (The SAS Institute, Cary, NC, USA).
+
+In total, 76 484 survey participants were potentially eligible for inclusion. Of those, 588 participants were subsequently excluded; 510 participants due to missing information on smoking status, 54 participants with a MPN diagnosis prior to data collection, 23 participants due to errors in the registration key, and one participant due to a diagnosis of “secondary cytosis”. Thus, a total of 75 896 persons were included in the final analyses, including 45 030 (59.7%) women and 30 866 (40.7%) men. Median age was 49.0 years (range 19‐99 years) for women and 52.8 years (range 18‐99) for men. During the follow‐up period, 2443 participants died and 580 were lost to follow‐up; 576 emigrated and 4 had their civil registration numbers changed. Among all women and men, 13.3% and 14.6% were daily smokers, stratification on daily amount of tobacco consumption can be seen in Table 1, and 34.4% and 40.5% were occasional/ex‐smokers, respectively. The total follow‐up time was 518 977 person‐years, and the mean time of follow up was 6.8 years (SD = 0.9 years).
+
+Baseline characteristics of the population from the Danish Health Examination Survey study (2007‐2008)
+
+Self‐rated health was assessed by the question “in general, would you say that your health is excellent, very good, good, fair, or poor?,” and low self‐rated health was defined by combining the latter three categories.
+
+Numbers do not sum up to 100% due to missing information.
+
+In total, 70 new cases of MPNs were diagnosed among the survey participants during the period of follow‐up; 41 were women and 29 were men. The distribution of MPNs was 23 ET, 17 PV, 10 MF, and 27 MPN‐U. Incidence rates are available in Table 2. Median age at MPN diagnosis was 63.0 years (range 21‐86 years). Similar results, shown in Table 1, were observed in both the age and sex adjusted analysis and the multivariable analysis. The multivariable HR of any MPN during the study period for daily smokers was 2.5 (95% CI: 1.3‐5.0) and 1.9 (95% CI: 1.1‐3.3) for occasional/ex‐smokers. Stratified by MPN subtype, only the risk estimate of MPN‐U was significantly increased with a HR of 6.2 (95% CI: 1.5‐25) among daily smokers and 6.2 (95% CI: 1.8‐21) among occasional/ex‐smokers. The HRs of all MPN subtypes are presented in Table 2. For daily amount of smoking, analysis showed that participants who smoked >15 g/day had a HR of 3.4 (95% CI: 1.4‐8.2), while participants who smoked ≤15 g/day had a HR of 2.1 (95% CI: 0.9‐4.7) for any MPN compared to never‐smokers. For cumulative smoking, analysis showed a HR of 1.14 (95% CI: 1.06‐1.22, P‐value for trend = 0.0005) per 10 pack‐years of smoking in ever‐smokers. The HR remained significant after adjusting for smoking status, HR = 1.10 (95% CI: 1.00‐1.21, P‐value for trend = 0.05).
+
+Hazard ratios of myeloproliferative neoplasms by smoking status with never‐smokers as the reference group. Age and sex‐adjusted and multivariable analysis
+
+ET, essential thrombocytosis; MF, myelofibrosis; MPN, myeloproliferative neoplasms; MPN‐U, unclassifiable myeloproliferative neoplasm; PV, polycythemia vera; ῲ, Adjusted for age, sex, body mass index, and education level.
+
+In this study with register‐based follow‐up of the DANHES survey participants, we found smoking to be a significant risk factor for the development of MPNs. The risk of MPNs was 2.5‐fold higher among daily smokers and 1.9‐fold higher among occasional/ex‐smokers compared to never‐smokers during follow‐up in the multivariable analyses. For the subtype analysis, daily and occasional/ex‐smokers had 6.2‐fold higher risks of MPN‐U compared to never‐smokers. Concerning ET, PV, and MF, the HRs for daily smokers were all above one, although not statistically significant. However, caution should be taken when interpreting these results as they are likely affected by the low number of cases because of a relatively short follow‐up period combined with the fact that MPNs are rare diseases,24 with approximately 500 patients being diagnosed each year in Denmark, with a population of approximately 5.5 million people.25 The observed dose–response relationship with a HR of 1.10 for any MPN per 10 pack‐years of smoking, as well as the observed 3.4‐fold and 2.1‐fold (95% CI: 0.9‐4.7) increased risk of any MPN in participants who smoked >15 g/day and ≤15 g/day, respectively, support the proposed concept of smoking as a potent inflammatory stimulus driving the MPN development; however, the observed associations are not conclusive per se.
+
+In line with the findings in this study, Kroll et al6 reported an increased risk of myeloproliferative diseases, including both classical MPNs, myelodysplastic syndrome, chronic myelogenous leukemia, and other myeloproliferative disorders, among smokers (relative risk of 1.42 (95% CI: 1.31‐1.55) per 10 cigarettes/day). However, this study did not investigate classical MPNs alone. Leal et al7 found that current smokers had an increased risk of all MPNs as well (relative risk of 1.72 [95% CI: 1.16‐2.56]). This showed mainly to be due to the risk of PV, as the risk of ET was nonsignificant. MF and MPN‐U were not investigated separately. In contrast to the present study, both studies were performed on middle‐aged women. Most recently, a Danish single‐institution case–control study found an association between history of smoking in a general MPN population compared to patients with chronic lymphocytic leukemia.8 It should be mentioned as well, that conflicting with the above‐mentioned results and the results in the present study, two earlier case–control studies could not find an association between smoking and risk of MPNs.26, 27 Pasqualetti et al26 pooled together CML (n = 69), idiopathic myelofibrosis (n = 11), PV (n = 8), and idiopathic thrombocythemia (n = 4), thereby increasing the heterogenicity and subsequently lowering the comparability with the present study. Mele et al27 only investigated cases of ET (n = 39) and smoking exposure was barely defined, thereby obscuring the transparency and conclusion of the study. Most recently, existing studies have been compiled in a meta‐analysis with 1 368 738 individuals and 2017 MPN cases.28 Pooled odds ratio for MPNs were 1.44 (95% CI: 1.33‐1.56) comparing smokers to nonsmokers; 1.10 (95% CI: 0.86‐1.41) comparing ex‐smokers to nonsmokers; and 1.30 (95% CI: 1.14‐1.49) comparing ever‐smokers to never smokers. In subgroup analysis, smokers had a statistically significantly increased risk of ET; however, odds ratios were above one for both PV and MF.
+
+The association found is supported by the many molecular and cellular similarities between the consequences of smoking and MPNs and has most recently been described as “The Smoke‐MPN‐Cancer Loop.”3 One of many inflammatory cytokines increased in smokers and playing a role in MPN pathogenesis is tumor necrosis factor alpha, which, in addition to nuclear factor kappa beta (NF‐kβ) upregulation, has been shown to facilitate clonal expansion in JAK2‐V617F‐bearing cells.7, 29 NF‐kβ is also associated with increased production of transforming growth factor beta and vascular endothelial growth factor,11 both highly immunosuppressive cytokines that are elevated in the circulation in MPNs and markedly expressed in the bone marrow.5, 30 Both cytokines may induce qualitative and quantitative alterations in immune cells, thereby potentially impairing the functionality of these immune cells and consequently “tumor immune surveillance,” the ultimate outcome being expansion of the malignant clone.4, 5, 30 Smoking is also associated with increased hypoxia‐inducible factor signaling12 and interleukin 1‐beta secretion from mononuclear cells,31 leading to upregulation of nuclear factor erythoid‐2 expression in megakaryocytic cells and IL‐8 secretion.10, 32 These observations are indeed intriguing, as both are believed to play a vigorous role in MPN‐pathogenesis as well.33, 34
+
+
+This cohort study, with focus on risk of MPNs in smokers, is, to our knowledge, the first in a general population including both women and men. Additionally, by including 75 896 individuals, it is the largest cohort study focusing isolated on smoking as a risk factor for classical MPNs as the comprehensive study by Kroll et al6 pooled myeloproliferative and myelodysplastic disorders among other diagnoses in their analyses. The main strengths in the study are the size of the cohort and the use of valid population‐based central administrative registries with minimal loss to follow‐up. We were able to include all MPNs among the DANHES participants as all MPN patients are followed at hospitals in Denmark and hospital diagnoses at Danish hospitals must be reported to the Danish National Patient Registry.17 In this context, diagnosis codes for hematological malignancies are found to be valid.35 Nevertheless, the study also has some limitations. Because MPNs can be difficult to diagnose and the MPN diagnoses in this study was not verified by information from medical files, we cannot exclude that a few participants could have been misclassified, for example, some heavy smokers could have been misclassified as having a MPN based upon a secondary cytosis or a reactive thrombocytosis. Although the impact of misclassified cases is hard to estimate without access to medical files, we are confident that it is minimal, because, in Denmark, a bone marrow biopsy is done routinely in all individuals suspected of having MPN. However, since patients who were diagnosed with MPNs and subsequently a “secondary cytosis” were excluded, we hereby tried to prevent this bias. Furthermore, we excluded 510 participants with missing information on smoking (<1%); in these participants, no MPN cases after follow‐up occurred. While selective missing bias cannot be ruled out, it does not seem that excluded participants had a higher risk as compared to participants with non‐missing information on smoking.
+
+Former studies have also investigated risk factors for MPNs, and rather convincing associations have been found concerning familial MPNs and some autoimmune disorders.36 Also, associations with some occupations and exposures to different toxins are found, although conflicting evidence exists in this area.36 As we did not have access to this information and due to the possibility, that subtypes of MPNs may have various carcinogenesis and, thus, different risk factors, we cannot rule out that the results in the present study are affected by some degree of residual confounding. Furthermore, with surveys, selection and reporting bias is possible. DANHES reported that individuals who were unmarried, had the lowest level of education, or lowest category of income were under‐represented compared to the Danish population.15 Under‐reporting of smoking could have occurred in our cohort as 13.3% and 14.6% of women and men reported daily smoking. This contrasts with a survey made upon the request of the Danish Health Authority in 2008 on 4523 persons, in which they found 22.3% and 24.1% of the Danish women and men as daily smokers.37 It should also be mentioned that occasional and ex‐smokers were combined in the present study. The risk estimate for this combined group may be higher than the risk estimate would be for a group of pure ex‐smokers because of the contribution from occasional smokers. Lastly, as smoking exposure was only reported at the time of inclusion in DANHES, we were not able to account for smoking status at the time the MPN diagnosis was reported to the Danish National Patient Registry.
+
+In conclusion, we have shown an increased risk of MPNs in smokers compared to never‐smokers in a cohort of selected individuals from the general population in Denmark. The results of this study support the growing evidence suggesting smoking to be a risk factor in the development of MPNs.
+
+None declared.

--- a/references_cache/PMID_33751548.md
+++ b/references_cache/PMID_33751548.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:33751548"
+title: "Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre."
+authors:
+- Deschamps P
+- Moonim M
+- Radia D
+- Curto-Garcia N
+- Woodley C
+- Bassiony S
+- "O'Sullivan J"
+- Harrington P
+- Raj K
+- Francis Y
+- Kordasti S
+- Ali S
+- Harrison CN
+- McLornan DP
+journal: Br J Haematol
+year: '2021'
+doi: 10.1111/bjh.17375
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Disease-Free Survival
+- Female
+- "Hematologic Neoplasms/blood, mortality, pathology"
+- Humans
+- Male
+- Middle Aged
+- "Myeloproliferative Disorders/blood, mortality, pathology"
+- Retrospective Studies
+- Survival Rate
+- Tertiary Care Centers
+- United Kingdom
+content_type: abstract_only
+---
+
+# Clinicopathological characterisation of myeloproliferative neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK tertiary referral centre.
+**Authors:** Deschamps P, Moonim M, Radia D, Curto-Garcia N, Woodley C, Bassiony S, O'Sullivan J, Harrington P, Raj K, Francis Y, Kordasti S, Ali S, Harrison CN, McLornan DP
+**Journal:** Br J Haematol (2021)
+**DOI:** [10.1111/bjh.17375](https://doi.org/10.1111/bjh.17375)
+
+## Content
+
+1. Br J Haematol. 2021 May;193(4):792-797. doi: 10.1111/bjh.17375. Epub 2021 Mar
+9.
+
+Clinicopathological characterisation of myeloproliferative 
+neoplasm-unclassifiable (MPN-U): a retrospective analysis from a large UK 
+tertiary referral centre.
+
+Deschamps P(1)(2), Moonim M(1)(3), Radia D(1), Curto-Garcia N(1), Woodley C(1), 
+Bassiony S(1), O'Sullivan J(1), Harrington P(1), Raj K(1), Francis Y(1), 
+Kordasti S(1)(4), Ali S(1), Harrison CN(1), McLornan DP(1).
+
+Author information:
+(1)Department of Haematology, Guy' s and St Thomas' NHS Foundation Trust, 
+London, UK.
+(2)Service d'Hématologie, Hôpital Cochin Assistance Publique Hôpitaux de Paris, 
+Paris, France.
+(3)Histopathology Department, Guy's and St Thomas' NHS Foundation Trust, London, 
+UK.
+(4)Systems Cancer Immunology, Comprehensive Cancer Centre, King's College 
+London, London, UK.
+
+Myeloproliferative neoplasm-unclassifiable (MPN-U) presents an MPN-type 
+phenotype that fails to meet diagnostic criteria for other MPN variants. 
+Variability in the clinicopathological phenotypes presents many challenges. 
+Amongst a registry cohort of 1512 patients with MPN, 82 with MPN-U were 
+included, with a median (range) age of 49·7 (13-79) years. Albeit heterogeneous, 
+common presentation features included raised lactate dehydrogenase, 
+thrombocytosis and clustered/pleomorphic megakaryocytes on trephine biopsy. 
+Thrombosis was common (21%), necessitating vigilance. The median event-free 
+survival was 11·25 years (95% confidence interval 9·3-not reached), 
+significantly shortened in cases with lower platelet counts (<500 × 109 /l) and 
+a leucocytosis (≥12 × 109 /l) at presentation. Generation of potential MPN-U 
+prognostic scores is required.
+
+© 2021 British Society for Haematology and John Wiley & Sons Ltd.
+
+DOI: 10.1111/bjh.17375
+PMID: 33751548 [Indexed for MEDLINE]

--- a/references_cache/PMID_34830822.md
+++ b/references_cache/PMID_34830822.md
@@ -1,0 +1,72 @@
+---
+reference_id: "PMID:34830822"
+title: "The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases."
+authors:
+- Pizzi M
+- Croci GA
+- Ruggeri M
+- Tabano S
+- Dei Tos AP
+- Sabattini E
+- Gianelli U
+journal: Cancers (Basel)
+year: '2021'
+doi: 10.3390/cancers13225666
+content_type: abstract_only
+---
+
+# The Classification of Myeloproliferative Neoplasms: Rationale, Historical Background and Future Perspectives with Focus on Unclassifiable Cases.
+**Authors:** Pizzi M, Croci GA, Ruggeri M, Tabano S, Dei Tos AP, Sabattini E, Gianelli U
+**Journal:** Cancers (Basel) (2021)
+**DOI:** [10.3390/cancers13225666](https://doi.org/10.3390/cancers13225666)
+
+## Content
+
+1. Cancers (Basel). 2021 Nov 12;13(22):5666. doi: 10.3390/cancers13225666.
+
+The Classification of Myeloproliferative Neoplasms: Rationale, Historical 
+Background and Future Perspectives with Focus on Unclassifiable Cases.
+
+Pizzi M(1), Croci GA(2)(3), Ruggeri M(4), Tabano S(5), Dei Tos AP(1), Sabattini 
+E(6), Gianelli U(2)(3).
+
+Author information:
+(1)Surgical Pathology and Cytopathology Unit, Department of Medicine-DIMED, 
+University of Padua, 35128 Padua, Italy.
+(2)Department of Pathophysiology and Transplantation, University of Milan, 20122 
+Milan, Italy.
+(3)Division of Pathology, Fondazione IRCCS Ca' Granda, Ospedale Maggiore 
+Policlinico, 20122 Milan, Italy.
+(4)Department of Hematology, San Bortolo Hospital, 36100 Vicenza, Italy.
+(5)Laboratory of Medical Genetics, Foundation IRCCS Ca' Granda, Ospedale 
+Maggiore Policlinico, 20122 Milan, Italy.
+(6)Haematopathology Unit, IRCCS Azienda Ospedaliero-Universitaria di Bologna, 
+40138 Bologna, Italy.
+
+Myeloproliferative neoplasms (MPNs) are a heterogeneous group of clonal 
+hematopoietic stem cell disorders, characterized by increased proliferation of 
+one or more myeloid lineages in the bone marrow. The classification and 
+diagnostic criteria of MPNs have undergone relevant changes over the years, 
+reflecting the increased awareness on these conditions and a better 
+understanding of their biological and clinical-pathological features. The 
+current World Health Organization (WHO) Classification acknowledges four main 
+sub-groups of MPNs: (i) Chronic Myeloid Leukemia; (ii) classical 
+Philadelphia-negative MPNs (Polycythemia Vera; Essential Thrombocythemia; 
+Primary Myelofibrosis); (iii) non-classical Philadelphia-negative MPNs (Chronic 
+Neutrophilic Leukemia; Chronic Eosinophilic Leukemia); and (iv) MPNs, 
+unclassifiable (MPN-U). The latter are currently defined as MPNs with 
+clinical-pathological findings not fulfilling the diagnostic criteria for any 
+other entity. The MPN-U spectrum traditionally encompasses early phase MPNs, 
+terminal (i.e., advanced fibrotic) MPNs, and cases associated with inflammatory 
+or neoplastic disorders that obscure the clinical-histological picture. Several 
+lines of evidence and clinical practice suggest the existence of additional 
+myeloid neoplasms that may expand the spectrum of MPN-U. To gain insight into 
+such disorders, this review addresses the history of MPN classification, the 
+evolution of their diagnostic criteria and the complex clinical-pathological and 
+biological features of MPN-U.
+
+DOI: 10.3390/cancers13225666
+PMCID: PMC8616346
+PMID: 34830822
+
+Conflict of interest statement: The Authors declare no conflict of interest.

--- a/references_cache/PMID_35191542.md
+++ b/references_cache/PMID_35191542.md
@@ -1,0 +1,63 @@
+---
+reference_id: "PMID:35191542"
+title: "How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond."
+authors:
+- McLornan DP
+- Hargreaves R
+- Hernández-Boluda JC
+- Harrison CN
+journal: Br J Haematol
+year: '2022'
+doi: 10.1111/bjh.18087
+keywords:
+- Anticoagulants
+- Humans
+- "Myeloproliferative Disorders/diagnosis, therapy"
+- Neoplasms
+- Venous Thromboembolism
+content_type: abstract_only
+---
+
+# How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond.
+**Authors:** McLornan DP, Hargreaves R, Hernández-Boluda JC, Harrison CN
+**Journal:** Br J Haematol (2022)
+**DOI:** [10.1111/bjh.18087](https://doi.org/10.1111/bjh.18087)
+
+## Content
+
+1. Br J Haematol. 2022 May;197(4):407-416. doi: 10.1111/bjh.18087. Epub 2022 Feb 
+22.
+
+How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches 
+for 2022 and beyond.
+
+McLornan DP(1)(2), Hargreaves R(2), Hernández-Boluda JC(3), Harrison CN(1).
+
+Author information:
+(1)Department of Haematology, 4th Floor Southwark Wing, Guy's and St. Thomas' 
+NHS Foundation Trust, Great Maze Pond, London, UK.
+(2)Department of Haematology, University College London Hospitals, London, UK.
+(3)Hematology Department, Hospital Clínico Universitario-INCLIVA, University of 
+Valencia, Valencia, Spain.
+
+Myeloproliferative neoplasm (MPN)-unclassifiable (MPN-U) or not otherwise 
+specified represents a rare, poorly defined and heterogeneous group of MPNs. 
+Disease incidence is difficult to define but likely represents close to 5% of 
+all MPNs when strict World Health Organisation (WHO) criteria are applied. 
+Dynamic review over time is required to assess if the disease can be 
+re-classified into another MPN entity. A diagnosis of MPN-U leads to many 
+challenges for both the patient and physician alike including lack of agreed 
+monitoring and therapeutic guidelines, validated prognostic markers and licenced 
+therapies coupled with exclusion from clinical trials. MPN-U has an inherent 
+risk of an aggressive clinical course and transformation in some but who, and 
+when to treat in the chronic phase, including identifying who may require more 
+aggressive therapy at an earlier stage, remains elusive. Moreover, despite the 
+significant thrombotic risk, there is no agreement on systematic primary 
+thromboprophylaxis. We hereby provide a contemporary overview of MPN-U in 
+addition to four illustrative cases providing our collective suggested 
+approaches to clinical challenges.
+
+© 2022 British Society for Haematology and John Wiley & Sons Ltd.
+
+DOI: 10.1111/bjh.18087
+PMID: 35191542 [Indexed for MEDLINE]

--- a/references_cache/PMID_35217310.md
+++ b/references_cache/PMID_35217310.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:35217310"
+title: "Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice."
+authors:
+- Hargreaves R
+- Harrison CN
+- McLornan DP
+journal: Curr Res Transl Med
+year: '2022'
+doi: 10.1016/j.retram.2022.103338
+keywords:
+- Humans
+- Incidence
+- "Myeloproliferative Disorders/diagnosis, epidemiology, therapy"
+- Neoplasms
+- "Splenomegaly/diagnosis, epidemiology, etiology"
+- Surveys and Questionnaires
+content_type: abstract_only
+---
+
+# Diagnostic and management strategies for Myeloproliferative Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary practice.
+**Authors:** Hargreaves R, Harrison CN, McLornan DP
+**Journal:** Curr Res Transl Med (2022)
+**DOI:** [10.1016/j.retram.2022.103338](https://doi.org/10.1016/j.retram.2022.103338)
+
+## Content
+
+1. Curr Res Transl Med. 2022 Jul;70(3):103338. doi: 10.1016/j.retram.2022.103338.
+ Epub 2022 Feb 23.
+
+Diagnostic and management strategies for Myeloproliferative 
+Neoplasm-Unclassifiable (MPN-U): An international survey of contemporary 
+practice.
+
+Hargreaves R(1), Harrison CN(2), McLornan DP(3).
+
+Author information:
+(1)Department of Haematology, University College Hospitals, London, UK.
+(2)Department of Haematology, Guy's and St.Thomas' NHS Foundation Trust, London, 
+UK.
+(3)Department of Haematology, University College Hospitals, London, UK; 
+Department of Haematology, Guy's and St.Thomas' NHS Foundation Trust, London, 
+UK. Electronic address: donal.mclornan@nhs.net.
+
+Myeloproliferative Neoplasm-Unclassifiable (MPN-U) is defined as an MPN that 
+fails to meet the diagnostic criteria for any of the other defined classical or 
+'non-classical' MPNs. The reported incidence is variable, dependent on 
+appropriate recognition, and the clinical course can be highly variable ranging 
+from an indolent disorder through to an aggressive disease course with a 
+significant risk of thrombosis, bulky splenomegaly, and debilitating symptom 
+burden. Clinicians frequently manage these conditions according to the clinical 
+concerns e.g. splenomegaly akin to the phenotype, but no evidence base exists. 
+Currently, there are no widely accepted guidelines to deal with both the 
+diagnostic work up and subsequent clinical management of this entity. We hence 
+surveyed major International MPN centres to gain an understanding of common 
+challenges in MPN-U management in 2021 and aid identification of considerable 
+practice variations where harmonisation would be desirable. Such information is 
+vital to support future consensus guidelines in addition to informing further 
+collaborative studies.
+
+Copyright © 2022 Elsevier Masson SAS. All rights reserved.
+
+DOI: 10.1016/j.retram.2022.103338
+PMID: 35217310 [Indexed for MEDLINE]

--- a/references_cache/PMID_36580136.md
+++ b/references_cache/PMID_36580136.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:36580136"
+title: "International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms."
+authors:
+- Gianelli U
+- Thiele J
+- Orazi A
+- Gangat N
+- Vannucchi AM
+- Tefferi A
+- Kvasnicka HM
+journal: Virchows Arch
+year: '2023'
+doi: 10.1007/s00428-022-03480-8
+keywords:
+- Humans
+- "Myeloproliferative Disorders/diagnosis, genetics"
+- Lymphoma
+- Hematologic Neoplasms
+content_type: abstract_only
+---
+
+# International Consensus Classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms.
+**Authors:** Gianelli U, Thiele J, Orazi A, Gangat N, Vannucchi AM, Tefferi A, Kvasnicka HM
+**Journal:** Virchows Arch (2023)
+**DOI:** [10.1007/s00428-022-03480-8](https://doi.org/10.1007/s00428-022-03480-8)
+
+## Content
+
+1. Virchows Arch. 2023 Jan;482(1):53-68. doi: 10.1007/s00428-022-03480-8. Epub
+2022  Dec 29.
+
+International Consensus Classification of myeloid and lymphoid neoplasms: 
+myeloproliferative neoplasms.
+
+Gianelli U(1), Thiele J(2), Orazi A(3), Gangat N(4), Vannucchi AM(5), Tefferi 
+A(4), Kvasnicka HM(6).
+
+Author information:
+(1)University of Milan, Department of Health Sciences and S.C. Anatomia 
+Patologica, ASST Santi Paolo e Carlo, Milan, Italy.
+(2)Institute of Pathology, University of Cologne, Cologne, Germany.
+(3)Department of Pathology, Texas Tech University Health Sciences Center, El 
+Paso, TX, USA.
+(4)Mayo Clinic, Rochester, MN, USA.
+(5)CRIMM-Centro Ricerca e Innovazione delle Malattie Mieloproliferative, Azienda 
+Ospedaliera-Universitaria Careggi, Department of Experimental and Clinical 
+Medicine, University of Florence, Florence, Italy.
+(6)University Clinic Wuppertal, University of Witten/Herdecke, Wuppertal, 
+Germany. hm.kvasnicka@patho-uwh.de.
+
+The recently published International Consensus Classification (ICC) of myeloid 
+neoplasms summarized the results of an in-depth effort by pathologists, 
+oncologists, and geneticists aimed to update the 2017 World Health Organization 
+classification system for hematopoietic tumors. Along these lines, several 
+important modifications were implemented in the classification of 
+myeloproliferative neoplasms (MPNs). For chronic myeloid leukemia, 
+BCR::ABL1-positive, the definition of accelerated and blast phase was 
+simplified, and in the BCR::ABL1-negative MPNs, the classification was slightly 
+updated to improve diagnostic specificity with a more detailed and better 
+validated morphologic approach and the recommendation of more sensitive 
+molecular techniques to capture in particular early stage diseases. In this 
+regard, high sensitive single target (RT-qPCR, ddPCR) or multi-target 
+next-generation sequencing assays with a minimal sensitivity of VAF 1% are now 
+important for a proper diagnostic identification of MPN cases with low allelic 
+frequencies at initial presentation. This review discusses the updated 
+diagnostic criteria of MPN according to the ICC, particularly by highlighting 
+the new concepts and how they can be applied in clinical settings to obtain an 
+appropriate prognostic relevant diagnosis.
+
+© 2022. The Author(s).
+
+DOI: 10.1007/s00428-022-03480-8
+PMCID: PMC9852206
+PMID: 36580136 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/research/Myeloproliferative_Neoplasm_Unclassifiable-deep-research-falcon.md
+++ b/research/Myeloproliferative_Neoplasm_Unclassifiable-deep-research-falcon.md
@@ -1,0 +1,1305 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:02:22.466369'
+end_time: '2026-05-11T11:32:37.450668'
+duration_seconds: 1814.99
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Myeloproliferative Neoplasm, Unclassifiable
+  mondo_id: ''
+  category: ''
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 43
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Myeloproliferative Neoplasm, Unclassifiable
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Myeloproliferative Neoplasm, Unclassifiable** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Myeloproliferative Neoplasm, Unclassifiable
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Myeloproliferative Neoplasm, Unclassifiable** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Disease Characteristics Research Report: Myeloproliferative Neoplasm, Unclassifiable (MPN-U) / MPN, Not Otherwise Specified (MPN-NOS)
+
+### Scope note
+This report is constrained to information available in the retrieved full-text excerpts and trial records in this run. Some requested identifier mappings (e.g., MONDO, Orphanet, MeSH), PMIDs, and model-organism details were not present in the retrieved corpus and are explicitly marked as unavailable/insufficient in this evidence set.
+
+| Topic | Key sourced facts | Citation |
+|---|---|---|
+| Definition | MPN-U is a rare, heterogeneous myeloproliferative neoplasm showing features of an MPN but not fulfilling diagnostic criteria for another defined MPN; dynamic reassessment is recommended because some cases can later be reclassified. | (mclornan2022howimanage pages 1-1, mclornan2022howimanage pages 1-2) |
+| WHO-HAEM5 vs ICC naming | WHO-HAEM5 retains the category as **MPN-NOS**; ICC 2022 uses **MPN-unclassifiable**. Both are catch-all categories for MPNs that cannot otherwise be classified. | (xiao2024apracticalapproach pages 2-4) |
+| Estimated proportion among MPNs | Published estimates vary widely from about **5% to 30%** of all MPNs, but recent expert reviews state the true proportion is likely near the lower end when strict criteria are applied. In a large UK tertiary registry, **82/1512 = 5.4%** of MPN patients were classified as MPN-U. Review articles also summarize a typical range of **~5–10%**. | (mclornan2022howimanage pages 1-1, hargreaves2022diagnosticandmanagement pages 1-2, deschamps2021clinicopathologicalcharacterisationof pages 1-2, mclornan2022howimanage pages 1-2, pizzi2021theclassificationof pages 7-8) |
+| Key diagnostic exclusions | A diagnosis of MPN-U should **not** be made when another defining lesion/entity is present, including **BCR::ABL1**, **PCM1-JAK2**, and rearrangements involving **PDGFRA, PDGFRB, or FGFR1**; reactive causes such as infection, toxin/drug exposure, growth factors, cytokines, or immunosuppressive drugs should be excluded. | (mclornan2022howimanage pages 2-2, hargreaves2022diagnosticandmanagement pages 1-2, gianelli2023internationalconsensusclassification pages 13-14, mclornan2022howimanage pages 1-2) |
+| Typical clinical features | Common presentations include **thrombocytosis**, **raised LDH**, **clustered/pleomorphic megakaryocytes** on marrow biopsy, **splenomegaly**, **pruritus**, constitutional symptoms, and clinically important **thrombosis**, including atypical sites such as splanchnic vein thrombosis. Early-phase cases may have overlapping ET/pre-PMF morphology; advanced fibrotic cases may be harder to subtype. | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, pizzi2021theclassificationof pages 7-8, mclornan2022howimanage pages 2-2, deschamps2021clinicopathologicalcharacterisationof pages 2-3, gianelli2023internationalconsensusclassification pages 13-14) |
+| Quantified phenotype frequencies in the UK cohort | In the 82-patient Guy’s and St Thomas’ cohort: **thrombocytosis 78%**, **elevated LDH 72%**, **splenomegaly 27%**, **pruritus 36%**, constitutional symptoms **29%**, thrombosis **20.7–21%**, and transfusion dependence **2.4%**. Median age was **49.7 years** and **56%** were female. | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, deschamps2021clinicopathologicalcharacterisationof pages 2-3) |
+| Driver mutation frequencies | In the same cohort, driver lesions were: **JAK2 V617F 53.7% (44/82)**, **JAK2 exon 12 2.4% (2/82)**, **CALR type 1 8.5% (7/82)**, **CALR type 2 4.8% (4/82)**, **MPL 6.1% (5/82)**; **triple-negative 24% (20/82)**. No **PDGFRA/B, CSF3R, BCR/ABL1, FGFR1, or PCM1-JAK2** rearrangements were found in that series. | (deschamps2021clinicopathologicalcharacterisationof pages 1-2) |
+| Other molecular findings | Extended molecular testing showed additional non-driver mutations in **24% (7/29)** of tested patients; review sources note that evidence of clonality may also come from mutations such as **ASXL1, EZH2, TET2, IDH1/2, SRSF2, SF3B1**. Cytogenetic abnormalities support diagnosis and occur in roughly **20–30%** of cases in review summaries, although **88.5%** of tested cases in the UK cohort had normal cytogenetics. | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, pizzi2021theclassificationof pages 7-8, gianelli2023internationalconsensusclassification pages 13-14) |
+| Prognosis: event-free and overall survival | In the UK cohort, median **event-free survival (EFS) was 11.25 years** (95% CI **9.3–not reached**); median **overall survival was not reached**; estimated **10-year OS was 88.8%** (95% CI **77.7–100.0%**). | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, deschamps2021clinicopathologicalcharacterisationof pages 2-3) |
+| Prognosis: transformation and progression | **7/82 (8.5%)** transformed to accelerated/blast phase, with median time to transformation **88.2 months**; approximately **19.2%** ultimately showed disease progression including accelerated phase/transformation or fibrosis. Advanced/fibrotic MPN-U is generally viewed as having worse prognosis than early-phase disease. | (mclornan2022howimanage pages 1-2, deschamps2021clinicopathologicalcharacterisationof pages 2-3, deschamps2021clinicopathologicalcharacterisationof pages 5-6, pizzi2021theclassificationof pages 7-8) |
+| Prognostic factors | Worse EFS was associated with **platelet count <500 × 10^9/L** and **leukocytosis ≥12 × 10^9/L** at presentation. Multivariable analysis found low platelets independently adverse (**HR 3.45, 95% CI 1.43–8.32**) and leukocytosis also adverse (**HR 2.91, 95% CI 1.11–7.64**). | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, deschamps2021clinicopathologicalcharacterisationof pages 2-3, deschamps2021clinicopathologicalcharacterisationof pages 5-6, deschamps2021clinicopathologicalcharacterisationof media cb1fee4a) |
+
+
+*Table: This table summarizes high-yield, source-backed facts on myeloproliferative neoplasm, unclassifiable, including nomenclature, diagnostic boundaries, phenotype, molecular findings, and prognosis. It is useful as a compact evidence table for building a disease knowledge base entry.*
+
+| Management domain | Therapy/approach | Real-world implementation in MPN-U / MPN-NOS | Quantitative details | Citation |
+|---|---|---|---|---|
+| Cytoreduction | Any cytoreductive therapy | Commonly used in practice, but indications are phenotype-driven rather than guideline-standardized | In the UK cohort, 51/82 patients (62.2%) received cytoreductive therapy; in the survey, 66% of centres would offer cytoreduction for thrombocytosis | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7) |
+| Cytoreduction | Hydroxycarbamide / hydroxyurea | Most commonly used first-line cytoreductive agent in cohort and survey practice | UK cohort: 40/82 (48.8%) received hydroxycarbamide; survey: 14 centres (41%) targeted platelets around 400 × 10^9/L, and 20 centres (59%) combined hydroxycarbamide with extended postoperative thromboprophylaxis | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Cytoreduction | Interferon / pegylated interferon | Used in a minority overall; may be considered in selected settings such as pregnancy or younger patients, but not a common first-choice agent in survey responses | UK cohort: 14/82 (17.1%) received interferon; survey of thrombocytosis management: no centres selected interferon as agent of choice; pregnancy-focused recommendations note interferon-based approaches at some centres | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6, mclornan2022howimanage pages 4-5) |
+| Cytoreduction | Anagrelide | Used infrequently for platelet control in selected patients | UK cohort: 8/82 (9.8%) received anagrelide | (deschamps2021clinicopathologicalcharacterisationof pages 1-2) |
+| Symptom/spleen-directed therapy | Ruxolitinib / JAK inhibitor | Off-label, phenotype-driven use for splenomegaly and symptom burden; many centres report little or no use, reflecting uncertainty and lack of approval | UK cohort: 5/82 (6.1%) received a JAK inhibitor; survey/review: about half of centres reported off-label ruxolitinib use for splenomegaly and/or symptoms, while many centres had no MPN-U patients on ruxolitinib | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 3-6, mclornan2022howimanage pages 7-7) |
+| Antithrombotic management | Aspirin | Frequently used, especially with thrombocytosis and in pregnancy; does not eliminate thrombosis risk | Review suggests aspirin 75 mg once daily in selected phenotype-driven strategies; pregnancy recommendations include aspirin throughout pregnancy; cohort noted thromboses still occurred despite low-dose aspirin plus effective cytoreduction | (mclornan2022howimanage pages 8-9, mclornan2022howimanage pages 4-5, deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Antithrombotic management | LMWH | Used particularly in pregnancy and postpartum; also part of broader thrombosis management strategies extrapolated from other MPNs | Pregnancy guidance: antenatal LMWH plus standard 6-week postpartum prophylaxis | (mclornan2022howimanage pages 4-5) |
+| Antithrombotic management | VKA / warfarin | Common choice after venous thromboembolism, especially in heterogeneous real-world practice | Survey: most centres preferred warfarin/VKA after VTE; some reserved VKA specifically for splanchnic vein thrombosis | (hargreaves2022diagnosticandmanagement pages 3-6) |
+| Antithrombotic management | DOACs | Used by some centres; authors cautiously support DOACs in uncomplicated acute SVT, but liver dysfunction may limit use | Review notes VKA vs DOAC decisions are individualized; cohort/international data cited as showing comparable recurrent thrombosis and bleeding rates with DOACs in selected settings | (mclornan2022howimanage pages 5-6, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Cytoreduction triggers | Thrombosis history | Many centres start cytoreduction after arterial or venous thrombosis, despite lack of MPN-U-specific evidence | 81% of surveyed centres initiate cytoreduction after venous or arterial thrombosis | (mclornan2022howimanage pages 7-7) |
+| Cytoreduction triggers | Blood count thresholds | Centres variably use platelet/WBC thresholds to start therapy | Survey: platelet threshold >450 × 10^9/L in 20% of centres, >1500 × 10^9/L in 72%, WBC >15 × 10^9/L in 45% | (mclornan2022howimanage pages 7-7) |
+| Response in cohort | Cytoreductive treatment outcomes | Outcomes are mixed, reinforcing need for better prognostic tools and standardized management | Among treated cohort patients, ~50% achieved adequate cytoreduction, 26.9% had stable blood counts, and 19.2% progressed (accelerated/transformation or fibrosis) | (deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Transplant | Allogeneic hematopoietic cell transplantation | Rare but considered for accelerated, blast-phase, fibrotic, or otherwise aggressive disease; early referral is recommended in suitable patients | UK cohort: 5/82 (6.1%) considered for allo-HCT and 2/82 (2.4%) transplanted; survey: observation 7%, HMA with planned allo-SCT 61%, induction chemotherapy then allo-SCT 7%, upfront allo-SCT 24% for progressive/accelerating disease | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, mclornan2022howimanage pages 6-7, deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Transplant outcomes | Allo-HCT registry data | Best evidence comes from retrospective registry series rather than MPN-U-specific trials | Reported 3-year OS after allo-SCT approximately 55% with myeloablative conditioning vs 44% with reduced-intensity conditioning; relapse rates 23% vs 36% | (hargreaves2022diagnosticandmanagement pages 6-7) |
+| Monitoring/implementation | Practice framework | Management is individualized because there are no agreed guidelines; cases often managed similarly to classical MPNs and re-reviewed over time | Survey explicitly reports “lack of agreed guidelines” and wide heterogeneity in MDT review, genomic testing, anticoagulant choice, pregnancy care, and transplant referral | (hargreaves2022diagnosticandmanagement pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Relevant trial/registry | NCT07362225 | Large observational registry tracking symptoms, treatments, and disease progression in people with MPNs; relevant because MPN-U patients are commonly excluded from interventional studies but can be captured in broad registries | Recruiting; observational; target enrollment 5000 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT03618485 | Taiwan MPN registry; observational real-world resource potentially capturing unclassifiable cases under broader MPN umbrella | Active, not recruiting; observational; target enrollment 500 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT07384039 | Supportive-care/exercise intervention in patients with MPNs; relevant to symptom burden and quality-of-life research though not MPN-U-specific | Not yet recruiting; interventional; target enrollment 80 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT06661915 | Phase 2 study in advanced MPNs using ASTX727 with or without iadademstat; relevant for transformed/advanced phenotypes that may include unclassifiable MPN biology | Recruiting; phase 2; target enrollment 62 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT04282187 | Phase 2 study of decitabine with ruxolitinib/fedratinib/pacritinib for accelerated/blast-phase MPN; relevant to aggressive MPN-U scenarios managed as advanced MPN | Recruiting; phase 2; target enrollment 25 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT03566446 | CALR-mutant peptide vaccine study in CALR-mutant MPN; relevant to molecularly defined subsets that may overlap with some MPN-U cases | Completed; phase 1; enrollment 10 | (xiao2024apracticalapproach pages 2-4) |
+
+
+*Table: This table summarizes how MPN-U/MPN-NOS is managed in real-world cohorts, surveys, and broader MPN studies. It highlights the absence of standardized guidelines, the phenotype-driven use of cytoreduction and antithrombotic therapy, transplant escalation in advanced disease, and relevant current trial or registry infrastructure.*
+
+### Key visual evidence (prognosis)
+Event-free survival stratified by platelet count and leukocytosis (and accompanying prognostic factor table) was extracted from the largest available contemporary cohort; this supports the statement that lower platelets and leukocytosis identify higher-risk MPN-U subgroups. (deschamps2021clinicopathologicalcharacterisationof media cb1fee4a, deschamps2021clinicopathologicalcharacterisationof media 1f80ac50)
+
+---
+
+## 1. Disease Information
+
+### Overview / definition
+Myeloproliferative neoplasm, unclassifiable (MPN-U) is defined as a myeloproliferative neoplasm with clinical/hematologic/morphologic features of an MPN that does not fulfill diagnostic criteria for any other defined MPN entity; it is described as rare, heterogeneous, and often requiring “dynamic review over time” because some cases may later become classifiable as PV/ET/PMF or another MPN. (mclornan2022howimanage pages 1-1, mclornan2022howimanage pages 1-2)
+
+### Current classification terminology (WHO vs ICC)
+Both WHO-HAEM5 and the International Consensus Classification (ICC) retain a “catch-all” entity for otherwise unclassifiable MPNs, but with different names: **MPN-NOS** in WHO-HAEM5 versus **MPN-unclassifiable** in the ICC. (xiao2024apracticalapproach pages 2-4)
+
+### Synonyms / alternative names
+Commonly used names include “myeloproliferative neoplasm, unclassifiable” and “MPN not otherwise specified (NOS)” in WHO-era usage. (mclornan2022howimanage pages 1-1, xiao2024apracticalapproach pages 2-4, pizzi2021theclassificationof pages 7-8)
+
+### Key identifiers (available in retrieved sources)
+* **ICD-10**: in a Danish population cohort using registry codes, MPN-U/MPN-NOS was identified using **ICD-10 D47.1**. (pedersen2018smokingisassociated pages 2-3)
+
+Identifiers not found in retrieved corpus: MONDO ID, Orphanet ID, and MeSH term mappings were not present in the excerpts retrieved for this run.
+
+### Evidence type note (patient-level vs aggregated)
+Evidence spans (i) aggregated cohort/registry studies (UK tertiary-center cohort; population-based Danish and Swedish studies) and (ii) expert review/survey synthesis. (deschamps2021clinicopathologicalcharacterisationof pages 2-3, hargreaves2022diagnosticandmanagement pages 6-7, landtblom2018secondmalignanciesin pages 3-4, pedersen2020twofoldriskof pages 1-2)
+
+---
+
+## 2. Etiology
+
+### Disease causal factors (current understanding)
+MPN-U is best understood as a **clonal hematopoietic stem/progenitor cell disorder** that manifests as myeloproliferation but lacks sufficient integrated clinicopathologic criteria to be assigned to a specific MPN subtype at a given timepoint. Clonality is commonly supported by canonical MPN “driver” mutations (JAK2/CALR/MPL) and/or other myeloid neoplasm–associated mutations and cytogenetic abnormalities. (gianelli2023internationalconsensusclassification pages 13-14, pizzi2021theclassificationof pages 7-8)
+
+### Risk factors
+**Smoking (lifestyle/environmental):** In a Danish general-population cohort (DANHES), smoking was associated with higher risk of incident MPN overall and particularly high relative risks for MPN-U. Multivariable HR for **any MPN** was 2.5 (95% CI 1.3–5.0) for daily smokers versus never-smokers; subtype analysis showed **MPN-U HR 6.2 (1.5–25)** for daily smokers and **MPN-U HR 6.2 (1.8–21)** for occasional/ex-smokers. (pedersen2018smokingisassociated pages 1-2)
+
+Other environmental/occupational risk factors were mentioned only qualitatively as conflicting/limited in the retrieved excerpts; no robust, MPN-U-specific quantitative estimates beyond smoking were retrieved. (pedersen2018smokingisassociated pages 5-6)
+
+### Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence set.
+
+### Gene–environment interactions
+No explicit gene–environment interaction evidence (e.g., JAK2 genotype-by-smoking) was available in the retrieved excerpts.
+
+---
+
+## 3. Phenotypes (clinical features) and HPO suggestions
+
+### Typical phenotype spectrum
+MPN-U shows a broad phenotype that can include constitutional symptoms, hepatosplenomegaly, thrombosis (including splanchnic vein thrombosis), and variable blood-count abnormalities; cases may represent a prodromal/pre-proliferative stage of classical MPN. (mclornan2022howimanage pages 2-2)
+
+### Quantified phenotype frequencies from a contemporary cohort (UK tertiary center)
+In a single-center cohort of **82 MPN-U** patients (median age 49.7 years; 56% female): splenomegaly **27%**, pruritus **36%**, constitutional symptoms **29%**, transfusion dependency **2.4%**; thrombocytosis **78%** (median platelets 650×10^9/L); LDH elevated **72%**; peripheral blood film features included teardrop cells (18.3%), leukoerythroblastosis (7%), and prominent large granular lymphocytes (19.7%). (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+
+### Thrombotic phenotype (including timing)
+In the same cohort, thrombosis occurred in **~21%** (arterial 10; portal vein 4; other venous 3), with median time from diagnosis to thrombotic event **0.2 months** (0–208.3); 47% of those with thrombosis presented with a “heralding” thrombosis (9.9% of the whole cohort). (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+
+### Suggested HPO terms (non-exhaustive; mapping requires ontology validation)
+* Thrombocytosis — **HP:0001894** (supported by cohort frequency) (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Elevated lactate dehydrogenase — **HP:0003287** (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Splenomegaly — **HP:0001744** (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Pruritus — **HP:0000989** (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Constitutional symptoms / weight loss / night sweats — consider **HP:0004377** (weight loss) and related terms (symptom list in review) (mclornan2022howimanage pages 2-2)
+* Portal vein thrombosis / splanchnic vein thrombosis — consider **HP:0030244** (portal vein thrombosis) and related SVT terms (deschamps2021clinicopathologicalcharacterisationof pages 2-3, pizzi2021theclassificationof pages 7-8)
+* Anemia — **HP:0001903** (not frequent in the cohort, but part of advanced phenotype in reviews) (pizzi2021theclassificationof pages 7-8)
+
+Quality-of-life: MPN-SAF symptom scores ranged 0–73/100 in a subset, indicating wide symptom-burden variability, but no standardized QoL instruments (EQ-5D/SF-36) or comparative QoL statistics were available in retrieved excerpts. (deschamps2021clinicopathologicalcharacterisationof pages 3-5)
+
+---
+
+## 4. Genetic/Molecular Information
+
+### Molecular hallmarks and clonality support
+Diagnosis requires exclusion of reactive conditions (infection/toxin/drug-related) and can be supported by detection of canonical MPN driver mutations or other myeloid neoplasm–associated mutations (e.g., ASXL1, EZH2, TET2, IDH1/2, SRSF2, SF3B1) and/or cytogenetic abnormalities. (gianelli2023internationalconsensusclassification pages 13-14, pizzi2021theclassificationof pages 7-8)
+
+### Driver mutation frequencies (cohort data)
+In the 82-patient UK cohort:
+* **JAK2 V617F**: 53.7% (44/82)
+* **JAK2 exon 12**: 2.4% (2/82)
+* **CALR type 1**: 8.5% (7/82)
+* **CALR type 2**: 4.8% (4/82)
+* **MPL**: 6.1% (5/82)
+* **Triple-negative (JAK2/CALR/MPL negative)**: 24% (20/82)
+No PDGFRA/B, CSF3R, BCR/ABL1, FGFR1, or PCM1-JAK2 rearrangements were detected in that series. (deschamps2021clinicopathologicalcharacterisationof pages 1-2)
+
+### Additional somatic mutations / cytogenetics
+Extended molecular testing identified additional non-driver mutations in 24% (7/29) of those tested in the UK cohort. (deschamps2021clinicopathologicalcharacterisationof pages 1-2)
+Reviews summarize cytogenetic abnormalities in ~20–30% (or ~30%) of MPN-U cases; in the UK cohort with available cytogenetics, 88.5% were normal (suggesting cohort and testing differences). (gianelli2023internationalconsensusclassification pages 13-14, deschamps2021clinicopathologicalcharacterisationof pages 1-2)
+
+### Variant classification / allele frequency / germline vs somatic
+Not available in the retrieved excerpts (no ClinVar/gnomAD-style allele frequency reporting was present).
+
+### Epigenetics / transcriptomics / proteomics / metabolomics
+Not available in the retrieved excerpts.
+
+---
+
+## 5. Environmental Information
+
+Beyond smoking (Section 2), no specific toxins/radiation/pollution or infectious triggers with reproducible quantitative evidence specific to MPN-U were available in the retrieved excerpts. (pedersen2018smokingisassociated pages 5-6)
+
+---
+
+## 6. Mechanism / Pathophysiology (high-level)
+
+Mechanistically, MPN-U is interpreted as clonal myeloid proliferation driven by canonical MPN signaling lesions (JAK2/CALR/MPL) in many cases, with additional cooperating mutations in epigenetic regulators and splicing factors in subsets; however, the defining feature of MPN-U is not a unique pathway but rather failure to meet integrated diagnostic thresholds for a specific MPN subtype at the time of evaluation. (gianelli2023internationalconsensusclassification pages 13-14, pizzi2021theclassificationof pages 7-8)
+
+Mechanistic details (e.g., JAK-STAT pathway activation, inflammatory cytokine loops) were not available as primary mechanistic experiments in this evidence set; only epidemiologic/mechanistic plausibility statements linking smoking to inflammatory signaling were present. (pedersen2018smokingisassociated pages 5-6)
+
+Suggested GO biological-process terms (hypothesis-driven; requires validation):
+* “myeloid cell proliferation” (GO:0008283 related), “hematopoietic stem cell proliferation” (GO terms vary)
+
+Suggested CL cell types (hypothesis-driven; requires validation):
+* Hematopoietic stem cell (CL:0000037), myeloid progenitor (CL:0000763), megakaryocyte (CL:0000554)
+
+---
+
+## 7. Anatomical Structures Affected
+
+Primary anatomic sites include:
+* **Bone marrow** (hypercellularity; megakaryocytic clustering/pleomorphism; variable fibrosis) (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* **Spleen** (splenomegaly; extramedullary hematopoiesis mentioned in reviews) (deschamps2021clinicopathologicalcharacterisationof pages 2-3, mclornan2022howimanage pages 2-2)
+* **Splanchnic vasculature** (portal vein thrombosis and broader SVT association; a major clinical presentation route) (deschamps2021clinicopathologicalcharacterisationof pages 2-3, pizzi2021theclassificationof pages 7-8)
+
+Suggested UBERON terms (requires validation):
+* Bone marrow — UBERON:0002371
+* Spleen — UBERON:0002106
+* Portal vein — UBERON:0001189
+
+Subcellular localization was not addressed in retrieved excerpts.
+
+---
+
+## 8. Temporal Development
+
+MPN-U is commonly conceptualized as including:
+* **Early/prodromal phase** with incompletely developed subtype-specific morphology (often overlapping ET/pre-PMF) and fewer organomegaly features (gianelli2023internationalconsensusclassification pages 13-14, pizzi2021theclassificationof pages 7-8)
+* **Advanced fibrotic phase** with cytopenias, organomegaly, fibrosis-related marrow changes, and higher transformation risk (pizzi2021theclassificationof pages 7-8)
+
+In the UK cohort, transformation to accelerated/blast phase occurred in 7/82 (8.5%) with median time to transformation 88.2 months (15.6–183.9). (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+
+---
+
+## 9. Inheritance and Population
+
+### Inheritance
+MPN-U is generally discussed as a somatic clonal neoplasm; explicit Mendelian inheritance patterns were not described in the retrieved excerpts.
+
+### Epidemiology (proportion among MPNs)
+MPN-U is estimated at **~5–10%** of MPNs in reviews/classification discussions. (pizzi2021theclassificationof pages 7-8, gianelli2023internationalconsensusclassification pages 11-13)
+In a UK tertiary registry, MPN-U constituted **82/1512 = 5.4%** of MPN patients. (deschamps2021clinicopathologicalcharacterisationof pages 1-2)
+
+### Age/sex distribution
+In the UK cohort: median age 49.7 years (range 13–79) and 56% female. (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+
+---
+
+## 10. Diagnostics (limited to retrieved evidence)
+
+### Diagnostic framing
+Diagnosis is clinicopathologic and by exclusion: “features of an MPN are present” but criteria for defined entities are not met, and exclusionary rearrangements/fusions (e.g., BCR::ABL1, PCM1-JAK2; PDGFRA/B; FGFR1) must be absent; reactive drivers such as infection/toxin/drug exposure should be ruled out. (gianelli2023internationalconsensusclassification pages 13-14, mclornan2022howimanage pages 1-2)
+
+### WHO vs ICC placement
+WHO-HAEM5 uses MPN-NOS; ICC uses MPN-unclassifiable. (xiao2024apracticalapproach pages 2-4)
+
+### Molecular testing sensitivity / contemporary updates
+ICC-focused review text recommends highly sensitive molecular techniques for identifying JAK2/CALR/MPL driver mutations, with “minimal level of VAF 1%” as a recommended diagnostic backbone (in the ICC MPN classification paper’s conclusion). (gianelli2023internationalconsensusclassification pages 14-15)
+
+### Differential diagnosis (high-level)
+Key exclusions include entities defined by specific lesions (e.g., BCR::ABL1; eosinophilia with tyrosine kinase fusions), and careful separation from MDS/MPN overlap neoplasms when dysplasia predominates. (gianelli2023internationalconsensusclassification pages 13-14)
+
+Not available in retrieved evidence: complete WHO-HAEM5/ICC “major/minor criteria” tables for MPN-NOS/MPN-U, SNOMED/LOINC mappings, and structured genetic testing panel recommendations beyond general statements.
+
+---
+
+## 11. Outcome / Prognosis
+
+### Cohort-based survival estimates
+In the UK cohort (n=82):
+* Median **event-free survival (EFS) 11.25 years** (95% CI 9.3–not reached)
+* Median OS not reached; **10-year OS 88.8%** (95% CI 77.7–100.0%) (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+
+### Transformation/progression
+* Transformation to accelerated/blast phase: **8.5%** (7/82), median 88.2 months (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Overall progression (accelerated/transformation or fibrosis): ~19.2% in treated subgroup reporting (deschamps2021clinicopathologicalcharacterisationof pages 3-5, deschamps2021clinicopathologicalcharacterisationof pages 5-6)
+
+### Prognostic factors (EFS)
+Lower platelets and leukocytosis stratified higher-risk groups: low platelet quartile HR 3.45 (95% CI 1.43–8.32) and leukocytosis HR 2.91 (95% CI 1.11–7.64) in multivariable analysis. (deschamps2021clinicopathologicalcharacterisationof pages 5-6, deschamps2021clinicopathologicalcharacterisationof media cb1fee4a)
+
+### Complications and comorbidity burden (population-based)
+* **Pneumonia and respiratory mortality:** In a Danish cohort, myelofibrosis/unclassifiable MPN had HR 3.03 (95% CI 1.86–4.93) for pneumonia and HR 2.40 (95% CI 1.11–5.19) for respiratory death (subtypes combined). (pedersen2020twofoldriskof pages 1-2)
+* **Second malignancies:** In a Swedish population cohort (9379 MPN patients; 1113 MPN-U), the hazard ratio for non-hematologic second malignancies in **MPN-U** was **HR 1.9 (95% CI 1.5–2.5)** versus controls. (landtblom2018secondmalignanciesin pages 3-4)
+
+---
+
+## 12. Treatment (evidence-limited; phenotype-driven)
+
+There are no licensed, MPN-U-specific therapies highlighted in the retrieved evidence; management is explicitly described as challenging due to “lack of agreed guidelines” and is generally **phenotype- and complication-driven** (treating cytoses, symptoms/splenomegaly, and thrombosis risk similarly to classical MPNs). (hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6)
+
+Real-world approaches are summarized in the management artifact (cytoreduction, antithrombotics, ruxolitinib off-label, allo-HCT escalation, and key MPN registries/trials). | Management domain | Therapy/approach | Real-world implementation in MPN-U / MPN-NOS | Quantitative details | Citation |
+|---|---|---|---|---|
+| Cytoreduction | Any cytoreductive therapy | Commonly used in practice, but indications are phenotype-driven rather than guideline-standardized | In the UK cohort, 51/82 patients (62.2%) received cytoreductive therapy; in the survey, 66% of centres would offer cytoreduction for thrombocytosis | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7) |
+| Cytoreduction | Hydroxycarbamide / hydroxyurea | Most commonly used first-line cytoreductive agent in cohort and survey practice | UK cohort: 40/82 (48.8%) received hydroxycarbamide; survey: 14 centres (41%) targeted platelets around 400 × 10^9/L, and 20 centres (59%) combined hydroxycarbamide with extended postoperative thromboprophylaxis | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Cytoreduction | Interferon / pegylated interferon | Used in a minority overall; may be considered in selected settings such as pregnancy or younger patients, but not a common first-choice agent in survey responses | UK cohort: 14/82 (17.1%) received interferon; survey of thrombocytosis management: no centres selected interferon as agent of choice; pregnancy-focused recommendations note interferon-based approaches at some centres | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6, mclornan2022howimanage pages 4-5) |
+| Cytoreduction | Anagrelide | Used infrequently for platelet control in selected patients | UK cohort: 8/82 (9.8%) received anagrelide | (deschamps2021clinicopathologicalcharacterisationof pages 1-2) |
+| Symptom/spleen-directed therapy | Ruxolitinib / JAK inhibitor | Off-label, phenotype-driven use for splenomegaly and symptom burden; many centres report little or no use, reflecting uncertainty and lack of approval | UK cohort: 5/82 (6.1%) received a JAK inhibitor; survey/review: about half of centres reported off-label ruxolitinib use for splenomegaly and/or symptoms, while many centres had no MPN-U patients on ruxolitinib | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 3-6, mclornan2022howimanage pages 7-7) |
+| Antithrombotic management | Aspirin | Frequently used, especially with thrombocytosis and in pregnancy; does not eliminate thrombosis risk | Review suggests aspirin 75 mg once daily in selected phenotype-driven strategies; pregnancy recommendations include aspirin throughout pregnancy; cohort noted thromboses still occurred despite low-dose aspirin plus effective cytoreduction | (mclornan2022howimanage pages 8-9, mclornan2022howimanage pages 4-5, deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Antithrombotic management | LMWH | Used particularly in pregnancy and postpartum; also part of broader thrombosis management strategies extrapolated from other MPNs | Pregnancy guidance: antenatal LMWH plus standard 6-week postpartum prophylaxis | (mclornan2022howimanage pages 4-5) |
+| Antithrombotic management | VKA / warfarin | Common choice after venous thromboembolism, especially in heterogeneous real-world practice | Survey: most centres preferred warfarin/VKA after VTE; some reserved VKA specifically for splanchnic vein thrombosis | (hargreaves2022diagnosticandmanagement pages 3-6) |
+| Antithrombotic management | DOACs | Used by some centres; authors cautiously support DOACs in uncomplicated acute SVT, but liver dysfunction may limit use | Review notes VKA vs DOAC decisions are individualized; cohort/international data cited as showing comparable recurrent thrombosis and bleeding rates with DOACs in selected settings | (mclornan2022howimanage pages 5-6, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Cytoreduction triggers | Thrombosis history | Many centres start cytoreduction after arterial or venous thrombosis, despite lack of MPN-U-specific evidence | 81% of surveyed centres initiate cytoreduction after venous or arterial thrombosis | (mclornan2022howimanage pages 7-7) |
+| Cytoreduction triggers | Blood count thresholds | Centres variably use platelet/WBC thresholds to start therapy | Survey: platelet threshold >450 × 10^9/L in 20% of centres, >1500 × 10^9/L in 72%, WBC >15 × 10^9/L in 45% | (mclornan2022howimanage pages 7-7) |
+| Response in cohort | Cytoreductive treatment outcomes | Outcomes are mixed, reinforcing need for better prognostic tools and standardized management | Among treated cohort patients, ~50% achieved adequate cytoreduction, 26.9% had stable blood counts, and 19.2% progressed (accelerated/transformation or fibrosis) | (deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Transplant | Allogeneic hematopoietic cell transplantation | Rare but considered for accelerated, blast-phase, fibrotic, or otherwise aggressive disease; early referral is recommended in suitable patients | UK cohort: 5/82 (6.1%) considered for allo-HCT and 2/82 (2.4%) transplanted; survey: observation 7%, HMA with planned allo-SCT 61%, induction chemotherapy then allo-SCT 7%, upfront allo-SCT 24% for progressive/accelerating disease | (deschamps2021clinicopathologicalcharacterisationof pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, mclornan2022howimanage pages 6-7, deschamps2021clinicopathologicalcharacterisationof pages 3-5) |
+| Transplant outcomes | Allo-HCT registry data | Best evidence comes from retrospective registry series rather than MPN-U-specific trials | Reported 3-year OS after allo-SCT approximately 55% with myeloablative conditioning vs 44% with reduced-intensity conditioning; relapse rates 23% vs 36% | (hargreaves2022diagnosticandmanagement pages 6-7) |
+| Monitoring/implementation | Practice framework | Management is individualized because there are no agreed guidelines; cases often managed similarly to classical MPNs and re-reviewed over time | Survey explicitly reports “lack of agreed guidelines” and wide heterogeneity in MDT review, genomic testing, anticoagulant choice, pregnancy care, and transplant referral | (hargreaves2022diagnosticandmanagement pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6) |
+| Relevant trial/registry | NCT07362225 | Large observational registry tracking symptoms, treatments, and disease progression in people with MPNs; relevant because MPN-U patients are commonly excluded from interventional studies but can be captured in broad registries | Recruiting; observational; target enrollment 5000 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT03618485 | Taiwan MPN registry; observational real-world resource potentially capturing unclassifiable cases under broader MPN umbrella | Active, not recruiting; observational; target enrollment 500 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT07384039 | Supportive-care/exercise intervention in patients with MPNs; relevant to symptom burden and quality-of-life research though not MPN-U-specific | Not yet recruiting; interventional; target enrollment 80 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT06661915 | Phase 2 study in advanced MPNs using ASTX727 with or without iadademstat; relevant for transformed/advanced phenotypes that may include unclassifiable MPN biology | Recruiting; phase 2; target enrollment 62 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT04282187 | Phase 2 study of decitabine with ruxolitinib/fedratinib/pacritinib for accelerated/blast-phase MPN; relevant to aggressive MPN-U scenarios managed as advanced MPN | Recruiting; phase 2; target enrollment 25 | (xiao2024apracticalapproach pages 2-4) |
+| Relevant trial/registry | NCT03566446 | CALR-mutant peptide vaccine study in CALR-mutant MPN; relevant to molecularly defined subsets that may overlap with some MPN-U cases | Completed; phase 1; enrollment 10 | (xiao2024apracticalapproach pages 2-4) |
+
+
+*Table: This table summarizes how MPN-U/MPN-NOS is managed in real-world cohorts, surveys, and broader MPN studies. It highlights the absence of standardized guidelines, the phenotype-driven use of cytoreduction and antithrombotic therapy, transplant escalation in advanced disease, and relevant current trial or registry infrastructure.*
+
+Suggested MAXO terms (requires ontology validation):
+* Cytoreductive therapy — e.g., MAXO term for “cytoreductive therapy”
+* Antiplatelet therapy (aspirin)
+* Anticoagulation therapy
+* Allogeneic hematopoietic stem cell transplantation
+
+---
+
+## 13. Prevention
+
+No primary-prevention interventions specific to MPN-U were identified. Smoking is a modifiable risk factor associated with MPN risk including MPN-U in one large cohort; smoking cessation is therefore a plausible risk-reduction strategy, although direct evidence for prevention of MPN-U is not established. (pedersen2018smokingisassociated pages 1-2)
+
+Secondary/tertiary prevention in practice focuses on prevention of thrombosis/bleeding and monitoring for disease evolution or transformation, but no consensus prevention protocols were available in the retrieved excerpts. (hargreaves2022diagnosticandmanagement pages 3-6, mclornan2022howimanage pages 7-7)
+
+---
+
+## 14. Other Species / Natural Disease
+
+No cross-species naturally occurring MPN-U analogs were identified in the retrieved evidence set.
+
+---
+
+## 15. Model Organisms
+
+The retrieved evidence set did not include dedicated model-organism studies for MPN-U. Mechanistic model systems for canonical MPN driver mutations (e.g., JAK2/CALR/MPL) are widely used in the broader MPN field, but explicit, citable details were not present in the retrieved excerpts and therefore are not asserted here.
+
+---
+
+## “Expert opinion” synthesis (authoritative-source analysis)
+Across expert reviews and international survey data, a consistent expert conclusion is that MPN-U is a **heterogeneous, diagnosis-of-exclusion category** with meaningful thrombotic and transformation risks but **insufficient evidence for standardized, disease-specific guidelines**, leading to high inter-center practice variability and reliance on extrapolation from classical MPN management and individualized risk assessment. (mclornan2022howimanage pages 1-2, hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6)
+
+---
+
+## References (URLs and publication dates from retrieved sources)
+* Xiao W et al. *A practical approach on the classifications of myeloid neoplasms and acute leukemia: WHO and ICC*. **Jul 2024**. https://doi.org/10.1186/s13045-024-01571-4 (xiao2024apracticalapproach pages 2-4)
+* Gianelli U et al. *International Consensus Classification… myeloproliferative neoplasms*. **Dec 2023**. https://doi.org/10.1007/s00428-022-03480-8 (gianelli2023internationalconsensusclassification pages 14-15, gianelli2023internationalconsensusclassification pages 13-14)
+* McLornan DP et al. *How I manage myeloproliferative neoplasm-unclassifiable: Practical approaches for 2022 and beyond*. **Feb 2022**. https://doi.org/10.1111/bjh.18087 (mclornan2022howimanage pages 1-2, mclornan2022howimanage pages 4-5)
+* Hargreaves R et al. *Diagnostic and management strategies for MPN-U: an international survey*. **Jul 2022**. https://doi.org/10.1016/j.retram.2022.103338 (hargreaves2022diagnosticandmanagement pages 6-7, hargreaves2022diagnosticandmanagement pages 3-6)
+* Deschamps P et al. *Clinicopathological characterisation of MPN-U… UK tertiary referral centre*. **Mar 2021**. https://doi.org/10.1111/bjh.17375 (deschamps2021clinicopathologicalcharacterisationof pages 2-3)
+* Pizzi M et al. *Classification of MPNs… focus on unclassifiable cases*. **Nov 2021**. https://doi.org/10.3390/cancers13225666 (pizzi2021theclassificationof pages 7-8)
+* Pedersen KM et al. *Smoking is associated with increased risk of MPNs*. **Oct 2018**. https://doi.org/10.1002/cam4.1815 (pedersen2018smokingisassociated pages 1-2, pedersen2018smokingisassociated pages 2-3)
+* Pedersen KM et al. *Two-fold risk of pneumonia and respiratory mortality in individuals with MPN*. **Apr 2020**. https://doi.org/10.1016/j.eclinm.2020.100295 (pedersen2020twofoldriskof pages 1-2)
+* Landtblom AR et al. *Second malignancies in patients with MPNs… 9379 patients*. **Jan 2018**. https://doi.org/10.1038/s41375-018-0027-y (landtblom2018secondmalignanciesin pages 3-4)
+
+PMIDs: Not available in the retrieved excerpts for the above sources in this run; therefore PMID numbers cannot be reliably provided from the current evidence context.
+
+References
+
+1. (mclornan2022howimanage pages 1-1): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+2. (mclornan2022howimanage pages 1-2): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+3. (xiao2024apracticalapproach pages 2-4): Wenbin Xiao, Valentina Nardi, Eytan Stein, and Robert P. Hasserjian. A practical approach on the classifications of myeloid neoplasms and acute leukemia: who and icc. Journal of Hematology & Oncology, Jul 2024. URL: https://doi.org/10.1186/s13045-024-01571-4, doi:10.1186/s13045-024-01571-4. This article has 40 citations and is from a domain leading peer-reviewed journal.
+
+4. (hargreaves2022diagnosticandmanagement pages 1-2): Rupen Hargreaves, Claire N Harrison, and Donal P McLornan. Diagnostic and management strategies for myeloproliferative neoplasm-unclassifiable (mpn-u): an international survey of contemporary practice. Current Research in Translational Medicine, 70:103338, Jul 2022. URL: https://doi.org/10.1016/j.retram.2022.103338, doi:10.1016/j.retram.2022.103338. This article has 6 citations and is from a peer-reviewed journal.
+
+5. (deschamps2021clinicopathologicalcharacterisationof pages 1-2): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+6. (pizzi2021theclassificationof pages 7-8): Marco Pizzi, Giorgio Alberto Croci, Marco Ruggeri, Silvia Tabano, Angelo Paolo Dei Tos, Elena Sabattini, and Umberto Gianelli. The classification of myeloproliferative neoplasms: rationale, historical background and future perspectives with focus on unclassifiable cases. Cancers, 13:5666, Nov 2021. URL: https://doi.org/10.3390/cancers13225666, doi:10.3390/cancers13225666. This article has 46 citations.
+
+7. (mclornan2022howimanage pages 2-2): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+8. (gianelli2023internationalconsensusclassification pages 13-14): Umberto Gianelli, Jürgen Thiele, Attilio Orazi, Naseema Gangat, Alessandro M. Vannucchi, Ayalew Tefferi, and Hans Michael Kvasnicka. International consensus classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms. Virchows Archiv, 482:53-68, Dec 2023. URL: https://doi.org/10.1007/s00428-022-03480-8, doi:10.1007/s00428-022-03480-8. This article has 61 citations and is from a peer-reviewed journal.
+
+9. (deschamps2021clinicopathologicalcharacterisationof pages 2-3): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+10. (deschamps2021clinicopathologicalcharacterisationof pages 5-6): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+11. (deschamps2021clinicopathologicalcharacterisationof media cb1fee4a): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+12. (hargreaves2022diagnosticandmanagement pages 6-7): Rupen Hargreaves, Claire N Harrison, and Donal P McLornan. Diagnostic and management strategies for myeloproliferative neoplasm-unclassifiable (mpn-u): an international survey of contemporary practice. Current Research in Translational Medicine, 70:103338, Jul 2022. URL: https://doi.org/10.1016/j.retram.2022.103338, doi:10.1016/j.retram.2022.103338. This article has 6 citations and is from a peer-reviewed journal.
+
+13. (hargreaves2022diagnosticandmanagement pages 3-6): Rupen Hargreaves, Claire N Harrison, and Donal P McLornan. Diagnostic and management strategies for myeloproliferative neoplasm-unclassifiable (mpn-u): an international survey of contemporary practice. Current Research in Translational Medicine, 70:103338, Jul 2022. URL: https://doi.org/10.1016/j.retram.2022.103338, doi:10.1016/j.retram.2022.103338. This article has 6 citations and is from a peer-reviewed journal.
+
+14. (mclornan2022howimanage pages 4-5): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+15. (mclornan2022howimanage pages 7-7): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+16. (mclornan2022howimanage pages 8-9): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+17. (deschamps2021clinicopathologicalcharacterisationof pages 3-5): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+18. (mclornan2022howimanage pages 5-6): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+19. (mclornan2022howimanage pages 6-7): Donal P. McLornan, Rupen Hargreaves, Juan Carlos Hernández‐Boluda, and Claire N. Harrison. How i manage myeloproliferative neoplasm‐unclassifiable: practical approaches for 2022 and beyond. British Journal of Haematology, 197:407-416, Feb 2022. URL: https://doi.org/10.1111/bjh.18087, doi:10.1111/bjh.18087. This article has 11 citations and is from a domain leading peer-reviewed journal.
+
+20. (deschamps2021clinicopathologicalcharacterisationof media 1f80ac50): Paul Deschamps, Mufaddal Moonim, Deepti Radia, Natalia Curto‐Garcia, Claire Woodley, Sarah Bassiony, Jennifer O'Sullivan, Patrick Harrington, Kavita Raj, Yvonne Francis, Shahram Kordasti, Sahra Ali, Claire N. Harrison, and Donal P. McLornan. Clinicopathological characterisation of myeloproliferative neoplasm‐unclassifiable (mpn‐u): a retrospective analysis from a large uk tertiary referral centre. British Journal of Haematology, 193:792-797, Mar 2021. URL: https://doi.org/10.1111/bjh.17375, doi:10.1111/bjh.17375. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+21. (pedersen2018smokingisassociated pages 2-3): Kasper M. Pedersen, Marie Bak, Anders L. Sørensen, Ann‐Dorthe Zwisler, Christina Ellervik, Morten K. Larsen, Hans C. Hasselbalch, and Janne S. Tolstrup. Smoking is associated with increased risk of myeloproliferative neoplasms: a general population‐based cohort study. Cancer Medicine, 7:5796-5802, Oct 2018. URL: https://doi.org/10.1002/cam4.1815, doi:10.1002/cam4.1815. This article has 47 citations and is from a peer-reviewed journal.
+
+22. (landtblom2018secondmalignanciesin pages 3-4): Anna Ravn Landtblom, Hannah Bower, Therese M.-L. Andersson, Paul W. Dickman, Jan Samuelsson, Magnus Björkholm, Sigurdur Yngvi Kristinsson, and Malin Hultcrantz. Second malignancies in patients with myeloproliferative neoplasms: a population-based cohort study of 9379 patients. Leukemia, 32:2203-2210, Jan 2018. URL: https://doi.org/10.1038/s41375-018-0027-y, doi:10.1038/s41375-018-0027-y. This article has 107 citations and is from a highest quality peer-reviewed journal.
+
+23. (pedersen2020twofoldriskof pages 1-2): Kasper Mønsted Pedersen, Yunus Çolak, Hans Carl Hasselbalch, Christina Ellervik, Børge Grønne Nordestgaard, and Stig Egil Bojesen. Two-fold risk of pneumonia and respiratory mortality in individuals with myeloproliferative neoplasm: a population-based cohort study. EClinicalMedicine, 21:100295, Apr 2020. URL: https://doi.org/10.1016/j.eclinm.2020.100295, doi:10.1016/j.eclinm.2020.100295. This article has 9 citations and is from a peer-reviewed journal.
+
+24. (pedersen2018smokingisassociated pages 1-2): Kasper M. Pedersen, Marie Bak, Anders L. Sørensen, Ann‐Dorthe Zwisler, Christina Ellervik, Morten K. Larsen, Hans C. Hasselbalch, and Janne S. Tolstrup. Smoking is associated with increased risk of myeloproliferative neoplasms: a general population‐based cohort study. Cancer Medicine, 7:5796-5802, Oct 2018. URL: https://doi.org/10.1002/cam4.1815, doi:10.1002/cam4.1815. This article has 47 citations and is from a peer-reviewed journal.
+
+25. (pedersen2018smokingisassociated pages 5-6): Kasper M. Pedersen, Marie Bak, Anders L. Sørensen, Ann‐Dorthe Zwisler, Christina Ellervik, Morten K. Larsen, Hans C. Hasselbalch, and Janne S. Tolstrup. Smoking is associated with increased risk of myeloproliferative neoplasms: a general population‐based cohort study. Cancer Medicine, 7:5796-5802, Oct 2018. URL: https://doi.org/10.1002/cam4.1815, doi:10.1002/cam4.1815. This article has 47 citations and is from a peer-reviewed journal.
+
+26. (gianelli2023internationalconsensusclassification pages 11-13): Umberto Gianelli, Jürgen Thiele, Attilio Orazi, Naseema Gangat, Alessandro M. Vannucchi, Ayalew Tefferi, and Hans Michael Kvasnicka. International consensus classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms. Virchows Archiv, 482:53-68, Dec 2023. URL: https://doi.org/10.1007/s00428-022-03480-8, doi:10.1007/s00428-022-03480-8. This article has 61 citations and is from a peer-reviewed journal.
+
+27. (gianelli2023internationalconsensusclassification pages 14-15): Umberto Gianelli, Jürgen Thiele, Attilio Orazi, Naseema Gangat, Alessandro M. Vannucchi, Ayalew Tefferi, and Hans Michael Kvasnicka. International consensus classification of myeloid and lymphoid neoplasms: myeloproliferative neoplasms. Virchows Archiv, 482:53-68, Dec 2023. URL: https://doi.org/10.1007/s00428-022-03480-8, doi:10.1007/s00428-022-03480-8. This article has 61 citations and is from a peer-reviewed journal.

--- a/research/Myeloproliferative_Neoplasm_Unclassifiable-deep-research-falcon.md.citations.md
+++ b/research/Myeloproliferative_Neoplasm_Unclassifiable-deep-research-falcon.md.citations.md
@@ -1,0 +1,494 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Myeloproliferative Neoplasm, Unclassifiable
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Myeloproliferative Neoplasm, Unclassifiable** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T11:32:37.450668
+
+1. xiao2024apracticalapproach pages 2-4
+2. deschamps2021clinicopathologicalcharacterisationof pages 1-2
+3. mclornan2022howimanage pages 4-5
+4. hargreaves2022diagnosticandmanagement pages 3-6
+5. mclornan2022howimanage pages 7-7
+6. deschamps2021clinicopathologicalcharacterisationof pages 3-5
+7. hargreaves2022diagnosticandmanagement pages 6-7
+8. pedersen2018smokingisassociated pages 2-3
+9. pedersen2018smokingisassociated pages 1-2
+10. pedersen2018smokingisassociated pages 5-6
+11. mclornan2022howimanage pages 2-2
+12. deschamps2021clinicopathologicalcharacterisationof pages 2-3
+13. pizzi2021theclassificationof pages 7-8
+14. gianelli2023internationalconsensusclassification pages 14-15
+15. gianelli2023internationalconsensusclassification pages 13-14
+16. pedersen2020twofoldriskof pages 1-2
+17. landtblom2018secondmalignanciesin pages 3-4
+18. mclornan2022howimanage pages 1-1
+19. mclornan2022howimanage pages 1-2
+20. hargreaves2022diagnosticandmanagement pages 1-2
+21. deschamps2021clinicopathologicalcharacterisationof pages 5-6
+22. mclornan2022howimanage pages 8-9
+23. mclornan2022howimanage pages 5-6
+24. mclornan2022howimanage pages 6-7
+25. gianelli2023internationalconsensusclassification pages 11-13
+26. https://doi.org/10.1186/s13045-024-01571-4
+27. https://doi.org/10.1007/s00428-022-03480-8
+28. https://doi.org/10.1111/bjh.18087
+29. https://doi.org/10.1016/j.retram.2022.103338
+30. https://doi.org/10.1111/bjh.17375
+31. https://doi.org/10.3390/cancers13225666
+32. https://doi.org/10.1002/cam4.1815
+33. https://doi.org/10.1016/j.eclinm.2020.100295
+34. https://doi.org/10.1038/s41375-018-0027-y
+35. https://doi.org/10.1111/bjh.18087,
+36. https://doi.org/10.1186/s13045-024-01571-4,
+37. https://doi.org/10.1016/j.retram.2022.103338,
+38. https://doi.org/10.1111/bjh.17375,
+39. https://doi.org/10.3390/cancers13225666,
+40. https://doi.org/10.1007/s00428-022-03480-8,
+41. https://doi.org/10.1002/cam4.1815,
+42. https://doi.org/10.1038/s41375-018-0027-y,
+43. https://doi.org/10.1016/j.eclinm.2020.100295,


### PR DESCRIPTION
## Summary

- Added a new DISMECH disorder page for myeloproliferative neoplasm, unclassifiable (MONDO:0019452).
- Integrated Falcon deep research into pathophysiology, phenotypes, histopathology, biochemical, genetic, environmental, treatment, diagnosis, and progression sections.
- Added fetched PMID reference caches actually cited by the YAML.

## Validation

- `just validate kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml` passed.
- `just validate-references kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml` passed.
- `just validate-terms kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml` passed. The requested `validate-terms-file` recipe is not present in this checkout.
- `just compliance kb/disorders/Myeloproliferative_Neoplasm_Unclassifiable.yaml` passed with global compliance 98.2% and weighted compliance 100.0%.

## Notes

- Restored generated tracked `cache/*` churn and uncited `references_cache/clinicaltrials_NCT*.md` churn before staging.
- Did not hand-edit any `references_cache/*.md` files.