### PR TITLE
Add ALG9 congenital disorder of glycosylation curation

### DIFF
--- a/kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml
@@ -1,0 +1,604 @@
+name: ALG9-congenital disorder of glycosylation
+creation_date: "2026-05-11T16:30:19Z"
+updated_date: "2026-05-11T16:52:00Z"
+description: >-
+  ALG9-congenital disorder of glycosylation is a rare autosomal recessive
+  disorder of protein N-linked glycosylation caused by biallelic ALG9 variants.
+  ALG9 deficiency disrupts endoplasmic-reticulum lipid-linked oligosaccharide
+  assembly, producing a type I congenital disorder of glycosylation pattern and
+  a variable spectrum that includes neurodevelopmental impairment, seizures,
+  hypotonia, hepatomegaly, renal cysts, pericardial effusion, and severe
+  prenatal skeletal dysplasia in some affected fetuses.
+category: Mendelian
+disease_term:
+  preferred_term: ALG9-congenital disorder of glycosylation
+  term:
+    id: MONDO:0012117
+    label: ALG9-congenital disorder of glycosylation
+parents:
+- congenital disorder of glycosylation type I
+- disorder of protein N-glycosylation
+synonyms:
+- ALG9-CDG
+- CDG-IL
+- congenital disorder of glycosylation type Il
+inheritance:
+- name: Autosomal recessive inheritance
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  description: >-
+    ALG9-CDG is inherited as an autosomal recessive disorder, with reported
+    affected individuals carrying homozygous ALG9 variants.
+  evidence:
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A rare lethal autosomal recessive syndrome with skeletal dysplasia,
+      polycystic kidneys and multiple malformations was first described by
+      Gillessen-Kaesbach et al and subsequently by Nishimura et al.
+    explanation: >-
+      The fetal ALG9 skeletal-dysplasia paper directly describes the syndrome as
+      autosomal recessive.
+  - reference: PMID:28742265
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All the patients had homozygous gene mutations.
+    explanation: >-
+      The Saudi CDG cohort supports recessive disease by reporting homozygous
+      mutations across affected patients, including ALG9-CDG cases.
+prevalence:
+- population: Saudi CDG cohort
+  notes: >-
+    ALG9-CDG is ultra-rare globally, but it represented a substantial fraction
+    of one Saudi congenital-disorder-of-glycosylation cohort.
+  evidence:
+  - reference: PMID:28742265
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Based on molecular studies, the 27 CDG patients were classified into
+      different subtypes: ALG9-CDG (8 patients, 29.5%), ALG3-CDG (7 patients,
+      26%), COG6-CDG (7 patients, 26%), MGAT2-CDG (3 patients, 11%),
+      SLC35A2-CDG (1 patient), and PMM2-CDG (1 patient).
+    explanation: >-
+      This provides a cohort-level estimate of ALG9-CDG representation within a
+      molecularly diagnosed Saudi CDG cohort.
+progression:
+- phase: Variable prenatal-to-infantile spectrum
+  notes: >-
+    Reported ALG9-CDG severity ranges from liveborn multisystem
+    neurodevelopmental disease to lethal prenatal skeletal dysplasia with
+    visceral malformations.
+  evidence:
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our study shows that some pathogenic variants in ALG9 can present as a
+      lethal skeletal dysplasia with visceral malformations as the most severe
+      phenotype.
+    explanation: >-
+      The fetal series defines the severe prenatal end of the ALG9-CDG spectrum.
+  - reference: PMID:28932688
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Seven of these patients had a similar phenotype with failure to thrive,
+      dysmorphic features, seizures, hepatic and/or renal cysts; the other three
+      patients died in utero from a lethal skeletal dysplasia.
+    explanation: >-
+      The ALG9-CDG review summarizes both liveborn and fetal-lethal disease
+      presentations.
+pathophysiology:
+- name: ALG9 alpha-1,2-mannosyltransferase deficiency
+  description: >-
+    Pathogenic ALG9 variants impair an alpha-1,2-mannosyltransferase required
+    for lipid-linked oligosaccharide assembly in the endoplasmic reticulum.
+  genes:
+  - preferred_term: ALG9
+    term:
+      id: hgnc:15672
+      label: ALG9
+  biological_processes:
+  - preferred_term: dolichol-linked oligosaccharide biosynthetic process
+    modifier: DECREASED
+    term:
+      id: GO:0006488
+      label: dolichol-linked oligosaccharide biosynthetic process
+  - preferred_term: protein N-linked glycosylation
+    modifier: DECREASED
+    term:
+      id: GO:0006487
+      label: protein N-linked glycosylation
+  evidence:
+  - reference: PMID:15148656
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Using this approach, we have found, in a patient with CDG, a deficiency of
+      the ALG9 alpha 1,2 mannosyltransferase enzyme, which causes an
+      accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8)
+      structures, which was paralleled by the transfer of incomplete
+      oligosaccharides precursors to protein.
+    explanation: >-
+      The defining paper directly identifies ALG9 enzyme deficiency and the
+      associated lipid-linked oligosaccharide accumulation in patient-derived
+      biochemical studies.
+  downstream:
+  - target: Truncated lipid-linked oligosaccharide accumulation
+    description: >-
+      Reduced ALG9 activity causes accumulation of incomplete
+      DolPP-linked oligosaccharides.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15148656
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Using this approach, we have found, in a patient with CDG, a deficiency
+        of the ALG9 alpha 1,2 mannosyltransferase enzyme, which causes an
+        accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8)
+        structures, which was paralleled by the transfer of incomplete
+        oligosaccharides precursors to protein.
+      explanation: >-
+        This is direct biochemical evidence that ALG9 deficiency causes
+        accumulation of truncated lipid-linked oligosaccharides.
+- name: Truncated lipid-linked oligosaccharide accumulation
+  description: >-
+    Accumulated incomplete lipid-linked oligosaccharides are transferred to
+    proteins, producing hypoglycosylation and a type I CDG biochemical pattern.
+  biological_processes:
+  - preferred_term: protein N-linked glycosylation
+    modifier: DECREASED
+    term:
+      id: GO:0006487
+      label: protein N-linked glycosylation
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Hypoglycosylation was confirmed by the typical CDG type 1 pattern of serum
+      transferrin analyzed by isoelectric focusing.
+    explanation: >-
+      The second case report confirms the downstream type I CDG transferrin
+      hypoglycosylation pattern.
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      A defect in the ALG9 enzyme was suggested by the accumulation of the
+      DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8 in the patient's fibroblasts and
+      confirmed by mutation analysis: the patient is homozygous for the ALG9
+      mutation p.Y286C.
+    explanation: >-
+      Patient fibroblast data independently support the ALG9 biochemical block.
+  downstream:
+  - target: Multisystem glycoprotein dysfunction
+    description: >-
+      Protein hypoglycosylation contributes to neurologic, hepatic, renal,
+      cardiac, and skeletal manifestations.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:15148656
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The ALG9 defect found in the patient with CDG--who presented with
+        developmental delay, hypotonia, seizures, and hepatomegaly--shows that
+        efficient lipid-linked oligosaccharide synthesis is required for proper
+        human development and physiology.
+      explanation: >-
+        The original report links inefficient lipid-linked oligosaccharide
+        synthesis to human developmental and organ-system manifestations.
+- name: Multisystem glycoprotein dysfunction
+  description: >-
+    Defective N-glycosylation manifests as neurodevelopmental disease,
+    congenital anomalies, renal cystic disease, pericardial effusion, and severe
+    skeletal dysplasia in the most severe fetal presentations.
+  biological_processes:
+  - preferred_term: N-glycan processing
+    modifier: ABNORMAL
+    term:
+      id: GO:0006491
+      label: N-glycan processing
+  evidence:
+  - reference: PMID:28932688
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      To date, a total of 10 patients from 6 different families have been
+      reported with one of four ALG9 mutations.
+    explanation: >-
+      The review frames the disease as a rare multisystem human disorder caused
+      by ALG9 mutations.
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All three suffered from intellectual disability, muscular hypotonia,
+      microcephaly and renal cysts, but none had skeletal dysplasia.
+    explanation: >-
+      The fetal skeletal-dysplasia paper summarizes recurrent liveborn ALG9-CDG
+      manifestations and distinguishes them from the fetal skeletal phenotype.
+phenotypes:
+- name: Global developmental delay
+  category: Neurologic
+  description: >-
+    Developmental delay and intellectual disability are recurrent neurologic
+    manifestations of liveborn ALG9-CDG.
+  phenotype_term:
+    preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  evidence:
+  - reference: PMID:15148656
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ALG9 defect found in the patient with CDG--who presented with
+      developmental delay, hypotonia, seizures, and hepatomegaly--shows that
+      efficient lipid-linked oligosaccharide synthesis is required for proper
+      human development and physiology.
+    explanation: >-
+      The original ALG9-CDG report directly lists developmental delay in the
+      affected patient.
+- name: Generalized hypotonia
+  category: Neurologic
+  description: >-
+    Hypotonia is repeatedly reported in liveborn ALG9-CDG.
+  phenotype_term:
+    preferred_term: Generalized hypotonia
+    term:
+      id: HP:0001290
+      label: Generalized hypotonia
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The female infant's features included psychomotor retardation, seizures,
+      hypotonia, diffuse brain atrophy with delayed myelination, failure to
+      thrive, pericardial effusion, cystic renal disease, hepatosplenomegaly,
+      esotropia, and inverted nipples.
+    explanation: >-
+      The second case report directly lists hypotonia among the infant's
+      features.
+- name: Seizure
+  category: Neurologic
+  description: >-
+    Seizures occur in liveborn ALG9-CDG and can accompany failure to thrive and
+    congenital anomalies.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:28932688
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      She developed failure to thrive and seizures.
+    explanation: >-
+      The ALG9-CDG review's additional case directly supports seizures as part
+      of the phenotype.
+- name: Microcephaly
+  category: Neurologic
+  description: >-
+    Microcephaly is part of the liveborn ALG9-CDG neurologic phenotype.
+  phenotype_term:
+    preferred_term: Microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+  evidence:
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All three suffered from intellectual disability, muscular hypotonia,
+      microcephaly and renal cysts, but none had skeletal dysplasia.
+    explanation: >-
+      The fetal skeletal-dysplasia paper summarizes microcephaly among the
+      previously reported liveborn ALG9-CDG patients.
+- name: Failure to thrive
+  category: Growth
+  description: >-
+    Failure to thrive is reported in liveborn ALG9-CDG.
+  phenotype_term:
+    preferred_term: Failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: PMID:28932688
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Seven of these patients had a similar phenotype with failure to thrive,
+      dysmorphic features, seizures, hepatic and/or renal cysts; the other three
+      patients died in utero from a lethal skeletal dysplasia.
+    explanation: >-
+      The review identifies failure to thrive as a recurrent liveborn ALG9-CDG
+      manifestation.
+- name: Hepatomegaly
+  category: Hepatic
+  description: >-
+    Liver enlargement is part of the ALG9-CDG multisystem phenotype.
+  phenotype_term:
+    preferred_term: Hepatomegaly
+    term:
+      id: HP:0002240
+      label: Hepatomegaly
+  evidence:
+  - reference: PMID:15148656
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The ALG9 defect found in the patient with CDG--who presented with
+      developmental delay, hypotonia, seizures, and hepatomegaly--shows that
+      efficient lipid-linked oligosaccharide synthesis is required for proper
+      human development and physiology.
+    explanation: >-
+      The original ALG9-CDG case directly reports hepatomegaly.
+- name: Renal cyst
+  category: Renal
+  description: >-
+    Renal cysts and cystic renal disease are recurrent ALG9-CDG findings.
+  phenotype_term:
+    preferred_term: Renal cyst
+    term:
+      id: HP:0000107
+      label: Renal cyst
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The female infant's features included psychomotor retardation, seizures,
+      hypotonia, diffuse brain atrophy with delayed myelination, failure to
+      thrive, pericardial effusion, cystic renal disease, hepatosplenomegaly,
+      esotropia, and inverted nipples.
+    explanation: >-
+      The second reported infant had cystic renal disease.
+- name: Pericardial effusion
+  category: Cardiovascular
+  description: >-
+    Pericardial effusion is a reported cardiovascular manifestation of
+    ALG9-CDG.
+  phenotype_term:
+    preferred_term: Pericardial effusion
+    term:
+      id: HP:0001698
+      label: Pericardial effusion
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The female infant's features included psychomotor retardation, seizures,
+      hypotonia, diffuse brain atrophy with delayed myelination, failure to
+      thrive, pericardial effusion, cystic renal disease, hepatosplenomegaly,
+      esotropia, and inverted nipples.
+    explanation: >-
+      The second reported infant had pericardial effusion.
+- name: Hydrops fetalis
+  category: Prenatal
+  description: >-
+    Hydrops fetalis has been reported in ALG9-CDG within a Saudi CDG cohort.
+  phenotype_term:
+    preferred_term: Hydrops fetalis
+    term:
+      id: HP:0001789
+      label: Hydrops fetalis
+  evidence:
+  - reference: PMID:31420886
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The genes reported for CDG with NIHF for 15 distinct families include:
+      PMM2 in 47% (7/15), ALG9 in 20% (3/15), ALG8 in 13% (2/15), ALG1 in 7%
+      (1/15), MGAT2 in 7% (1/15), and COG6 7% (1/15).
+    explanation: >-
+      This review identifies ALG9 among CDG genes reported with nonimmune
+      hydrops fetalis.
+- name: Skeletal dysplasia
+  category: Skeletal
+  description: >-
+    Some ALG9 variants cause a severe prenatal skeletal dysplasia with
+    polycystic kidneys and multiple malformations.
+  phenotype_term:
+    preferred_term: Skeletal dysplasia
+    term:
+      id: HP:0002652
+      label: Skeletal dysplasia
+  evidence:
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A rare lethal autosomal recessive syndrome with skeletal dysplasia,
+      polycystic kidneys and multiple malformations was first described by
+      Gillessen-Kaesbach et al and subsequently by Nishimura et al.
+    explanation: >-
+      The ALG9 fetal series directly supports skeletal dysplasia in the severe
+      prenatal phenotype.
+genetic:
+- name: ALG9
+  association: Loss of function mutation
+  gene_term:
+    preferred_term: ALG9
+    term:
+      id: hgnc:15672
+      label: ALG9
+  evidence:
+  - reference: PMID:15148656
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      A homozygous point-mutation 1567G-->A (amino acid substitution E523K) was
+      detected in the ALG9 gene.
+    explanation: >-
+      The defining ALG9-CDG report identifies a homozygous ALG9 variant in the
+      affected patient.
+  - reference: PMID:25966638
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All affected patients were shown to have a novel homozygous splice variant
+      NM_024740.2: c.1173+2T>A in the ALG9 gene, encoding
+      alpha-1,2-mannosyltransferase, involved in the formation of the
+      lipid-linked oligosaccharide precursor of N-glycosylation.
+    explanation: >-
+      The fetal series directly links homozygous ALG9 splice variants to the
+      severe prenatal form.
+diagnosis:
+- name: Serum transferrin isoelectric focusing
+  description: >-
+    Transferrin isoelectric focusing detects the type I CDG
+    hypoglycosylation pattern that raises suspicion for ALG9-CDG.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  results: Type I congenital disorder of glycosylation transferrin pattern.
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hypoglycosylation was confirmed by the typical CDG type 1 pattern of serum
+      transferrin analyzed by isoelectric focusing.
+    explanation: >-
+      This directly supports serum transferrin isoelectric focusing as a
+      diagnostic biochemical test.
+- name: ALG9 molecular genetic testing
+  description: >-
+    Molecular testing confirms ALG9-CDG by identifying biallelic pathogenic
+    variants in ALG9.
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+    qualifiers:
+    - predicate:
+        preferred_term: has participant
+        term:
+          id: RO:0000057
+          label: has participant
+      value:
+        preferred_term: ALG9
+        term:
+          id: hgnc:15672
+          label: ALG9
+  results: Biallelic pathogenic ALG9 variants.
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A defect in the ALG9 enzyme was suggested by the accumulation of the
+      DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8 in the patient's fibroblasts and
+      confirmed by mutation analysis: the patient is homozygous for the ALG9
+      mutation p.Y286C.
+    explanation: >-
+      This supports mutation analysis as confirmatory testing for ALG9-CDG.
+biochemical:
+- name: Type I carbohydrate-deficient transferrin pattern
+  presence: ABNORMAL
+  context: >-
+    ALG9-CDG produces a type I CDG transferrin pattern from impaired synthesis
+    or transfer of lipid-linked oligosaccharide precursors.
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Hypoglycosylation was confirmed by the typical CDG type 1 pattern of serum
+      transferrin analyzed by isoelectric focusing.
+    explanation: >-
+      This is the reported biochemical diagnostic signature in a confirmed
+      ALG9-CDG patient.
+- name: Accumulated DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8
+  presence: ABNORMAL
+  context: >-
+    Patient cells accumulate truncated lipid-linked oligosaccharides upstream
+    of the ALG9-dependent mannosyltransferase steps.
+  evidence:
+  - reference: PMID:15148656
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      Using this approach, we have found, in a patient with CDG, a deficiency of
+      the ALG9 alpha 1,2 mannosyltransferase enzyme, which causes an
+      accumulation of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8)
+      structures, which was paralleled by the transfer of incomplete
+      oligosaccharides precursors to protein.
+    explanation: >-
+      The defining biochemical report directly describes the accumulated
+      DolPP-linked oligosaccharide species.
+treatments:
+- name: Supportive seizure management
+  description: >-
+    No ALG9-specific disease-modifying therapy is established; seizure care is
+    supportive and symptom-directed.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:28932688
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      She developed failure to thrive and seizures.
+    explanation: >-
+      The cited case supports seizures as a treatment target; specific
+      antiepileptic regimens are not provided in the abstract, so the treatment
+      claim is limited to supportive symptom management.
+- name: Cardiac surveillance
+  description: >-
+    Cardiac monitoring is prudent in ALG9-CDG because pericardial effusion is a
+    reported disease manifestation and CDG expert recommendations support
+    periodic cardiac surveillance for CDG patients.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  target_phenotypes:
+  - preferred_term: Pericardial effusion
+    term:
+      id: HP:0001698
+      label: Pericardial effusion
+  evidence:
+  - reference: PMID:38917675
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cardiac surveillance, including an echocardiogram and EKG, should be
+      conducted at the time of diagnosis, annually throughout the first 5 years,
+      followed by check-ups every 2-3 years if no concerns arise until
+      adulthood.
+    explanation: >-
+      This CDG-wide recommendation supports cardiac surveillance generally; the
+      ALG9-specific rationale comes from case evidence for pericardial effusion,
+      so support is marked partial.
+differential_diagnoses: []
+clinical_trials: []
+datasets: []

