### PR TITLE
[codex] Link ITP platelet count endpoints

### DIFF
--- a/kb/disorders/Immune_Thrombocytopenia.yaml
+++ b/kb/disorders/Immune_Thrombocytopenia.yaml
@@ -211,6 +211,40 @@ biochemical:
 - name: Platelet Count
   presence: Decreased
   context: Typically <100,000/μL, may be severe <10,000/μL
+  readouts:
+  - target: Thrombocytopenia
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-072
+    - FDA-SE-pediatric-noncancer-050
+    interpretation: >-
+      Higher platelet count indicates reduced thrombocytopenia burden and can
+      serve as a treatment-response readout in ITP.
+    evidence:
+    - reference: PMID:38396839
+      reference_title: "Current Understanding of Immune Thrombocytopenia: A Review of Pathogenesis and Treatment Options."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A major risk of ITP is bleeding, but knowledge on the exact relationship
+        between the degree of thrombocytopenia and bleeding symptoms, especially
+        at a lower platelet count, is lacking.
+      explanation: >-
+        This review links platelet count to the degree of thrombocytopenia and
+        bleeding risk context in ITP, supporting platelet count as a local
+        disease-burden readout.
+    - reference: DOI:10.1182/bloodadvances.2023012044
+      reference_title: Long-term treatment with rilzabrutinib in patients with immune thrombocytopenia
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        With continued rilzabrutinib treatment in the LTE, platelet responses
+        were durable and stable over time with no new safety signals.
+      explanation: >-
+        This ITP clinical study supports platelet response as a treatment
+        readout, consistent with the FDA platelet-count endpoint context.
 - name: Antiplatelet Antibodies
   presence: Variable
   context: Not routinely tested; poor sensitivity
@@ -283,34 +317,26 @@ classifications:
   - classification_value: autoimmune disease
 references:
 - reference: DOI:10.1007/s00277-024-05999-z
-  title: The effects of complement-independent, autoantibody-induced apoptosis
-    of platelets in immune thrombocytopenia (ITP)
+  title: The effects of complement-independent, autoantibody-induced apoptosis of platelets in immune thrombocytopenia (ITP)
   findings: []
 - reference: DOI:10.1007/s40268-024-00490-6
-  title: Pharmacokinetics, Pharmacodynamics, and Safety of Intravenous
-    Efgartigimod and Subcutaneous Efgartigimod PH20 in Healthy Chinese
-    Participants
+  title: Pharmacokinetics, Pharmacodynamics, and Safety of Intravenous Efgartigimod and Subcutaneous Efgartigimod PH20 in Healthy Chinese Participants
   findings: []
 - reference: DOI:10.1007/s44337-024-00008-8
-  title: 'Immune thrombocytopenia (ITP): historical perspectives, pathophysiology,
-    and treatment advances'
+  title: 'Immune thrombocytopenia (ITP): historical perspectives, pathophysiology, and treatment advances'
   findings: []
 - reference: DOI:10.1007/s44337-024-00040-8
   title: 'Immune thrombocytopenia: a review of pathogenesis and current treatment'
   findings: []
 - reference: DOI:10.1182/bloodadvances.2023012044
-  title: Long-term treatment with rilzabrutinib in patients with immune
-    thrombocytopenia
+  title: Long-term treatment with rilzabrutinib in patients with immune thrombocytopenia
   findings: []
 - reference: DOI:10.3390/hematolrep16020021
-  title: 'Pathophysiology, Clinical Manifestations and Diagnosis of Immune Thrombocytopenia:
-    Contextualization from a Historical Perspective'
+  title: 'Pathophysiology, Clinical Manifestations and Diagnosis of Immune Thrombocytopenia: Contextualization from a Historical Perspective'
   findings: []
 - reference: DOI:10.3390/ijms25042163
-  title: 'Current Understanding of Immune Thrombocytopenia: A Review of Pathogenesis
-    and Treatment Options'
+  title: 'Current Understanding of Immune Thrombocytopenia: A Review of Pathogenesis and Treatment Options'
   findings: []
 - reference: DOI:10.3390/jox13010005
-  title: 'Safety and Efficacy of Tyrosine Kinase Inhibitors in Immune Thrombocytopenic
-    Purpura: A Systematic Review of Clinical Trials'
+  title: 'Safety and Efficacy of Tyrosine Kinase Inhibitors in Immune Thrombocytopenic Purpura: A Systematic Review of Clinical Trials'
   findings: []

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1776,8 +1776,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with Thrombocytopenia due
     to immune (idiopathic) thrombocytopenia or chronic hepatitis C; endpoint: Platelet count response;
     approval context: traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Immune Thrombocytopenia
+  mapped_disease_files:
+  - kb/disorders/Immune_Thrombocytopenia.yaml
+  mapping_notes: >-
+    Manually reviewed for ITP platelet-count biomarker integration. The FDA row
+    is broader than the disease page because it covers thrombocytopenia due to
+    immune/idiopathic thrombocytopenia or chronic hepatitis C.
 - row_id: FDA-SE-adult-noncancer-073
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4894,8 +4901,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with thrombocytopenia due
     to immune (idiopathic) thrombocytopenia or chronic hepatitis C; endpoint: Platelet count; approval
     context: traditional; drug mechanism: Thrombopoietin receptor agonist; age range: 1 year and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Immune Thrombocytopenia
+  mapped_disease_files:
+  - kb/disorders/Immune_Thrombocytopenia.yaml
+  mapping_notes: >-
+    Manually reviewed for ITP platelet-count biomarker integration. The FDA row
+    is broader than the disease page because it covers thrombocytopenia due to
+    immune/idiopathic thrombocytopenia or chronic hepatitis C.
 - row_id: FDA-SE-pediatric-noncancer-051
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Add an ITP platelet-count biomarker readout linked to the `Thrombocytopenia` phenotype with pharmacodynamic endpoint context.
- Link the readout to FDA adult and pediatric platelet-count surrogate endpoint rows.
- Mark the two broad FDA nonmalignant-hematology rows as candidate DisMech mappings because the FDA context also includes chronic hepatitis C thrombocytopenia.

## Validation

- `just validate kb/disorders/Immune_Thrombocytopenia.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`