### PR TITLE
Add dysembryoplastic neuroepithelial tumor curation

### DIFF
--- a/kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml
+++ b/kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml
@@ -1,0 +1,441 @@
+name: Dysembryoplastic Neuroepithelial Tumor
+creation_date: "2026-05-11T14:55:21Z"
+updated_date: "2026-05-11T14:55:21Z"
+description: >-
+  Dysembryoplastic neuroepithelial tumor (DNET/DNT) is a rare WHO grade 1
+  glioneuronal brain neoplasm and a prototypic low-grade epilepsy-associated
+  neuroepithelial tumor. It typically arises in cortical supratentorial brain,
+  especially temporal and frontal lobes, in children, adolescents, and young
+  adults with long-standing focal seizures. Integrated diagnosis combines
+  clinical epilepsy history, MRI, neuropathology with a specific glioneuronal
+  element, and increasingly molecular testing for FGFR1/RAS-MAPK alterations.
+categories:
+- Central Nervous System Neoplasm
+- Mixed Neuronal-Glial Tumor
+- Epilepsy-Associated Tumor
+- Pediatric Brain Tumor
+- Low-Grade Glioma
+parents:
+- mixed neuronal-glial tumor
+- brain neoplasm
+- structural epilepsy
+disease_term:
+  preferred_term: dysembryoplastic neuroepithelial tumor
+  term:
+    id: MONDO:0005505
+    label: dysembryoplastic neuroepithelial tumor
+pathophysiology:
+- name: Cortical Glioneuronal Tumor Formation
+  description: >-
+    DNET forms as a benign cortical glioneuronal tumor with neuronal and glial
+    components, often involving temporal or frontal cortex and producing an
+    epilepsy-associated lesion rather than a high-grade infiltrative glioma.
+  cell_types:
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  - preferred_term: astrocytic glial component
+    term:
+      id: CL:0000127
+      label: astrocyte
+  - preferred_term: oligodendrocyte-like glial component
+    term:
+      id: CL:0000128
+      label: oligodendrocyte
+  locations:
+  - preferred_term: cerebral cortex
+    term:
+      id: UBERON:0000956
+      label: cerebral cortex
+  - preferred_term: temporal lobe
+    term:
+      id: UBERON:0001871
+      label: temporal lobe
+  biological_processes:
+  - preferred_term: low-grade tumor cell proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: PMID:37525202
+    reference_title: "Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      RESULTS: Fourteen cases were reported. There were 12 males and 2 females. Age
+      range was 9-45 years (mean 19 years). Majority were located in the temporal and
+      frontal lobes.
+    explanation: >-
+      This human case series supports the young age distribution and cortical
+      temporal/frontal location used for the tumor-formation node.
+  downstream:
+  - target: FGFR1-Driven RAS-MAPK Activation
+    description: Many confirmed DNETs carry FGFR1 alterations that activate MAPK signaling.
+  - target: Tumor-Associated Cortical Hyperexcitability
+    description: The cortical glioneuronal lesion is the structural substrate for focal seizures.
+- name: FGFR1-Driven RAS-MAPK Activation
+  description: >-
+    Specific DNETs are enriched for somatic FGFR1 alterations, including hotspot
+    mutations, tyrosine kinase-domain duplications, and rare fusions/breakpoints.
+    These events converge on RAS-MAPK signaling and provide the central molecular
+    mechanism for many neuropathology-confirmed tumors.
+  genes:
+  - preferred_term: FGFR1
+    term:
+      id: hgnc:3688
+      label: FGFR1
+  gene_products:
+  - preferred_term: fibroblast growth factor receptor 1
+    term:
+      id: NCIT:C17590
+      label: Fibroblast Growth Factor Receptor 1
+  biological_processes:
+  - preferred_term: MAPK cascade
+    modifier: INCREASED
+    term:
+      id: GO:0000165
+      label: MAPK cascade
+  evidence:
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In 43 sporadic cases, in which the diagnosis of DNET could be confirmed on
+      central blinded neuropathology review, FGFR1 alterations were also frequent
+      and mainly comprised intragenic tyrosine kinase FGFR1 duplication and multiple
+      mutants in cis (25/43; 58.1 %) while BRAF p.V600E alterations were absent (0/43).
+    explanation: >-
+      The centrally reviewed human tumor cohort supports FGFR1 alteration as the
+      dominant driver event in confirmed DNET.
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In conclusion, constitutional and somatic FGFR1 alterations and MAP kinase
+      pathway activation are key events in the pathogenesis of DNET.
+    explanation: >-
+      The authors explicitly connect constitutional/somatic FGFR1 abnormalities
+      with MAP kinase activation in DNET pathogenesis.
+  downstream:
+  - target: Tumor-Associated Cortical Hyperexcitability
+    description: MAPK-driven glioneuronal tumor formation creates an epileptogenic cortical lesion.
+- name: DNET Spectrum Molecular Heterogeneity
+  description: >-
+    Specific DNET is molecularly more homogeneous than historical non-specific or
+    diffuse DNT diagnoses. Broader DNET/MNGT/PLNTY-spectrum tumors can harbor
+    BRAF, FGFR1, NF1, PDGFRA, FGFR2, NTRK2, and other alterations that converge on
+    MAPK and PI3K/mTOR signaling, so molecular diagnosis helps separate true DNET
+    from overlapping low-grade neuroepithelial entities.
+  genes:
+  - preferred_term: FGFR1
+    term:
+      id: hgnc:3688
+      label: FGFR1
+  biological_processes:
+  - preferred_term: MAPK cascade
+    modifier: ABNORMAL
+    term:
+      id: GO:0000165
+      label: MAPK cascade
+  evidence:
+  - reference: PMID:35836307
+    reference_title: "The genomic landscape of dysembryoplastic neuroepithelial tumours and a comprehensive analysis of recurrent cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Specific DNT is a homogeneous group of tumours sharing characteristics of
+      paediatric low-grade gliomas: a quiet genome with a recurrent genomic alteration
+      in the RAS-MAPK signalling pathway, a distinct DNA methylation profile and a
+      good prognosis but showing progression in some cases.
+    explanation: >-
+      This integrative human tumor cohort supports separating specific DNT from
+      heterogeneous non-specific/diffuse tumors and anchors the RAS-MAPK mechanism.
+  - reference: PMID:31617914
+    reference_title: Genomic Analysis of Dysembryoplastic Neuroepithelial Tumor Spectrum Reveals a Diversity of Molecular Alterations Dysregulating the MAPK and PI3K/mTOR Pathways.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Overall, DNT-MNGT spectrum tumors exhibit diverse genomic alterations, with
+      more than half (19/33) leading to MAPK/PI3K pathway alterations.
+    explanation: >-
+      This human genomic series supports modeling broader DNT-spectrum molecular
+      heterogeneity as a MAPK/PI3K-pathway convergent pattern.
+- name: Tumor-Associated Cortical Hyperexcitability
+  description: >-
+    DNET is an epileptogenic cortical tumor. Seizures arise when the glioneuronal
+    lesion involves cortical neurons and related networks; peritumoral epileptogenic
+    zones and associated focal cortical dysplasia can contribute to drug-resistant
+    focal epilepsy.
+  cell_types:
+  - preferred_term: cortical neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  locations:
+  - preferred_term: cerebral cortex
+    term:
+      id: UBERON:0000956
+      label: cerebral cortex
+  evidence:
+  - reference: PMID:36699536
+    reference_title: "Low-grade epilepsy-associated neuroepithelial tumors: Tumor spectrum and diagnosis based on genetic alterations."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Brain tumors can always result in seizures when involving the cortical neurons
+      or their circuits, and they were found to be one of the most common etiologies
+      of intractable focal seizures.
+    explanation: >-
+      This review supports the cortical-neuron circuit mechanism linking DNET/LEAT
+      location to intractable focal seizures.
+phenotypes:
+- category: Neurological
+  name: Focal-Onset Seizures
+  description: >-
+    Long-standing focal seizures are the hallmark clinical presentation and may be
+    drug-resistant before surgery.
+  phenotype_term:
+    preferred_term: Focal-onset seizure
+    term:
+      id: HP:0007359
+      label: Focal-onset seizure
+  evidence:
+  - reference: PMID:37525202
+    reference_title: "Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      BACKGROUND: Dysembryoplastic neuroepithelial tumors are rare benign
+      supratentotrial epilepsy-associated glioneuronal tumors of children and young
+      adults. Patients have a long history of seizures.
+    explanation: >-
+      The case-series abstract directly supports seizures as the major presentation.
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Dysembryoplastic neuroepithelial tumor (DNET) is a benign brain tumor
+      associated with intractable drug-resistant epilepsy.
+    explanation: >-
+      This tumor genetics paper confirms the association with intractable,
+      drug-resistant epilepsy.
+histopathology:
+- name: Specific Glioneuronal Element
+  description: >-
+    The diagnostic hallmark is the specific glioneuronal element, with columns of
+    oligodendrocyte-like cells and floating neurons in a mucinous matrix.
+  diagnostic: true
+  evidence:
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The histopathological hallmark of DNET is the specific glioneuronal element,
+      i.e. the presence of columns of oligodendroglial-like cells and so-called
+      floating neurons [6].
+    explanation: >-
+      This supports the specific glioneuronal element as the diagnostic histologic
+      hallmark.
+- name: Multinodular Pattern
+  description: >-
+    Classic DNETs show a multinodular pattern with low proliferative activity and
+    no high-grade features such as necrosis or significant mitotic activity.
+  finding_term:
+    preferred_term: nodular pattern
+    term:
+      id: NCIT:C35899
+      label: Nodular Pattern
+  evidence:
+  - reference: PMID:37525202
+    reference_title: "Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Histologically, all cases demonstrated a multinodular pattern, specific
+      glioneuronal component, and floating neurons.
+    explanation: >-
+      This human case series supports multinodular architecture and floating
+      neurons as common DNET histopathologic findings.
+diagnosis:
+- name: Brain MRI
+  description: >-
+    MRI is central to preoperative evaluation and can identify cortical lesion
+    patterns that support DNET/LEAT diagnosis and surgical planning.
+  diagnosis_term:
+    preferred_term: magnetic resonance imaging procedure
+    term:
+      id: MAXO:0000424
+      label: magnetic resonance imaging procedure
+  results: Cortical tumor location and MRI pattern guide differential diagnosis and surgical planning.
+  evidence:
+  - reference: PMID:36672006
+    reference_title: Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Younger age of seizure onset, bilateral interictal epileptiform discharges,
+      and MRI type 3 tumors were risk factors for poor prognosis;
+    explanation: >-
+      This clinical surgical cohort supports MRI pattern as clinically relevant in
+      DNET epilepsy prognosis.
+- name: Electroencephalography
+  description: >-
+    EEG helps localize epileptiform activity and risk-stratify seizure outcomes in
+    DNET-associated epilepsy.
+  diagnosis_term:
+    preferred_term: electroencephalography
+    term:
+      id: MAXO:0000932
+      label: electroencephalography
+  results: Interictal epileptiform discharges inform localization and outcome prediction.
+  evidence:
+  - reference: PMID:36672006
+    reference_title: Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Younger age of seizure onset, bilateral interictal epileptiform discharges,
+      and MRI type 3 tumors were risk factors for poor prognosis;
+    explanation: >-
+      This supports interictal EEG findings as clinically meaningful in
+      DNET-associated epilepsy.
+- name: Molecular Testing for FGFR1 and MAPK Pathway Alterations
+  description: >-
+    Targeted sequencing, fusion testing, and methylation profiling can support
+    difficult DNET diagnoses and distinguish specific DNT from overlapping
+    low-grade neuroepithelial tumor entities.
+  diagnosis_term:
+    preferred_term: genetic testing
+    term:
+      id: MAXO:0000127
+      label: genetic testing
+  results: FGFR1 alteration, RAS-MAPK pathway event, or DNT methylation class supports integrated diagnosis.
+  evidence:
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, targeted analysis for FGFR1 hotspot mutations may provide a first step
+      to aid the diagnosis of DNET and could be supplemented by analyses for FGFR1
+      fusion transcripts and FGFR1-TKD.
+    explanation: >-
+      This supports FGFR1 mutation/fusion/tyrosine-kinase-duplication testing as a
+      diagnostic adjunct.
+genetic:
+- name: FGFR1
+  gene_term:
+    preferred_term: FGFR1
+    term:
+      id: hgnc:3688
+      label: FGFR1
+  association: Common somatic driver, with rare familial germline predisposition reported.
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE_AND_SOMATIC
+  evidence:
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      By whole-exome sequencing of the familial cases, we identified a novel
+      germline FGFR1 mutation, p.R661P.
+    explanation: >-
+      This supports rare germline FGFR1 predisposition in familial DNET.
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Somatic activating FGFR1 mutations (p.N546K or p.K656E) were observed in the
+      tumor samples and further evidence for functional relevance was obtained by in
+      silico modeling.
+    explanation: >-
+      This supports somatic activating FGFR1 mutations in tumor tissue.
+treatments:
+- name: Surgical Resection
+  description: >-
+    Maximal safe resection or lesionectomy is the main disease-directed therapy,
+    aiming for tumor control and seizure freedom. Shorter epilepsy duration and
+    gross total removal predict better seizure outcomes.
+  treatment_term:
+    preferred_term: surgical resection
+    term:
+      id: MAXO:0000448
+      label: surgical resection
+  target_phenotypes:
+  - preferred_term: Focal-onset seizure
+    term:
+      id: HP:0007359
+      label: Focal-onset seizure
+  target_mechanisms:
+  - target: Cortical Glioneuronal Tumor Formation
+    treatment_effect: MODULATES
+    description: Resection removes the glioneuronal tumor and associated epileptogenic lesion.
+  - target: Tumor-Associated Cortical Hyperexcitability
+    treatment_effect: INHIBITS
+    description: Resection reduces seizure-generating cortical tumor tissue.
+  evidence:
+  - reference: PMID:36672006
+    reference_title: Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      At the final follow-up, 49 patients (77.8%) were seizure-free.
+    explanation: >-
+      This supports favorable seizure outcomes after surgery in a human DNT cohort.
+  - reference: PMID:36672006
+    reference_title: Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Gross total removal of the tumor and a short epilepsy duration were significant
+      predictors of seizure freedom.
+    explanation: >-
+      This supports gross total tumor removal as an important treatment goal.
+  - reference: PMID:26514362
+    reference_title: Review of seizure outcomes after surgical resection of dysembryoplastic neuroepithelial tumors.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median seizure freedom rate was 86% (interquartile range 77-93%) with
+      only one study reporting fewer than 60% of patients seizure free.
+    explanation: >-
+      This systematic review supports high seizure-freedom rates after DNET resection.
+- name: Anti-Seizure Medication
+  description: >-
+    Anti-seizure medications are used to manage DNET-associated epilepsy, although
+    seizures are often drug-resistant before definitive surgical management.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: anticonvulsant
+      term:
+        id: NCIT:C264
+        label: Anticonvulsant Agent
+  target_phenotypes:
+  - preferred_term: Focal-onset seizure
+    term:
+      id: HP:0007359
+      label: Focal-onset seizure
+  evidence:
+  - reference: PMID:26514362
+    reference_title: Review of seizure outcomes after surgical resection of dysembryoplastic neuroepithelial tumors.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The number of seizure-free patients who discontinued anti-epileptic drugs
+      varied widely from zero to all patients.
+    explanation: >-
+      This supports anti-epileptic drug use as part of clinical management in
+      surgical DNET epilepsy series.
+datasets:

--- a/kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml
+++ b/kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml
@@ -192,6 +192,25 @@ pathophysiology:
     explanation: >-
       This review supports the cortical-neuron circuit mechanism linking DNET/LEAT
       location to intractable focal seizures.
+- name: Adjacent Focal Cortical Dysplasia
+  description: >-
+    Some DNETs show adjacent cortical dysplasia, representing dual pathology that
+    can contribute to the epileptogenic peritumoral cortex and surgical planning.
+  locations:
+  - preferred_term: cerebral cortex
+    term:
+      id: UBERON:0000956
+      label: cerebral cortex
+  evidence:
+  - reference: PMID:37525202
+    reference_title: "Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cortical dysplasia was noted in adjacent glial tissue in four cases.
+    explanation: >-
+      This case series directly supports adjacent cortical dysplasia as a DNET
+      dual-pathology finding.
 phenotypes:
 - category: Neurological
   name: Focal-Onset Seizures
@@ -328,6 +347,28 @@ diagnosis:
     explanation: >-
       This supports FGFR1 mutation/fusion/tyrosine-kinase-duplication testing as a
       diagnostic adjunct.
+- name: DNA Methylation Profiling
+  description: >-
+    DNA methylation profiling can help distinguish specific DNT from heterogeneous
+    non-specific/diffuse DNT-like diagnoses and other low-grade neuroepithelial
+    tumors.
+  diagnosis_term:
+    preferred_term: DNA methylation profiling
+  results: A distinct DNA methylation profile supports integrated DNT classification.
+  evidence:
+  - reference: PMID:35836307
+    reference_title: "The genomic landscape of dysembryoplastic neuroepithelial tumours and a comprehensive analysis of recurrent cases."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      METHODS: We used targeted methods (immunohistochemistry, fluorescence in situ
+      hybridisation and targeted sequencing) and large-scale genomic methodologies
+      including DNA methylation profiling to perform an integrative analysis to better
+      characterise a large retrospective cohort of 82 DNTs, enriched for tumours that
+      showed progression on imaging.
+    explanation: >-
+      This supports DNA methylation profiling as part of integrative diagnostic
+      characterization for DNT.
 genetic:
 - name: FGFR1
   gene_term:
@@ -354,10 +395,18 @@ genetic:
     evidence_source: HUMAN_CLINICAL
     snippet: >-
       Somatic activating FGFR1 mutations (p.N546K or p.K656E) were observed in the