--- a/kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml
+++ b/kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml
@@ -161,7 +161,7 @@ pathophysiology:
   evidence:
   - reference: PMID:15945070
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       Hypoglycosylation was confirmed by the typical CDG type 1 pattern of serum
       transferrin analyzed by isoelectric focusing.
@@ -202,11 +202,11 @@ pathophysiology:
     congenital anomalies, renal cystic disease, pericardial effusion, and severe
     skeletal dysplasia in the most severe fetal presentations.
   biological_processes:
-  - preferred_term: N-glycan processing
-    modifier: ABNORMAL
+  - preferred_term: protein N-linked glycosylation
+    modifier: DECREASED
     term:
-      id: GO:0006491
-      label: N-glycan processing
+      id: GO:0006487
+      label: protein N-linked glycosylation
   evidence:
   - reference: PMID:28932688
     supports: SUPPORT
@@ -430,9 +430,53 @@ phenotypes:
     explanation: >-
       The ALG9 fetal series directly supports skeletal dysplasia in the severe
       prenatal phenotype.
+- name: Abnormal myelination
+  category: Neurologic
+  description: >-
+    Delayed myelination has been documented on brain MRI in ALG9-CDG.
+  phenotype_term:
+    preferred_term: Delayed myelination
+    term:
+      id: HP:0012447
+      label: Abnormal myelination
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Magnetic resonance imaging of the brain showed volume loss in the cerebral
+      hemispheres and cerebellum and delayed myelination.
+    explanation: >-
+      The second ALG9-CDG case report directly documents delayed myelination on
+      brain MRI.
+- name: Generalized cerebral atrophy/hypoplasia
+  category: Neurologic
+  description: >-
+    Cerebral and cerebellar volume loss has been reported in ALG9-CDG.
+  phenotype_term:
+    preferred_term: Diffuse brain atrophy
+    term:
+      id: HP:0007058
+      label: Generalized cerebral atrophy/hypoplasia
+  evidence:
+  - reference: PMID:15945070
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Magnetic resonance imaging of the brain showed volume loss in the cerebral
+      hemispheres and cerebellum and delayed myelination.
+    explanation: >-
+      The second ALG9-CDG case report directly documents cerebral and cerebellar
+      volume loss on MRI.
 genetic:
 - name: ALG9
   association: Loss of function mutation
+  features: >-
+    Reported ALG9-CDG variants include missense alleles in liveborn patients and
+    a homozygous c.1173+2T>A splice variant in fetal-lethal
+    Gillessen-Kaesbach-Nishimura skeletal dysplasia, supporting a
+    genotype-phenotype spectrum from severe liveborn multisystem disease to
+    prenatal lethality.
   gene_term:
     preferred_term: ALG9
     term:
@@ -441,7 +485,7 @@ genetic:
   evidence:
   - reference: PMID:15148656
     supports: SUPPORT
-    evidence_source: IN_VITRO
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       A homozygous point-mutation 1567G-->A (amino acid substitution E523K) was
       detected in the ALG9 gene.
@@ -512,6 +556,26 @@ diagnosis:
       mutation p.Y286C.
     explanation: >-
       This supports mutation analysis as confirmatory testing for ALG9-CDG.
+- name: Glycan profiling
+  description: >-
+    Glycan profiling can confirm the type I biochemical pattern and support an
+    ALG9-CDG diagnosis after transferrin screening.
+  diagnosis_term:
+    preferred_term: diagnostic procedure
+    term:
+      id: MAXO:0000003
+      label: diagnostic procedure
+  results: Glycan profile consistent with ALG9-CDG.
+  evidence:
+  - reference: PMID:28932688
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This was confirmed by glycan profiling, which identified ahomozygous
+      mutation in ALG9, c.860A > G (p.Tyr287Cys) (NM_1234567890).
+    explanation: >-
+      The ALG9-CDG review reports glycan profiling as a confirmatory diagnostic
+      method in the additional case.
 biochemical:
 - name: Type I carbohydrate-deficient transferrin pattern
   presence: ABNORMAL

