### PR TITLE
[codex] Link arginase plasma arginine endpoints

### DIFF
--- a/kb/disorders/Arginase_Deficiency.yaml
+++ b/kb/disorders/Arginase_Deficiency.yaml
@@ -639,6 +639,30 @@ biochemical:
   context: 'Markedly elevated plasma arginine is the hallmark biochemical abnormality, with levels often exceeding 300 umol/L (normal upper limit approximately 75 umol/L). The therapeutic target is to reduce plasma arginine below 200 umol/L. Arginine is the primary biomarker for diagnosis, monitoring, and therapeutic response assessment.
 
     '
+  readouts:
+  - target: Impaired ureagenesis and hyperargininemia
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-009
+    - FDA-SE-pediatric-noncancer-005
+    interpretation: >-
+      Higher plasma arginine reflects the ARG1-D hyperargininemia mechanism;
+      therapeutic reduction after arginine-specific enzyme treatment reports
+      pharmacodynamic correction of that mechanism.
+    evidence:
+    - reference: PMID:38292042
+      reference_title: "Efficacy and safety of pegzilarginase in arginase 1 deficiency (PEACE): a phase 3, randomized, double-blind, placebo-controlled, multi-centre trial."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Pegzilarginase lowered geometric mean pArg from 354.0 μmol/L to 86.4 μmol/L at Week 24 vs 464.7 to 426.6 μmol/L for placebo
+      explanation: Supports plasma arginine reduction as a pharmacodynamic response to enzyme replacement in ARG1-D.
+  mappings_list:
+  - preferred_term: L-arginine
+    term:
+      id: CHEBI:16467
+      label: L-arginine
   evidence:
   - reference: PMID:38292042
     reference_title: "Efficacy and safety of pegzilarginase in arginase 1 deficiency (PEACE): a phase 3, randomized, double-blind, placebo-controlled, multi-centre trial."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -230,8 +230,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Arginase 1 deficiency; population: treatment of hyperargininemia in adult
     with Arginase 1 Deficiency; endpoint: Reduction in plasma arginine; approval context: accelerated;
     drug mechanism: Arginine specific enzyme.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Arginase Deficiency
+  mapped_disease_files:
+  - kb/disorders/Arginase_Deficiency.yaml
+  mapping_notes: >-
+    Curated synonym match: FDA disease/use "Arginase 1 deficiency" maps to the
+    Arginase Deficiency disease page and its plasma arginine pharmacodynamic
+    readout.
 - row_id: FDA-SE-adult-noncancer-010
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -3760,8 +3767,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Arginase 1 deficiency; population: Pediatric patients 2 years of age and
     older with Arginase 1 Deficiency; endpoint: reduction in plasma arginine; approval context: accelerated;
     drug mechanism: arginine specific enzyme; age range: 2 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Arginase Deficiency
+  mapped_disease_files:
+  - kb/disorders/Arginase_Deficiency.yaml
+  mapping_notes: >-
+    Curated synonym match: FDA disease/use "Arginase 1 deficiency" maps to the
+    Arginase Deficiency disease page and its plasma arginine pharmacodynamic
+    readout.
 - row_id: FDA-SE-pediatric-noncancer-006
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- add a pharmacodynamic readout from plasma arginine to the ARG1-D hyperargininemia pathograph node
- link adult and pediatric FDA arginase 1 deficiency plasma arginine rows back to Arginase_Deficiency.yaml
- add CHEBI mapping for L-arginine on the plasma arginine marker

## Validation
- just validate kb/disorders/Arginase_Deficiency.yaml
- uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q
- git diff --check