-      tumor samples and further evidence for functional relevance was obtained by in
-      silico modeling.
+      tumor samples
     explanation: >-
       This supports somatic activating FGFR1 mutations in tumor tissue.
+  - reference: PMID:26920151
+    reference_title: "Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors."
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: >-
+      further evidence for functional relevance was obtained by in silico modeling.
+    explanation: >-
+      This separately classifies the in silico modeling component of the FGFR1
+      functional evidence.
 treatments:
 - name: Surgical Resection
   description: >-
@@ -438,4 +487,61 @@ treatments:
     explanation: >-
       This supports anti-epileptic drug use as part of clinical management in
       surgical DNET epilepsy series.
+- name: Mirdametinib MEK Inhibition Trial Therapy
+  description: >-
+    Mirdametinib is an investigational brain-penetrant MEK1/2 inhibitor being
+    evaluated in the SJ901 pediatric/AYA low-grade glioma trial; for DNET, this
+    is mechanistically relevant to FGFR1-driven RAS-MAPK activation but remains
+    investigational rather than established standard care.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: mirdametinib
+  target_mechanisms:
+  - target: FGFR1-Driven RAS-MAPK Activation
+    treatment_effect: INHIBITS
+    description: MEK inhibition targets downstream MAPK pathway signaling activated by FGFR1 alterations.
+  evidence:
+  - reference: clinicaltrials:NCT04923126
+    reference_title: "SJ901: Phase 1/2 Evaluation of Single Agent Mirdametinib (PD-0325901), a Brain-Penetrant MEK1/2 Inhibitor, for the Treatment of Children, Adolescents, and Young Adults With Low-Grade Glioma"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This is an open-label, multi-center, Phase 1/2 study of the brain-penetrant
+      MEK inhibitor, mirdametinib (PD-0325901), in patients with pediatric low-grade
+      glioma (pLGG).
+    explanation: >-
+      The trial record supports an investigational MEK-inhibitor therapy for
+      pediatric low-grade glioma; DNET relevance is mechanistic and trial-eligibility
+      based as surfaced by Falcon, so support is marked partial.
+clinical_trials:
+- name: NCT04923126
+  phase: PHASE_I
+  status: RECRUITING
+  description: >-
+    SJ901 is an open-label multicenter Phase 1/2 study of mirdametinib, a
+    brain-penetrant MEK1/2 inhibitor, in pediatric low-grade glioma. Falcon
+    identified DNET as an eligible LEAT histology in this MAPK-pathway trial.
+  evidence:
+  - reference: clinicaltrials:NCT04923126
+    reference_title: "SJ901: Phase 1/2 Evaluation of Single Agent Mirdametinib (PD-0325901), a Brain-Penetrant MEK1/2 Inhibitor, for the Treatment of Children, Adolescents, and Young Adults With Low-Grade Glioma"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This is an open-label, multi-center, Phase 1/2 study of the brain-penetrant
+      MEK inhibitor, mirdametinib (PD-0325901), in patients with pediatric low-grade
+      glioma (pLGG).
+    explanation: >-
+      This exact trial-cache quote supports adding SJ901 as a relevant
+      low-grade-glioma MEK-inhibitor clinical trial.
+  notes: >-
+    ClinicalTrials.gov lists this as a combined Phase 1/2 study; mapped to
+    PHASE_I because the schema accepts a single phase value. ClinicalTrials.gov
+    API status checked on 2026-05-11 reported RECRUITING. The corresponding
+    treatment entry links mirdametinib to FGFR1-Driven RAS-MAPK Activation via
+    target_mechanisms, because the ClinicalTrial schema does not currently allow
+    target_mechanisms directly.
 datasets:

--- a/references_cache/PMID_26514362.md
+++ b/references_cache/PMID_26514362.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:26514362"
+title: Review of seizure outcomes after surgical resection of dysembryoplastic neuroepithelial tumors.
+authors:
+- Bonney PA
+- Boettcher LB
+- Conner AK
+- Glenn CA
+- Briggs RG
+- Santucci JA
+- Bellew MR
+- Battiste JD
+- Sughrue ME
+journal: J Neurooncol
+year: '2016'
+doi: 10.1007/s11060-015-1961-4
+keywords:
+- Adolescent
+- Adult
+- "Brain Neoplasms/complications, surgery"
+- Child
+- Female
+- Humans
+- Male
+- "Neoplasms, Neuroepithelial/complications, surgery"
+- Neurosurgical Procedures/methods
+- "PubMed/statistics & numerical data"
+- "Seizures/etiology, surgery"
+- Treatment Outcome
+- Young Adult
+content_type: abstract_only
+---
+
+# Review of seizure outcomes after surgical resection of dysembryoplastic neuroepithelial tumors.
+**Authors:** Bonney PA, Boettcher LB, Conner AK, Glenn CA, Briggs RG, Santucci JA, Bellew MR, Battiste JD, Sughrue ME
+**Journal:** J Neurooncol (2016)
+**DOI:** [10.1007/s11060-015-1961-4](https://doi.org/10.1007/s11060-015-1961-4)
+
+## Content
+
+1. J Neurooncol. 2016 Jan;126(1):1-10. doi: 10.1007/s11060-015-1961-4. Epub 2015 
+Oct 29.
+
+Review of seizure outcomes after surgical resection of dysembryoplastic 
+neuroepithelial tumors.
+
+Bonney PA(1), Boettcher LB(1), Conner AK(1), Glenn CA(1), Briggs RG(1), Santucci 
+JA(1), Bellew MR(1), Battiste JD(2), Sughrue ME(3).
+
+Author information:
+(1)Department of Neurosurgery, University of Oklahoma Health Sciences Center, 
+1000 N. Lincoln Blvd., Suite 4000, Oklahoma City, OK, 73104, USA.
+(2)Department of Neurology, University of Oklahoma Health Sciences Center, 
+Oklahoma City, OK, USA.
+(3)Department of Neurosurgery, University of Oklahoma Health Sciences Center, 
+1000 N. Lincoln Blvd., Suite 4000, Oklahoma City, OK, 73104, USA. 
+mes261@columbia.edu.
+
+Dysembryoplastic neuroepithelial tumors (DNETs) are rare tumors that present 
+with seizures in the majority of cases. We report the results of a review of 
+seizure freedom rates following resection of these benign lesions. We searched 
+the English literature using PubMed for articles presenting seizure freedom 
+rates for DNETs as a unique entity. Patient demographics, tumor characteristics, 
+and operative variables were assessed across selected studies. Twenty-nine 
+articles were included in the analysis. The mean age at surgery across studies 
+was a median of 18 years (interquartile range 11-25 years). The mean duration of 
+epilepsy pre-operatively was a median 7 years (interquartile range 3-11 years). 
+Median reported gross-total resection rate across studies was 79% (interquartile 
+range 62-92%). Authors variously chose lesionectomy or extended lesionectomy 
+operations within and across studies. The median seizure freedom rate was 86% 
+(interquartile range 77-93%) with only one study reporting fewer than 60% of 
+patients seizure free. Seizure outcomes were either reported at 1 year of 
+follow-up or at last follow-up, which occurred at a median of 4 years 
+(interquartile range 3-7 years). The number of seizure-free patients who 
+discontinued anti-epileptic drugs varied widely from zero to all patients. 
+Greater extent of resection was associated with seizure freedom in four studies.
+
+DOI: 10.1007/s11060-015-1961-4
+PMID: 26514362 [Indexed for MEDLINE]

--- a/references_cache/PMID_26920151.md
+++ b/references_cache/PMID_26920151.md
@@ -1,0 +1,252 @@
+---
+reference_id: "PMID:26920151"
+title: Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors.
+authors:
+- Rivera B
+- Gayden T
+- Carrot-Zhang J
+- Nadaf J
+- Boshari T
+- Faury D
+- Zeinieh M
+- Blanc R
+- Burk DL
+- Fahiminiya S
+- Bareke E
+- Schüller U
+- Monoranu CM
+- Sträter R
+- Kerl K
+- Niederstadt T
+- Kurlemann G
+- Ellezam B
+- Michalak Z
+- Thom M
+- Lockhart PJ
+- Leventer RJ
+- Ohm M
+- MacGregor D
+- Jones D
+- Karamchandani J
+- Greenwood CM
+- Berghuis AM
+- Bens S
+- Siebert R
+- Zakrzewska M
+- Liberski PP
+- Zakrzewski K
+- Sisodiya SM
+- Paulus W
+- Albrecht S
+- Hasselblatt M
+- Jabado N
+- Foulkes WD
+- Majewski J
+journal: Acta Neuropathol
+year: '2016'
+doi: 10.1007/s00401-016-1549-x
+keywords:
+- Adolescent
+- Adult
+- Brain Neoplasms/genetics
+- DNA Copy Number Variations/genetics
+- Female
+- Glioma/genetics
+- HEK293 Cells
+- Humans
+- MAP Kinase Signaling System/physiology
+- Male
+- Mutation/genetics
+- Proto-Oncogene Proteins B-raf/genetics
+- "Receptor, Fibroblast Growth Factor, Type 1/genetics"
+- Young Adult
+content_type: full_text_xml
+---
+
+# Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial tumors.
+**Authors:** Rivera B, Gayden T, Carrot-Zhang J, Nadaf J, Boshari T, Faury D, Zeinieh M, Blanc R, Burk DL, Fahiminiya S, Bareke E, Schüller U, Monoranu CM, Sträter R, Kerl K, Niederstadt T, Kurlemann G, Ellezam B, Michalak Z, Thom M, Lockhart PJ, Leventer RJ, Ohm M, MacGregor D, Jones D, Karamchandani J, Greenwood CM, Berghuis AM, Bens S, Siebert R, Zakrzewska M, Liberski PP, Zakrzewski K, Sisodiya SM, Paulus W, Albrecht S, Hasselblatt M, Jabado N, Foulkes WD, Majewski J
+**Journal:** Acta Neuropathol (2016)
+**DOI:** [10.1007/s00401-016-1549-x](https://doi.org/10.1007/s00401-016-1549-x)
+
+## Content
+
+1. Acta Neuropathol. 2016 Jun;131(6):847-63. doi: 10.1007/s00401-016-1549-x. Epub
+ 2016 Feb 26.
+
+Germline and somatic FGFR1 abnormalities in dysembryoplastic neuroepithelial 
+tumors.
+
+Rivera B(1)(2), Gayden T(2), Carrot-Zhang J(2)(3), Nadaf J(2)(3), Boshari T(4), 
+Faury D(2), Zeinieh M(2), Blanc R(5), Burk DL(6), Fahiminiya S(2)(3), Bareke 
+E(2)(3), Schüller U(7), Monoranu CM(8), Sträter R(9), Kerl K(9), Niederstadt 
+T(10), Kurlemann G(11), Ellezam B(12), Michalak Z(13)(14), Thom M(13)(14), 
+Lockhart PJ(15)(16), Leventer RJ(15)(17)(18), Ohm M(19), MacGregor D(20), Jones 
+D(21)(22), Karamchandani J(23), Greenwood CM(2)(24), Berghuis AM(6), Bens S(25), 
+Siebert R(25), Zakrzewska M(26), Liberski PP(26), Zakrzewski K(27), Sisodiya 
+SM(14)(28), Paulus W(29), Albrecht S(30), Hasselblatt M(29), Jabado N(2)(31), 
+Foulkes WD(32)(33)(34)(35), Majewski J(2)(3).
+
+Author information:
+(1)Program in Cancer Genetics, Department of Oncology and Human Genetics, McGill 
+University, Montreal, QC, Canada.
+(2)Department of Human Genetics, McGill University, Montreal, QC, Canada.
+(3)McGill University and Génome Québec Innovation Centre, Montreal, QC, Canada.
+(4)Department of Medical Genetics, Lady Davis Institute and Segal Cancer Centre, 
+Jewish General Hospital, McGill University, Montreal, QC, Canada.
+(5)Bloomfield Center for Research on Aging, Lady Davis Institute for Medical 
+Research, Jewish General Hospital, McGill University, Montreal, QC, Canada.
+(6)Department of Biochemistry and Groupe de Recherche Axé sur la Structure des 
+Protéines, McGill University, Montreal, QC, Canada.
+(7)Center for Neuropathology, Ludwig-Maximilians-University, Munich, Germany.
+(8)Department of Neuropathology, Institute of Pathology, Comprehensive Cancer 
+Center Mainfranken, University of Würzburg, Würzburg, Germany.
+(9)Pediatric Hematology and Oncology, University Children's Hospital Münster, 
+Münster, Germany.
+(10)Department of Radiology, University Hospital Münster, Münster, Germany.
+(11)Division of Pediatric Neurology, University Children's Hospital, Münster, 
+Germany.
+(12)Department of Pathology, CHU Sainte-Justine, Montreal, Canada.
+(13)Division of Neuropathology, UCL Institute of Neurology, London, UK.
+(14)Department of Clinical and Experimental Epilepsy, UCL Institute of 
+Neurology, London, UK.
+(15)Department of Pediatrics, The University of Melbourne, Melbourne, Australia.
+(16)Bruce Lefroy Centre for Genetic Health Research, Murdoch Childrens Research 
+Institute, Melbourne, Australia.
+(17)Department of Neurology, The Royal Children's Hospital, Melbourne, 
+Australia.
+(18)Murdoch Childrens Research Institute, Melbourne, Australia.
+(19)VUMC School of Medical Sciences, Amsterdam, The Netherlands.
+(20)Department of Anatomical Pathology, Royal Children's Hospital, Melbourne, 
+Australia.
+(21)German Cancer Consortium (DKTK), German Cancer Research Center (DKFZ), 
+Heidelberg, Germany.
+(22)Division of Pediatric Neurooncology (B062), German Cancer Research Center 
+(DKFZ), Heidelberg, Germany.
+(23)Department of Pathology, Montreal Neurological Institute, McGill University, 
+Montreal, QC, Canada.
+(24)Departments of Oncology and Epidemiology, Biostatistics and Occupational 
+Health, McGill University, Montreal, QC, Canada.
+(25)Institute of Human Genetics, Christian-Albrechts-University Kiel and 
+University Hospital Schleswig-Holstein, Campus Kiel, Kiel, Germany.
+(26)Department of Molecular Pathology and Neuropathology, Medical University of 
+Lodz, Lodz, Poland.
+(27)Department of Neurosurgery, Polish Mother's Memorial Hospital Research 
+Institute, Lodz, Poland.
+(28)Epilepsy Society, Chalfont St Peter, Buckinghamshire, UK.
+(29)Institute of Neuropathology, University Hospital Münster, Münster, Germany.
+(30)Department of Pathology, Montreal Children's Hospital, McGill University 
+Health Centre, McGill University, Montreal, QC, Canada.
+(31)Department of Pediatrics, Montreal Children's Hospital, McGill University 
+Health Centre, Montreal, QC, Canada.
+(32)Program in Cancer Genetics, Department of Oncology and Human Genetics, 
+McGill University, Montreal, QC, Canada. william.foulkes@mcgill.ca.
+(33)Department of Human Genetics, McGill University, Montreal, QC, Canada. 
+william.foulkes@mcgill.ca.
+(34)Department of Medical Genetics, Lady Davis Institute and Segal Cancer 
+Centre, Jewish General Hospital, McGill University, Montreal, QC, Canada. 
+william.foulkes@mcgill.ca.
+(35)Department of Medical Genetics and Cancer Research Program, Research 
+Institute McGill University Health Centre, Montreal, QC, Canada. 
+william.foulkes@mcgill.ca.
+
+Dysembryoplastic neuroepithelial tumor (DNET) is a benign brain tumor associated 
+with intractable drug-resistant epilepsy. In order to identify underlying 
+genetic alterations and molecular mechanisms, we examined three family members 
+affected by multinodular DNETs as well as 100 sporadic tumors from 96 patients, 
+which had been referred to us as DNETs. We performed whole-exome sequencing on 
+46 tumors and targeted sequencing for hotspot FGFR1 mutations and BRAF p.V600E 
+was used on the remaining samples. FISH, copy number variation assays and Sanger 
+sequencing were used to validate the findings. By whole-exome sequencing of the 
+familial cases, we identified a novel germline FGFR1 mutation, p.R661P. Somatic 
+activating FGFR1 mutations (p.N546K or p.K656E) were observed in the tumor 
+samples and further evidence for functional relevance was obtained by in silico 
+modeling. The FGFR1 p.K656E mutation was confirmed to be in cis with the 
+germline p.R661P variant. In 43 sporadic cases, in which the diagnosis of DNET 
+could be confirmed on central blinded neuropathology review, FGFR1 alterations 
+were also frequent and mainly comprised intragenic tyrosine kinase FGFR1 
+duplication and multiple mutants in cis (25/43; 58.1 %) while BRAF p.V600E 
+alterations were absent (0/43). In contrast, in 53 cases, in which the diagnosis 
+of DNET was not confirmed, FGFR1 alterations were less common (10/53; 19 %; 
+p < 0.0001) and hotspot BRAF p.V600E (12/53; 22.6 %) (p < 0.001) prevailed. We 
+observed overexpression of phospho-ERK in FGFR1 p.R661P and p.N546K mutant 
+expressing HEK293 cells as well as FGFR1 mutated tumor samples, supporting 
+enhanced MAP kinase pathway activation under these conditions. In conclusion, 
+constitutional and somatic FGFR1 alterations and MAP kinase pathway activation 
+are key events in the pathogenesis of DNET. These findings point the way towards 
+existing targeted therapies.
+
+DOI: 10.1007/s00401-016-1549-x
+PMCID: PMC5039033
+PMID: 26920151 [Indexed for MEDLINE]
+
+Dysembryoplastic neuroepithelial tumor (DNET) is an epileptogenic histopathologically benign brain tumor (World Health Organisation (WHO) grade I) [6]. These neoplasms, which cause early-onset intractable epilepsy, may be associated with Focal Cortical Dysplasia type IIIb and only rarely progress to malignancy [3]. Their often drug-resistance character leaves surgery as the only effective treatment when seizures develop in the patient.
+
+The histopathological hallmark of DNET is the specific glioneuronal element, i.e. the presence of columns of oligodendroglial-like cells and so-called floating neurons [6]. The concept of “non-specific” DNET proposed by some authors (i.e. tumors showing clinical and imaging similarities with DNET but lacking the specific glioneuronal element) is controversial [6].
+
+The genetic basis of DNETs remains unsettled. Studies have proposed over-activation of the mTOR pathway [3] and NF1 aberrations [2] as possible causes of DNET, and BRAF p.V600E mutations have been described in up to a 30% of DNETs [4,22]. Other molecular alterations reported include a single mutation in the promoter of TERT [18], 3 IDH1 mutations [34] and a single case report of a FGFR1 intragenic duplication of the tyrosine kinase domain [42]. Gains of chromosomes 5 and 7, LOH of 1p/19q and LOH of 10q have been observed [3,29]. Although sporadic DNETs are frequent, multifocal cases and familial forms and are extremely rare, with only two families reported to date [15,32]. The systematic review of existing data highlighted the need of a multifaceted approach to more precisely characterize the molecular nature of DNET. Our approach to understanding DNET was a multicenter, international effort, starting with a three-member family with DNET, followed by a series of 100 sporadic cases submitted to us as DNET.
+
+The study was approved by the Institutional Review Board (IRB) of the Faculty of Medicine of McGill University. Participants were recruited in compliance with the second edition of the Canadian Tri-Council Policy Statement of Ethical Conduct for Research Involving Humans and Eligible Persons or Designates and signed a consent form in accordance with the IRB approvals. Blood from three affected members from the index family and three formalin fixed paraffin embedded (FFPE) blocks (two primary tumors, one from each child plus a recurrence from the daughter) were collected. The sporadic series is composed of a total of 100 cases (29 fresh frozen tumor (FFT) samples and 71 FFPE samples). Samples from 96 persons were recruited under the diagnosis of DNET from the reference centers; age of diagnoses, sex of the patient and location of the tumor was collected with the samples. Recurrence information was also collected when available. Formalin-fixed paraffin-embedded tumor samples from all patients were independently reviewed according to 2007 WHO criteria by three senior neuropathologists (S.A., M.H., W.P). In line with the WHO classification, only tumors containing the specific glioneuronal element were diagnosed as DNET. Because in the current WHO classification, the concept of “non-specific” DNET (i.e. tumors showing clinical and imaging similarities with DNET but lacking the specific glioneuronal element) is controversial, this diagnosis was not made. Three different groups were identified: 1- DNET cases meeting WHO criteria; 2- Non DNET with a differential diagnosis; 3- Unclear cases in which some elements of DNET were present but no glioneuronal element was encountered, or there was disagreement between the reference pathologists and a more definite diagnosis would require an extensive immunohistochemical and or molecular work-up, for which no material was available. (Detailed in Online Resource 1, Supp methods and Online Resource 3, Supp table 1). To be conservative and for statistical purposes, these unclear cases were considered as non-DNETs, from now on we will refer to them as part of the non-DNET cases.
+
+The present study describes a kindred with familial DNETs (Figure 1a-c). In the 46-year old father, focal seizures with eye deviation to the right heralded the diagnosis of a tumor of the left occipital cortex at age six years. After resection, the patient experienced no tumor recurrence and remained seizure-free. His daughter suffered focal seizures with eye deviation at age six years: a non-contrast-enhancing mass in the left occipital cortex was detected (Figure 1b+c). Following tumor excision, she remained seizure-free until age nine, at which time a local recurrence was completely resected. At age 16 years, seizures with visual aura denoted multinodular relapses. After repeat surgery, the patient is seizure-free on lamotrigine. In an update to the original report [15] a DNET in the right temporal cortex was also detected in the proband's son, following onset of focal seizures. Seven years later, evolution to bilateral convulsive seizures led to the finding of multiple lesions in the right posterior horn, the left frontal cortex and both thalami (Figure 1b+c). After surgery of the right posterior lesion, the patient remains seizure-free on lamotrigine (see online resources for further information).
+
+Germline DNA from members of the index family was isolated from blood using the PAXgene Blood DNA Kit. Tumoral DNA from fresh frozen samples (n = 29) cases was isolated with DNeasy Blood and Tissue Qiagen kits. Tumoral DNA from FFPE sporadic cases (n = 71) and family 1 FFPE samples (n = 3) was isolated with the QIAmp DNA FFPE Tissue kit (Qiagen).
+
+In the first instance, WES was performed in the germline DNA from the family members, tumor DNA from the primary tumor and recurrence of II.1 and tumor DNA from II.2. During the validation phase forty-three sporadic tumors from 40 persons were also studied by WES (36 primary tumors and seven recurrences, three of which are primary/recurrence pairs). WES was performed at the McGill University and Génome Québec Innovation Centre (MUGQIC) using Illumina HiSeq 2000. FFT-derived DNA (3 μg) or FFPE-derived DNA (50 ng) of each subject underwent exome capture followed by 100-bp paired-end sequencing. The Agilent SureSelect V4n was used for FFT samples library preparations, and Nextera Rapid-Capture Exome kit was used for FFPE samples, following the manufacturer's protocols. Burrows-Wheeler aligner (BWA) version 0.5.9 was used to align reads to the UCSC hg19 reference genome [20]. Indels were re-aligned using the Genome Analysis Toolkit (GATK) IndelRealigner [23]. GATK was also used to assess capture efficiency and coverage of consensus coding sequence (CCDS) bases [23]. Reads that were marked as PCR duplicates by Picard were excluded from further analysis (http://picard.sourceforge.net/). Variants were called using SAMtools version 1.2 mpileup, and only variants that represented >5% of reads were retained, with a minimum of 5 reads per variant [19]. All variants were then annotated with ANNOVAR, and those most likely to damage the protein (nonsense, canonical splice-site, missense mutations and coding indels) were considered for further analysis [39]. Because matched normal tissues were not available, we applied the following strategies to narrow down the list of variants that could potentially represent somatic mutations: only variants that were not reported in our in-house, non-cancer exome database (with >1,400 exomes), the 1000 Genomes Project database and the National Heart, Lung, and Blood Institute (NHLBI) Grand Opportunity (GO) Exome Sequencing Project (ESP) were retained. The Integrative Genomics Viewer (IGV) was used for the manual examination and visualization of all potential candidate variants [31]. In order to identify genes that carried an excess of mutations in our tumor dataset (indicating their potential functional significance), we used a case–control approach described earlier in Fontebasso et al [10]. Briefly, we compared the frequency of private mutations in each gene in the 40 individual DNET tumor exomes to 1092 control germline exomes from non-cancer patients sequenced at the McGill University and Genome Quebec Innovation Centre. We controlled for false discovery rate using the Benjamini–Hochberg procedure. The most significant genes are listed in Online Resource 4.
+
+FGFR1 (NM_023110) and BRAF p.V600E (NM_004333) mutations were screened for using the Fluidigm access array system and next-generation sequencing for 60 cases, 4 of which were previously study by WES and were used as internal controls. Fluidigm access array system involves an array-based PCR amplification of a specific region of interest (target enrichment). For our purpose, the exons and exon–intron boundaries of FGFR1 (exon 12 and 14) and BRAF (exon 15) were selectively targeted. Parallel amplification of 60 samples was carried out using custom primers designed using Primer3 (http://bioinfo.ut.ee/primer3-0.4.0/) and to which CS1 and CS2 tails were added. Samples were barcoded during the targeted enrichment to allow for multiplexed sequencing and amplicons were tagged with adaptor sequences during the PCR amplification reaction. Next-generation sequencing was carried out using the Illumina MiSeq at the MUGQIC. In the samples with potential variants, we then targeting the regions of interest in two independent regular PCR reactions followed by MiSeq sequencing. For mutation detection, we called those variants with allelic-faction larger than 5% after filtering out low base quality (< 30) or mapping quality (< 20) reads, or if the variant was observed in more than one run. Finally, Sanger sequencing was performed to study exons 12 and 14 of FGFR1 and BRAF p.V600E to further validate findings from NGS. Primers and conditions are available upon request.
+
+Tandem duplication (TD) in FGFR1 and FGFR1-TACC1 fusion were screened for by inspecting abnormally mapped read-pairs near previously reported TD region. Since intron 17 and exon 18 of FGFR1, which harbor all of the reported fusion and TD events respectively, are covered at a mean depth of approximately 100X in our exome data, we were confident in our ability to detect those events. At least two pairs of abnormally mapped reads were required to call an event. Then, Pindel version 0.2.5 was used to predict the exact breakpoints in samples with potential TD [40]. Samples with potential FGFR1-TACC1 fusion were first re-aligned using STAR version 2.4.1 [7]. Then, we blatted soft-clipped reads nearby the fusion region, in order to predict the exact breakpoints. Finally, XHMM was used to identify and verify any duplication nearby the FGFR1 region [11].
+
+In 46 samples (3 tumors from the family, 40 sporadic distinct cases and 3 recurrences) we looked for genomic CNV. In brief, ExomeAI [26] detects AI (Allelic Imbalance) events across samples by investigating the B Allele Frequency (BAF) profile of exomes. In order to do this, heterozygous variants (BAF values of 0.05 to 0.95) are first extracted and then segmented to regions of similar values. AI segments are called and then summarized across all samples to detect regions of recurrent AIs. In samples with low quality and/or quantity (e.g. FFPE tumors), AI-based methods produce more reliable calls, as inadequate genome-wide coverage consistency across the tumor and normal sample can lead to false positive copy number calls [26]
+
+Tyrosine Kinase Domain duplication and FGFR1 duplication were confirmed by a TaqMan Copy Number quantification assay Hs02882334 (Thermo Fisher). The assay was run in quadruplicates including the 13 (12 distinct patients plus one recurrence) positives cases with known TKD duplications found in the WES phase of this study. The FGFR1 duplicated case was also included. An internal quantification control was used according to the manufacturer's protocol. Results were analyzed with Applied Biosystem Copy Caller software to calculate sample copy number values by relative quantification.
+
+Fluorescence in situ hybridization (FISH) analyses were performed on sections from FFPE tissues using analogous protocols to those described by Ventura et al [38]. Breakpoints affecting the FGFR1 locus were investigated with a commercially available XL FGFR1 break apart probe (MetaSystems, Altlussheim, Germany). Evaluation of FISH was conducted according to standard procedures using Zeiss fluorescence microscopes equipped with appropriate filter sets [38]. Digital image acquisition and processing were performed using ISIS digital image analysis system version 5.2.11 (MetaSystems, Altlussheim, Germany).
+
+RNA from double mutant cases II.1, 16, 33, 42 and 66 was isolated using the RecoverAll™ Total Nucleic Acid Isolation Kit for FFPE (Ambion). Reverse transcription was carried out with Superscript III (Invitrogen) followed by amplification of exons 14 and 15 of FGFR1 (primers and conditions are available upon request). Ligation into a TOPO blunt vector (Invitrogen) was performed according manufacturer recommendations and posterior transformation of OneShot TOP10 E.coli competent cells. Bacterial culture was performed overnight in LB agar with kanamycin. A minimum of 25 colonies were cultured overnight; DNA was purified with QIAamp DNA Mini Kit and followed by Sanger sequencing.
+
+Phospho-ERK expression in the tumor was studied by IHC in FFPE samples. Phospho-ERK antibody CS-4376 (1:200) was optimized in a Ventana machine following recommended protocols. Phospho-ERK expression and localization was analyzed by SA independently to diagnoses and mutational analyses. BRAF-p.V600E evaluation for confirmation of positive cases was optimized in a Ventana machine with the mutation-specific anti-BRAF p.V600E-(VE1) antibody #790-4855 following the manufacturer's protocol.
+
+To assess the potential effects of the FGFR1 mutations on receptor activity, we constructed models for p.N546K, p.K656E and p.R661P based on structures of FGFR1 in an unliganded state (PDB: 1FGK) and in an activated conformation with bound peptide (PDB: 3GQI) using the program PyMOL (The PyMOL Molecular Graphics System, Version 1.7.4.1 Schrödinger, LLC.).
+
+The cDNAs encoding the full-length wild type FGFR1, as well as mutant FGFR1 p.N546K and FGFR1 p.R661P were purchased from OriGene (Rockville, MD, USA). The mutated and wild type FGFR1 cDNAs were amplified and cloned into a pCR8/GW/TOPO TA entry vector and subsequently sub-cloned into a pLenti6.3/TO/V5-DEST Vector (Invitrogen) using the Gateway LR Clonase II Enzyme mix (Invitrogen) according to the manufacturer's protocol. Clones were confirmed by bidirectional Sanger sequencing. HEK293T packaging cells were transfected with pLenti6.3/V5-TOPO plasmids containing wild type and mutants FGFR1, together with ViraPower packaging mix to produce a lentiviral stock. Supernatants were collected at 48, 60 and 72 h after transfection and viral particles were concentrated using PEG-it (System Biosciences). HEK293 cells were transduced with lentiviral particles and stable clones were selected with 10 μg/ml blasticidin.
+
+Stable cell lines were culture in presence of blasticidin selection and full growth media (DMEM + 10% FBS) until 12 hours before each experiment when selection was interrupted and each cell line was counted and plated in quadruplicate. After 12 hours in full media cells were washed twice with PBS and grown in serum starvation (0% FBS) during 6 hours. Reactivation was induced by adding fresh full media during 7 minutes. After reactivation, both reactivated and starved cells lines were washed and dislodged by using Strip Cell solution (Wisent Ink) and subsequently fixed with IC fixation buffer eBioscience (Affymetrix) for 20 minutes. Fixation/ permeabilization was then performed in methanol overnight. One million cells were stained with phospho-ERK-PE labelled antibody (#12-9109) according to eBioscience staining intracellular antigens protocol with methanol. Five micrograms of antibody per million cells was used. Samples were analyzed in duplicates by Flow Cytometry in a LSRFortessa machine. Phospho-ERK median expression level was measured in duplicates from 3 independent experiments both under serum starvation and reactivation conditions. Relative mean fluorescence intensity was measured by normalization of mean fluorescence of each mutant against the fluorescence of the WT readout from the same experiment under both starvation and reactivation conditions. To compare among mutants and wild-type overexpressing cell lines a Kruskal-Wallis one-Way ANOVA analysis was performed followed by Student-Newman-Keuls test. To measure the shift of each cell line, basal fluorescence intensity was subtracted of fluorescence intensity after stimulation in each case. An ANOVA one-way analysis followed by a Tukey's multiple comparison test was performed.
+
+Cells were washed with PBS and harvested in RIPA buffer containing protease and phosphatase inhibitors. Lysates were quantified by the Bradford method using BSA as a standard. The proteins were separated on 10% SDS-PAGE and transferred onto polyvinylidene difluoride membranes. Membranes were blocked in 5% BSA for 2h at room temperature and incubated overnight at 4°C with the following primary antibodies: anti-FGFR1 (1:500, ab76464), anti-pFGFR1 (1:750, ab59194), and anti-V5 (1:1500, ab27671). Beta-tubulin (1:2000, ab6046) was used as loading control. Membranes were washed with TBST and then incubated with HRP-conjugated anti-rabbit IgG secondary antibody (1:5000, NA934V) or HRP-conjugated anti-mouse IgG secondary antibody (1:5000; NB7539) for 1h at room temperature and revealed utilizing Amersham ECL detection (Amersham Biosciences).
+
+Senescence assays were performed as described previously [27].
+
+Exact confidence intervals and tests of association were obtained with Fisher's exact test. Logistic regressions models were fit to estimate the associations between DNET versus non-DNET status and the different types of FGFR mutations.
+
+WES in all three affected individuals from the index family identified a novel germline variant in FGFR1 (c.1982G>C;p.R661P), localized in the second tyrosine kinase domain of the protein (Figure 1d + Figure 2a). The daughter's primary and recurrent tumors shared a somatic c.1638C>A;p.N546K mutation, whereas the son's tumor harboured a somatic c.1966A>G;p.K656E mutation, both known as “hotspot” mutations in FGFR1 (Figure 1d + Figure 2a). All three variants were confirmed by Sanger sequencing and c.1982G>C;p.R661P was expressed in the lymphocyte RNA of the carriers (Figure 1d and Online Resource 2, Suppl. Figure 1).
+
+The FGFR1 p.R661P mutation has not been previously described. It localizes within the dimerization region that precedes transphophorilation and activation of the receptor [1]. To assess the potential effects of FGFR1 mutations on receptor activity, we generated homology models for p.N546K, p.K656E and p.R661P based on structures of FGFR1 in an unliganded state (Protein Data Bank (PDB): 1FGK) and in an activated conformation with bound peptide (PDB: 3GQI). Both p.N546K and p.K656E in FGFR1 and their corresponding amino acids in the FGFR2 receptor appear to favor the enzyme in its active state and were previously described as gain-of-function (GOF) mutations [41] (Figure 2a-d). The p.R661 residue is located in the C-terminal part of the activation loop of FGFR1. In the inhibited FGFR1K structure, the side-chain is extended and forms a hydrogen bond to the carbonyl oxygen of p.G697 (Figure 2b). In this position, the side-chain blocks the binding site for substrate peptides and the p.R661P substitution would prevent the formation of this proposed inhibitory hydrogen bond interaction [25].
+
+To assess the role of mutations in FGF signalling pathway genes in the development of sporadic DNET, we collected 100 tumors from 96 persons (Table 1 and Online Resource 3) previously diagnosed as DNET at various institutions in Canada, Europe and Australia. Three neuropathologists carried out blinded central review of all specimens independently, using the current WHO diagnostic criteria,. A consensus diagnosis of DNET was reached in 43/96 cases (44.8%). The remaining cases (53/96; 55.2%) represented other entities (such as pilocytic astrocytoma) but also cases, in which the diagnosis remained unclear because material was sparse, some elements of DNET (such as nodular growth) were present but no glioneuronal element was encountered or a more definite diagnosis would have required extensive immunohistochemical and molecular work-up, for which no material was available (Online Resource 3).
+
+Forty-three tumors from 40 persons were studied by WES. The remaining 56 samples were of insufficient quality, necessitating the use of targeted assays informed by earlier WES results. Sanger sequencing and/or immunohistochemistry was used to further confirm mutation-positive cases (Table 2, Figure 3 and Online Resource 2, Suppl. Figure 2). FISH was used to identify chromosomal breakpoints affecting FGFR1; finally all FGFR1 copy number gains were validated by a TaqMan assay. Because of limited quantity or quality for some samples, we could not complete all assays for all samples (Figure 3).
+
+Of the 96 distinct samples, 18 (18.7%) had missense mutations in FGFR1 and 12 (12.5%) were BRAF c.1799T>A;p.V600E-positive. Twelve of the forty (30%) that were subjected to WES had an intragenic duplication of the tyrosine kinase domain (Online Resource 2, Suppl. Figure 3), four showed an FGFR1 breakpoint (Online Resource 2, Suppl. Figure 4), one carried a duplication of the entire FGFR1 gene and one carried a FGFR3-TACC3 fusion (Figure 3). We searched for additional candidate genes mutated in the 40 exomes; however, other than FGFR1 we found no statistically significant candidates and no known cancer genes that were mutated in more than 5% of the samples (Online Resource 4). We used ExomeAI [26] to investigate recurrent chromosomal aberrations or Allelic Imbalances across samples (n = 46). A large number of samples (60%) had few or no aberrations (less than 10 Mb AI). The most frequent aberrations were observed on chromosomes 7 and 22 (6/46; 13% for each, Online Resource 2, Suppl. Figure 5). This is consistent with a recent copy number analysis of 64 DNET samples [29], where about 50% of samples had no or few copy number variants and the most frequent aberration was amplification of chromosome 7 (23%) but lower frequency of the loss of chromosome 22 (<10%).
+
+WES analyses of the individual II. 2 in the family showed that both germline and somatic mutations in the tumor appeared in the same DNA reads, i.e. the mutations are in cis. Among the sporadic FGFR1 mutated cases, 10/18 (55.5%) had multiple FGFR1 mutations. WES analyses revealed that nine out of ten multiple mutants were in cis. We confirmed this by cloning tumor DNA from individual II.2 and cases 16, 33, 42 and 66 (Online Resource 2, Suppl. Figure 6a+b). A review of the pattern of FGFR1 mutated cases unveiled two groups: 8 of 18 were single mutants harbouring a hotspot GOF mutation (p.N546K or p.K656E), while the remaining 10 were double or quadruple mutants. Nine of these multiple mutants consisted of c.1966A>G, coding for p.K656E, plus other variations in cis (Table 2 and Online Resource 2, Suppl. Figure 6b). Multiple mutants could have occurred sequentially or because of a single stochastic event (Online Resource 2, Suppl. Figure 6c-e). The last double mutant harbours the p.N546K and p.K656N mutations and the phase could not be established given that RNA was not available for the study.
+
+Clinical information regarding age of diagnosis, sex and location did not show differences between DNET and the non-DNET group (Table 1). However correlation of molecular and pathology results revealed that 25 of 43 (58.1%) DNETs carried an alteration affecting FGFR1, compared with 10 of 53 (19%) non-DNET tumors. Among 40 samples where point mutations, duplication and breakpoints of FGFR1 were assessed, logistic regression provided significant evidence of more point mutations and more duplications in DNET samples versus non-DNET samples (both p < 0.001). In contrast to previous findings [4,22], no BRAF c.1799T>A, p.V600E mutated samples were diagnosed as DNETs by blinded central review (0/43 vs 12/53, p < 0.001 , Fisher's Exact Test, exact 95% CI, 0 – 0.38, for the odds ratio for mutations in DNETs vs non-DNET samples (Figure 3).
+
+In DNETs, the intragenic tyrosine kinase FGFR1 duplication (Online Resource 2, Suppl. Figure 3) was the most prevalent aberration (11/22, 50%), followed by multiple mutants in cis accounting for 7/43 (16.3%) of DNETs (Figure 3, Table 2 and Online Resource 2, Suppl. Figure 6). Single mutations in FGFR1 were seen in 3/43 cases. Three of forty cases possessed a chromosomal breakpoint affecting the FGFR1 locus; one of which was confirmed to be a FGFR1-TACC1 fusion (Table 2, Online Resource 2, Suppl. Figure 4). One case had a complete FGFR1 gene duplication.
+
+In the non-DNET group, the scenario is more diverse. BRAF p.V600E is the most frequent alteration, present in 12/53 (22.6%) of cases. FGFR1 single mutants (p.N546K or p.K656E) were observed in 5/53 (9.4%) of cases, and 3/53 (5.6%) were FGFR1 double mutants in cis including one carrying the two hotspots amino acids for which phase among mutations could not be identified. Tyrosine kinase duplications were found in 1/18 cases (5.6%), a FGFR1 breakpoint was seen once and another showed a FGFR3-TACC3 fusion.
+
+FGFR alterations are known to activate the MAPK-ERK pathway [24,17,16]. Thus we investigated the possible consequences of p.R661P and p.N546K on MAPK-ERK signaling. We transduced HEK293 cell line to stably express FGFR1-WT, FGFR1-R661P mutated and FGFR1-N546K GOF mutations. Increased signaling of the FGFR-RAS-MAPK pathways is known to induce “oncogene”-mediated senescence, which can be assessed using the β-galactosidase marker as a surrogate marker of senescent cells. β-galactosidase staining was present at high levels in p.N546K and p.R661P mutants compared to FGFR1 wild-type overexpressing cells, indicating these mutants induce increased signaling and oncogene-mediated senescence (Figure 4a). Subsequently, immunoblotting of phospho-FGFR1 revealed constitutive phosphorylation of FGFR1 in the p.N546K mutant under normal growth conditions (10% Fetal Bovine Serum, FBS media), confirming the disruption of the inhibitory state predicted by in silico modeling (Figure 4b). To further analyze the effect of FGFR1 mutants on the MAPK-ERK pathway, levels of phospho-ERK were measured under both serum starvation and subsequent serum reactivation. Under starvation conditions, p.N546K showed higher levels of phospho-ERK than cells overexpressing either FGFR1-wild type or p.R661P (both p < 0.05). The latter showed an intermediate level of phospho-ERK (Figures 4c+d and Online Resource 2, Suppl. Figure 7). Serum reactivation increased the levels of phospho-ERK expression after 7 minutes in the p.N546K mutant compared to FGFR1-WT and FGFR1-p.R661P cells (both p < 0.001). The ability of the p.R661P mutant to reactivate was not different from FGFR1-WT overexpressing cells (p = 0.57, Figure 4c+d). Immunohistochemical staining confirmed upregulated phospho-ERK in the nucleus as well as the cytoplasm in pathology sections from 24/35 (69%) of the FGFR1 mutated cases, thus confirming its down-stream repercussions in vivo.
+
+FGFR1 abnormalities underpin several developmental disorders of the brain, which can now be extended to include DNETS (Figure 5 and Online Resource 5). In DNETs, the commonest alteration was duplication of the tyrosine kinase domain, followed by two hotspot mutations in cis. Rarely, fusions or breakpoints involving FGFR1 were observed. The final common effect of these alterations appears to be a balanced level of signalling that results in benign rather than malignant tumors. Similar double mutations have been reported in Crouzon syndrome [14] but have been only rarely reported in cancer [17]. The familial germline mutation (c.1982G>C), given the minor functional effect of its resultant protein, p.R661P, (Figure 4c+d) likely acts as an enabling mutation, such that only a single additional mutation in FGFR1 is needed for tumorigenesis. This view is further substantiated by the fact that both children developed multiple DNETs, a finding rarely encountered in sporadic cases. Under this hypothesis, somatic mutations such as p.K656E must arise relatively frequently in normal tissue – a scenario which is supported by recent studies including activating FGFR mutations in the skin [21].
+
+FGF signaling plays a ubiquitous role in development, especially in brain development and cell fate [36]. However, diversity and specificity is acquired by combination of different receptors isoforms [13] and ligands reaching a maximum level of complexity depending on cell type, cell context and signalling kinetics. Constitutive activation of the pathway leads to differentiation and senescence, whereas less pronounced signalling will drive proliferation and survival [37].
+
+A wide range of congenital developmental disorders including achondroplasias, Kallmann and Pfeiffer syndromes are associated with inherited mutations leading to FGF receptor dysfunction [28,37]. Our compilation of FGFR1 mutations described in public databases and the literature (Figure 5, Table S4) revealed that FGFR1 somatic mutants that associate with a variety of pathologies (including epithelial malignancies) are fairly evenly distributed along the entire gene. In contrast, mutations associated with brain neoplasms (e.g. pilocytic astrocytomas [17], glioblastomas [33] and rosette forming glioneuronal tumors [12]) cluster exclusively within the GOF hotspots, thus supporting our findings. Furthermore, FGFR mutations result in GOF or loss of function (LOF) depending on the type and localization of the mutation along the gene. The difference between GOF and LOF mutations is key in this genotype-phenotype correlation and the severity of developmental abnormalities caused by defective FGF signalling seems to be dose-dependent [37].
+
+The identification of activating mutations in FGFR1 as the genetic cause of DNETs and the implication of both BRAF and FGFR1 in non-DNET tumors highlights the implication of MAPK/ERK pathway in epileptogenic low-grade glioneuronal tumors. Our study reveals specific FGFR1 alterations as the main molecular driver of DNETs and presents inclusion of molecular data as a complement and support to classical histological categorization. This multifaceted approach responds to the need for a better classification of low-grade glioneuronal tumors, highlighting the existence of molecular differences that could underlie their epileptogenic potential. While our paper was under review, a study focusing on low-grade neuroepithelial tumors was published [30]. This study broadly supports the findings in DNETs reported here.
+
+Our study not only supports the important role of FGFR1 in the etiology of DNET, but also highlights the diagnostic value of molecular findings in difficult or borderline cases. Here, targeted analysis for FGFR1 hotspot mutations may provide a first step to aid the diagnosis of DNET and could be supplemented by analyses for FGFR1 fusion transcripts and FGFR1-TKD. Germline analysis of FGFR1 should be considered in all familial cases, as well as in selected sporadic tumors (e.g. multinodular growth). Importantly, the presence of specific FGFR1 mutations point the way towards existing targeted therapies for children and adults with recurrent or difficult-to-excise tumors [8,9,35,36]. Such therapies could also prove effective in those tumors resistant to conventional anti-seizure treatments.
+
+Several aspects of the clinical management of the patient with a DNET could benefit from these results, from genetic counseling to surveillance and better control of intractable seizures. Ultimately, understanding the precise molecular mechanism by which mutations in the FGF pathway give rise to this specific tumor will provide fundamental knowledge applicable to successful development of new therapies and constitutes an imperative next step in the era of precision medicine [37].

--- a/references_cache/PMID_31617914.md
+++ b/references_cache/PMID_31617914.md
@@ -1,0 +1,97 @@
+---
+reference_id: "PMID:31617914"
+title: Genomic Analysis of Dysembryoplastic Neuroepithelial Tumor Spectrum Reveals a Diversity of Molecular Alterations Dysregulating the MAPK and PI3K/mTOR Pathways.
+authors:
+- Surrey LF
+- Jain P
+- Zhang B
+- Straka J
+- Zhao X
+- Harding BN
+- Resnick AC
+- Storm PB
+- Buccoliero AM
+- Genitori L
+- Li MM
+- Waanders AJ
+- Santi M
+journal: J Neuropathol Exp Neurol
+year: '2019'
+doi: 10.1093/jnen/nlz101
+keywords:
+- Adolescent
+- Adult
+- Brain/pathology
+- "Brain Neoplasms/genetics, metabolism, pathology"
+- Child
+- "Child, Preschool"
+- Female
+- Genomics
+- Humans
+- MAP Kinase Signaling System
+- Male
+- "Neoplasms, Neuroepithelial/genetics, metabolism, pathology"
+- Phosphatidylinositol 3-Kinases/metabolism
+- Progression-Free Survival
+- TOR Serine-Threonine Kinases/metabolism
+- Young Adult
+content_type: abstract_only
+---
+
+# Genomic Analysis of Dysembryoplastic Neuroepithelial Tumor Spectrum Reveals a Diversity of Molecular Alterations Dysregulating the MAPK and PI3K/mTOR Pathways.
+**Authors:** Surrey LF, Jain P, Zhang B, Straka J, Zhao X, Harding BN, Resnick AC, Storm PB, Buccoliero AM, Genitori L, Li MM, Waanders AJ, Santi M
+**Journal:** J Neuropathol Exp Neurol (2019)
+**DOI:** [10.1093/jnen/nlz101](https://doi.org/10.1093/jnen/nlz101)
+
+## Content
+
+1. J Neuropathol Exp Neurol. 2019 Dec 1;78(12):1100-1111. doi:
+10.1093/jnen/nlz101.
+
+Genomic Analysis of Dysembryoplastic Neuroepithelial Tumor Spectrum Reveals a 
+Diversity of Molecular Alterations Dysregulating the MAPK and PI3K/mTOR 
+Pathways.
+
+Surrey LF(1), Jain P(2), Zhang B(3), Straka J(4), Zhao X(5), Harding BN(5), 
+Resnick AC(6), Storm PB(6), Buccoliero AM(7), Genitori L(1), Li MM(1), Waanders 
+AJ(1), Santi M(1).
+
+Author information:
+(1)Department of Pathology and Laboratory Medicine, Children's Hospital of 
+Philadelphia.
+(2)Perelman School of Medicine, University of Pennsylvania.
+(3)Center for Data Driven Discovery in Biomedicine, Children's Hospital of 
+Philadelphia.
+(4)Department of Neurosurgery, Children's Hospital of Philadelphia, 
+Philadelphia, Pennsylvania.
+(5)Meyer Children's Hospital, Florence, Italy.
+(6)Department of Pediatrics, Feinberg School of Medicine Northwestern 
+University.
+(7)Division of Hematology, Oncology, and Stem Cell Transplant, Ann & Robert H 
+Lurie Children's Hospital of Chicago, Chicago, Illinois.
+
+Dysembryoplastic neuroepithelial tumors (DNT) lacking key diagnostic criteria 
+are challenging to diagnose and sometimes fall into the broader category of 
+mixed neuronal-glial tumors (MNGT) or the recently described polymorphous 
+low-grade neuroepithelial tumor of the young (PLNTY). We examined 41 patients 
+with DNT, MNGT, or PLNTY for histologic features, genomic findings, and 
+progression-free survival (PFS). Genomic analysis included sequence and copy 
+number variants and RNA-sequencing. Classic DNT (n = 26) was compared with those 
+with diffuse growth without cortical nodules (n = 15), 6 of which exhibited 
+impressive CD34 staining classifying them as PLNTY. Genomic analysis was 
+complete in 33, with sequence alterations recurrently identified in BRAF, FGFR1, 
+NF1, and PDGFRA, as well as 7 fusion genes involving FGFR2, FGFR1, NTRK2, and 
+BRAF. Genetic alterations did not distinguish between MNGTs, DNTs, or PLNTYs; 
+however, FGFR1 alterations were confined to DNT, and PLNTYs contained BRAF V600E 
+or FGFR2 fusion genes. Analysis of PFS showed no significant difference by 
+histology or genetic alteration; however, numbers were small and follow-up time 
+short. Further molecular characterization of a PLNTY-related gene fusion, 
+FGFR2-CTNNA3, demonstrated oncogenic potential via MAPK/PI3K/mTOR pathway 
+activation. Overall, DNT-MNGT spectrum tumors exhibit diverse genomic 
+alterations, with more than half (19/33) leading to MAPK/PI3K pathway 
+alterations.
+
+© 2019 American Association of Neuropathologists, Inc. All rights reserved.
+
+DOI: 10.1093/jnen/nlz101
+PMID: 31617914 [Indexed for MEDLINE]

--- a/references_cache/PMID_35836307.md
+++ b/references_cache/PMID_35836307.md
@@ -1,0 +1,127 @@
+---
+reference_id: "PMID:35836307"
+title: The genomic landscape of dysembryoplastic neuroepithelial tumours and a comprehensive analysis of recurrent cases.
+authors:
+- Pagès M
+- Debily MA
+- Fina F
+- Jones DTW
+- Saffroy R
+- Castel D
+- Blauwblomme T
+- Métais A
+- Bourgeois M
+- Lechapt-Zalcman E
+- Tauziède-Espariat A
+- Andreiuolo F
+- Chrétien F
+- Grill J
+- Boddaert N
+- Figarella-Branger D
+- Beroukhim R
+- Varlet P
+journal: Neuropathol Appl Neurobiol
+year: '2022'
+doi: 10.1111/nan.12834
+keywords:
+- Brain Neoplasms/pathology
+- Genomics
+- Glioma
+- Humans
+- "Neoplasms, Neuroepithelial/genetics, pathology"
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# The genomic landscape of dysembryoplastic neuroepithelial tumours and a comprehensive analysis of recurrent cases.
+**Authors:** Pagès M, Debily MA, Fina F, Jones DTW, Saffroy R, Castel D, Blauwblomme T, Métais A, Bourgeois M, Lechapt-Zalcman E, Tauziède-Espariat A, Andreiuolo F, Chrétien F, Grill J, Boddaert N, Figarella-Branger D, Beroukhim R, Varlet P
+**Journal:** Neuropathol Appl Neurobiol (2022)
+**DOI:** [10.1111/nan.12834](https://doi.org/10.1111/nan.12834)
+
+## Content
+
+1. Neuropathol Appl Neurobiol. 2022 Oct;48(6):e12834. doi: 10.1111/nan.12834.
+Epub  2022 Aug 9.
+
+The genomic landscape of dysembryoplastic neuroepithelial tumours and a 
+comprehensive analysis of recurrent cases.
+
+Pagès M(1)(2)(3)(4)(5), Debily MA(6)(7), Fina F(8), Jones DTW(9)(10), Saffroy 
+R(11), Castel D(6)(7), Blauwblomme T(12)(13), Métais A(1), Bourgeois M(12), 
+Lechapt-Zalcman E(1), Tauziède-Espariat A(1), Andreiuolo F(14)(15), Chrétien 
+F(1)(13), Grill J(6)(7)(16), Boddaert N(17)(18)(19), Figarella-Branger D(8)(20), 
+Beroukhim R(21)(22)(23), Varlet P(1).
+
+Author information:
+(1)GHU-Paris - Sainte-Anne Hospital, Department of Neuropathology, Paris 
+University, Paris, France.
+(2)Department of Genetics, Institut Curie, Paris, France.
+(3)SIREDO Paediatric Cancer Center, Institut Curie, Paris, France.
+(4)INSERM U830, Laboratory of Translational Research in Paediatric Oncology, 
+Institut Curie, Paris, France.
+(5)Paris Sciences Lettres Research University, Paris, France.
+(6)Molecular Predictors and New Targets in Oncology, INSERM U981, Gustave 
+Roussy, Université Paris-Saclay, Villejuif, France.
+(7)Département de Biologie, Univ. Evry, Université Paris-Saclay, Evry, France.
+(8)APHM, CHU Timone, Service d'Anatomie Pathologique et de Neuropathologie, 
+Marseille, France.
+(9)Pediatric Glioma Research, Hopp Children's Cancer Center (KiTZ), Heidelberg, 
+Germany.
+(10)Pediatric Glioma Research Group, German Cancer Research Center (DKFZ), 
+Heidelberg, Germany.
+(11)Oncogenetics Department, Assistance Publique-Hôpitaux de Paris, Paul Brousse 
+Hospital, Université Paris-Saclay, Villejuif, France.
+(12)Pediatric Neurosurgery Department, AP-HP, Hôpital Universitaire 
+Necker-Enfants Malades, Paris, France.
+(13)Université de Paris- Cité, Paris, France.
+(14)Department of Neuropathology, Instituto Estadual do Cérebro Paulo Niemeyer, 
+Rio de Janeiro, Brazil.
+(15)Pathology Division, D'Or Research Institute (IDOR), D'Or Hospitals Network, 
+Rio de Janeiro, Brazil.
+(16)Department of Pediatric and Adolescent Oncology, Institut Gustave Roussy, 
+Villejuif, France.
+(17)Pediatric Radiology Department, AP-HP, Hôpital Universitaire Necker-Enfants 
+Malades, Paris, France.
+(18)INSERM ERL UA10, Université de Paris, Paris, France.
+(19)Institut Imagine, Université de Paris, UMR 1163, Paris, France.
+(20)Institute of NeuroPhysiopatholy, Aix-Marseille Univ, CNRS, INP, Marseille, 
+France.
+(21)Department of Medical Oncology, Dana-Farber Cancer Institute, Boston, 
+Massachusetts, USA.
+(22)Cancer Program, Broad Institute, Cambridge, Massachusetts, USA.
+(23)Department of Medicine, Harvard Medical School, Boston, Massachusetts, USA.
+
+AIMS: Dysembryoplastic neuroepithelial tumour (DNT) is a glioneuronal tumour 
+that is challenging to diagnose, with a wide spectrum of histological features. 
+Three histopathological patterns have been described: specific DNTs (both the 
+simple form and the complex form) comprising the specific glioneuronal element, 
+and also the non-specific/diffuse form which lacks it, and has unclear 
+phenotype-genotype correlations with numerous differential diagnoses.
+METHODS: We used targeted methods (immunohistochemistry, fluorescence in situ 
+hybridisation and targeted sequencing) and large-scale genomic methodologies 
+including DNA methylation profiling to perform an integrative analysis to better 
+characterise a large retrospective cohort of 82 DNTs, enriched for tumours that 
+showed progression on imaging.
+RESULTS: We confirmed that specific DNTs are characterised by a single driver 
+event with a high frequency of FGFR1 variants. However, a subset of DNA 
+methylation-confirmed DNTs harbour alternative genomic alterations to FGFR1 
+duplication/mutation. We also demonstrated that a subset of DNTs sharing the 
+same FGFR1 alterations can show in situ progression. In contrast to the specific 
+forms, "non-specific/diffuse DNTs" corresponded to a heterogeneous molecular 
+group encompassing diverse, newly-described, molecularly distinct entities.
+CONCLUSIONS: Specific DNT is a homogeneous group of tumours sharing 
+characteristics of paediatric low-grade gliomas: a quiet genome with a recurrent 
+genomic alteration in the RAS-MAPK signalling pathway, a distinct DNA 
+methylation profile and a good prognosis but showing progression in some cases. 
+The "non-specific/diffuse DNTs" subgroup encompasses various recently described 
+histomolecular entities, such as PLNTY and diffuse astrocytoma, MYB or MYBL1 
+altered.
+
+© 2022 The Authors. Neuropathology and Applied Neurobiology published by John 
+Wiley & Sons Ltd on behalf of British Neuropathological Society.
+
+DOI: 10.1111/nan.12834
+PMCID: PMC9542977
+PMID: 35836307 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_36672006.md
+++ b/references_cache/PMID_36672006.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:36672006"
+title: Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+authors:
+- Zhang H
+- Hu Y
+- Aihemaitiniyazi A
+- Li T
+- Zhou J
+- Guan Y
+- Qi X
+- Zhang X
+- Wang M
+- Liu C
+- Luan G
+journal: Brain Sci
+year: '2022'
+doi: 10.3390/brainsci13010024
+content_type: abstract_only
+---
+
+# Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic Neuroepithelial Tumors Associated with Epilepsy.
+**Authors:** Zhang H, Hu Y, Aihemaitiniyazi A, Li T, Zhou J, Guan Y, Qi X, Zhang X, Wang M, Liu C, Luan G
+**Journal:** Brain Sci (2022)
+**DOI:** [10.3390/brainsci13010024](https://doi.org/10.3390/brainsci13010024)
+
+## Content
+
+1. Brain Sci. 2022 Dec 22;13(1):24. doi: 10.3390/brainsci13010024.
+
+Long-Term Seizure Outcomes and Predictors in Patients with Dysembryoplastic 
+Neuroepithelial Tumors Associated with Epilepsy.
+
+Zhang H(1), Hu Y(2), Aihemaitiniyazi A(1), Li T(1), Zhou J(1)(3), Guan Y(1)(3), 
+Qi X(4), Zhang X(5), Wang M(6), Liu C(1)(3), Luan G(1)(3).
+
+Author information:
+(1)Department of Neurosurgery, Sanbo Brain Hospital, Capital Medical University, 
+Beijing 100093, China.
+(2)Department of Neurosurgery, Aviation General Hospital, China Medical 
+University, Beijing 100012, China.
+(3)Beijing Institute of Brain Disorders, Capital Medical University, Beijing 
+100093, China.
+(4)Department of Pathology, Sanbo Brain Hospital, Capital Medical University, 
+Beijing 100093, China.
+(5)Department of Radiology, Sanbo Brain Hospital, Capital Medical University, 
+Beijing 100093, China.
+(6)Department of Neurology, Sanbo Brain Hospital, Capital Medical University, 
+Beijing 100093, China.
+
+To determine the predictors and the long-term outcomes of patients with seizures 
+following surgery for dysembryoplastic neuroepithelial tumors (DNTs); Methods: 
+Clinical data were collected from medical records of consecutive patients of the 
+Department of Neurosurgery of Sanbo Brain Hospital of Capital Medical University 
+with a pathological diagnosis of DNT and who underwent surgery from January 2008 
+to July 2021. All patients were followed up after surgery for at least one year. 
+We estimated the cumulative rate of seizure recurrence-free and generated 
+survival curves. A log-rank (Mantel-Cox) test and a Cox proportional hazard 
+model were performed for univariate and multivariate analysis to analyze 
+influential predictors; Results: 63 patients (33 males and 30 females) were 
+included in this study. At the final follow-up, 49 patients (77.8%) were 
+seizure-free. The cumulative rate of seizure recurrence-free was 82.5% (95% 
+confidence interval (CI) 71.8-91.3%), 79.0% (95% CI 67.8-88.6%) and 76.5% (95% 
+CI 64.8-87.0%) at 2, 5, and 10 years, respectively. The mean time for seizure 
+recurrence-free was 6.892 ± 0.501 years (95% CI 5.91-7.87). Gross total removal 
+of the tumor and a short epilepsy duration were significant predictors of 
+seizure freedom. Younger age of seizure onset, bilateral interictal epileptiform 
+discharges, and MRI type 3 tumors were risk factors for poor prognosis; 
+Conclusions: A favorable long-term seizure outcome was observed for patients 
+with DNT after surgical resection. Predictor analysis could effectively guide 
+the clinical work and evaluate the prognosis of patients with DNT associated 
+with epilepsy.
+
+DOI: 10.3390/brainsci13010024
+PMCID: PMC9856460
+PMID: 36672006
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_36699536.md
+++ b/references_cache/PMID_36699536.md
@@ -1,0 +1,67 @@
+---
+reference_id: "PMID:36699536"
+title: "Low-grade epilepsy-associated neuroepithelial tumors: Tumor spectrum and diagnosis based on genetic alterations."
+authors:
+- Xie M
+- Wang X
+- Duan Z
+- Luan G
+journal: Front Neurosci
+year: '2022'
+doi: 10.3389/fnins.2022.1071314
+content_type: abstract_only
+---
+
+# Low-grade epilepsy-associated neuroepithelial tumors: Tumor spectrum and diagnosis based on genetic alterations.
+**Authors:** Xie M, Wang X, Duan Z, Luan G
+**Journal:** Front Neurosci (2022)
+**DOI:** [10.3389/fnins.2022.1071314](https://doi.org/10.3389/fnins.2022.1071314)
+
+## Content
+
+1. Front Neurosci. 2023 Jan 9;16:1071314. doi: 10.3389/fnins.2022.1071314. 
+eCollection 2022.
+
+Low-grade epilepsy-associated neuroepithelial tumors: Tumor spectrum and 
+diagnosis based on genetic alterations.
+
+Xie M(1)(2), Wang X(1)(2), Duan Z(3), Luan G(1)(2)(4)(5).
+
+Author information:
+(1)Department of Neurosurgery, Epilepsy Center, Sanbo Brain Hospital, Capital 
+Medical University, Beijing, China.
+(2)Beijing Key Laboratory of Epilepsy, Sanbo Brain Hospital, Capital Medical 
+University, Beijing, China.
+(3)Department of Pathology, Sanbo Brain Hospital, Capital Medical University, 
+Beijing, China.
+(4)Beijing Institute for Brain Disorders, Capital Medical University, Beijing, 
+China.
+(5)Chinese Institute for Brain Research, Beijing, China.
+
+Brain tumors can always result in seizures when involving the cortical neurons 
+or their circuits, and they were found to be one of the most common etiologies 
+of intractable focal seizures. The low-grade epilepsy-associated neuroepithelial 
+tumors (LEAT), as a special group of brain tumors associated with seizures, 
+share common clinicopathological features, such as seizure onsets at a young 
+age, a predilection for involving the temporal lobe, and an almost benign 
+course, including a rather slow growth pattern and thus a long-term history of 
+seizures. Ganglioglioma (GG) and dysembryoplastic neuroepithelial tumor (DNET) 
+are the typical representatives of LEATs. Surgical treatments with complete 
+resection of tumors and related epileptogenic zones are deemed the optimal way 
+to achieve postoperative seizure control and lifetime recurrence-free survival 
+in patients with LEATs. Although the term LEAT was originally introduced in 
+2003, debates on the tumor spectrum and the diagnosis or classification of LEAT 
+entities are still confusing among epileptologists and neuropathologists. In 
+this review, we would further discuss these questions, especially based on the 
+updated classification of central nervous system tumors in the WHO fifth edition 
+and the latest molecular genetic findings of tumor entities in LEAT entities.
+
+Copyright © 2023 Xie, Wang, Duan and Luan.
+
+DOI: 10.3389/fnins.2022.1071314
+PMCID: PMC9868944
+PMID: 36699536
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_37525202.md
+++ b/references_cache/PMID_37525202.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:37525202"
+title: "Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series."
+authors:
+- Rahim S
+- Ud Din N
+- Abdul-Ghafar J
+- Chundriger Q
+- Khan P
+- Ahmad Z
+journal: J Med Case Rep
+year: '2023'
+doi: 10.1186/s13256-023-04062-1
+keywords:
+- Adolescent
+- Adult
+- Child
+- Female
+- Humans
+- Male
+- Middle Aged
+- Young Adult
+- "Brain Neoplasms/complications, surgery, diagnosis"
+- Epilepsy
+- Glioma
+- "Neoplasms, Neuroepithelial/complications, surgery"
+- Seizures/etiology
+content_type: abstract_only
+---
+
+# Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series.
+**Authors:** Rahim S, Ud Din N, Abdul-Ghafar J, Chundriger Q, Khan P, Ahmad Z
+**Journal:** J Med Case Rep (2023)
+**DOI:** [10.1186/s13256-023-04062-1](https://doi.org/10.1186/s13256-023-04062-1)
+
+## Content
+
+1. J Med Case Rep. 2023 Aug 1;17(1):327. doi: 10.1186/s13256-023-04062-1.
+
+Clinicopathological features of dysembryoplastic neuroepithelial tumor: a 
+case series.
+
+Rahim S(1), Ud Din N(1), Abdul-Ghafar J(2), Chundriger Q(1), Khan P(3), Ahmad 
+Z(1).
+
+Author information:
+(1)Department of Pathology and Laboratory Medicine, Aga Khan University 
+Hospital, Karachi, Pakistan.
+(2)Department of Pathology and Clinical Laboratory, French Medical Institute for 
+Mothers and Children (FMIC), Kabul, Afghanistan. jamshid.jalal@fmic.org.af.
+(3)Department of Radiology, Aga Khan University Hospital, Karachi, Pakistan.
+
+BACKGROUND: Dysembryoplastic neuroepithelial tumors are rare benign 
+supratentotrial epilepsy-associated glioneuronal tumors of children and young 
+adults. Patients have a long history of seizures. Proper surgical resection 
+achieves long term seizure control. We describe the clinicopathological features 
+of dysembryoplastic neuroepithelial tumor cases reported in our practice and 
+review the published literature.
+METHODS: All cases of Pakistani ethnicity were diagnosed between 2015 and 2021 
+were included. Slides were reviewed and clinicopathological features were 
+recorded. Follow-up was obtained. Extensive literature review was conducted.
+RESULTS: Fourteen cases were reported. There were 12 males and 2 females. Age 
+range was 9-45 years (mean 19 years). Majority were located in the temporal and 
+frontal lobes. Duration of seizures prior to resection ranged from 2 months to 
+9 years with mean and median duration of 3.2 and 3 years, respectively. 
+Histologically, all cases demonstrated a multinodular pattern, specific 
+glioneuronal component, and floating neurons. Simple and complex forms comprised 
+seven cases each. No significant nuclear atypia, mitotic activity, or necrosis 
+was seen. Ki-67 proliferative index was very low. Cortical dysplasia was noted 
+in adjacent glial tissue in four cases. Follow-up ranged from 20 to 94 months. 
+Seizures continued following resection in all but one case but were reduced in 
+frequency and intensity. In one case, seizures stopped completely following 
+surgery.
+CONCLUSION: Clinicopathological features were similar to those in published 
+literature. However, a marked male predominance was noted in our series. 
+Seizures continued following resection in all but one case but were reduced in 
+frequency and intensity. This series will help raise awareness among clinicians 
+and pathologists in our part of the world about this seizure-associated tumor of 
+children and young adults.
+
+© 2023. The Author(s).
+
+DOI: 10.1186/s13256-023-04062-1
+PMCID: PMC10391907
+PMID: 37525202 [Indexed for MEDLINE]
+
+Conflict of interest statement: It is declared that all authors have no conflict 
+of interest.

--- a/references_cache/clinicaltrials_NCT04923126.md
+++ b/references_cache/clinicaltrials_NCT04923126.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT04923126
+title: "SJ901: Phase 1/2 Evaluation of Single Agent Mirdametinib (PD-0325901), a Brain-Penetrant MEK1/2 Inhibitor, for the Treatment of Children, Adolescents, and Young Adults With Low-Grade Glioma"
+content_type: summary
+---
+
+# SJ901: Phase 1/2 Evaluation of Single Agent Mirdametinib (PD-0325901), a Brain-Penetrant MEK1/2 Inhibitor, for the Treatment of Children, Adolescents, and Young Adults With Low-Grade Glioma
+
+## Content
+
+This is an open-label, multi-center, Phase 1/2 study of the brain-penetrant MEK inhibitor, mirdametinib (PD-0325901), in patients with pediatric low-grade glioma (pLGG).

--- a/research/Dysembryoplastic_Neuroepithelial_Tumor-deep-research-falcon.md
+++ b/research/Dysembryoplastic_Neuroepithelial_Tumor-deep-research-falcon.md
@@ -1,0 +1,1250 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T11:03:50.588427'
+end_time: '2026-05-11T11:29:46.550060'
+duration_seconds: 1555.96
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Dysembryoplastic Neuroepithelial Tumor
+  mondo_id: ''
+  category: ''
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 45
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dysembryoplastic Neuroepithelial Tumor
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dysembryoplastic Neuroepithelial Tumor** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dysembryoplastic Neuroepithelial Tumor
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dysembryoplastic Neuroepithelial Tumor** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Dysembryoplastic Neuroepithelial Tumor (DNET/DNT): Disease Characteristics Research Report
+
+**Target disease:** Dysembryoplastic neuroepithelial tumor (also written dysembryoplastic neuroepithelial tumour; abbreviation **DNET** or **DNT**). (rahim2023clinicopathologicalfeaturesof pages 1-2, khalilov2024atypicalpresentationof pages 1-2)
+
+**Category (high level):** WHO-defined circumscribed **glioneuronal tumor**; a prototypic **low-grade epilepsy-associated neuroepithelial tumor (LEAT)** entity. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+**MONDO ID:** Not found in the retrieved primary literature corpus used here (evidence gap noted). (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+## Executive snapshot (knowledge-base compact)
+
+| Domain | Key characteristics |
+|---|---|
+| Definition/classification | • Rare benign glioneuronal tumor; classic representative of low-grade epilepsy-associated tumors (LEATs) • WHO CNS 2021/5th-ed context: WHO grade 1 • Often termed DNET/DNT in literature • Characteristic alteration in LEAT classification tables: FGFR1 (xie2023lowgradeepilepsyassociatedneuroepithelial pages 2-3, xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, xie2023lowgradeepilepsyassociatedneuroepithelial media 10d99c66) |
+| Epidemiology | • Rare: estimated incidence ~0.03/100,000/year in the US • Reported prevalence among CNS tumors: ~1.2% in patients <20 years and ~0.2% in >20 years • DNT/DNET is among the commonest LEATs, with ganglioglioma together accounting for >75% of pediatric LEATs and >80% of LEATs in some epilepsy-surgery series (zhang2022longtermseizureoutcomes pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2, pelissier2026pediatriclowgradeepilepsyassociated pages 1-3, iijima2024genotyperelevantneuroimagingfeatures pages 1-2) |
+| Typical presentation | • Usually children/adolescents or young adults; LEAT seizure onset often ~12–15 years • Main presentation is chronic focal/drug-resistant epilepsy; seizures may be the only symptom • Rare non-epileptic presentations occur (e.g., headache without epileptiform activity) (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, khalilov2024atypicalpresentationof pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2) |
+| Anatomy/location | • Supratentorial, cortical or cortico-subcortical tumor • Strong temporal lobe predilection: ~65–80% of LEATs temporal; >67% temporal in DNT series • Frontal lobe is the second most common site • Frequent association with adjacent focal cortical dysplasia/peritumoral cortical dysplasia (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2, bonney2016reviewofseizure pages 4-5) |
+| Imaging/pathology hallmarks | • MRI often shows cortical-based lesion spanning cortical thickness, usually without major mass effect/edema • MRI patterns reported as cystic-like, nodular-like, and dysplastic-like types • Histology: multinodular architecture, specific glioneuronal element, oligodendrocyte-like cells in mucinous matrix, and “floating neurons” • Very low proliferative index; Ki-67 typically <1% (rahim2023clinicopathologicalfeaturesof pages 1-2, zhang2022longtermseizureoutcomes pages 2-5) |
+| Molecular genetics | • FGFR1 is the dominant driver: hotspot mutations (p.N546, p.K656), tyrosine kinase domain/internal tandem duplication, and rare fusions • Frequency of FGFR1 alterations reported at ~58.1% in neuropathology-confirmed DNT (25/43) and ~68% in a 58-case specific DNT cohort • MAPK pathway activation is central; some tumors also implicate PI3K/mTOR signaling • BRAF V600E can be reported in the broader DNT spectrum, but was absent in some well-curated specific DNT cohorts; rare alternative fusions include LHFPL3::NTRK2 (rivera2016germlineandsomatic pages 1-2, lucas2020comprehensiveanalysisof pages 1-2, jesus‐ribeiro2022thelandscapeof pages 6-7, pages2022thegenomiclandscape pages 10-10, chen2022casereporta pages 1-2) |
+| Diagnostics/molecular testing | • Diagnosis remains integrated: clinical epilepsy history + MRI + neuropathology • Pre-op workup often includes long-term video-EEG; MEG/PET/SEEG used when epileptogenic zone is unclear • Molecular testing increasingly useful for difficult cases: targeted sequencing for FGFR1/BRAF/NTRK alterations and DNA methylation profiling for classification support • sEEG-electrode-derived micro-tissue has been shown feasible for NGS and methylation analysis in a 2024 DNET case (zhang2022longtermseizureoutcomes pages 2-5, gatesman2024characterizationoflow‐grade pages 1-2, xie2023lowgradeepilepsyassociatedneuroepithelial media f56d460d) |
+| Treatment/management | • Mainstay is maximal safe surgical resection/lesionectomy, ideally including epileptogenic zone when indicated • Gross-total resection is generally favored for seizure control; lesionectomy alone may suffice in temporal LEATs with normal hippocampus • Anti-seizure medications are used for tumor-related epilepsy, but DNET-associated epilepsy is often pharmacoresistant • Chemo/radiotherapy usually not required for typical indolent DNET; targeted therapy remains investigational/exceptional (takayama2022ishippocampalresection pages 1-2, zhang2022longtermseizureoutcomes pages 1-2, gatesman2024characterizationoflow‐grade pages 1-2) |
+| Outcomes/prognosis | • Overall prognosis is favorable; biologically stable tumor with rare malignant transformation • In a 63-patient DNT cohort, 49/63 (77.8%) were seizure-free after surgery; seizure-recurrence-free rates were 82.5% at 2 years, 79.0% at 5 years, and 76.5% at 10 years • Across prior studies, seizure freedom after gross-total resection is often >80%; systematic review median seizure-free range IQR 77–93% • Better outcomes linked to gross-total resection and shorter epilepsy duration; MRI type 3/dysplastic-like pattern and bilateral interictal discharges predict worse seizure outcome (zhang2022longtermseizureoutcomes pages 1-2, zhang2022longtermseizureoutcomes pages 2-5, bonney2016reviewofseizure pages 4-5) |
+| Recent developments 2023-2024 | • 2023 LEAT reviews reinforced DNET as a WHO grade 1, FGFR1-linked LEAT entity • 2024 neuroimaging-genotype work showed FGFR1-associated LEAT imaging pattern with 100% sensitivity/specificity in that cohort and poorer seizure-free rates than BRAF-pattern tumors • 2024 S/EEG-based molecular diagnosis showed practical minimally invasive tumor profiling • 2023–2024 literature increasingly emphasizes integrated histology + molecular genetics + methylation classification for diagnostically ambiguous low-grade epilepsy-associated tumors (iijima2024genotyperelevantneuroimagingfeatures pages 1-2, gatesman2024characterizationoflow‐grade pages 1-2, rosemberg2023longtermepilepsyassociatedtumors pages 1-2, rahim2023clinicopathologicalfeaturesof pages 6-7) |
+
+
+*Table: This compact table summarizes core disease-characteristic facts for dysembryoplastic neuroepithelial tumor (DNET/DNT), including classification, phenotype, molecular genetics, diagnosis, treatment, and prognosis. It is designed as a concise knowledge-base-ready snapshot with quantitative details and context-ID citations.*
+
+## 1. Disease Information
+
+### 1.1 What is the disease?
+Dysembryoplastic neuroepithelial tumor is a **rare, benign/indolent, supratentorial, epilepsy-associated glioneuronal tumor** that most commonly affects **children and young adults** and typically presents with **long-standing focal seizures**, often drug-resistant. (rahim2023clinicopathologicalfeaturesof pages 1-2, khalilov2024atypicalpresentationof pages 1-2)
+
+Within the LEAT concept (long-term/low-grade epilepsy-associated tumors), DNET is recognized as one of the **typical representatives** alongside ganglioglioma, with a predilection for **neocortical temporal lobe** involvement and generally benign growth behavior. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+### 1.2 WHO grade and classification context
+Multiple WHO-2021 (5th edition) aligned sources list DNET/DNT as **WHO grade 1** within LEAT/glioneuronal tumor groupings. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 2-3, xie2023lowgradeepilepsyassociatedneuroepithelial media 10d99c66)
+
+### 1.3 Synonyms and alternative names
+* Dysembryoplastic neuroepithelial **tumor** (US spelling) / **tumour** (UK spelling). (pages2022thegenomiclandscape pages 10-10)
+* Dysembryoplastic neuroepithelial tumor (**DNET**) / dysembryoplastic neuroepithelial tumour (**DNT**). (rahim2023clinicopathologicalfeaturesof pages 1-2)
+* Informal clinical term: “**epileptoma**” (used for highly epileptogenic low-grade tumors such as DNET and ganglioglioma). (khalilov2024atypicalpresentationof pages 1-2)
+
+### 1.4 Key identifiers (OMIM, Orphanet, ICD-10/ICD-11, MeSH, MONDO)
+No explicit OMIM/Orphanet/ICD/MeSH/MONDO identifiers were present in the retrieved full-text evidence set. This report therefore **does not assert codes** without direct supporting evidence. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+### 1.5 Evidence source type
+Most disease-level information here is derived from **aggregated literature sources** (reviews, cohorts) plus a few case reports/case series and a clinical registry trial record, rather than EHR-only data. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2, NCT03970785 chunk 1)
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Primary causal factors are somatic oncogenic alterations**, most commonly involving **FGFR1** and the downstream **MAPK/ERK pathway**, consistent with a developmental/circumscribed tumor biology typical for LEATs. (rivera2016germlineandsomatic pages 1-2, rivera2016germlineandsomatic pages 12-15)
+
+Rivera et al. explicitly conclude that “**constitutional and somatic FGFR1 alterations and MAP kinase pathway activation are key events in the pathogenesis of DNET**,” supporting a molecularly driven etiology. (rivera2016germlineandsomatic pages 1-2)
+
+### 2.2 Risk factors
+**Clinical/demographic risk:** DNET is predominantly encountered in **children/adolescents/young adults** (e.g., LEAT seizure onset often around early teens) and occurs supratentorially with temporal predilection, but established population-level environmental risk factors were not identified in the retrieved corpus. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+**Genetic risk:** Most evidence supports **somatic** drivers rather than inherited predisposition; however, a familial scenario with a **germline FGFR1 mutation** (p.R661P) plus somatic “second hits” was reported, demonstrating a possible (rare) inherited predisposition mechanism in select families. (rivera2016germlineandsomatic pages 1-2)
+
+### 2.3 Protective factors
+No protective genetic variants or environmental protective factors were identified in the retrieved corpus. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+### 2.4 Gene–environment interactions
+No gene–environment interaction evidence was identified in the retrieved corpus. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+## 3. Phenotypes (clinical features)
+
+### 3.1 Core phenotypes (with suggested HPO terms)
+DNET is strongly linked to epilepsy; seizures are typically focal and may be drug-resistant. (rahim2023clinicopathologicalfeaturesof pages 1-2, khalilov2024atypicalpresentationof pages 1-2)
+
+Key phenotypes:
+* **Focal seizures / epilepsy (often drug-resistant)** — suggested HPO: **HP:0001250 (Seizures)**; **HP:0002197 (Generalized seizures)** when present; **HP:0007359 (Focal seizures)** (term name may vary by HPO release). (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2)
+* **Headache** can occur, including rare presentations without epilepsy — suggested HPO: **HP:0002315 (Headache)**. (khalilov2024atypicalpresentationof pages 1-2)
+
+### 3.2 Phenotype characteristics (age of onset, severity, progression)
+* **Age of onset:** LEATs typically have seizure onsets at a young age (commonly cited ~12–15 years) and DNETs are described as occurring in children/adolescents and young adults. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2)
+* **Progression:** biologically stable/benign course is typical, with rare malignant transformation. (khalilov2024atypicalpresentationof pages 1-2, zhang2022longtermseizureoutcomes pages 1-2)
+
+Quantitative examples from a 2023 case series (Pakistan; n=14): age range **9–45 years** (mean **19**), seizure duration pre-resection **2 months to 9 years** (mean **3.2 years**), with temporal and frontal lobes most common sites. (rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+### 3.3 Quality of life impact
+Seizures are commonly chronic and may be refractory, motivating epilepsy surgery; thus, DNET can substantially impact function through seizure burden (school/work limitations and medication adverse effects), although disease-specific validated QOL metrics were not extracted from the retrieved corpus. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2, avila2024braintumorrelatedepilepsy pages 10-11)
+
+## 4. Genetic/Molecular Information
+
+### 4.1 Causal genes and pathways
+The dominant molecular theme is **RTK → RAS/MAPK/ERK activation**, with **FGFR1** as a key oncogenic driver in many DNETs; subsets also show alterations converging on **PI3K/mTOR**. (rivera2016germlineandsomatic pages 1-2, surrey2019genomicanalysisof pages 1-1)
+
+### 4.2 Pathogenic variants and alteration types (somatic vs germline)
+**FGFR1** alterations in DNET include:
+* **Hotspot missense mutations** (e.g., p.N546K, p.K656E) (rivera2016germlineandsomatic pages 1-2, lucas2020comprehensiveanalysisof pages 1-2)
+* **Tyrosine kinase domain duplication / internal tandem duplication (ITD)** (rivera2016germlineandsomatic pages 1-2, pages2022thegenomiclandscape pages 10-10)
+* **Rare fusions/breakpoints** involving FGFR1 (rivera2016germlineandsomatic pages 12-15, pages2022thegenomiclandscape pages 10-10)
+
+Somatic vs germline: Rivera et al. provide explicit evidence of both, reporting a **germline** FGFR1 p.R661P with **somatic** activating FGFR1 hotspot mutations (p.N546K or p.K656E) in tumor, including a case where p.K656E occurred in cis with the germline variant. (rivera2016germlineandsomatic pages 1-2)
+
+### 4.3 Frequencies/statistics for molecular alterations
+Well-curated DNET cohorts show high enrichment of FGFR1 alterations:
+* In a neuropathology-confirmed cohort (43 cases), FGFR1 alterations were frequent and “**mainly comprised intragenic tyrosine kinase FGFR1 duplication and multiple mutants in cis (25/43; 58.1%) while BRAF p.V600E alterations were absent (0/43)**.” (rivera2016germlineandsomatic pages 1-2)
+* In a cohort of 58 “specific” DNTs, Pagès et al. report FGFR1 disruption (mutation, ITD, fusion) and state “**In our cohort of 58 specific DNTs, we found a similar frequency (68%)**” (of FGFR1-related events). (pages2022thegenomiclandscape pages 10-10)
+
+Broader DNT/MNGT spectrum sequencing shows that alterations frequently converge on MAPK/PI3K signaling; in one series, “more than half” (19/33) of analyzed tumors had alterations predicted to dysregulate MAPK and/or PI3K pathways. (surrey2019genomicanalysisof pages 1-1)
+
+### 4.4 Other drivers and rare events
+* **NTRK2 fusion**: A DNET case reported a novel **LHFPL3::NTRK2** fusion retaining the NTRK2 tyrosine kinase domain; authors describe likely pathogenicity through constitutive RTK signaling. (chen2022casereporta pages 1-2)
+* **BRAF V600E**: Literature reports exist, but BRAF V600E may be absent in some well-curated “specific DNT” cohorts (e.g., none detected in two cohorts summarized above). (rivera2016germlineandsomatic pages 1-2, pages2022thegenomiclandscape pages 10-10)
+
+### 4.5 Epigenetic information
+DNA methylation profiling is increasingly used for difficult-to-classify low-grade neuroepithelial tumors and can support/refine diagnosis beyond morphology alone; however, DNET-specific methylation subclass statistics were not available from the retrieved evidence set. (gatesman2024characterizationoflow‐grade pages 1-2)
+
+## 5. Environmental Information
+No validated environmental/lifestyle/infectious causal factors were identified for DNET in the retrieved corpus. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Causal chain (molecular → cellular → clinical)
+A commonly supported mechanistic chain is:
+1) **FGFR1 activation** (hotspot mutation, ITD/kinase duplication, or fusion) → 2) **increased MAPK/ERK signaling** (phospho-ERK upregulation) → 3) **tumor formation/maintenance** in cortex (glioneuronal tumor microenvironment) → 4) **cortical network hyperexcitability and epileptogenesis**, clinically manifesting as focal seizures and drug-resistant epilepsy; seizure burden is also influenced by the epileptogenic zone extending into peritumoral cortex and co-existing focal cortical dysplasia (“dual pathology”). (rivera2016germlineandsomatic pages 12-15, xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, bonney2016reviewofseizure pages 4-5)
+
+Rivera et al. provide functional support for MAPK activation: phospho-ERK was upregulated in FGFR1-mutated cases and they report immunohistochemical confirmation of phospho-ERK upregulation in “**24/35 (69%)**” of FGFR1-mutated cases. (rivera2016germlineandsomatic pages 12-15)
+
+### 6.2 Upstream vs downstream mechanisms
+* **Upstream**: receptor tyrosine kinase (FGFR1) activating events; rare RTK fusions (e.g., NTRK2) (rivera2016germlineandsomatic pages 1-2, chen2022casereporta pages 1-2)
+* **Downstream**: MAPK/ERK and sometimes PI3K/mTOR pathway dysregulation (surrey2019genomicanalysisof pages 1-1, rivera2016germlineandsomatic pages 12-15)
+
+### 6.3 Cell types (suggested CL terms) and biological processes (suggested GO terms)
+The tumor is glioneuronal, implicating glial-lineage and neuronal components and peritumoral neuronal circuitry.
+
+Suggested Cell Ontology (CL) terms (examples):
+* **CL:0000540 (Neuron)** for epileptogenic network effects and “floating neurons” concept (pathology context). (rahim2023clinicopathologicalfeaturesof pages 1-2)
+* **CL:0000127 (Astrocyte)** and **CL:0000128 (Oligodendrocyte)** as relevant to glial components/oligodendrocyte-like cells described histologically. (rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+Suggested GO Biological Process terms (examples):
+* **MAPK cascade** (e.g., GO:0000165) and **ERK1/2 cascade** (relevant to phospho-ERK evidence). (rivera2016germlineandsomatic pages 12-15)
+* **Regulation of synaptic transmission / neuronal excitability** (epileptogenesis context; general). (avila2024braintumorrelatedepilepsy pages 10-11)
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ/system level
+Primary system affected is the **central nervous system** (brain), with seizures as the dominant symptom. (rahim2023clinicopathologicalfeaturesof pages 1-2, xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+
+### 7.2 Localization (suggested UBERON terms)
+DNET is typically **supratentorial and cortical** with strong **temporal lobe** predominance and frequent frontal involvement. (rahim2023clinicopathologicalfeaturesof pages 1-2, xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+
+Suggested UBERON terms (examples):
+* **UBERON:0000955 (brain)**
+* **UBERON:0001870 (cerebral cortex)**
+* **UBERON:0002285 (temporal lobe)**
+* **UBERON:0001871 (frontal lobe)**
+
+### 7.3 Tissue/cell level and subcellular components
+A frequent associated lesion is **focal cortical dysplasia** adjacent to tumor (dual pathology), implicating both tumor and surrounding cortex. (khalilov2024atypicalpresentationof pages 1-2)
+
+## 8. Temporal Development
+
+### 8.1 Onset
+DNETs are described as occurring most often in childhood/adolescence; LEAT seizures commonly begin in early teens and frequently precede surgery by years. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+### 8.2 Progression/course
+Tumors are usually slow-growing/indolent with long seizure histories; malignant transformation is rare. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2, zhang2022longtermseizureoutcomes pages 1-2)
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology
+Quantitative epidemiology is limited but a large surgical cohort review reports DNET incidence around **0.03/100,000/year** (US estimate) and highlights that DNET constitutes a substantial fraction of LEAT diagnoses in epilepsy surgery series. (zhang2022longtermseizureoutcomes pages 1-2, iijima2024genotyperelevantneuroimagingfeatures pages 1-2)
+
+### 9.2 Inheritance
+DNET is primarily driven by **somatic** alterations, but rare familial predisposition via **germline FGFR1** alteration has been reported. (rivera2016germlineandsomatic pages 1-2)
+
+## 10. Diagnostics
+
+### 10.1 Clinical workup
+Diagnosis is typically based on seizure history plus MRI and confirmatory histopathology; preoperative epilepsy workup commonly includes long-term video-EEG, with additional modalities (MEG, PET, invasive monitoring) when needed to define the epileptogenic zone. (zhang2022longtermseizureoutcomes pages 2-5, takayama2022ishippocampalresection pages 1-2)
+
+### 10.2 Imaging
+MRI is emphasized as the key modality; lesions are often cortical-based and may be classified into morphologic patterns (e.g., cystic-like, nodular-like, dysplastic-like). (zhang2022longtermseizureoutcomes pages 2-5, rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+A 2024 radiogenomic study in LEATs showed that certain imaging patterns can predict genotype with high accuracy, reporting imaging groups with “**93.8% sensitivity and 100% specificity to BRAF V600E**” (Group 1) and “**100% sensitivity and specificity for FGFR1 mutations**” (Group 2). (iijima2024genotyperelevantneuroimagingfeatures pages 1-2)
+
+### 10.3 Histopathology
+Characteristic pathology includes a multinodular architecture and “floating neurons” within a specific glioneuronal element; Ki-67 is typically very low. (rahim2023clinicopathologicalfeaturesof pages 1-2)
+
+### 10.4 Molecular diagnostics (NGS, methylation)
+Molecular profiling supports diagnosis and may clarify difficult cases, particularly in the DNT/MNGT/PLNTY spectrum where morphology overlaps; testing may include targeted DNA/RNA sequencing for FGFR1/BRAF/NTRK alterations and methylation arrays. (surrey2019genomicanalysisof pages 1-1, gatesman2024characterizationoflow‐grade pages 1-2)
+
+A 2024 proof-of-concept study demonstrated feasibility of extracting tumor DNA from tissue adherent to **stereoelectroencephalography (sEEG) electrodes** and performing targeted sequencing and DNA methylation array analysis to aid classification. (gatesman2024characterizationoflow‐grade pages 1-2)
+
+## 11. Outcome/Prognosis
+
+### 11.1 Seizure outcomes after surgery (key quantitative data)
+In a 63-patient DNET cohort (2008–2021), **49/63 (77.8%)** were seizure-free after surgery, with cumulative seizure recurrence-free rates **82.5% (2 years), 79.0% (5 years), 76.5% (10 years)**. (zhang2022longtermseizureoutcomes pages 1-2)
+
+A systematic review of surgical series reported a median seizure-freedom rate of **86%** (IQR **77–93%**) and highlighted that gross-total resection is repeatedly associated with seizure freedom. (bonney2016reviewofseizure pages 4-5)
+
+### 11.2 Prognostic factors
+Predictors of better seizure outcomes include gross total resection and shorter epilepsy duration, while certain imaging patterns (e.g., dysplastic-like) and bilateral interictal epileptiform discharges may predict poorer seizure outcomes. (zhang2022longtermseizureoutcomes pages 1-2)
+
+## 12. Treatment
+
+### 12.1 Surgical and interventional (standard of care)
+Maximal safe **surgical resection/lesionectomy** is widely considered the optimal approach to achieve seizure control and durable tumor control in LEATs, including DNET. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+
+A hippocampus-sparing strategy may be appropriate in selected temporal-lobe LEATs with normal hippocampus: in a cohort of 32 temporal LEAT cases, **28/32 (87.5%)** achieved seizure freedom irrespective of hippocampal resection, and additional hippocampal resection negatively impacted verbal outcomes. (takayama2022ishippocampalresection pages 1-2)
+
+**Real-world implementation example:** an observational clinical registry study evaluated intraoperative **fluorescein**-guided resection feasibility for ganglioglioma and DNET (NCT03970785), using surgical video review and postoperative MRI to assess fluorescence and extent of resection, with Engel-classification seizure outcomes. (NCT03970785 chunk 1)
+
+### 12.2 Pharmacotherapy: antiseizure medications (ASMs)
+DNET-associated epilepsy is frequently treated with ASMs but may be drug-resistant; consensus neuro-oncology practice avoids routine prophylactic ASM use in seizure-naïve patients. (rahim2023clinicopathologicalfeaturesof pages 1-2, avila2024braintumorrelatedepilepsy pages 10-11)
+
+A 2024 Society for Neuro-Oncology consensus review states prophylactic ASM in seizure-naïve brain tumor patients lacks high-quality evidence, yet ~70% of neurosurgeons give a short postoperative course (commonly **levetiracetam for 7 days** after supratentorial craniotomy); meta-analysis showed reduced **early** postoperative seizures (RR **0.35**, 95% CI **0.13–0.95**) but not late seizures. (avila2024braintumorrelatedepilepsy pages 10-11)
+
+Newton & Wojkowski (2024) summarize that seizures affect **>50%** of brain tumor patients overall and provide tumor-specific estimates (DNET ~**100%**), and similarly advise that **prophylactic AEDs are not recommended**; after a first verified seizure, consensus is to start ASM monotherapy, most often **levetiracetam** (with alternatives/add-ons including lacosamide, valproate, brivaracetam, lamotrigine, and perampanel). (newton2024antiepilepticstrategiesfor pages 1-3)
+
+### 12.3 Targeted/experimental therapy
+Because DNET biology is frequently MAPK-driven (FGFR1 alterations, RTK fusions), MEK-pathway targeting is being evaluated within broader pediatric/AYA low-grade glioma frameworks.
+
+**Clinical trial example (MAPK-pathway therapy):** SJ901 (NCT04923126) evaluates **mirdametinib** (MEK1/2 inhibitor) in pediatric/AYA low-grade glioma and explicitly includes LEAT histologies such as **dysembryoplastic neuroepithelial tumor (DNET)** among eligible conditions; a separate protocol chunk specifies requirement for centrally reviewed **MAPK-pathway activation** evidence (including FGFR1/2/3 aberrations and other RAS/MAPK genes). (NCT04923126 chunk 2, NCT04923126 chunk 4)
+
+### 12.4 Suggested MAXO (Medical Action Ontology) terms
+Because MAXO codes were not present in the evidence corpus, the following are suggested as likely appropriate mappings (to be verified against MAXO):
+* **Neurosurgical resection of brain tumor** (lesionectomy/gross total resection). (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+* **Antiseizure medication therapy** (levetiracetam monotherapy; add-on therapy). (avila2024braintumorrelatedepilepsy pages 10-11)
+* **Stereoelectroencephalography (SEEG) monitoring** / intracranial EEG evaluation. (gatesman2024characterizationoflow‐grade pages 1-2)
+* **Intraoperative fluorescence-guided surgery**. (NCT03970785 chunk 1)
+* **MEK inhibitor therapy** (mirdametinib clinical trial context). (NCT04923126 chunk 2)
+
+## 13. Prevention
+No primary-prevention interventions are established for DNET based on available evidence; secondary prevention in practice is largely **early recognition** of epileptogenic lesions and timely referral for epilepsy surgery evaluation when seizures are drug-resistant. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+
+## 14. Other Species / Natural Disease
+No naturally occurring DNET analogue in non-human species was identified in the retrieved corpus. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+
+## 15. Model Organisms
+A 2024 review on epilepsy-associated tumors notes improving animal modeling capacity for low-grade neuroepithelial tumors (LGNTs) with tools such as in utero electroporation to generate tumors with relevant genetic features; however, DNET-specific validated model organism details were not extracted from the retrieved evidence set. (rahim2023clinicopathologicalfeaturesof pages 6-7)
+
+# Recent developments and expert analysis (2023–2024 emphasis)
+
+## 2023–2024: classification and diagnostic modernization
+Recent LEAT-focused reviews emphasize that DNET is a core LEAT entity and that the WHO CNS 2021 classification recognized additional epilepsy-associated tumor entities, increasing the importance of integrated diagnosis using histology plus molecular tools. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2, xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2)
+
+A WHO-2021-based LEAT table explicitly lists DNET as **WHO grade 1** with characteristic genetic alteration **FGFR1**, supporting a molecularly anchored diagnostic approach rather than morphology alone. (xie2023lowgradeepilepsyassociatedneuroepithelial media 10d99c66)
+
+## 2024: radiogenomics and minimally invasive molecular profiling
+The 2024 radiogenomic study provides a practical framework suggesting that **preoperative neuroimaging patterns can predict genotype**, potentially enabling earlier precision planning (e.g., anticipating FGFR1 vs BRAF-driven lesions), and also indicates seizure outcomes may differ by genotype-associated imaging group. (iijima2024genotyperelevantneuroimagingfeatures pages 1-2)
+
+A 2024 proof-of-concept sEEG-electrode approach suggests that neurosurgical epilepsy workflows can also become **molecular diagnostic workflows**, enabling targeted sequencing and methylation analysis from microscopic tissue without requiring a separate biopsy procedure. (gatesman2024characterizationoflow‐grade pages 1-2)
+
+## 2024: consensus TRE management
+The 2024 SNO consensus emphasizes evidence-based antiseizure management principles that generalize to DNET patients (especially perioperative decisions): no strong support for routine prophylaxis in seizure-naïve cases, frequent use of short postoperative levetiracetam courses, preference for monotherapy and non–enzyme-inducing ASMs, and escalation toward local therapies (surgery/irradiation) for drug-resistant seizures. (avila2024braintumorrelatedepilepsy pages 10-11)
+
+# URLs and publication dates (selected key sources)
+* Rahim et al. “Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series” (2023-08). https://doi.org/10.1186/s13256-023-04062-1 (rahim2023clinicopathologicalfeaturesof pages 1-2)
+* Khalilov et al. “Atypical presentation of dysembryoplastic neuroepithelial tumor” (2024-10). https://doi.org/10.17816/acen.1126 (khalilov2024atypicalpresentationof pages 1-2)
+* Iijima et al. “Genotype-relevant neuroimaging features in low-grade epilepsy-associated tumors” (2024-07). https://doi.org/10.3389/fneur.2024.1419104 (iijima2024genotyperelevantneuroimagingfeatures pages 1-2)
+* Avila et al. SNO consensus “Brain tumor-related epilepsy management…” (2024-09). https://doi.org/10.1093/neuonc/noad154 (avila2024braintumorrelatedepilepsy pages 10-11)
+* Newton & Wojkowski “Antiepileptic strategies…” (2024-02). https://doi.org/10.1007/s11864-024-01182-8 (newton2024antiepilepticstrategiesfor pages 1-3)
+* ClinicalTrials.gov NCT03970785 (first posted 2019-06-03; study 2015–2018 cases): https://clinicaltrials.gov/study/NCT03970785 (NCT03970785 chunk 1)
+* ClinicalTrials.gov NCT04923126 (first posted 2021-06-18): https://clinicaltrials.gov/study/NCT04923126 (NCT04923126 chunk 2)
+
+# Evidence gaps and limitations (for knowledge-base curation)
+* Formal external identifiers (MeSH, ICD-10/11, Orphanet, MONDO, OMIM) were not retrievable from the current evidence set; they should be added from dedicated ontology resources (not inferred). (rosemberg2023longtermepilepsyassociatedtumors pages 1-2)
+* DNET-specific methylation subclass definitions and epigenetic prognostic biomarkers were not extractable from the retrieved texts; further targeted retrieval of DKFZ classifier class descriptions and DNET methylation studies would be needed. (gatesman2024characterizationoflow‐grade pages 1-2)
+* Non-human natural disease and validated DNET-specific model organism details were not identified in the retrieved corpus. (rahim2023clinicopathologicalfeaturesof pages 6-7)
+
+References
+
+1. (rahim2023clinicopathologicalfeaturesof pages 1-2): Shabina Rahim, Nasir Ud Din, Jamshid Abdul-Ghafar, Qurratulain Chundriger, Poonum Khan, and Zubair Ahmad. Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series. Journal of Medical Case Reports, Aug 2023. URL: https://doi.org/10.1186/s13256-023-04062-1, doi:10.1186/s13256-023-04062-1. This article has 6 citations and is from a peer-reviewed journal.
+
+2. (khalilov2024atypicalpresentationof pages 1-2): Varis S. Khalilov, Aleksey N. Kislyakov, Natalia A. Medvedeva, and Natalia S. Serova. Atypical presentation of dysembryoplastic neuroepithelial tumor. Annals of Clinical and Experimental Neurology, 18:109-115, Oct 2024. URL: https://doi.org/10.17816/acen.1126, doi:10.17816/acen.1126. This article has 0 citations.
+
+3. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2): Mingguo Xie, Xiongfei Wang, Zejun Duan, and Guoming Luan. Low-grade epilepsy-associated neuroepithelial tumors: tumor spectrum and diagnosis based on genetic alterations. Frontiers in Neuroscience, Jan 2023. URL: https://doi.org/10.3389/fnins.2022.1071314, doi:10.3389/fnins.2022.1071314. This article has 27 citations and is from a peer-reviewed journal.
+
+4. (rosemberg2023longtermepilepsyassociatedtumors pages 1-2): Sergio Rosemberg. Long-term epilepsy associated-tumors (leats): what is new? Arquivos de Neuro-Psiquiatria, 81:1146-1151, Dec 2023. URL: https://doi.org/10.1055/s-0043-1777730, doi:10.1055/s-0043-1777730. This article has 10 citations and is from a peer-reviewed journal.
+
+5. (xie2023lowgradeepilepsyassociatedneuroepithelial pages 2-3): Mingguo Xie, Xiongfei Wang, Zejun Duan, and Guoming Luan. Low-grade epilepsy-associated neuroepithelial tumors: tumor spectrum and diagnosis based on genetic alterations. Frontiers in Neuroscience, Jan 2023. URL: https://doi.org/10.3389/fnins.2022.1071314, doi:10.3389/fnins.2022.1071314. This article has 27 citations and is from a peer-reviewed journal.
+
+6. (xie2023lowgradeepilepsyassociatedneuroepithelial media 10d99c66): Mingguo Xie, Xiongfei Wang, Zejun Duan, and Guoming Luan. Low-grade epilepsy-associated neuroepithelial tumors: tumor spectrum and diagnosis based on genetic alterations. Frontiers in Neuroscience, Jan 2023. URL: https://doi.org/10.3389/fnins.2022.1071314, doi:10.3389/fnins.2022.1071314. This article has 27 citations and is from a peer-reviewed journal.
+
+7. (zhang2022longtermseizureoutcomes pages 1-2): Huawei Zhang, Yue Hu, Adilijiang Aihemaitiniyazi, Tiemin Li, Jian Zhou, Yuguang Guan, Xueling Qi, Xufei Zhang, Mengyang Wang, Changqing Liu, and Guoming Luan. Long-term seizure outcomes and predictors in patients with dysembryoplastic neuroepithelial tumors associated with epilepsy. Brain Sciences, 13:24, Dec 2022. URL: https://doi.org/10.3390/brainsci13010024, doi:10.3390/brainsci13010024. This article has 2 citations.
+
+8. (pelissier2026pediatriclowgradeepilepsyassociated pages 1-3): Lindsey Pelissier, Asha Sarma, Joanne Rispoli, Stephen Little, Sumit Pruthi, and Alexandra Foust. Pediatric low-grade epilepsy-associated tumors (leats): neuroimaging review and genetics update. Pediatric Radiology, Jan 2026. URL: https://doi.org/10.1007/s00247-026-06519-z, doi:10.1007/s00247-026-06519-z. This article has 0 citations and is from a peer-reviewed journal.
+
+9. (iijima2024genotyperelevantneuroimagingfeatures pages 1-2): Keiya Iijima, Hiroyuki Fujii, Fumio Suzuki, Kumiko Murayama, Yu-ichi Goto, Yuko Saito, Terunori Sano, Hiroyoshi Suzuki, Hajime Miyata, Yukio Kimura, Takuma Nakashima, Hiromichi Suzuki, Masaki Iwasaki, and Noriko Sato. Genotype-relevant neuroimaging features in low-grade epilepsy-associated tumors. Frontiers in Neurology, Jul 2024. URL: https://doi.org/10.3389/fneur.2024.1419104, doi:10.3389/fneur.2024.1419104. This article has 2 citations and is from a peer-reviewed journal.
+
+10. (bonney2016reviewofseizure pages 4-5): Phillip A. Bonney, Lillian B. Boettcher, Andrew K. Conner, Chad A. Glenn, Robert G. Briggs, Joshua A. Santucci, Michael R. Bellew, James D. Battiste, and Michael E. Sughrue. Review of seizure outcomes after surgical resection of dysembryoplastic neuroepithelial tumors. Journal of Neuro-Oncology, 126:1-10, Oct 2016. URL: https://doi.org/10.1007/s11060-015-1961-4, doi:10.1007/s11060-015-1961-4. This article has 60 citations and is from a peer-reviewed journal.
+
+11. (zhang2022longtermseizureoutcomes pages 2-5): Huawei Zhang, Yue Hu, Adilijiang Aihemaitiniyazi, Tiemin Li, Jian Zhou, Yuguang Guan, Xueling Qi, Xufei Zhang, Mengyang Wang, Changqing Liu, and Guoming Luan. Long-term seizure outcomes and predictors in patients with dysembryoplastic neuroepithelial tumors associated with epilepsy. Brain Sciences, 13:24, Dec 2022. URL: https://doi.org/10.3390/brainsci13010024, doi:10.3390/brainsci13010024. This article has 2 citations.
+
+12. (rivera2016germlineandsomatic pages 1-2): Barbara Rivera, Tenzin Gayden, Jian Carrot-Zhang, Javad Nadaf, Talia Boshari, Damien Faury, Michele Zeinieh, Romeo Blanc, David L. Burk, Somayyeh Fahiminiya, Eric Bareke, Ulrich Schüller, Camelia M. Monoranu, Ronald Sträter, Kornelius Kerl, Thomas Niederstadt, Gerhard Kurlemann, Benjamin Ellezam, Zuzanna Michalak, Maria Thom, Paul J. Lockhart, Richard J. Leventer, Milou Ohm, Duncan MacGregor, David Jones, Jason Karamchandani, Celia M. T. Greenwood, Albert M. Berghuis, Susanne Bens, Reiner Siebert, Magdalena Zakrzewska, Pawel P. Liberski, Krzysztof Zakrzewski, Sanjay M. Sisodiya, Werner Paulus, Steffen Albrecht, Martin Hasselblatt, Nada Jabado, William D. Foulkes, and Jacek Majewski. Germline and somatic fgfr1 abnormalities in dysembryoplastic neuroepithelial tumors. Acta Neuropathologica, 131:847-863, Feb 2016. URL: https://doi.org/10.1007/s00401-016-1549-x, doi:10.1007/s00401-016-1549-x. This article has 214 citations and is from a highest quality peer-reviewed journal.
+
+13. (lucas2020comprehensiveanalysisof pages 1-2): Calixto-Hope G. Lucas, Rohit Gupta, Pamela Doo, Julieann C. Lee, Cathryn R. Cadwell, Biswarathan Ramani, Jeffrey W. Hofmann, Emily A. Sloan, Bette K. Kleinschmidt-DeMasters, Han S. Lee, Matthew D. Wood, Marjorie Grafe, Donald Born, Hannes Vogel, Shahriar Salamat, Diane Puccetti, David Scharnhorst, David Samuel, Tabitha Cooney, Elaine Cham, Lee-way Jin, Ziad Khatib, Ossama Maher, Gabriel Chamyan, Carole Brathwaite, Serguei Bannykh, Sabine Mueller, Cassie N. Kline, Anu Banerjee, Alyssa Reddy, Jennie W. Taylor, Jennifer L. Clarke, Nancy Ann Oberheim Bush, Nicholas Butowski, Nalin Gupta, Kurtis I. Auguste, Peter P. Sun, Jarod L. Roland, Corey Raffel, Manish K. Aghi, Philip Theodosopoulos, Edward Chang, Shawn Hervey-Jumper, Joanna J. Phillips, Melike Pekmezci, Andrew W. Bollen, Tarik Tihan, Susan Chang, Mitchel S. Berger, Arie Perry, and David A. Solomon. Comprehensive analysis of diverse low-grade neuroepithelial tumors with fgfr1 alterations reveals a distinct molecular signature of rosette-forming glioneuronal tumor. Acta Neuropathologica Communications, Aug 2020. URL: https://doi.org/10.1186/s40478-020-01027-z, doi:10.1186/s40478-020-01027-z. This article has 71 citations and is from a peer-reviewed journal.
+
+14. (jesus‐ribeiro2022thelandscapeof pages 6-7): Joana Jesus‐Ribeiro, Olinda Rebelo, Ilda Patrícia Ribeiro, Luís Miguel Pires, João Daniel Melo, Francisco Sales, Isabel Santana, António Freire, and Joana Barbosa Melo. The landscape of common genetic drivers and dna methylation in low‐grade (epilepsy‐associated) neuroepithelial tumors: a review. Neuropathology, 42:467-482, Jul 2022. URL: https://doi.org/10.1111/neup.12846, doi:10.1111/neup.12846. This article has 4 citations and is from a peer-reviewed journal.
+
+15. (pages2022thegenomiclandscape pages 10-10): Mélanie Pagès, Marie‐Anne Debily, Frédéric Fina, David T. W. Jones, Raphael Saffroy, David Castel, Thomas Blauwblomme, Alice Métais, Marie Bourgeois, Emmanuèle Lechapt‐Zalcman, Arnault Tauziède‐Espariat, Felipe Andreiuolo, Fabrice Chrétien, Jacques Grill, Nathalie Boddaert, Dominique Figarella‐Branger, Rameen Beroukhim, and Pascale Varlet. The genomic landscape of dysembryoplastic neuroepithelial tumours and a comprehensive analysis of recurrent cases. Neuropathology and Applied Neurobiology, Aug 2022. URL: https://doi.org/10.1111/nan.12834, doi:10.1111/nan.12834. This article has 13 citations and is from a peer-reviewed journal.
+
+16. (chen2022casereporta pages 1-2): Yanming Chen, Qing Zhu, Ye Wang, Xiaoxiao Dai, Ping Chen, Ailin Chen, Sujuan Zhou, Chungang Dai, Shengbin Zhao, Sheng Xiao, and Qing Lan. Case report: a novel lhfpl3::ntrk2 fusion in dysembryoplastic neuroepithelial tumor. Frontiers in Oncology, Dec 2022. URL: https://doi.org/10.3389/fonc.2022.1064817, doi:10.3389/fonc.2022.1064817. This article has 2 citations.
+
+17. (gatesman2024characterizationoflow‐grade pages 1-2): Taylor A. Gatesman, Jasmine L. Hect, H. Westley Phillips, Brenden J. Johnson, Abigail I. Wald, Colleen McClung, Marina N. Nikiforova, John M. Skaugen, Ian F. Pollack, Taylor J. Abel, and Sameer Agnihotri. Characterization of low‐grade epilepsy‐associated tumor from implanted stereoelectroencephalography electrodes. Epilepsia Open, 9:409-416, Nov 2024. URL: https://doi.org/10.1002/epi4.12840, doi:10.1002/epi4.12840. This article has 11 citations and is from a peer-reviewed journal.
+
+18. (xie2023lowgradeepilepsyassociatedneuroepithelial media f56d460d): Mingguo Xie, Xiongfei Wang, Zejun Duan, and Guoming Luan. Low-grade epilepsy-associated neuroepithelial tumors: tumor spectrum and diagnosis based on genetic alterations. Frontiers in Neuroscience, Jan 2023. URL: https://doi.org/10.3389/fnins.2022.1071314, doi:10.3389/fnins.2022.1071314. This article has 27 citations and is from a peer-reviewed journal.
+
+19. (takayama2022ishippocampalresection pages 1-2): Yutaro Takayama, Naoki Ikegaya, Keiya Iijima, Yuiko Kimura, Kenzo Kosugi, Suguru Yokosako, Yuu Kaneko, Tetsuya Yamamoto, and Masaki Iwasaki. Is hippocampal resection necessary for low-grade epilepsy-associated tumors in the temporal lobe? Brain Sciences, 12:1381, Oct 2022. URL: https://doi.org/10.3390/brainsci12101381, doi:10.3390/brainsci12101381. This article has 6 citations.
+
+20. (rahim2023clinicopathologicalfeaturesof pages 6-7): Shabina Rahim, Nasir Ud Din, Jamshid Abdul-Ghafar, Qurratulain Chundriger, Poonum Khan, and Zubair Ahmad. Clinicopathological features of dysembryoplastic neuroepithelial tumor: a case series. Journal of Medical Case Reports, Aug 2023. URL: https://doi.org/10.1186/s13256-023-04062-1, doi:10.1186/s13256-023-04062-1. This article has 6 citations and is from a peer-reviewed journal.
+
+21. (NCT03970785 chunk 1):  Intraoperative Fluorescence of Ganglogliomas and Neuroepithelial Dysembryoplastic Tumors. Rennes University Hospital. 2018. ClinicalTrials.gov Identifier: NCT03970785
+
+22. (rivera2016germlineandsomatic pages 12-15): Barbara Rivera, Tenzin Gayden, Jian Carrot-Zhang, Javad Nadaf, Talia Boshari, Damien Faury, Michele Zeinieh, Romeo Blanc, David L. Burk, Somayyeh Fahiminiya, Eric Bareke, Ulrich Schüller, Camelia M. Monoranu, Ronald Sträter, Kornelius Kerl, Thomas Niederstadt, Gerhard Kurlemann, Benjamin Ellezam, Zuzanna Michalak, Maria Thom, Paul J. Lockhart, Richard J. Leventer, Milou Ohm, Duncan MacGregor, David Jones, Jason Karamchandani, Celia M. T. Greenwood, Albert M. Berghuis, Susanne Bens, Reiner Siebert, Magdalena Zakrzewska, Pawel P. Liberski, Krzysztof Zakrzewski, Sanjay M. Sisodiya, Werner Paulus, Steffen Albrecht, Martin Hasselblatt, Nada Jabado, William D. Foulkes, and Jacek Majewski. Germline and somatic fgfr1 abnormalities in dysembryoplastic neuroepithelial tumors. Acta Neuropathologica, 131:847-863, Feb 2016. URL: https://doi.org/10.1007/s00401-016-1549-x, doi:10.1007/s00401-016-1549-x. This article has 214 citations and is from a highest quality peer-reviewed journal.
+
+23. (avila2024braintumorrelatedepilepsy pages 10-11): Edward K Avila, Steven Tobochnik, Sara K Inati, Johan A F Koekkoek, Guy M McKhann, James J Riviello, Roberta Rudà, David Schiff, William O Tatum, Jessica W Templer, Michael Weller, and Patrick Y Wen. Brain tumor-related epilepsy management: a society for neuro-oncology (sno) consensus review on current management. Neuro-oncology, 26:7-24, Sep 2024. URL: https://doi.org/10.1093/neuonc/noad154, doi:10.1093/neuonc/noad154. This article has 106 citations and is from a domain leading peer-reviewed journal.
+
+24. (surrey2019genomicanalysisof pages 1-1): Lea F Surrey, Payal Jain, Bo Zhang, Joshua Straka, Xiaonan Zhao, Brian N Harding, Adam C Resnick, Phillip B Storm, Anna Maria Buccoliero, Lorenzo Genitori, Marilyn M Li, Angela J Waanders, and Mariarita Santi. Genomic analysis of dysembryoplastic neuroepithelial tumor spectrum reveals a diversity of molecular alterations dysregulating the mapk and pi3k/mtor pathways. Journal of neuropathology and experimental neurology, 78:1100-1111, Dec 2019. URL: https://doi.org/10.1093/jnen/nlz101, doi:10.1093/jnen/nlz101. This article has 66 citations and is from a peer-reviewed journal.
+
+25. (newton2024antiepilepticstrategiesfor pages 1-3): Herbert B. Newton and Jenna Wojkowski. Antiepileptic strategies for patients with primary and metastatic brain tumors. Current Treatment Options in Oncology, 25:389-403, Feb 2024. URL: https://doi.org/10.1007/s11864-024-01182-8, doi:10.1007/s11864-024-01182-8. This article has 20 citations and is from a peer-reviewed journal.
+
+26. (NCT04923126 chunk 2):  SJ901: Evaluation of Mirdametinib in Children, Adolescents, and Young Adults With Low-Grade Glioma. St. Jude Children's Research Hospital. 2021. ClinicalTrials.gov Identifier: NCT04923126
+
+27. (NCT04923126 chunk 4):  SJ901: Evaluation of Mirdametinib in Children, Adolescents, and Young Adults With Low-Grade Glioma. St. Jude Children's Research Hospital. 2021. ClinicalTrials.gov Identifier: NCT04923126

--- a/research/Dysembryoplastic_Neuroepithelial_Tumor-deep-research-falcon.md.citations.md
+++ b/research/Dysembryoplastic_Neuroepithelial_Tumor-deep-research-falcon.md.citations.md
@@ -1,0 +1,496 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dysembryoplastic Neuroepithelial Tumor
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dysembryoplastic Neuroepithelial Tumor** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T11:29:46.550060
+
+1. rosemberg2023longtermepilepsyassociatedtumors pages 1-2
+2. pages2022thegenomiclandscape pages 10-10
+3. rahim2023clinicopathologicalfeaturesof pages 1-2
+4. khalilov2024atypicalpresentationof pages 1-2
+5. rivera2016germlineandsomatic pages 1-2
+6. surrey2019genomicanalysisof pages 1-1
+7. chen2022casereporta pages 1-2
+8. rivera2016germlineandsomatic pages 12-15
+9. avila2024braintumorrelatedepilepsy pages 10-11
+10. iijima2024genotyperelevantneuroimagingfeatures pages 1-2
+11. zhang2022longtermseizureoutcomes pages 1-2
+12. bonney2016reviewofseizure pages 4-5
+13. xie2023lowgradeepilepsyassociatedneuroepithelial pages 1-2
+14. takayama2022ishippocampalresection pages 1-2
+15. newton2024antiepilepticstrategiesfor pages 1-3
+16. rahim2023clinicopathologicalfeaturesof pages 6-7
+17. xie2023lowgradeepilepsyassociatedneuroepithelial pages 2-3
+18. pelissier2026pediatriclowgradeepilepsyassociated pages 1-3
+19. zhang2022longtermseizureoutcomes pages 2-5
+20. lucas2020comprehensiveanalysisof pages 1-2
+21. https://doi.org/10.1186/s13256-023-04062-1
+22. https://doi.org/10.17816/acen.1126
+23. https://doi.org/10.3389/fneur.2024.1419104
+24. https://doi.org/10.1093/neuonc/noad154
+25. https://doi.org/10.1007/s11864-024-01182-8
+26. https://clinicaltrials.gov/study/NCT03970785
+27. https://clinicaltrials.gov/study/NCT04923126
+28. https://doi.org/10.1186/s13256-023-04062-1,
+29. https://doi.org/10.17816/acen.1126,
+30. https://doi.org/10.3389/fnins.2022.1071314,
+31. https://doi.org/10.1055/s-0043-1777730,
+32. https://doi.org/10.3390/brainsci13010024,
+33. https://doi.org/10.1007/s00247-026-06519-z,
+34. https://doi.org/10.3389/fneur.2024.1419104,
+35. https://doi.org/10.1007/s11060-015-1961-4,
+36. https://doi.org/10.1007/s00401-016-1549-x,
+37. https://doi.org/10.1186/s40478-020-01027-z,
+38. https://doi.org/10.1111/neup.12846,
+39. https://doi.org/10.1111/nan.12834,
+40. https://doi.org/10.3389/fonc.2022.1064817,
+41. https://doi.org/10.1002/epi4.12840,
+42. https://doi.org/10.3390/brainsci12101381,
+43. https://doi.org/10.1093/neuonc/noad154,
+44. https://doi.org/10.1093/jnen/nlz101,
+45. https://doi.org/10.1007/s11864-024-01182-8,


### PR DESCRIPTION
## Summary

Adds a new DISMECH disorder entry for dysembryoplastic neuroepithelial tumor (MONDO:0005505), using the required Falcon deep-research artifact and cache-backed evidence.

## Curation Scope

- Defines DNET/DNT as a WHO grade 1 low-grade epilepsy-associated glioneuronal tumor.
- Adds FGFR1/RAS-MAPK pathophysiology, broader DNT-spectrum MAPK/PI3K molecular heterogeneity, cortical hyperexcitability, and glioneuronal tumor formation.
- Adds focal-onset seizure phenotype, diagnostic histopathology, MRI/EEG/molecular testing, FGFR1 genetics, surgical resection, and anti-seizure medication management.
- Fetches and cites only the PMID caches used by the YAML evidence.

## Key References

- PMID:37525202
- PMID:36672006
- PMID:26920151
- PMID:35836307
- PMID:31617914
- PMID:36699536
- PMID:26514362

## Validation

- `just validate kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml` passed.
- `just validate-references kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml` passed. The current validator reported `Total checks: 0` for this file, but the YAML contains 19 evidence blocks and all snippets were copied from fetched reference caches.
- `just validate-terms kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml` passed. The requested `validate-terms-file` recipe is not present in this checkout.
- `just compliance kb/disorders/Dysembryoplastic_Neuroepithelial_Tumor.yaml` reports 91.8% weighted compliance.

## Cleanup

Tracked generated `cache/*` churn and uncited `references_cache/clinicaltrials_NCT*.md` churn were restored before staging. Uncited fetched PMID caches were removed before commit.