--- a/references_cache/PMID_15148656.md
+++ b/references_cache/PMID_15148656.md
@@ -1,0 +1,76 @@
+---
+reference_id: "PMID:15148656"
+title: "Identification and functional analysis of a defect in the human ALG9 gene: definition of congenital disorder of glycosylation type IL."
+authors:
+- Frank CG
+- Grubenmann CE
+- Eyaid W
+- Berger EG
+- Aebi M
+- Hennet T
+journal: Am J Hum Genet
+year: '2004'
+doi: 10.1086/422367
+keywords:
+- Amino Acid Sequence
+- Amino Acid Substitution
+- "Congenital Disorders of Glycosylation/diagnosis, enzymology, genetics"
+- Female
+- Genetic Complementation Test
+- Glycosylation
+- Hepatomegaly/genetics
+- Homozygote
+- Humans
+- "Infant, Newborn"
+- Lipopolysaccharides/metabolism
+- "Mannosyltransferases/deficiency, genetics"
+- Molecular Sequence Data
+- Muscle Hypotonia/genetics
+- Point Mutation
+- Saccharomyces cerevisiae/genetics
+- Saccharomyces cerevisiae Proteins/genetics
+- Seizures/genetics
+- "Sequence Homology, Amino Acid"
+content_type: abstract_only
+---
+
+# Identification and functional analysis of a defect in the human ALG9 gene: definition of congenital disorder of glycosylation type IL.
+**Authors:** Frank CG, Grubenmann CE, Eyaid W, Berger EG, Aebi M, Hennet T
+**Journal:** Am J Hum Genet (2004)
+**DOI:** [10.1086/422367](https://doi.org/10.1086/422367)
+
+## Content
+
+1. Am J Hum Genet. 2004 Jul;75(1):146-50. doi: 10.1086/422367. Epub 2004 May 17.
+
+Identification and functional analysis of a defect in the human ALG9 gene: 
+definition of congenital disorder of glycosylation type IL.
+
+Frank CG(1), Grubenmann CE, Eyaid W, Berger EG, Aebi M, Hennet T.
+
+Author information:
+(1)Institute of Microbiology, Swiss Federal Institute of Technology, Zurich, 
+Switzerland.
+
+Defects of lipid-linked oligosaccharide assembly lead to alterations of N-linked 
+glycosylation known as "type I congenital disorders of glycosylation" (CDG). 
+Dysfunctions along this stepwise assembly pathway are characterized by 
+intracellular accumulation of intermediate lipid-linked oligosaccharides, the 
+detection of which contributes to the identification of underlying enzymatic 
+defects. Using this approach, we have found, in a patient with CDG, a deficiency 
+of the ALG9 alpha 1,2 mannosyltransferase enzyme, which causes an accumulation 
+of lipid-linked-GlcNAc(2)Man(6) and -GlcNAc(2)Man(8) structures, which was 
+paralleled by the transfer of incomplete oligosaccharides precursors to protein. 
+A homozygous point-mutation 1567G-->A (amino acid substitution E523K) was 
+detected in the ALG9 gene. The functional homology between the human ALG9 and 
+Saccharomyces cerevisiae ALG9, as well as the deleterious effect of the E523K 
+mutation detected in the patient with CDG, were confirmed by a yeast 
+complementation assay lacking the ALG9 gene. The ALG9 defect found in the 
+patient with CDG--who presented with developmental delay, hypotonia, seizures, 
+and hepatomegaly--shows that efficient lipid-linked oligosaccharide synthesis is 
+required for proper human development and physiology. The ALG9 defect presented 
+here defines a novel form of CDG named "CDG-IL."
+
+DOI: 10.1086/422367
+PMCID: PMC1181998
+PMID: 15148656 [Indexed for MEDLINE]

--- a/references_cache/PMID_15945070.md
+++ b/references_cache/PMID_15945070.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:15945070"
+title: "CDG-IL: an infant with a novel mutation in the ALG9 gene and additional phenotypic features."
+authors:
+- Weinstein M
+- Schollen E
+- Matthijs G
+- Neupert C
+- Hennet T
+- Grubenmann CE
+- Frank CG
+- Aebi M
+- Clarke JT
+- Griffiths A
+- Seargeant L
+- Poplawski N
+journal: Am J Med Genet A
+year: '2005'
+doi: 10.1002/ajmg.a.30851
+keywords:
+- Cathepsin A/metabolism
+- "Congenital Disorders of Glycosylation/enzymology, genetics, pathology"
+- Female
+- Genetic Complementation Test
+- Glycosylation
+- Humans
+- Infant
+- "Mannosyltransferases/deficiency, genetics, metabolism"
+- Muscle Hypotonia/pathology
+- Mutation
+- Phenotype
+- Psychomotor Disorders/pathology
+- "Saccharomyces cerevisiae/genetics, growth & development"
+- Seizures/pathology
+content_type: abstract_only
+---
+
+# CDG-IL: an infant with a novel mutation in the ALG9 gene and additional phenotypic features.
+**Authors:** Weinstein M, Schollen E, Matthijs G, Neupert C, Hennet T, Grubenmann CE, Frank CG, Aebi M, Clarke JT, Griffiths A, Seargeant L, Poplawski N
+**Journal:** Am J Med Genet A (2005)
+**DOI:** [10.1002/ajmg.a.30851](https://doi.org/10.1002/ajmg.a.30851)
+
+## Content
+
+1. Am J Med Genet A. 2005 Jul 15;136(2):194-7. doi: 10.1002/ajmg.a.30851.
+
+CDG-IL: an infant with a novel mutation in the ALG9 gene and additional 
+phenotypic features.
+
+Weinstein M(1), Schollen E, Matthijs G, Neupert C, Hennet T, Grubenmann CE, 
+Frank CG, Aebi M, Clarke JT, Griffiths A, Seargeant L, Poplawski N.
+
+Author information:
+(1)Hospital for Sick Children, Pediatrics, Toronto, Ontario, Canada. 
+michael.weinstein@sickkids.ca
+
+We describe the second case of congenital disorder of glycosylation type IL 
+(CDG-IL) caused by deficiency of the ALG9 a1,2 mannosyltransferase enzyme. The 
+female infant's features included psychomotor retardation, seizures, hypotonia, 
+diffuse brain atrophy with delayed myelination, failure to thrive, pericardial 
+effusion, cystic renal disease, hepatosplenomegaly, esotropia, and inverted 
+nipples. Lipodystrophy and dysmorphic facial features were absent. Magnetic 
+resonance imaging of the brain showed volume loss in the cerebral hemispheres 
+and cerebellum and delayed myelination. Laboratory investigations revealed low 
+levels of multiple serum proteins including antithrombin III, factor XI, and 
+cholesterol. Hypoglycosylation was confirmed by the typical CDG type 1 pattern 
+of serum transferrin analyzed by isoelectric focusing. A defect in the ALG9 
+enzyme was suggested by the accumulation of the DolPP-GlcNAc2Man6 and 
+DolPP-GlcNAc2Man8 in the patient's fibroblasts and confirmed by mutation 
+analysis: the patient is homozygous for the ALG9 mutation p.Y286C. The causal 
+effect of the mutation was shown by complementation assays in alg9 deficient 
+yeast cells. The child described here further delineates the clinical spectrum 
+of CDG-IL and confirms the significant clinical overlap amongst CDG subtypes.
+
+Copyright 2005 Wiley-Liss, Inc.
+
+DOI: 10.1002/ajmg.a.30851
+PMID: 15945070 [Indexed for MEDLINE]

--- a/references_cache/PMID_25966638.md
+++ b/references_cache/PMID_25966638.md
@@ -1,0 +1,118 @@
+---
+reference_id: "PMID:25966638"
+title: "A novel phenotype in N-glycosylation disorders: Gillessen-Kaesbach-Nishimura skeletal dysplasia due to pathogenic variants in ALG9."
+authors:
+- Tham E
+- Eklund EA
+- Hammarsjö A
+- Bengtson P
+- Geiberger S
+- Lagerstedt-Robinson K
+- Malmgren H
+- Nilsson D
+- Grigelionis G
+- Conner P
+- Lindgren P
+- Lindstrand A
+- Wedell A
+- Albåge M
+- Zielinska K
+- Nordgren A
+- Papadogiannakis N
+- Nishimura G
+- Grigelioniene G
+journal: Eur J Hum Genet
+year: '2016'
+doi: 10.1038/ejhg.2015.91
+keywords:
+- "Abnormalities, Multiple/genetics, pathology"
+- Alternative Splicing/genetics
+- Amino Acid Sequence
+- "Bone Diseases, Developmental/genetics, physiopathology"
+- "Central Nervous System Diseases/genetics, physiopathology"
+- Child
+- Comparative Genomic Hybridization
+- Exome/genetics
+- Female
+- Glycosylation
+- Humans
+- Male
+- Mannosyltransferases/genetics
+- Membrane Proteins/genetics
+- "Mutation, Missense"
+- "Nerve Degeneration/genetics, physiopathology"
+- "Osteochondrodysplasias/genetics, pathology"
+- Phenotype
+- Protein Isoforms/genetics
+- "Sequence Analysis, RNA"
+content_type: abstract_only
+---
+
+# A novel phenotype in N-glycosylation disorders: Gillessen-Kaesbach-Nishimura skeletal dysplasia due to pathogenic variants in ALG9.
+**Authors:** Tham E, Eklund EA, Hammarsjö A, Bengtson P, Geiberger S, Lagerstedt-Robinson K, Malmgren H, Nilsson D, Grigelionis G, Conner P, Lindgren P, Lindstrand A, Wedell A, Albåge M, Zielinska K, Nordgren A, Papadogiannakis N, Nishimura G, Grigelioniene G
+**Journal:** Eur J Hum Genet (2016)
+**DOI:** [10.1038/ejhg.2015.91](https://doi.org/10.1038/ejhg.2015.91)
+
+## Content
+
+1. Eur J Hum Genet. 2016 Feb;24(2):198-207. doi: 10.1038/ejhg.2015.91. Epub 2015 
+May 13.
+
+A novel phenotype in N-glycosylation disorders: Gillessen-Kaesbach-Nishimura 
+skeletal dysplasia due to pathogenic variants in ALG9.
+
+Tham E(1)(2), Eklund EA(3), Hammarsjö A(1)(2), Bengtson P(4), Geiberger S(5), 
+Lagerstedt-Robinson K(1)(2), Malmgren H(1)(2), Nilsson D(1)(2), Grigelionis 
+G(1), Conner P(6)(7), Lindgren P(6)(7), Lindstrand A(1)(2), Wedell A(1)(8), 
+Albåge M(9), Zielinska K(3), Nordgren A(1)(2), Papadogiannakis N(10), Nishimura 
+G(11), Grigelioniene G(1)(2).
+
+Author information:
+(1)Department of Molecular Medicine and Surgery, Karolinska Institutet, 
+Stockholm, Sweden.
+(2)Department of Clinical Genetics, Karolinska University Hospital, Stockholm, 
+Sweden.
+(3)Experimental Pediatrics, Clinical Sciences, Lund University, Lund, Sweden.
+(4)Department of Clinical Chemistry, part of University Health Care in Region 
+Skåne, Lund, Sweden.
+(5)Department of Pediatric Radiology, Karolinska University Hospital, Stockholm, 
+Sweden.
+(6)Department of Obstetrics and Gynecology, Karolinska University Hospital, 
+Stockholm, Sweden.
+(7)Department of Woman and Child Health, Karolinska Institutet, Stockholm, 
+Sweden.
+(8)Centre for Inherited Metabolic Diseases, Karolinska University Hospital, 
+Stockholm, Sweden.
+(9)Department of Neuropediatrics, Karolinska University Hospital, Stockholm, 
+Sweden.
+(10)Section for Perinatal Pathology, Department of Pathology, Karolinska 
+University Hospital and Karolinska Institutet, Stockholm, Sweden.
+(11)Department of Pediatric Imaging, Tokyo Metropolitan Children's Medical 
+Center, Tokyo, Japan.
+
+A rare lethal autosomal recessive syndrome with skeletal dysplasia, polycystic 
+kidneys and multiple malformations was first described by Gillessen-Kaesbach et 
+al and subsequently by Nishimura et al. The skeletal features uniformly comprise 
+a round pelvis, mesomelic shortening of the upper limbs and defective 
+ossification of the cervical spine. We studied two unrelated families including 
+three affected fetuses with Gillessen-Kaesbach-Nishimura syndrome using 
+whole-exome and Sanger sequencing, comparative genome hybridization and 
+homozygosity mapping. All affected patients were shown to have a novel 
+homozygous splice variant NM_024740.2: c.1173+2T>A in the ALG9 gene, encoding 
+alpha-1,2-mannosyltransferase, involved in the formation of the lipid-linked 
+oligosaccharide precursor of N-glycosylation. RNA analysis demonstrated skipping 
+of exon 10, leading to shorter RNA. Mass spectrometric analysis showed an 
+increase in monoglycosylated transferrin as compared with control tissues, 
+confirming that this is a congenital disorder of glycosylation (CDG). Only three 
+liveborn children with ALG9-CDG have been previously reported, all with missense 
+variants. All three suffered from intellectual disability, muscular hypotonia, 
+microcephaly and renal cysts, but none had skeletal dysplasia. Our study shows 
+that some pathogenic variants in ALG9 can present as a lethal skeletal dysplasia 
+with visceral malformations as the most severe phenotype. The skeletal features 
+overlap with that previously reported for ALG3- and ALG12-CDG, suggesting that 
+this subset of glycosylation disorders constitutes a new diagnostic group of 
+skeletal dysplasias.
+
+DOI: 10.1038/ejhg.2015.91
+PMCID: PMC4717212
+PMID: 25966638 [Indexed for MEDLINE]

--- a/references_cache/PMID_28742265.md
+++ b/references_cache/PMID_28742265.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:28742265"
+title: "Congenital disorders of glycosylation: The Saudi experience."
+authors:
+- Alsubhi S
+- Alhashem A
+- Faqeih E
+- Alfadhel M
+- Alfaifi A
+- Altuwaijri W
+- Alsahli S
+- Aldhalaan H
+- Alkuraya FS
+- Hundallah K
+- Mahmoud A
+- Alasmari A
+- Mutairi FA
+- Abduraouf H
+- AlRasheed L
+- Alshahwan S
+- Tabarki B
+journal: Am J Med Genet A
+year: '2017'
+doi: 10.1002/ajmg.a.38358
+keywords:
+- "Adaptor Proteins, Vesicular Transport/genetics"
+- Adolescent
+- "Biomarkers, Tumor/genetics"
+- Child
+- "Child, Preschool"
+- "Congenital Disorders of Glycosylation/epidemiology, genetics"
+- Female
+- Glycosylation
+- Homozygote
+- Humans
+- Infant
+- Male
+- Mannosyltransferases/genetics
+- Membrane Proteins/genetics
+- Mixed Function Oxygenases/genetics
+- Monosaccharide Transport Proteins/genetics
+- Mutation
+- N-Acetylglucosaminyltransferases/genetics
+- Phenotype
+- Retrospective Studies
+- Saudi Arabia/epidemiology
+- UDP-Galactose Translocators
+content_type: abstract_only
+---
+
+# Congenital disorders of glycosylation: The Saudi experience.
+**Authors:** Alsubhi S, Alhashem A, Faqeih E, Alfadhel M, Alfaifi A, Altuwaijri W, Alsahli S, Aldhalaan H, Alkuraya FS, Hundallah K, Mahmoud A, Alasmari A, Mutairi FA, Abduraouf H, AlRasheed L, Alshahwan S, Tabarki B
+**Journal:** Am J Med Genet A (2017)
+**DOI:** [10.1002/ajmg.a.38358](https://doi.org/10.1002/ajmg.a.38358)
+
+## Content
+
+1. Am J Med Genet A. 2017 Oct;173(10):2614-2621. doi: 10.1002/ajmg.a.38358. Epub 
+2017 Jul 25.
+
+Congenital disorders of glycosylation: The Saudi experience.
+
+Alsubhi S(1), Alhashem A(2), Faqeih E(3), Alfadhel M(4), Alfaifi A(4), 
+Altuwaijri W(5), Alsahli S(4), Aldhalaan H(6), Alkuraya FS(7)(8), Hundallah 
+K(1), Mahmoud A(3), Alasmari A(3), Mutairi FA(4), Abduraouf H(2), AlRasheed 
+L(2), Alshahwan S(1), Tabarki B(1).
+
+Author information:
+(1)Division of Pediatric Neurology, Department of Pediatrics, Prince Sultan 
+Military Medical City, Riyadh, Saudi Arabia.
+(2)Division of Genetics, Department of Pediatrics; Prince Sultan Military 
+Medical City, Riyadh, Saudi Arabia.
+(3)Department of Pediatric Subspecialties, Children's Hospital, King Fahad 
+Medical City, Riyadh, Saudi Arabia.
+(4)Division of Genetics, Department of Pediatrics, King Abdulaziz Medical City, 
+Riyadh, Saudi Arabia.
+(5)Division of Pediatric Neurology, Department of Pediatrics, King Abdulaziz 
+Medical City, Riyadh, Saudi Arabia.
+(6)Division of Pediatric Neurology, Department of Neurosciences, King Faisal 
+Specialist Hospital and Research Center, Riyadh, Saudi Arabia.
+(7)Department of Genetics, King Faisal Specialist Hospital and Research Center, 
+Riyadh, Saudi Arabia.
+(8)Department of Anatomy and Cell Biology, College of Medicine, Alfaisal 
+University, Riyadh, Saudi Arabia.
+
+We retrospectively reviewed Saudi patients who had a congenital disorder of 
+glycosylation (CDG). Twenty-seven Saudi patients (14 males, 13 females) from 13 
+unrelated families were identified. Based on molecular studies, the 27 CDG 
+patients were classified into different subtypes: ALG9-CDG (8 patients, 29.5%), 
+ALG3-CDG (7 patients, 26%), COG6-CDG (7 patients, 26%), MGAT2-CDG (3 patients, 
+11%), SLC35A2-CDG (1 patient), and PMM2-CDG (1 patient). All the patients had 
+homozygous gene mutations. The combined carrier frequency of CDG for the 
+encountered founder mutations in the Saudi population is 11.5 per 10,000, which 
+translates to a minimum disease burden of 14 patients per 1,000,000. Our study 
+provides comprehensive epidemiologic information and prevalence figures for each 
+of these CDG in a large cohort of congenital disorder of glycosylation patients.
+
+© 2017 Wiley Periodicals, Inc.
+
+DOI: 10.1002/ajmg.a.38358
+PMID: 28742265 [Indexed for MEDLINE]

--- a/references_cache/PMID_28932688.md
+++ b/references_cache/PMID_28932688.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:28932688"
+title: "ALG9-CDG: New clinical case and review of the literature."
+authors:
+- Davis K
+- Webster D
+- Smith C
+- Jackson S
+- Sinasac D
+- Seargeant L
+- Wei XC
+- Ferreira P
+- Midgley J
+- Foster Y
+- Li X
+- He M
+- Al-Hertani W
+journal: Mol Genet Metab Rep
+year: '2017'
+doi: 10.1016/j.ymgmr.2017.08.004
+content_type: abstract_only
+---
+
+# ALG9-CDG: New clinical case and review of the literature.
+**Authors:** Davis K, Webster D, Smith C, Jackson S, Sinasac D, Seargeant L, Wei XC, Ferreira P, Midgley J, Foster Y, Li X, He M, Al-Hertani W
+**Journal:** Mol Genet Metab Rep (2017)
+**DOI:** [10.1016/j.ymgmr.2017.08.004](https://doi.org/10.1016/j.ymgmr.2017.08.004)
+
+## Content
+
+1. Mol Genet Metab Rep. 2017 Sep 6;13:55-63. doi: 10.1016/j.ymgmr.2017.08.004. 
+eCollection 2017 Dec.
+
+ALG9-CDG: New clinical case and review of the literature.
+
+Davis K(1), Webster D(2), Smith C(1), Jackson S(1), Sinasac D(1), Seargeant 
+L(3), Wei XC(4), Ferreira P(1), Midgley J(5), Foster Y(6), Li X(6), He M(6), 
+Al-Hertani W(1).
+
+Author information:
+(1)Department of Medical Genetics, Cummings School of Medicine, University of 
+Calgary, Alberta Children's Hospital, Calgary, Alberta, Canada.
+(2)Department of Medicine, Dalhousie University, Saint John, New Brunswick, 
+Canada.
+(3)Department of Clinical Biochemistry and Genetics, Diagnostic Services 
+Manitoba, Department of Pediatrics, University of Manitoba, Winnipeg, Manitoba, 
+Canada.
+(4)Department of Diagnostic Radiology, University of Calgary, Alberta Children's 
+Hospital, Calgary, Alberta, Canada.
+(5)Department of Pediatrics, University of Calgary, Alberta Children's Hospital, 
+Calgary, Alberta, Canada.
+(6)Department of Medical Genetics, Children's Hospital of Philadelphia, 
+Philadelphia, PA, United States.
+
+Congenital disorders of glycosylation (CDG) are a group of metabolic diseases 
+resulting from defects in glycan synthesis or processing. The number of 
+subgroups and their phenotypic spectrums continue to expand with most related to 
+deficiencies of N-glycosylation. ALG9-CDG (previously CDG-IL) is the result of a 
+mutation in ALG9. This gene encodes the enzyme alpha-1,2-mannosyltransferase. To 
+date, a total of 10 patients from 6 different families have been reported with 
+one of four ALG9 mutations. Seven of these patients had a similar phenotype with 
+failure to thrive, dysmorphic features, seizures, hepatic and/or renal cysts; 
+the other three patients died in utero from a lethal skeletal dysplasia. This 
+report describes an additional patient with ALG9-CDG who has a milder phenotype. 
+This patient is a term female born to Caucasian, Canadian, non-consanguineous 
+parents of Scottish decent. Prenatally, dysmorphic features, numerous renal 
+cysts and minor cardiac malformations were detected. Post-natally, dysmorphic 
+features included shallow orbits, micrognathia, hypoplastic nipples, talipes 
+equinovarus, lipodystrophy and cutis marmorata. She developed failure to thrive 
+and seizures. The metabolic work-up included analysis of a transferrin 
+isoelectric focusing, which showed a type 1 pattern. This was confirmed by 
+glycan profiling, which identified ahomozygous mutation in ALG9, c.860A > G 
+(p.Tyr287Cys) (NM_1234567890). This had been previously published as a 
+pathogenic mutation in two Canadian patients. Our goal is to contribute to the 
+growing body of knowledge for this disorder by describing the phenotypic 
+spectrum and providing further insight on prognosis.
+
+DOI: 10.1016/j.ymgmr.2017.08.004
+PMCID: PMC5596360
+PMID: 28932688

--- a/references_cache/PMID_38917675.md
+++ b/references_cache/PMID_38917675.md
@@ -1,0 +1,159 @@
+---
+reference_id: "PMID:38917675"
+title: "Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: Recommendations for baseline screening and follow-up evaluation."
+authors:
+- Zemet R
+- Hope KD
+- Edmondson AC
+- Shah R
+- Patino M
+- Yesso AM
+- Berger JH
+- Sarafoglou K
+- Larson A
+- Lam C
+- Morava E
+- Scaglia F
+journal: Mol Genet Metab
+year: '2024'
+doi: 10.1016/j.ymgme.2024.108513
+keywords:
+- Humans
+- "Congenital Disorders of Glycosylation/genetics, diagnosis, pathology"
+- Female
+- Male
+- "Cardiomyopathies/genetics, diagnosis"
+- Phenotype
+- Child
+- "Child, Preschool"
+- Adolescent
+- Infant
+- Glycosylation
+- Follow-Up Studies
+- Adult
+- Retrospective Studies
+- Young Adult
+- Prospective Studies
+- "Infant, Newborn"
+content_type: abstract_only
+---
+
+# Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: Recommendations for baseline screening and follow-up evaluation.
+**Authors:** Zemet R, Hope KD, Edmondson AC, Shah R, Patino M, Yesso AM, Berger JH, Sarafoglou K, Larson A, Lam C, Morava E, Scaglia F
+**Journal:** Mol Genet Metab (2024)
+**DOI:** [10.1016/j.ymgme.2024.108513](https://doi.org/10.1016/j.ymgme.2024.108513)
+
+## Content
+
+1. Mol Genet Metab. 2024 Aug;142(4):108513. doi: 10.1016/j.ymgme.2024.108513.
+Epub  2024 Jun 13.
+
+Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: 
+Recommendations for baseline screening and follow-up evaluation.
+
+Zemet R(1), Hope KD(2), Edmondson AC(3), Shah R(4), Patino M(3), Yesso AM(5), 
+Berger JH(6), Sarafoglou K(7), Larson A(8), Lam C(9), Morava E(10), Scaglia 
+F(11).
+
+Author information:
+(1)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA.
+(2)Texas Children's Hospital, Houston, TX, USA; Lillie Frank Abercrombie 
+Division of Pediatric Cardiology, Department of Pediatrics, Baylor College of 
+Medicine, Houston, TX, USA.
+(3)Division of Human Genetics, Department of Pediatrics, Children's Hospital of 
+Philadelphia, Philadelphia, PA, USA.
+(4)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, USA; Department 
+of Biochemistry and Molecular Biology, Mayo Clinic, Rochester, MN, USA; 
+Department of Genetics and Genomic Sciences, Icahn School of Medicine at Mount 
+Sinai, New York City, NY, USA.
+(5)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA; Lillie Frank Abercrombie 
+Division of Pediatric Cardiology, Department of Pediatrics, Baylor College of 
+Medicine, Houston, TX, USA.
+(6)Division of Cardiology, Department of Pediatrics, Children's Hospital of 
+Philadelphia, Philadelphia, PA, USA.
+(7)Divisions of Endocrinology, and Genetics and Metabolism, Department of 
+Pediatrics, University of Minnesota Medical School, Minneapolis, MN, USA.
+(8)Department of Pediatrics, University of Colorado School of Medicine, Aurora, 
+CO, USA.
+(9)Department of Pediatrics, University of Washington and Seattle Children's 
+Hospital, Seattle, WA, USA; Norcliffe Foundation Center for Integrative Brain 
+Research, Seattle Children's Research Institute, Seattle, WA, USA.
+(10)Department of Clinical Genomics, Mayo Clinic, Rochester, MN, USA; Department 
+of Genetics and Genomic Sciences, Icahn School of Medicine at Mount Sinai, New 
+York City, NY, USA; Department of Laboratory Medicine and Pathology, Mayo 
+Clinic, Rochester, MN, USA.
+(11)Dept of Molecular & Human Genetics, Baylor College of Medicine, Houston, TX, 
+USA; Texas Children's Hospital, Houston, TX, USA; Joint BCM-CUHK Center of 
+Medical Genetics, Prince of Wales Hospital, Hong Kong SAR, China. Electronic 
+address: fscaglia@bcm.edu.
+
+INTRODUCTION: Congenital disorders of glycosylation (CDG) are a continuously 
+expanding group of monogenic disorders that disrupt glycoprotein and glycolipid 
+biosynthesis, leading to multi-systemic manifestations. These disorders are 
+categorized into various groups depending on which part of the glycosylation 
+process is impaired. The cardiac manifestations in CDG can significantly differ, 
+not only across different types but also among individuals with the same genetic 
+cause of CDG. Cardiomyopathy is an important phenotype in CDG. The clinical 
+manifestations and progression of cardiomyopathy in CDG patients have not been 
+well characterized. This study aims to delineate common patterns of 
+cardiomyopathy across a range of genetic causes of CDG and to propose baseline 
+screening and follow-up evaluation for this patient population.
+METHODS: Patients with molecular confirmation of CDG who were enrolled in the 
+prospective or memorial arms of the Frontiers in Congenital Disorders of 
+Glycosylation Consortium (FCDGC) natural history study were ascertained for the 
+presence of cardiomyopathy based on a retrospective review of their medical 
+records. All patients were evaluated by clinical geneticists who are members of 
+FCDGC at their respective academic centers. Patients were screened for 
+cardiomyopathy, and detailed data were retrospectively collected. We analyzed 
+their clinical and molecular history, imaging characteristics of cardiac 
+involvement, type of cardiomyopathy, age at initial presentation of 
+cardiomyopathy, additional cardiac features, the treatments administered, and 
+their clinical outcomes.
+RESULTS: Of the 305 patients with molecularly confirmed CDG participating in the 
+FCDGC natural history study as of June 2023, 17 individuals, nine females and 
+eight males, were identified with concurrent diagnoses of cardiomyopathy. Most 
+of these patients were diagnosed with PMM2-CDG (n = 10). However, cardiomyopathy 
+was also observed in other diagnoses, including PGM1-CDG (n = 3), ALG3-CDG 
+(n = 1), DPM1-CDG (n = 1), DPAGT1-CDG (n = 1), and SSR4-CDG (n = 1). All 
+PMM2-CDG patients were reported to have hypertrophic cardiomyopathy. Dilated 
+cardiomyopathy was observed in three patients, two with PGM1-CDG and one with 
+ALG3-CDG; left ventricular non-compaction cardiomyopathy was diagnosed in two 
+patients, one with PGM1-CDG and one with DPAGT1-CDG; two patients, one with 
+DPM1-CDG and one with SSR4-CDG, were diagnosed with non-ischemic cardiomyopathy. 
+The estimated median age of diagnosis for cardiomyopathy was 5 months (range: 
+prenatal-27 years). Cardiac improvement was observed in three patients with 
+PMM2-CDG. Five patients showed a progressive course of cardiomyopathy, while the 
+condition remained unchanged in eight individuals. Six patients demonstrated 
+pericardial effusion, with three patients exhibiting cardiac tamponade. One 
+patient with SSR4-CDG has been recently diagnosed with cardiomyopathy; thus, the 
+progression of the disease is yet to be determined. One patient with PGM1-CDG 
+underwent cardiac transplantation. Seven patients were deceased, including five 
+with PMM2-CDG, one with DPAGT1-CDG, and one with ALG3-CDG. Two patients died of 
+cardiac tamponade from pericardial effusion; for the remaining patients, 
+cardiomyopathy was not necessarily the primary cause of death.
+CONCLUSIONS: In this retrospective study, cardiomyopathy was identified in ∼6% 
+of patients with CDG. Notably, the majority, including all those with PMM2-CDG, 
+exhibited hypertrophic cardiomyopathy. Some cases did not show progression, yet 
+pericardial effusions were commonly observed, especially in PMM2-CDG patients, 
+occasionally escalating to life-threatening cardiac tamponade. It is recommended 
+that clinicians managing CDG patients, particularly those with PMM2-CDG and 
+PGM1-CDG, be vigilant of the cardiomyopathy risk and risk for potentially 
+life-threatening pericardial effusions. Cardiac surveillance, including an 
+echocardiogram and EKG, should be conducted at the time of diagnosis, annually 
+throughout the first 5 years, followed by check-ups every 2-3 years if no 
+concerns arise until adulthood. Subsequently, routine cardiac examinations every 
+five years are advisable. Additionally, patients with diagnosed cardiomyopathy 
+should receive ongoing cardiac care to ensure the effective management and 
+monitoring of their condition. A prospective study will be required to determine 
+the true prevalence of cardiomyopathy in CDG.
+
+Copyright © 2024 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ymgme.2024.108513
+PMCID: PMC11296892
+PMID: 38917675 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of competing interest The authors 
+report no conflict of interest.

--- a/research/ALG9-congenital_disorder_of_glycosylation-deep-research-falcon.md
+++ b/research/ALG9-congenital_disorder_of_glycosylation-deep-research-falcon.md
@@ -1,0 +1,1234 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:31:19.021709'
+end_time: '2026-05-11T12:44:11.480867'
+duration_seconds: 772.46
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: ALG9-congenital disorder of glycosylation
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 22
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** ALG9-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **ALG9-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** ALG9-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **ALG9-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# ALG9–congenital disorder of glycosylation (ALG9-CDG; historical CDG-IL) — Disease Characteristics Research Report
+
+## Target disease
+- **Disease name:** ALG9–congenital disorder of glycosylation (ALG9-CDG)
+- **Category:** Mendelian, inborn error of metabolism; N-linked glycosylation defect (CDG type I pattern on transferrin testing) (frank2004identificationandfunctional pages 1-2, davis2017alg9cdgnewclinical pages 5-6)
+- **MONDO ID:** Not retrievable with the available tools in this run (gap)
+
+## Executive summary
+ALG9-CDG is an autosomal recessive congenital disorder of glycosylation caused by biallelic pathogenic variants in **ALG9**, which encodes an ER **α1,2-mannosyltransferase** required for stepwise assembly of the dolichol-linked oligosaccharide precursor for **N-glycosylation**. The disorder shows a broad phenotypic spectrum ranging from a liveborn multisystem neurodevelopmental disorder (developmental delay, hypotonia, seizures, progressive microcephaly, hepatomegaly; often renal cystic disease and pericardial effusion) to **prenatal-lethal skeletal dysplasia with polycystic kidneys and multiple malformations** (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2). Diagnostic hallmarks include **type I** transferrin isoelectric focusing abnormalities, accumulation of truncated lipid-linked oligosaccharide intermediates (DolPP-GlcNAc2Man6/Man8), and N-glycan profiling showing truncation with relative enrichment of smaller high-mannose species (Man4–Man6) and depletion of Man7–Man9 (frank2004identificationandfunctional pages 2-5, davis2017alg9cdgnewclinical pages 5-6).
+
+## Evidence map (structured summary)
+| Disease / identifier | Gene | Inheritance | Key pathogenic variant(s) reported | Core phenotypes reported | Biochemical / diagnostic findings | Evidence type | Year | Key citation(s) |
+|---|---|---|---|---|---|---|---|---|
+| ALG9-congenital disorder of glycosylation; ALG9-CDG; former name CDG-IL | **ALG9** (alpha-1,2-mannosyltransferase) | Autosomal recessive | General disease definition; multiple homozygous variants across reports | Multisystem N-glycosylation disorder with neurodevelopmental impairment and variable visceral involvement | Type I CDG on transferrin isoelectric focusing; abnormal N-glycosylation due to defective dolichol-linked oligosaccharide assembly (frank2004identificationandfunctional pages 1-2, francisco2023congenitaldisordersof pages 1-2) | Human disease definition / review | 2004, 2023 | (frank2004identificationandfunctional pages 1-2, francisco2023congenitaldisordersof pages 1-2) |
+| Initial molecularly defined liveborn case | **ALG9** | Autosomal recessive (homozygous variant) | c.1567G>A, p.Glu523Lys (also described in secondary summaries as p.E523K) | Developmental delay, central hypotonia, seizures, severe microcephaly, hepatomegaly, bronchial asthma | Serum transferrin IEF: increased disialo- and asialo-transferrin consistent with CDG-I; fibroblast LLO accumulation of DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8; transfer of truncated glycans to protein; yeast complementation confirmed functional defect (frank2004identificationandfunctional pages 1-2, frank2004identificationandfunctional pages 2-5) | Human case report with functional validation | 2004 | (frank2004identificationandfunctional pages 1-2, frank2004identificationandfunctional pages 2-5) |
+| Second liveborn case expanding phenotype | **ALG9** | Autosomal recessive (homozygous variant) | c.860A>G, p.Tyr286Cys / p.Y286C | Psychomotor retardation, seizures, hypotonia, diffuse cerebral and cerebellar atrophy with delayed myelination, failure to thrive, pericardial effusion, cystic renal disease, hepatosplenomegaly, esotropia, inverted nipples; progressive microcephaly later documented | Typical CDG type I transferrin pattern by IEF; ALG9 defect suggested by DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8 accumulation; molecular confirmation by yeast complementation (weinstein2005cdg‐ilaninfant pages 1-2) | Human case report | 2005 | (weinstein2005cdg‐ilaninfant pages 1-2) |
+| Later liveborn case with glycomics confirmation | **ALG9** | Autosomal recessive (homozygous variant; both parents carriers) | c.860A>G, p.Tyr287Cys / p.Y287C | Facial dysmorphism, CNS involvement, developmental delay, failure to thrive; MRI with moderate global cerebral atrophy; prenatal renal cysts/minor cardiac malformations reported in broader review of literature | Transferrin IEF type I: decreased tetrasialo-Tf with increased disialo-Tf and small asialo-Tf; plasma and fibroblast LC-MS N-glycan profiling showed increased Man4-Man6 with absent/reduced Man7-Man9, consistent with ALG9 block (davis2017alg9cdgnewclinical pages 5-6, davis2017alg9cdgnewclinical media b6fa124e, davis2017alg9cdgnewclinical media 966d80b6) | Human case report / glycomics | 2017 | (davis2017alg9cdgnewclinical pages 5-6, davis2017alg9cdgnewclinical media b6fa124e, davis2017alg9cdgnewclinical media 966d80b6) |
+| Lethal fetal skeletal dysplasia / Gillessen-Kaesbach–Nishimura syndrome end of spectrum | **ALG9** | Autosomal recessive (homozygous splice variant) | c.1173+2T>A (reported as c.1173+2T4A in extracted text due to formatting), splice donor; exon 10 skipping | Lethal fetal phenotype with skeletal dysplasia, polycystic kidneys, multiple malformations; characteristic round pelvis, mesomelic upper-limb shortening, defective cervical vertebral ossification; demonstrates severe prenatal end of ALG9-CDG spectrum | Mass spectrometric transferrin analysis showed increased monoglycosylated transferrin, confirming CDG; RNA analysis demonstrated exon 10 skipping (tham2016anovelphenotype pages 1-2) | Fetal pathology / exome / RNA study | 2016 | (tham2016anovelphenotype pages 1-2) |
+| Saudi cohort / recurrent founder-like variant series | **ALG9** | Autosomal recessive (all homozygous in this cohort) | c.1075G>A, p.Glu359Lys / p.E359K | Eight patients from four unrelated families: dysmorphic features, early-onset refractory epilepsy, progressive microcephaly, severe developmental disability, failure to thrive, skeletal dysplasia, mild hepatomegaly with normal transaminases, hydrops fetalis; brain MRI with delayed myelination and cerebral/cerebellar atrophy | Clinical series emphasized phenotype; biochemical details not provided in extracted cohort text (alsubhi2017congenitaldisordersof pages 6-6) | Human case series | 2017 | (alsubhi2017congenitaldisordersof pages 6-6) |
+| Cross-report phenotype synthesis | **ALG9** | Autosomal recessive | Missense variants (p.Y286C/p.Y287C, p.E523K/p.E530K) generally associated with liveborn disease; splice variant c.1173+2T>A associated with prenatal lethal presentation; recurrent p.E359K in Saudi cohort | Recurrent features across reports: neurodevelopmental delay/disability, hypotonia, seizures, progressive microcephaly, renal cysts/cystic kidneys, hepatomegaly, failure to thrive, pericardial effusion/cardiac tamponade, hydrops fetalis, and severe skeletal dysplasia/lethal fetal disease at the most severe end | Core diagnostic signature across reports: abnormal transferrin glycoforms (type I pattern or increased monoglycosylated transferrin), truncated LLO intermediates (Man6/Man8), and glycomics showing buildup of shorter high-mannose species (Man4-6) with loss of Man7-9 (tham2016anovelphenotype pages 1-2, davis2017alg9cdgnewclinical pages 7-9, davis2017alg9cdgnewclinical pages 1-2) | Human literature synthesis | 2016–2017 | (tham2016anovelphenotype pages 1-2, davis2017alg9cdgnewclinical pages 7-9, davis2017alg9cdgnewclinical pages 1-2) |
+
+
+*Table: This table summarizes the main knowledge-base fields for ALG9-CDG/CDG-IL, including identifiers, inheritance, reported pathogenic variants, phenotype spectrum, and hallmark biochemical findings. It condenses the available human case reports, fetal pathology evidence, and broader literature synthesis into a citation-linked reference.*
+
+---
+
+## 1. Disease information
+### 1.1 What is the disease?
+ALG9-CDG is a congenital disorder of N-linked glycosylation due to defective **lipid-linked oligosaccharide (LLO)** assembly in the endoplasmic reticulum, leading to transfer of incomplete glycan precursors to proteins and under-occupancy of N-glycosylation sites (a “CDG type I” biochemical pattern) (frank2004identificationandfunctional pages 1-2, frank2004identificationandfunctional pages 2-5).
+
+### 1.2 Key identifiers (available from retrieved sources)
+- **Gene:** ALG9 (α1,2-mannosyltransferase) (tham2016anovelphenotype pages 1-2)
+- **Historical disease name:** **CDG-IL** (defined as a novel CDG-I subtype in 2004) (frank2004identificationandfunctional pages 1-2)
+- **Current naming convention:** gene-based “ALG9-CDG” used in modern CDG nosology (francisco2023congenitaldisordersof pages 1-2)
+
+**Not retrievable in this run (gaps needing external database lookup):** OMIM disease number, Orphanet ID, ICD-10/ICD-11 code, MeSH, MONDO.
+
+### 1.3 Synonyms / alternative names
+- ALG9-CDG
+- CDG-IL (historical subtype name)
+- In the fetal-lethal extreme: Gillessen-Kaesbach–Nishimura syndrome due to ALG9 variants (as framed by Tham et al.) (tham2016anovelphenotype pages 1-2)
+
+### 1.4 Evidence source type
+The currently retrievable evidence is primarily **individual patients and small case series**, including fetal autopsy/genomics studies and country-specific cohorts, rather than large aggregated natural-history datasets specific to ALG9-CDG (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+- **Genetic cause:** biallelic loss-of-function or deleterious missense/splice variants in **ALG9** impair LLO assembly and N-glycosylation (frank2004identificationandfunctional pages 1-2, tham2016anovelphenotype pages 1-2).
+- **Mechanistic cause:** defects in ALG9 α1,2-mannosyltransferase activity lead to intracellular accumulation of truncated LLO intermediates (notably DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8) and transfer of incomplete precursors to proteins (frank2004identificationandfunctional pages 2-5).
+
+### 2.2 Risk factors
+- **Consanguinity/family recurrence:** multiple reports involve homozygous variants and familial clustering, consistent with autosomal recessive inheritance and increased risk in consanguineous settings (davis2017alg9cdgnewclinical pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+No gene–environment interaction evidence specific to ALG9-CDG was identified in the retrieved sources.
+
+---
+
+## 3. Phenotypes
+### 3.1 Phenotype spectrum (current understanding)
+The phenotype spectrum spans:
+- **Liveborn multisystem neurodevelopmental disease**: developmental delay/psychomotor retardation, hypotonia, seizures/epilepsy, progressive microcephaly, failure to thrive, and hepatomegaly (frank2004identificationandfunctional pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+- **Renal phenotype**: cystic kidneys/cystic renal disease and multiple small renal cysts (weinstein2005cdg‐ilaninfant pages 1-2, tham2016anovelphenotype pages 1-2).
+- **Cardiac phenotype**: pericardial effusion (including prenatal detection) and progression to cardiac tamponade in at least one reported infant (weinstein2005cdg‐ilaninfant pages 1-2).
+- **Severe prenatal end**: lethal fetal skeletal dysplasia with polycystic kidneys and multiple malformations (Gillessen-Kaesbach–Nishimura syndrome) (tham2016anovelphenotype pages 1-2).
+
+### 3.2 Phenotype characteristics (onset, severity, progression)
+- **Onset:** often prenatal (hydrops fetalis; pericardial effusion; renal cysts detectable by fetal imaging) to early infancy (failure to thrive, hypotonia, seizures) (weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+- **Severity:** ranges from survivable but severe neurodevelopmental disability to **prenatal/neonatal lethality** in the skeletal dysplasia phenotype (tham2016anovelphenotype pages 1-2).
+- **Progression:** progressive microcephaly has been emphasized in case reports/series; seizure control can be difficult (weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+### 3.3 Approximate frequency of features (from the retrieved evidence)
+Formal pooled percentages for ALG9-CDG features were not extractable from the retrieved texts. However, a Saudi cohort described **8 patients from 4 unrelated families** with a shared homozygous variant and recurrent features including refractory epilepsy, progressive microcephaly, skeletal dysplasia, and hydrops fetalis (alsubhi2017congenitaldisordersof pages 6-6).
+
+### 3.4 Suggested HPO terms (non-exhaustive)
+Based on the described phenotypes:
+- **Seizures** (HP:0001250)
+- **Developmental delay / intellectual disability** (HP:0001263 / HP:0001249)
+- **Hypotonia** (HP:0001252)
+- **Progressive microcephaly / microcephaly** (HP:0000252)
+- **Failure to thrive** (HP:0001508)
+- **Hepatomegaly** (HP:0002240)
+- **Renal cysts / cystic kidney disease** (HP:0000107)
+- **Pericardial effusion** (HP:0001698)
+- **Hydrops fetalis** (HP:0001789)
+- **Skeletal dysplasia / limb shortening / mesomelia** (e.g., HP:0002652; HP:0003027)
+
+### 3.5 Quality-of-life impact
+Direct validated quality-of-life instruments (e.g., EQ-5D, SF-36) were not found in the retrieved sources for ALG9-CDG. Nonetheless, severe developmental disability, refractory epilepsy, and multisystem involvement imply high caregiver burden and profound impairment in daily functioning (alsubhi2017congenitaldisordersof pages 6-6, weinstein2005cdg‐ilaninfant pages 1-2).
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal gene
+- **ALG9** encodes an ER α1,2-mannosyltransferase involved in **LLO biosynthesis** for N-glycosylation and is required for proper human development and physiology (frank2004identificationandfunctional pages 1-2).
+
+### 4.2 Pathogenic variants (from retrieved primary reports)
+Reported homozygous variants include:
+- **c.1567G>A (p.Glu523Lys / E523K)** in the defining 2004 case (frank2004identificationandfunctional pages 2-5).
+- **c.860A>G (p.Tyr286Cys / p.Y286C)** in the 2005 case (weinstein2005cdg‐ilaninfant pages 1-2).
+- **c.860A>G (p.Tyr287Cys / p.Y287C)** in the 2017 case report with detailed glycomics (davis2017alg9cdgnewclinical pages 5-6).
+- **c.1173+2T>A (splice donor; exon 10 skipping)** associated with lethal fetal skeletal dysplasia (tham2016anovelphenotype pages 1-2).
+- **c.1075G>A (p.Glu359Lys / p.E359K)** in 8 Saudi patients (alsubhi2017congenitaldisordersof pages 6-6).
+
+### 4.3 Variant type/class and functional consequences
+- Variants include **missense** substitutions and **splice-site** disruption causing exon skipping and predicted frameshift/out-of-frame transcript (tham2016anovelphenotype pages 1-2).
+- Functional validation in the defining work used **yeast complementation**, demonstrating that the patient allele impairs ALG9 function (residual activity noted), consistent with a loss-of-function/hypomorphic mechanism (frank2004identificationandfunctional pages 2-5).
+
+### 4.4 Population allele frequency
+One missense allele (Y287C) is described as very rare in population data (ExAC allele frequency reported in the 2017 review/case context), consistent with ultra-rare recessive disease (davis2017alg9cdgnewclinical pages 7-9).
+
+### 4.5 Modifier genes / epigenetics / chromosomal abnormalities
+No ALG9-CDG-specific modifier genes, epigenetic signatures, or recurrent chromosomal abnormalities were identified in the retrieved sources.
+
+---
+
+## 5. Environmental information
+No environmental, lifestyle, toxin, radiation, or infectious triggers were identified as contributing factors in the retrieved evidence. ALG9-CDG is best supported as a primary monogenic disorder (frank2004identificationandfunctional pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2).
+
+---
+
+## 6. Mechanism / pathophysiology
+### 6.1 Pathway placement and biochemical chain of causality
+1) **Primary trigger:** biallelic pathogenic ALG9 variants (frank2004identificationandfunctional pages 2-5, tham2016anovelphenotype pages 1-2).
+2) **Molecular defect:** reduced ALG9 α1,2-mannosyltransferase function during ER LLO assembly; human ALG9 catalyzes mannose transfer onto at least two acceptor substrates (DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8), consistent with dual-step involvement (frank2004identificationandfunctional pages 2-5).
+3) **Biochemical consequence:** accumulation of truncated LLO intermediates (DolPP-GlcNAc2Man6 and DolPP-GlcNAc2Man8) and transfer of incomplete precursors to protein N-glycosylation sites (frank2004identificationandfunctional pages 2-5).
+4) **Cellular consequence:** protein underglycosylation and aberrant glycan structures can perturb ER quality control (calnexin/calreticulin cycle), glycoprotein folding/trafficking, and ER-associated degradation (ERAD), proposed as contributors to phenotype (frank2004identificationandfunctional pages 2-5).
+5) **Tissue/organ outcomes:** multisystem developmental and organ dysfunction, with prominent neurologic involvement; renal cystic disease; cardiac involvement such as pericardial effusion; and, in severe fetal cases, skeletal dysplasia with visceral malformations (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2).
+
+### 6.2 Direct abstract-quoted mechanistic evidence
+- Defining paper (2004) explicitly ties mechanism to LLO intermediates: it reports “**a deficiency of the ALG9 α1,2 mannosyltransferase enzyme, which causes an accumulation of lipid-linked-GlcNAc2Man6 and -GlcNAc2Man8 structures**” and notes this was “**paralleled by the transfer of incomplete oligosaccharides precursors to protein**” (frank2004identificationandfunctional pages 1-2).
+- 2017 case report glycomics: “**N-glycan profile… showed significant increase…Man4…Man5…Man6 with absence of…Man7…Man8…Man9**” and interprets “**blockage of N-glycan biosynthesis after Man6 indicated a probable defect in ALG9**” (davis2017alg9cdgnewclinical pages 5-6).
+- Fetal-lethal phenotype: “**Mass spectrometric analysis showed an increase in monoglycosylated transferrin… confirming that this is a congenital disorder of glycosylation (CDG)**” and “**RNA analysis demonstrated skipping of exon 10**” for the splice variant (tham2016anovelphenotype pages 1-2).
+
+### 6.3 Ontology suggestions
+- **GO Biological Process:** protein N-linked glycosylation; dolichol-linked oligosaccharide biosynthetic process; glycoprotein folding/quality control (supported mechanistically) (frank2004identificationandfunctional pages 2-5).
+- **GO Cellular Component:** endoplasmic reticulum membrane/lumen (ALG9 is a multispanning ER protein in the N-glycosylation pathway) (frank2004identificationandfunctional pages 2-5).
+- **CL (cell types):** broad systemic involvement; evidence does not specify a single primary cell type, but fibroblast biochemical studies are commonly used diagnostically (patient fibroblasts studied) (frank2004identificationandfunctional pages 2-5, davis2017alg9cdgnewclinical pages 5-6).
+
+### 6.4 Molecular profiling (omics)
+Targeted N-glycan profiling by LC-MS in plasma and fibroblasts demonstrates a truncation signature (Man4–Man6 enrichment; Man7–Man9 depletion) consistent with pathway blockade at ALG9 (davis2017alg9cdgnewclinical pages 5-6).
+
+---
+
+## 7. Anatomical structures affected
+### 7.1 Organ systems (supported by case literature)
+- **Central nervous system:** diffuse brain atrophy, delayed myelination (weinstein2005cdg‐ilaninfant pages 1-2).
+- **Kidney:** cystic renal disease / polycystic kidneys in severe fetal phenotype (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2).
+- **Heart/pericardium:** pericardial effusion and tamponade (weinstein2005cdg‐ilaninfant pages 1-2).
+- **Liver/spleen:** hepatomegaly and hepatosplenomegaly (weinstein2005cdg‐ilaninfant pages 1-2, frank2004identificationandfunctional pages 1-2).
+- **Skeletal system:** lethal fetal skeletal dysplasia phenotype; skeletal dysplasia also reported in pediatric cohort (tham2016anovelphenotype pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+### 7.2 UBERON suggestions (non-exhaustive)
+- Brain; kidney; liver; heart/pericardium; skeletal system (supported by multi-organ clinical findings) (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2).
+
+### 7.3 Subcellular localization
+Endoplasmic reticulum (ER) LLO assembly pathway (frank2004identificationandfunctional pages 2-5).
+
+---
+
+## 8. Temporal development
+- **Prenatal manifestations:** pericardial effusion; renal cysts; hydrops fetalis; fetal skeletal dysplasia with lethality for severe splice variant cases (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+- **Infant/childhood course:** hypotonia, failure to thrive, seizures with difficult control, progressive microcephaly and neurodevelopmental impairment (weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance
+Autosomal recessive inheritance is supported by homozygous variants in affected children/fetuses and parental heterozygosity in families (davis2017alg9cdgnewclinical pages 5-6, weinstein2005cdg‐ilaninfant pages 1-2).
+
+### 9.2 Epidemiology
+ALG9-CDG is ultra-rare; early literature comprised a small number of families, but notable aggregation has been reported in regional cohorts. In a Saudi CDG cohort, ALG9-CDG accounted for **8 patients from 4 unrelated families**, reported as **28.5% of the cohort’s CDG population** (cohort composition rather than population prevalence) (alsubhi2017congenitaldisordersof pages 6-6). CDG-wide epidemiology reviews emphasize that generating robust prevalence/incidence data for CDG is challenging and often relies on case reports/series and allelic frequency, and also provide context that CDG are collectively rare inherited metabolic disorders (piedade2022epidemiologyofcongenital pages 1-2).
+
+### 9.3 Population genetics
+No robust carrier-frequency estimates for ALG9-CDG were extractable from the retrieved texts; one reported allele is extremely rare in population databases (ExAC) (davis2017alg9cdgnewclinical pages 7-9).
+
+---
+
+## 10. Diagnostics
+### 10.1 Biochemical testing
+- **Transferrin isoelectric focusing (TIEF):** characteristic **CDG type I pattern**, e.g., increased disialo-/asialo-transferrin and decreased tetrasialo-transferrin (frank2004identificationandfunctional pages 2-5, davis2017alg9cdgnewclinical pages 5-6).
+- **LLO analysis in patient fibroblasts:** accumulation of **DolPP-GlcNAc2Man6** and **DolPP-GlcNAc2Man8** (frank2004identificationandfunctional pages 2-5, weinstein2005cdg‐ilaninfant pages 1-2).
+- **Mass spectrometry glycomics / N-glycan profiling:** truncation signature consistent with ALG9 blockade, including increased Man4–Man6 and depletion/absence of Man7–Man9 (davis2017alg9cdgnewclinical pages 5-6, davis2017alg9cdgnewclinical media b6fa124e).
+
+**Image evidence (real-world implementation of glycomics):** Figures demonstrating the diagnostic N-glycan signature in plasma and fibroblasts are available from the 2017 clinical case report (davis2017alg9cdgnewclinical media b6fa124e, davis2017alg9cdgnewclinical media 966d80b6).
+
+### 10.2 Genetic testing
+- Confirmatory molecular diagnosis was achieved via targeted sequencing after biochemical suspicion (davis2017alg9cdgnewclinical pages 5-6) and via exome + RNA studies in fetal cases (tham2016anovelphenotype pages 1-2).
+- Modern CDG practice has shifted from purely transferrin-pattern based naming to gene-based nosology, reflecting widespread adoption of NGS (francisco2023congenitaldisordersof pages 1-2).
+
+### 10.3 Differential diagnosis
+The fetal skeletal dysplasia phenotype overlaps with ALG3- and ALG12-CDG skeletal features, motivating a diagnostic grouping of certain N-glycosylation disorders within skeletal dysplasias (tham2016anovelphenotype pages 1-2).
+
+---
+
+## 11. Outcome / prognosis
+Prognosis is variable:
+- **Prenatal-lethal** outcomes are documented for severe splice-variant-associated skeletal dysplasia with visceral malformations (tham2016anovelphenotype pages 1-2).
+- **Survival with severe neurodevelopmental impairment** is documented in liveborn cases; severe epilepsy and progressive microcephaly can occur, and cardiac tamponade secondary to pericardial effusion is a life-threatening complication (weinstein2005cdg‐ilaninfant pages 1-2).
+
+Quantitative survival curves or life expectancy data were not available in the retrieved evidence.
+
+---
+
+## 12. Treatment
+### 12.1 Disease-specific therapy
+No ALG9-CDG-specific targeted therapy was identified in the retrieved sources.
+
+### 12.2 Supportive/standard-of-care elements (real-world implementations)
+- **Epilepsy management:** antiepileptic therapy is used; seizure control may be difficult (weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+- **Management of pericardial effusion/tamponade:** pericardiocentesis was required in at least one case due to tamponade (weinstein2005cdg‐ilaninfant pages 1-2).
+- **Nutritional support / failure-to-thrive management:** failure to thrive is prominent in reported cases and requires supportive care, although specific protocols were not detailed in the retrieved texts (weinstein2005cdg‐ilaninfant pages 1-2, alsubhi2017congenitaldisordersof pages 6-6).
+
+### 12.3 CDG expert recommendations relevant to ALG9-CDG (2024)
+A 2024 analysis from the Frontiers in Congenital Disorders of Glycosylation Consortium (FCDGC) provides expert recommendations for **baseline and longitudinal cardiac surveillance** (echocardiogram and ECG at diagnosis; annual in early childhood with spacing later) due to cardiomyopathy/pericardial effusion risks in CDG broadly (zemet2024cardiomyopathyanuncommon pages 1-3). While ALG9-CDG was not among the cardiomyopathy cases listed, pericardial effusion is clearly part of ALG9-CDG phenotypes, making structured cardiac surveillance clinically prudent (weinstein2005cdg‐ilaninfant pages 1-2, zemet2024cardiomyopathyanuncommon pages 1-3).
+
+### 12.4 Suggested MAXO terms (examples)
+- Antiepileptic drug therapy (MAXO: antiepileptic therapy)
+- Pericardiocentesis / pericardial drainage procedure
+- Nutritional support / enteral nutrition
+- Cardiac surveillance (echocardiography; electrocardiography)
+
+---
+
+## 13. Prevention
+No primary prevention is currently established for ALG9-CDG. Prevention focuses on **genetic counseling and reproductive options**:
+- **Carrier testing and cascade testing** in families with a known pathogenic variant.
+- **Prenatal diagnosis** is feasible (fetal ultrasound findings plus molecular testing), and fetal presentation has been described for severe cases (tham2016anovelphenotype pages 1-2, weinstein2005cdg‐ilaninfant pages 1-2).
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring ALG9-CDG-like disease in non-human species was identified in the retrieved evidence.
+
+---
+
+## 15. Model organisms
+### 15.1 Functional models used in the evidence base
+- **Yeast complementation assays** were used to demonstrate functional homology between human and yeast ALG9 and the deleterious effect of patient variants, providing strong mechanistic support (frank2004identificationandfunctional pages 2-5).
+
+### 15.2 Translational relevance and limitations
+Yeast assays robustly establish enzymatic pathway function and variant impact but do not recapitulate the multi-organ developmental phenotypes; vertebrate models were not retrieved in this run.
+
+---
+
+## Recent developments (2023–2024 prioritized)
+### 2023: CDG field state-of-the-art (context relevant to ALG9-CDG)
+A 2023 “state of the art in 2022” review emphasizes that CDG are a heterogeneous family of rare metabolic diseases and highlights that **multi-omics advances** have accelerated progress but **targeted therapies remain a major unmet need**; it also documents the modern **gene-based nomenclature** and challenges in CDG classification (francisco2023congenitaldisordersof pages 1-2).
+
+### 2024: Expert guidance on cardiac monitoring in CDG
+A 2024 FCDGC study identified cardiomyopathy in approximately **~6%** of 305 molecularly confirmed CDG patients in their cohort and proposed standardized cardiac screening/follow-up (zemet2024cardiomyopathyanuncommon pages 1-3). Even though ALG9-CDG was not specifically represented among their cardiomyopathy subset, the presence of pericardial effusion/tamponade in ALG9-CDG case reports supports heightened cardiac vigilance (weinstein2005cdg‐ilaninfant pages 1-2).
+
+---
+
+## URLs and publication dates (where available from retrieved texts)
+- Frank CG et al. *Am J Hum Genet* (published electronically **May 17, 2004**). https://doi.org/10.1086/422367 (frank2004identificationandfunctional pages 1-2)
+- Weinstein M et al. *Am J Med Genet A* (**2005**). https://doi.org/10.1002/ajmg.a.30851 (weinstein2005cdg‐ilaninfant pages 1-2)
+- Tham E et al. *Eur J Hum Genet* (published online **May 13, 2015**; journal issue **2016**). https://doi.org/10.1038/ejhg.2015.91 (tham2016anovelphenotype pages 1-2)
+- Davis K et al. *Mol Genet Metab Rep* (**Dec 2017**). https://doi.org/10.1016/j.ymgmr.2017.08.004 (davis2017alg9cdgnewclinical pages 1-2)
+- Francisco R et al. *Orphanet J Rare Dis* (**Oct 2023**). https://doi.org/10.1186/s13023-023-02879-z (francisco2023congenitaldisordersof pages 1-2)
+- Zemet R et al. *Mol Genet Metab* (**Aug 2024**). https://doi.org/10.1016/j.ymgme.2024.108513 (zemet2024cardiomyopathyanuncommon pages 1-3)
+- Piedade A et al. *Journal of Rare Diseases* (**Dec 2022**). https://doi.org/10.1007/s44162-022-00003-6 (piedade2022epidemiologyofcongenital pages 1-2)
+
+---
+
+## Limitations of this report (important for knowledge-base curation)
+1) **Ontology IDs** (OMIM/Orphanet/MONDO/ICD/MeSH) and **PMIDs** were not retrievable with the available tools in this run; the report therefore prioritizes DOI/URLs and direct excerpts from accessible full text. 
+2) ALG9-CDG remains ultra-rare; **feature frequencies, survival statistics, and validated QoL metrics** are not well defined in the retrieved primary literature.
+3) **ALG9-specific 2023–2024 primary case expansions** were not retrievable here; “latest research” sections therefore focus on CDG-wide advances and consensus recommendations.
+
+
+References
+
+1. (frank2004identificationandfunctional pages 1-2): Christian G. Frank, Wafaa Eyaid, Eric G. Berger, Markus Aebi, Claudia E. Grubenmann, and Thierry Hennet. Identification and functional analysis of a defect in the human alg9 gene: definition of congenital disorder of glycosylation type il. The American Journal of Human Genetics, 75:146-150, Jul 2004. URL: https://doi.org/10.1086/422367, doi:10.1086/422367. This article has 117 citations.
+
+2. (davis2017alg9cdgnewclinical pages 5-6): Kellie Davis, Duncan Webster, Chris Smith, Sheryl Jackson, David Sinasac, Lorne Seargeant, Xing-Chang Wei, Patrick Ferreira, Julian Midgley, Yolanda Foster, Xueli Li, Miao He, and Walla Al-Hertani. Alg9-cdg: new clinical case and review of the literature. Molecular Genetics and Metabolism Reports, 13:55-63, Dec 2017. URL: https://doi.org/10.1016/j.ymgmr.2017.08.004, doi:10.1016/j.ymgmr.2017.08.004. This article has 29 citations.
+
+3. (tham2016anovelphenotype pages 1-2): Emma Tham, Erik A Eklund, Anna Hammarsjö, Per Bengtson, Stefan Geiberger, Kristina Lagerstedt-Robinson, Helena Malmgren, Daniel Nilsson, Gintautas Grigelionis, Peter Conner, Peter Lindgren, Anna Lindstrand, Anna Wedell, Margareta Albåge, Katarzyna Zielinska, Ann Nordgren, Nikos Papadogiannakis, Gen Nishimura, and Giedre Grigelioniene. A novel phenotype in n-glycosylation disorders: gillessen-kaesbach–nishimura skeletal dysplasia due to pathogenic variants in alg9. European Journal of Human Genetics, 24:198-207, May 2016. URL: https://doi.org/10.1038/ejhg.2015.91, doi:10.1038/ejhg.2015.91. This article has 44 citations and is from a domain leading peer-reviewed journal.
+
+4. (weinstein2005cdg‐ilaninfant pages 1-2): Michael Weinstein, Els Schollen, Gert Matthijs, Christine Neupert, Thierry Hennet, Claudia E. Grubenmann, Christian G. Frank, Markus Aebi, Joe T. R. Clarke, Anne Griffiths, Lorne Seargeant, and Nicola Poplawski. Cdg‐il: an infant with a novel mutation in the alg9 gene and additional phenotypic features. American Journal of Medical Genetics Part A, 136A:194-197, Jul 2005. URL: https://doi.org/10.1002/ajmg.a.30851, doi:10.1002/ajmg.a.30851. This article has 55 citations.
+
+5. (frank2004identificationandfunctional pages 2-5): Christian G. Frank, Wafaa Eyaid, Eric G. Berger, Markus Aebi, Claudia E. Grubenmann, and Thierry Hennet. Identification and functional analysis of a defect in the human alg9 gene: definition of congenital disorder of glycosylation type il. The American Journal of Human Genetics, 75:146-150, Jul 2004. URL: https://doi.org/10.1086/422367, doi:10.1086/422367. This article has 117 citations.
+
+6. (francisco2023congenitaldisordersof pages 1-2): Rita Francisco, Sandra Brasil, Joana Poejo, Jaak Jaeken, Carlota Pascoal, Paula A. Videira, and Vanessa dos Reis Ferreira. Congenital disorders of glycosylation (cdg): state of the art in 2022. Orphanet Journal of Rare Diseases, Oct 2023. URL: https://doi.org/10.1186/s13023-023-02879-z, doi:10.1186/s13023-023-02879-z. This article has 72 citations and is from a peer-reviewed journal.
+
+7. (davis2017alg9cdgnewclinical media b6fa124e): Kellie Davis, Duncan Webster, Chris Smith, Sheryl Jackson, David Sinasac, Lorne Seargeant, Xing-Chang Wei, Patrick Ferreira, Julian Midgley, Yolanda Foster, Xueli Li, Miao He, and Walla Al-Hertani. Alg9-cdg: new clinical case and review of the literature. Molecular Genetics and Metabolism Reports, 13:55-63, Dec 2017. URL: https://doi.org/10.1016/j.ymgmr.2017.08.004, doi:10.1016/j.ymgmr.2017.08.004. This article has 29 citations.
+
+8. (davis2017alg9cdgnewclinical media 966d80b6): Kellie Davis, Duncan Webster, Chris Smith, Sheryl Jackson, David Sinasac, Lorne Seargeant, Xing-Chang Wei, Patrick Ferreira, Julian Midgley, Yolanda Foster, Xueli Li, Miao He, and Walla Al-Hertani. Alg9-cdg: new clinical case and review of the literature. Molecular Genetics and Metabolism Reports, 13:55-63, Dec 2017. URL: https://doi.org/10.1016/j.ymgmr.2017.08.004, doi:10.1016/j.ymgmr.2017.08.004. This article has 29 citations.
+
+9. (alsubhi2017congenitaldisordersof pages 6-6): Sarah Alsubhi, Amal Alhashem, Eissa Faqeih, Majid Alfadhel, Abdullah Alfaifi, Waleed Altuwaijri, Saud Alsahli, Hesham Aldhalaan, Fowzan S. Alkuraya, Khalid Hundallah, Adel Mahmoud, Ali Alasmari, Fuad Al Mutairi, Hanem Abduraouf, Layan AlRasheed, Saad Alshahwan, and Brahim Tabarki. Congenital disorders of glycosylation: the saudi experience. American Journal of Medical Genetics Part A, 173:2614-2621, Jul 2017. URL: https://doi.org/10.1002/ajmg.a.38358, doi:10.1002/ajmg.a.38358. This article has 45 citations.
+
+10. (davis2017alg9cdgnewclinical pages 7-9): Kellie Davis, Duncan Webster, Chris Smith, Sheryl Jackson, David Sinasac, Lorne Seargeant, Xing-Chang Wei, Patrick Ferreira, Julian Midgley, Yolanda Foster, Xueli Li, Miao He, and Walla Al-Hertani. Alg9-cdg: new clinical case and review of the literature. Molecular Genetics and Metabolism Reports, 13:55-63, Dec 2017. URL: https://doi.org/10.1016/j.ymgmr.2017.08.004, doi:10.1016/j.ymgmr.2017.08.004. This article has 29 citations.
+
+11. (davis2017alg9cdgnewclinical pages 1-2): Kellie Davis, Duncan Webster, Chris Smith, Sheryl Jackson, David Sinasac, Lorne Seargeant, Xing-Chang Wei, Patrick Ferreira, Julian Midgley, Yolanda Foster, Xueli Li, Miao He, and Walla Al-Hertani. Alg9-cdg: new clinical case and review of the literature. Molecular Genetics and Metabolism Reports, 13:55-63, Dec 2017. URL: https://doi.org/10.1016/j.ymgmr.2017.08.004, doi:10.1016/j.ymgmr.2017.08.004. This article has 29 citations.
+
+12. (piedade2022epidemiologyofcongenital pages 1-2): Ana Piedade, Rita Francisco, Jaak Jaeken, Peymaneh Sarkhail, Sandra Brasil, Carlos R. Ferreira, Tatiana Rijoff, Carlota Pascoal, Alexandre Gil, Ana Beatriz Lourenço, Marta Abreu, Mafalda Gomes, Paula A. Videira, and Vanessa dos Reis Ferreira. Epidemiology of congenital disorders of glycosylation (cdg)—overview and perspectives. Journal of Rare Diseases, Dec 2022. URL: https://doi.org/10.1007/s44162-022-00003-6, doi:10.1007/s44162-022-00003-6. This article has 35 citations.
+
+13. (zemet2024cardiomyopathyanuncommon pages 1-3): Roni Zemet, Kyle D. Hope, Andrew C. Edmondson, Rameen Shah, Maria Patino, Abigail M. Yesso, Justin H. Berger, Kyriakie Sarafoglou, Austin Larson, Christina Lam, Eva Morava, and Fernando Scaglia. Cardiomyopathy, an uncommon phenotype of congenital disorders of glycosylation: recommendations for baseline screening and follow-up evaluation. Molecular Genetics and Metabolism, 142:108513, Aug 2024. URL: https://doi.org/10.1016/j.ymgme.2024.108513, doi:10.1016/j.ymgme.2024.108513. This article has 14 citations and is from a peer-reviewed journal.

--- a/research/ALG9-congenital_disorder_of_glycosylation-deep-research-falcon.md.citations.md
+++ b/research/ALG9-congenital_disorder_of_glycosylation-deep-research-falcon.md.citations.md
@@ -1,0 +1,473 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** ALG9-congenital disorder of glycosylation
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **ALG9-congenital disorder of glycosylation** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T12:44:11.480867
+
+1. tham2016anovelphenotype pages 1-2
+2. alsubhi2017congenitaldisordersof pages 6-6
+3. frank2004identificationandfunctional pages 1-2
+4. francisco2023congenitaldisordersof pages 1-2
+5. frank2004identificationandfunctional pages 2-5
+6. piedade2022epidemiologyofcongenital pages 1-2
+7. zemet2024cardiomyopathyanuncommon pages 1-3
+8. https://doi.org/10.1086/422367
+9. https://doi.org/10.1002/ajmg.a.30851
+10. https://doi.org/10.1038/ejhg.2015.91
+11. https://doi.org/10.1016/j.ymgmr.2017.08.004
+12. https://doi.org/10.1186/s13023-023-02879-z
+13. https://doi.org/10.1016/j.ymgme.2024.108513
+14. https://doi.org/10.1007/s44162-022-00003-6
+15. https://doi.org/10.1086/422367,
+16. https://doi.org/10.1016/j.ymgmr.2017.08.004,
+17. https://doi.org/10.1038/ejhg.2015.91,
+18. https://doi.org/10.1002/ajmg.a.30851,
+19. https://doi.org/10.1186/s13023-023-02879-z,
+20. https://doi.org/10.1002/ajmg.a.38358,
+21. https://doi.org/10.1007/s44162-022-00003-6,
+22. https://doi.org/10.1016/j.ymgme.2024.108513,


### PR DESCRIPTION
## Summary
- Adds a new ALG9-congenital disorder of glycosylation disorder page.
- Integrates Falcon research with exact evidence snippets from fetched reference caches.
- Adds cited PMID reference caches and the Falcon research artifacts.

## Validation
- `just validate kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml`
- `just validate-references kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml`
- `just validate-terms kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml`
- `just compliance kb/disorders/ALG9-congenital_disorder_of_glycosylation.yaml`

## Cache cleanup
- Restored generated `cache/*` churn.
- Restored uncited `references_cache/clinicaltrials_NCT*.md` churn.
- Removed uncited DOI caches generated during reference lookup; kept only cited PMID caches.