### PR TITLE
Add nevus of Ota curation

### DIFF
--- a/kb/disorders/Nevus_of_Ota.yaml
+++ b/kb/disorders/Nevus_of_Ota.yaml
@@ -1,0 +1,385 @@
+name: Nevus of Ota
+creation_date: "2026-05-11T00:00:00Z"
+updated_date: "2026-05-11T16:50:00Z"
+category: Skin Disorder
+disease_term:
+  preferred_term: nevus of Ota
+  term:
+    id: MONDO:0016984
+    label: nevus of Ota
+parents:
+- Melanocytic Nevus
+- Ophthalmic Disorder
+synonyms:
+- Ota's nevus
+- oculodermal melanocytosis
+- oculodermal melanosis
+description: >-
+  Nevus of Ota is an oculodermal melanocytosis with usually unilateral brown or
+  blue-gray pigmentation of facial skin, mucosae, episclera or sclera, and uvea
+  in trigeminal nerve distributions. Falcon research emphasized a neural
+  crest-derived melanocyte mosaicism model, ophthalmic surveillance for glaucoma
+  and uveal melanoma, and pigment-directed laser therapy for cosmetic treatment.
+pathophysiology:
+- name: Mosaic GNAQ-GNA11 Melanocyte Signaling
+  description: >-
+    Postzygotic activating mutations in GNAQ or GNA11 can drive extensive dermal
+    melanocytosis through mosaic activation of heterotrimeric G-protein signaling
+    and MAPK-family pathways in melanocyte lineages.
+  genes:
+  - preferred_term: GNAQ
+    term:
+      id: hgnc:4390
+      label: GNAQ
+  - preferred_term: GNA11
+    term:
+      id: hgnc:4379
+      label: GNA11
+  cell_types:
+  - preferred_term: melanocyte
+    term:
+      id: CL:0000148
+      label: melanocyte
+  biological_processes:
+  - preferred_term: G protein-coupled receptor signaling pathway
+    term:
+      id: GO:0007186
+      label: G protein-coupled receptor signaling pathway
+    modifier: INCREASED
+  - preferred_term: MAPK cascade
+    term:
+      id: GO:0000165
+      label: MAPK cascade
+    modifier: INCREASED
+  downstream:
+  - target: Dermal and Ocular Melanocyte Accumulation
+    description: >-
+      Mosaic GNAQ/GNA11 signaling increases melanocyte burden in affected
+      pigmentary tissues.
+  evidence:
+  - reference: PMID:26778290
+    reference_title: "Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, we discover that extensive dermal melanocytosis and phakomatosis
+      pigmentovascularis are associated with activating mutations in GNA11 and
+      GNAQ, genes that encode Gα subunits of heterotrimeric G proteins.
+    explanation: >-
+      This supports mosaic GNAQ/GNA11 activation as a mechanistic basis for
+      extensive dermal melanocytosis, the pigmentary process Falcon highlighted
+      as mechanistically relevant to nevus of Ota.
+  - reference: PMID:26778290
+    reference_title: "Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      In vitro expression of mutant GNA11(R183C) and GNA11(Q209L) in human cell
+      lines demonstrated activation of the downstream p38 MAPK signaling pathway
+      and the p38, JNK, and ERK pathways, respectively.
+    explanation: >-
+      This directly supports downstream MAPK-family activation from mutant
+      GNA11 signaling.
+  - reference: PMID:26778290
+    reference_title: "Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: >-
+      Transgenic mosaic zebrafish models expressing mutant GNA11(R183C) under
+      promoter mitfa developed extensive dermal melanocytosis recapitulating the
+      human phenotype.
+    explanation: >-
+      This model-organism evidence supports causal sufficiency of melanocyte-lineage
+      mutant GNA11 for dermal melanocytosis.
+- name: Dermal and Ocular Melanocyte Accumulation
+  description: >-
+    Melanocytes accumulate in facial skin and ocular tissues, producing
+    asymptomatic brown or blue-gray lesions of skin, mucosae, episclera or
+    sclera, and uvea.
+  cell_types:
+  - preferred_term: melanocyte
+    term:
+      id: CL:0000148
+      label: melanocyte
+  biological_processes:
+  - preferred_term: pigmentation
+    term:
+      id: GO:0043473
+      label: pigmentation
+    modifier: INCREASED
+  locations:
+  - preferred_term: skin of face
+    term:
+      id: UBERON:1000021
+      label: skin of face
+  - preferred_term: eye
+    term:
+      id: UBERON:0000970
+      label: eye
+  - preferred_term: iris
+    term:
+      id: UBERON:0001769
+      label: iris
+  - preferred_term: conjunctiva
+    term:
+      id: UBERON:0001811
+      label: conjunctiva
+  downstream:
+  - target: Facial Blue-Gray Hyperpigmentation
+  - target: Ocular Melanocytosis
+  - target: Glaucoma Risk
+  - target: Uveal Melanoma Risk
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ODM is a rare, prevalently unilateral, congenital condition that presents
+      with brown or blue/gray flat asymptomatic lesions of the skin, mucosae,
+      episclera/sclera, and uvea localized within the territory of distribution
+      of the ophthalmic and mandibular branches of the trigeminal nerve.
+    explanation: >-
+      This clinical review directly supports the tissue distribution and
+      pigmentary phenotype captured by this mechanism node.
+- name: Glaucoma Risk
+  description: >-
+    Ocular melanocytosis can be complicated by glaucoma, so patients require
+    ophthalmic assessment and ongoing surveillance.
+  locations:
+  - preferred_term: eye
+    term:
+      id: UBERON:0000970
+      label: eye
+  downstream:
+  - target: Glaucoma
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Glaucoma and predisposition to uveal melanoma are the main ophthalmic
+      complications.
+    explanation: >-
+      This supports glaucoma as a major nevus of Ota ophthalmic complication.
+  - reference: DOI:10.1136/bjophthalmol-2019-313984
+    reference_title: "Naevus of Ota: clinical characteristics and proposal for a new ocular classification and grading system"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three patients developed malignant transformation to choroidal melanoma
+      and four patients developed glaucoma.
+    explanation: >-
+      This ocular clinical series documents glaucoma among observed complications.
+- name: Uveal Melanoma Risk
+  description: >-
+    Ocular or oculodermal melanocytosis increases the risk of uveal melanoma in
+    the affected eye, with tumor development localizing to melanocytotic tissue
+    in reported series.
+  cell_types:
+  - preferred_term: melanocyte
+    term:
+      id: CL:0000148
+      label: melanocyte
+  locations:
+  - preferred_term: iris
+    term:
+      id: UBERON:0001769
+      label: iris
+  downstream:
+  - target: Uveal Melanoma
+  evidence:
+  - reference: PMID:6677847
+    reference_title: Ocular and oculodermal melanocytosis associated with uveal melanoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The melanoma in each of these patients developed in the eye affected with
+      ocular or oculodermal melanocytosis and not in the unaffected eye.
+    explanation: >-
+      This supports localization of uveal melanoma to the melanocytosis-affected
+      eye.
+  - reference: PMID:6677847
+    reference_title: Ocular and oculodermal melanocytosis associated with uveal melanoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A comparison of the prevalence of ocular or oculodermal melanocytosis in
+      patients with uveal melanoma with the prevalence of ocular or oculodermal
+      melanocytosis in the general population, implies that there is an increased
+      incidence of uveal melanomas in patients with ocular or oculodermal
+      melanocytosis.
+    explanation: >-
+      This directly supports increased uveal melanoma incidence in ocular or
+      oculodermal melanocytosis.
+phenotypes:
+- category: Dermatologic
+  name: Facial Blue-Gray Hyperpigmentation
+  diagnostic: true
+  description: >-
+    Usually unilateral brown or blue-gray flat facial pigmentation affects skin
+    in trigeminal nerve distributions.
+  phenotype_term:
+    preferred_term: Hyperpigmentation of the skin
+    term:
+      id: HP:0000953
+      label: Hyperpigmentation of the skin
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ODM is a rare, prevalently unilateral, congenital condition that presents
+      with brown or blue/gray flat asymptomatic lesions of the skin, mucosae,
+      episclera/sclera, and uvea localized within the territory of distribution
+      of the ophthalmic and mandibular branches of the trigeminal nerve.
+    explanation: >-
+      This supports the characteristic unilateral blue-gray skin pigmentation.
+- category: Ophthalmologic
+  name: Ocular Melanocytosis
+  diagnostic: true
+  description: >-
+    Pigmentation can involve episclera or sclera and uveal structures of the
+    affected eye.
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ODM is a rare, prevalently unilateral, congenital condition that presents
+      with brown or blue/gray flat asymptomatic lesions of the skin, mucosae,
+      episclera/sclera, and uvea localized within the territory of distribution
+      of the ophthalmic and mandibular branches of the trigeminal nerve.
+    explanation: >-
+      This supports ocular tissue involvement as part of the defining phenotype.
+- category: Ophthalmologic
+  name: Glaucoma
+  description: Glaucoma is a major ophthalmic complication of nevus of Ota.
+  phenotype_term:
+    preferred_term: Glaucoma
+    term:
+      id: HP:0000501
+      label: Glaucoma
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Glaucoma and predisposition to uveal melanoma are the main ophthalmic
+      complications.
+    explanation: >-
+      This review identifies glaucoma as a main complication.
+  - reference: DOI:10.1136/bjophthalmol-2019-313984
+    reference_title: "Naevus of Ota: clinical characteristics and proposal for a new ocular classification and grading system"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Three patients developed malignant transformation to choroidal melanoma
+      and four patients developed glaucoma.
+    explanation: >-
+      This clinical series documents glaucoma in four nevus of Ota patients.
+- category: Cancer
+  name: Uveal Melanoma
+  description: >-
+    Uveal melanoma is a serious malignancy risk in ocular or oculodermal
+    melanocytosis.
+  evidence:
+  - reference: PMID:6677847
+    reference_title: Ocular and oculodermal melanocytosis associated with uveal melanoma.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Fifteen patients with ocular or oculodermal melanocytosis were found after
+      reviewing 1210 cases of histologically proven uveal melanomas.
+    explanation: >-
+      This case-series review supports the association between oculodermal
+      melanocytosis and uveal melanoma.
+genetic:
+- name: Postzygotic GNAQ/GNA11 mosaicism
+  association: Causative
+  gene_term:
+    preferred_term: GNAQ
+    term:
+      id: hgnc:4390
+      label: GNAQ
+  variant_origin: SOMATIC
+  notes: >-
+    Falcon identified postzygotic GNAQ and GNA11 activation as the strongest
+    molecular mechanism for extensive dermal melanocytosis and related
+    oculodermal melanocytosis phenotypes, rather than a germline inheritance
+    pattern for typical isolated nevus of Ota.
+  evidence:
+  - reference: PMID:26778290
+    reference_title: "Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The mutations were detected at very low levels in affected tissues but were
+      undetectable in the blood, indicating that these conditions are postzygotic
+      mosaic disorders.
+    explanation: >-
+      This supports postzygotic mosaicism as the molecular genetic pattern.
+progression:
+- phase: Congenital or early-life onset
+  age_range: Birth to childhood
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ODM is a rare, prevalently unilateral, congenital condition that presents
+      with brown or blue/gray flat asymptomatic lesions of the skin, mucosae,
+      episclera/sclera, and uvea localized within the territory of distribution
+      of the ophthalmic and mandibular branches of the trigeminal nerve.
+    explanation: >-
+      This supports congenital onset as the typical temporal pattern.
+diagnosis:
+- name: Comprehensive ophthalmological examination and multimodal imaging
+  description: >-
+    Diagnosis is primarily clinical, but comprehensive ophthalmologic evaluation
+    and imaging are important because pigmentation can obscure retinal and
+    choroidal findings and because glaucoma or melanoma can involve anterior and
+    posterior ocular structures.
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Diagnosis and management are through comprehensive opthalmological
+      examination and traditional imaging methods such as ultrasonography and
+      fluorescein/indocyanine green angiography as pigmentation of the fundus can
+      conceal subtle retinal and choroidal alterations.
+    explanation: >-
+      This supports comprehensive ophthalmologic examination and imaging in
+      diagnosis and management.
+treatments:
+- name: Q-switched or picosecond laser therapy
+  description: >-
+    Pigment-directed laser treatment, including Q-switched Nd:YAG and picosecond
+    laser approaches, is used for cosmetic treatment of nevus of Ota pigmentation.
+  treatment_term:
+    preferred_term: laser ablation therapy
+    term:
+      id: MAXO:0000453
+      label: laser ablation therapy
+  evidence:
+  - reference: clinicaltrials:NCT04481178
+    reference_title: A Retrospective Study on Laser Treatment of Nevus of Ota in Thai Patients
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A retrospective study on efficacy and complication of laser treatment
+      (Q-switched Nd:YAG and picosecond laser) of nevus of Ota in Thai patients
+    explanation: >-
+      This ClinicalTrials.gov record supports laser treatment as an evaluated
+      therapeutic approach for nevus of Ota.
+notes: >-
+  Falcon found no strong evidence for routine germline testing, infectious
+  etiology, environmental causation, or established primary prevention for
+  typical isolated nevus of Ota.

--- a/kb/disorders/Nevus_of_Ota.yaml
+++ b/kb/disorders/Nevus_of_Ota.yaml
@@ -326,6 +326,11 @@ phenotypes:
   description: >-
     Uveal melanoma is a serious malignancy risk in ocular or oculodermal
     melanocytosis.
+  phenotype_term:
+    preferred_term: Uveal melanoma
+    term:
+      id: HP:0007716
+      label: Uveal melanoma
   evidence:
   - reference: PMID:6677847
     reference_title: Ocular and oculodermal melanocytosis associated with uveal melanoma.

--- a/kb/disorders/Nevus_of_Ota.yaml
+++ b/kb/disorders/Nevus_of_Ota.yaml
@@ -21,6 +21,40 @@ description: >-
   crest-derived melanocyte mosaicism model, ophthalmic surveillance for glaucoma
   and uveal melanoma, and pigment-directed laser therapy for cosmetic treatment.
 pathophysiology:
+- name: Aberrant Neural Crest Melanoblast Migration
+  description: >-
+    Altered migration or persistence of neural crest-derived melanoblasts during
+    embryogenesis is modeled as an upstream developmental event that places
+    melanocyte precursors in facial dermis and ocular tissues along trigeminal
+    distributions.
+  cell_types:
+  - preferred_term: neural crest cell
+    term:
+      id: CL:0011012
+      label: neural crest cell
+  biological_processes:
+  - preferred_term: neural crest cell migration
+    term:
+      id: GO:0001755
+      label: neural crest cell migration
+    modifier: ABNORMAL
+  downstream:
+  - target: Mosaic GNAQ-GNA11 Melanocyte Signaling
+  - target: Dermal and Ocular Melanocyte Accumulation
+  evidence:
+  - reference: PMID:35851619
+    reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ODM is a rare, prevalently unilateral, congenital condition that presents
+      with brown or blue/gray flat asymptomatic lesions of the skin, mucosae,
+      episclera/sclera, and uvea localized within the territory of distribution
+      of the ophthalmic and mandibular branches of the trigeminal nerve.
+    explanation: >-
+      The congenital, unilateral, trigeminal-territory distribution supports a
+      developmental melanoblast migration or persistence model, although the
+      cached abstract does not directly name neural crest migration.
 - name: Mosaic GNAQ-GNA11 Melanocyte Signaling
   description: >-
     Postzygotic activating mutations in GNAQ or GNA11 can drive extensive dermal
@@ -243,6 +277,11 @@ phenotypes:
   description: >-
     Pigmentation can involve episclera or sclera and uveal structures of the
     affected eye.
+  phenotype_term:
+    preferred_term: Ocular melanocytosis
+    term:
+      id: HP:0000610
+      label: Abnormal choroid morphology
   evidence:
   - reference: PMID:35851619
     reference_title: "An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota)."
@@ -299,7 +338,7 @@ phenotypes:
       This case-series review supports the association between oculodermal
       melanocytosis and uveal melanoma.
 genetic:
-- name: Postzygotic GNAQ/GNA11 mosaicism
+- name: Postzygotic GNAQ mosaicism
   association: Causative
   gene_term:
     preferred_term: GNAQ
@@ -323,6 +362,28 @@ genetic:
       mosaic disorders.
     explanation: >-
       This supports postzygotic mosaicism as the molecular genetic pattern.
+- name: Postzygotic GNA11 mosaicism
+  association: Causative
+  gene_term:
+    preferred_term: GNA11
+    term:
+      id: hgnc:4379
+      label: GNA11
+  variant_origin: SOMATIC
+  notes: >-
+    GNA11 is a co-equal somatic mosaic driver in extensive dermal
+    melanocytosis and related oculodermal melanocytosis phenotypes.
+  evidence:
+  - reference: PMID:26778290
+    reference_title: "Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here, we discover that extensive dermal melanocytosis and phakomatosis
+      pigmentovascularis are associated with activating mutations in GNA11 and
+      GNAQ, genes that encode Gα subunits of heterotrimeric G proteins.
+    explanation: >-
+      This identifies GNA11 as a somatic mosaic driver alongside GNAQ.
 progression:
 - phase: Congenital or early-life onset
   age_range: Birth to childhood

--- a/references_cache/DOI_10.1136_bjophthalmol-2019-313984.md
+++ b/references_cache/DOI_10.1136_bjophthalmol-2019-313984.md
@@ -1,0 +1,27 @@
+---
+reference_id: "DOI:10.1136/bjophthalmol-2019-313984"
+title: "Naevus of Ota: clinical characteristics and proposal for a new ocular classification and grading system"
+authors:
+- Vicktoria Vishnevskia-Dai
+- Iris Moroz
+- Tal Davidy
+- Keren Zloto
+- Yael Birger
+- Ido Didi Fabian
+- Guy Ben Simon
+- Ayelet Priel
+- Ofira Zloto
+journal: British Journal of Ophthalmology
+year: '2021'
+doi: 10.1136/bjophthalmol-2019-313984
+content_type: abstract_only
+---
+
+# Naevus of Ota: clinical characteristics and proposal for a new ocular classification and grading system
+**Authors:** Vicktoria Vishnevskia-Dai, Iris Moroz, Tal Davidy, Keren Zloto, Yael Birger, Ido Didi Fabian, Guy Ben Simon, Ayelet Priel, Ofira Zloto
+**Journal:** British Journal of Ophthalmology (2021)
+**DOI:** [10.1136/bjophthalmol-2019-313984](https://doi.org/10.1136/bjophthalmol-2019-313984)
+
+## Content
+
+IntroductionNaevus of Ota is a congenital condition that may involve the skin, eyeball and even intracranial structures usually in the distribution of the ophthalmic and maxillary divisions of the trigeminal cranial nerve. The purpose of this study was to summarise our experience with the ocular clinical presentation, imaging, outcome, treatment of complications and to offer a new classification of patients with naevus of Ota.MethodsWe retrospectively reviewed the patients’ medical records and the following parameters were retrieved and analysed: demographics, clinical presentation complications and treatment of complications. Imaging characteristics of patients with naevus of Ota were compared with images from the same period of time of 57 age-matched and gender-matched patients without naevus of Ota (control group).ResultsThe series was composed of 40 patients (18 males, 22 females) whose mean age at diagnosis was 35.27 years (range 0.5–77 years). Thirty-three patients (82.5%) were type I naevus of Ota according to the Tanino classification, three patients (7.5%) were type II, one patient (2.5%) was type III and three patient (7.5%) were type IV (bilateral naevus of Ota). We further classified all cases in according to the ocular involvement extent. Three patients developed malignant transformation to choroidal melanoma and four patients developed glaucoma.ConclusionsIn this study, a new clinical classification based on the involved ocular component and extent of the involvement (in quadrants) of the globe is suggested first. Further studies are needed to assess whether our clinical ocular classification can assist in identifying patients at risk for developing glaucoma and malignant transformation.

--- a/references_cache/PMID_26778290.md
+++ b/references_cache/PMID_26778290.md
@@ -1,0 +1,180 @@
+---
+reference_id: "PMID:26778290"
+title: Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis.
+authors:
+- Thomas AC
+- Zeng Z
+- Rivière JB
+- "O'Shaughnessy R"
+- Al-Olabi L
+- St-Onge J
+- Atherton DJ
+- Aubert H
+- Bagazgoitia L
+- Barbarot S
+- Bourrat E
+- Chiaverini C
+- Chong WK
+- Duffourd Y
+- Glover M
+- Groesser L
+- Hadj-Rabia S
+- Hamm H
+- Happle R
+- Mushtaq I
+- Lacour JP
+- Waelchli R
+- Wobser M
+- Vabres P
+- Patton EE
+- Kinsler VA
+journal: J Invest Dermatol
+year: '2016'
+doi: 10.1016/j.jid.2015.11.027
+keywords:
+- Alleles
+- Animals
+- "Animals, Genetically Modified"
+- Base Sequence
+- DNA Mutational Analysis
+- GTP-Binding Protein alpha Subunits/genetics
+- "GTP-Binding Protein alpha Subunits, Gq-G11"
+- HEK293 Cells
+- Humans
+- Infant
+- Molecular Sequence Data
+- Mongolian Spot/genetics
+- Mutation
+- "Mutation, Missense"
+- Neurocutaneous Syndromes/genetics
+- Phenotype
+- Phosphorylation
+- Signal Transduction
+- Skin Diseases/genetics
+- Zebrafish
+content_type: full_text_xml
+---
+
+# Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis Pigmentovascularis and Extensive Dermal Melanocytosis.
+**Authors:** Thomas AC, Zeng Z, Rivière JB, O'Shaughnessy R, Al-Olabi L, St-Onge J, Atherton DJ, Aubert H, Bagazgoitia L, Barbarot S, Bourrat E, Chiaverini C, Chong WK, Duffourd Y, Glover M, Groesser L, Hadj-Rabia S, Hamm H, Happle R, Mushtaq I, Lacour JP, Waelchli R, Wobser M, Vabres P, Patton EE, Kinsler VA
+**Journal:** J Invest Dermatol (2016)
+**DOI:** [10.1016/j.jid.2015.11.027](https://doi.org/10.1016/j.jid.2015.11.027)
+
+## Content
+
+1. J Invest Dermatol. 2016 Apr;136(4):770-778. doi: 10.1016/j.jid.2015.11.027.
+Epub  2016 Jan 14.
+
+Mosaic Activating Mutations in GNA11 and GNAQ Are Associated with Phakomatosis 
+Pigmentovascularis and Extensive Dermal Melanocytosis.
+
+Thomas AC(1), Zeng Z(2), Rivière JB(3), O'Shaughnessy R(4), Al-Olabi L(1), 
+St-Onge J(3), Atherton DJ(5), Aubert H(6), Bagazgoitia L(7), Barbarot S(6), 
+Bourrat E(8), Chiaverini C(9), Chong WK(10), Duffourd Y(3), Glover M(5), 
+Groesser L(11), Hadj-Rabia S(12), Hamm H(13), Happle R(14), Mushtaq I(15), 
+Lacour JP(9), Waelchli R(5), Wobser M(13), Vabres P(16), Patton EE(17), Kinsler 
+VA(18).
+
+Author information:
+(1)Genetics and Genomic Medicine, UCL Institute of Child Health, London, UK.
+(2)MRC Institute of Genetics and Molecular Medicine, MRC Human Genetics Unit & 
+Edinburgh Cancer Research UK Centre, Edinburgh, UK.
+(3)Equipe d'Accueil 4271, Génétique des Anomalies du Développement, University 
+of Burgundy, Dijon, France.
+(4)Livingstone Skin Research Unit, UCL Institute of Child Health, London, UK.
+(5)Paediatric Dermatology, Great Ormond Street Hospital for Children, London, 
+UK.
+(6)Department of Dermatology, Nantes University Hospital, Nantes, France.
+(7)Dermatology, Hospital Universitario Ramón y Cajal, Madrid, Spain.
+(8)Dermatology, Saint-Louis Hospital, Paris, France; General Paediatrics, 
+Robert-Debré Hospital, Paris, France.
+(9)Dermatology, University Hospital of Nice, Nice, France.
+(10)Neuroradiology, Great Ormond Street Hospital for Children, London, UK.
+(11)Dermatology, Regensburg University Clinic, Regensburg, Germany.
+(12)Paediatric Dermatology, Necker Enfants-Malades Hospital, Paris, France.
+(13)Dermatology, University Hospital Wuerzburg, Wuerzburg, Germany.
+(14)Dermatology, Freiburg University Medical Center, University of Freiburg, 
+Freiburg, Germany.
+(15)Paediatric Urology, Great Ormond Street Hospital for Children, London, UK.
+(16)Equipe d'Accueil 4271, Génétique des Anomalies du Développement, University 
+of Burgundy, Dijon, France; Dermatology, Dijon University Hospital, Dijon, 
+France.
+(17)MRC Institute of Genetics and Molecular Medicine, MRC Human Genetics Unit & 
+Edinburgh Cancer Research UK Centre, Edinburgh, UK. Electronic address: 
+e.patton@igmm.ed.ac.uk.
+(18)Genetics and Genomic Medicine, UCL Institute of Child Health, London, UK; 
+Paediatric Dermatology, Great Ormond Street Hospital for Children, London, UK. 
+Electronic address: v.kinsler@ucl.ac.uk.
+
+Common birthmarks can be an indicator of underlying genetic disease but are 
+often overlooked. Mongolian blue spots (dermal melanocytosis) are usually 
+localized and transient, but they can be extensive, permanent, and associated 
+with extracutaneous abnormalities. Co-occurrence with vascular birthmarks 
+defines a subtype of phakomatosis pigmentovascularis, a group of syndromes 
+associated with neurovascular, ophthalmological, overgrowth, and malignant 
+complications. Here, we discover that extensive dermal melanocytosis and 
+phakomatosis pigmentovascularis are associated with activating mutations in 
+GNA11 and GNAQ, genes that encode Gα subunits of heterotrimeric G proteins. The 
+mutations were detected at very low levels in affected tissues but were 
+undetectable in the blood, indicating that these conditions are postzygotic 
+mosaic disorders. In vitro expression of mutant GNA11(R183C) and GNA11(Q209L) in 
+human cell lines demonstrated activation of the downstream p38 MAPK signaling 
+pathway and the p38, JNK, and ERK pathways, respectively. Transgenic mosaic 
+zebrafish models expressing mutant GNA11(R183C) under promoter mitfa developed 
+extensive dermal melanocytosis recapitulating the human phenotype. Phakomatosis 
+pigmentovascularis and extensive dermal melanocytosis are therefore diagnoses in 
+the group of mosaic heterotrimeric G-protein disorders, joining McCune-Albright 
+and Sturge-Weber syndromes. These findings will allow accurate clinical and 
+molecular diagnosis of this subset of common birthmarks, thereby identifying 
+infants at risk for serious complications, and provide novel therapeutic 
+opportunities.
+
+Copyright © 2016 The Authors. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.jid.2015.11.027
+PMCID: PMC4803466
+PMID: 26778290 [Indexed for MEDLINE]
+
+Mongolian blue spots (or, more appropriately, dermal melanocytosis) are common birthmarks, seen in up to 95% of African neonates and approximately 10% of white Caucasians (Cordova, 1981). As a result they are easily overlooked as a possible sign of underlying genetic disease. Classically they are flat, dark-blue lesions with indistinct edges overlying the buttocks and lower back, which undergo spontaneous resolution over a period of years. However, the appearances and behavior are not always classic (Gupta and Thappa, 2013). Some dermal melanocytosis involve unusual sites, cover large areas of the body surface, are more deeply pigmented, are better defined, and persist rather than resolve. These more atypical patterns of dermal melanocytosis can be associated with anomalies such as colocalized cleft lip (Igawa et al., 1994), ocular melanocytosis (Teekhasaenee et al., 1990), ocular melanoma (Shields et al., 2013), lysosomal storage disorders (Hanson et al., 2003), or vascular birthmarks. This latter association then falls under the diagnostic group of phakomatosis pigmentovascularis (PPV) (for clinical examples see Figure 1). Phakomatosis pigmentovascularis is a group of sporadic disorders of unknown frequency, defined by the co-occurrence of pigmentary and vascular birthmarks and subclassified clinically by the exact cutaneous phenotypes (Supplementary Table S1 online) (Happle, 2013, Hasegawa and Yasuhara, 1979; Ota et al., 1947). Whether the subtypes are distinct disorders or variable expressions of a single disorder has not been clear as the molecular and developmental pathogenesis of PPV has been unknown. The hypothesis of non-allelic twin spotting was previously expounded to explain the co-occurrence of two disparate birthmarks (Danarti and Happle, 2003) but was recently retracted by the author because of lack of supporting molecular evidence (Happle, 2013). Extracutaneous associations of PPV can be severe, including scleral or intraocular melanocytosis (Shields et al., 2011), glaucoma (Henry et al., 2013, Teekhasaenee and Ritch, 1997, Vidaurri-de la Cruz H, 2003), intracerebral vascular or other malformations leading to seizures and cognitive delay (Hall et al., 2007, Shields et al., 2011, Tsuruta et al., 1999, Vidaurri-de la Cruz H, 2003), overgrowth of soft tissues or limbs (Chhajed et al., 2010, Jeon et al., 2013, Vidaurri-de la Cruz H, 2003), and melanoma. The latter can arise in choroid or conjunctiva, with melanocytoma of the optic disk also described (Krema et al., 2013, Shields et al., 2011, Teekhasaenee and Ritch, 1997, Tran and Zografos, 2005). Without an understanding of the genetic pathogenesis of the disease, targeted therapies for the congenital and neoplastic aspects of the disease have been impossible.
+
+When considering the genetic basis of extensive dermal melanocytosis and of PPV, we hypothesized that these conditions could be the result of a postzygotic mutation in a member of the G-protein nucleotide binding protein alpha subunit family. This hypothesis was generated by the rare concurrent description of PPV with Sturge-Weber syndrome (SWS) (Chhajed et al., 2010; Vidaurri-de la Cruz et al., 2003), a vascular disorder with no pigmentary phenotype recently found to be the result of postzygotic mosaicism for activating mutations in GNAQ (Shirley et al., 2013). We also hypothesized that an identical mutation could be present in both types of birthmarks in PPV, secondary to a single mutation in a pluripotent progenitor cell.
+
+Missense GNA11 or GNAQ mutations were found in 8 of 11 patients tested. In each case, these mutations were detected in affected skin (and in one case ocular tissue) at very low levels and were undetectable in blood, indicating postzygotic mosaicism (Table 1). When levels of mutant allele <1% were detected in blood, these could not be distinguished from background noise despite the substantial depth of coverage (Supplementary Table S2 online) and were therefore called as wild type (WT). In the three patients with extensive dermal melanocytosis, we identified mutations in GNAQ in two, one c.548G>A, p.R183Q, and one c.626A>C, Q209P. In the eight patients with PPV, we identified somatic GNA11 mutations in four, three at position c.547C>T, p.R183C, and one novel mutation in the same codon c.547C>A, p.R183S. and GNAQ mutations in two, both at position c.548G>A, p.R183Q (Figure 2). Importantly there was conservation of mutation between pigmentary and vascular lesions in each patient for whom more than one skin biopsy was available (Table 1 and Supplementary Table S2). Measured percentage of mosaicism in skin samples was lowest at 1.5% using next-generation sequencing mutant allele count as a percentage of the total number of reads (Supplementary Table S2). None of these mutations in GNA11 and GNAQ is described in the largest current population database (Exome Aggregation Consortium, 2015).
+
+For the in vitro transfection experiments, HEK293 cells were transfected with vector, WT GNA11, or mutant GNA11 constructs encoding R183C and Q209L. Figure 3 shows results of western blots for Flag, total GNA11, and the phosphorylated and total p38, JNK, ERK and AKT in total protein lysates from these cells. Analysis of the ratio of phosphorylated to total p38, JNK, ERK and AKT normalized by the actin loading control (from two replicates, pooled results of WT compared to those of mutant) demonstrated increased phosphorylation and therefore activation of the p38 MAPK pathway by the R183C mutant and of ERK, p38 MAPK, and JNK pathways by Q209L, in keeping with previous results for Q209L (Li et al., 2014). These results were significant at the 0.05 level using a one-tailed t test.
+
+GNA11R183C- and GNA11Q209L-expressing zebrafish exhibited dark cutaneous patches of melanocytes by 1 month. When the mutant transgenic zebrafish reached adulthood at 3 months, nearly all injected fish (n = 17/18 for R183C and n = 16/16 for Q209L) developed large and clearly visible pigmentary lesions (Figure 4a and b), recapitulating the human phenotype of dermal melanocytosis. Wild-type GNA11 expression in melanocytes also produced mosaic animals with some pigmentary lesions (n = 10/27); however, these were usually smaller and less dark, suggesting that the melanocyte lineage is highly sensitive to GNA11-coupled receptor signaling. Histopathology revealed many extra melanocytes in both the epidermis (over the scales, not shown) and the dermis in the pigmentary lesion of mutant GNA11R183C injected fish, with occasional involvement of the underlying muscle (Figure 4c).
+
+We sought to differentiate a subgroup of the common birthmark dermal melanocytosis in infants who are at risk of extra-cutaneous complications, by elucidating the underlying genetic cause. We show here that extensive dermal melanocytosis and PPV are genetic conditions associated with postzygotic mutations in genes encoding Gα subunits of heterotrimeric G proteins. Specifically, postzygotic mutations in GNAQ have been found in extensive dermal melanocytosis, and mutations in GNA11 or GNAQ have been found in PPV types I, II (cesioflammea), IV, and V (cesiomarmorata), as well as the unclassifiable achromico-melano-marmorata type. Type IV is considered to be exceptionally rare and was not tested because no samples were available. Type III (spilorosea) is distinguished clinically from all other types of PPV by the absence of dermal melanocytosis, and because only one patient from this group was tested (and was WT), we cannot yet conclude anything about the genetic etiology of this type. Of note, the percentage mosaicism was often very low, the result of very few mutant cells within a skin biopsy of a completely macular birthmark, thus emphasizing the need for adequately sensitive detection techniques in this type of genetic disease. A possible alternative explanation for our findings is that these patients are somehow genetically predisposed to somatic mutations in the same genes, and this is particularly relevant for those in whom we have only been able to obtain one sample. Although this cannot be entirely excluded, it is a much less convincing explanation of the results than postzygotic mosaicism, as we discovered different mutations in different patients, but the same mutation was present in more than one location when two samples were obtained from one individual. As candidate gene sequencing was performed in this study, we cannot exclude the presence of further mutation in other genes. Further exome sequencing could be performed to look for secondary mutations.
+
+True embryonic mosaicism has not yet been described for GNA11 mutations. Isolated somatic GNA11 mutations have been found in uveal melanoma and single blue nevi (a lesion distinct from dermal melanocytosis both clinically and histologically) (Van Raamsdonk et al., 2010). In contrast to our findings in PPV, the prevalence of codon 183 mutations in single melanomas and blue nevi was much lower than of codon 209 mutations (Van Raamsdonk et al., 2010). Postzygotic mosaicism for GNAQ mutations has been described as the major cause of SWS, a purely vascular disorder with no pigmentary phenotype. Somatic mutations in GNAQ are frequent in uveal melanoma and single blue nevi (Van Raamsdonk et al., 2009). Therefore, our findings not only describe GNA11 mosaicism but also extend the phenotypic spectrum of human GNAQ mosaicism from SWS (vascular only), through to PPV (vascular and pigmentary), to extensive dermal melanocytosis (pigmentary only). Exactly how the same mutation can generate these three distinct phenotypes is not yet clear.
+
+Codon 183 in both GNA11 and GNAQ is located within the guanosine triphosphate binding region of the human Gα subunit, a region required for hydrolysis of guanosine triphosphate to guanosine diphosphate and an essential step for inactivation of G-protein coupled receptor signaling. Therefore, these mutations lead to decreased function of guanosine triphosphatase and to constitutive activation of downstream effector pathways. We have shown that the most common mutation at codon 183 of GNA11 activates the downstream p38 MAPK pathway in human cells, whereas the codon 209 mutant (not found in this cohort in GNA11 but in one patient in GNAQ) activates p38 MAPK, JNK and ERK pathways, broadly supporting previous findings of effects of mutations in both GNA11 (Li et al., 2014, Van Raamsdonk et al., 2010) and GNAQ (Van Raamsdonk et al., 2010).
+
+Of interest, different mutations in GNA11 in the germline leading to altered sensitivity of cells to extracellular calcium concentrations have been described in autosomal dominant hypoparathyroidism and hypocalciuric hypercalcemia, respectively (Nesbit et al., 2013). One of these mutations (GNA11R60L) has been characterized as less activating than GNA11Q209L (Li et al., 2014). This pattern of less severe mutations being supportable in the germline, whereas more severe mutations can survive only by mosaicism, once again confirms Happle’s established theory (Happle, 1987). Patients with PPV and SWS have not been documented to have abnormalities of calcium homeostasis; however, intravascular calcification can be a feature of neurological abnormalities in PPV, which could hypothetically involve localized mosaic calcium imbalances. This is an area that merits future careful research.
+
+A causal link between our genetic findings and mechanism is strongly supported by the mosaic zebrafish models demonstrated here, in which expression of GNA11R183C or GNA11Q209L leads to ectopic and increased numbers of melanocytes in the epidermal and dermal layers, recapitulating the human phenotype of dermal melanocytosis. Overexpression of WT GNA11 in melanocytes also leads to a low level of pigmentary mosaicism in zebrafish, underscoring the importance of close regulation of G-protein coupled receptor signaling in the melanocyte lineage. No other mosaic animal models of GNA11 gain-of-function mutations exist; however, further conformation of our findings comes from germline hypermorphic alleles of GNA11, which lead to increased cutaneous pigmentation in the murine Dsk phenotype (Van Raamsdonk et al., 2004).
+
+We found no evidence for the now-retracted theory of twin spotting or didymosis. Rather, we have shown that a single somatic mutation in GNA11 or GNAQ is responsible for both types of cutaneous lesion in PPV, mirroring closely the pathogenesis of the disparate birthmarks seen in HRAS mosaicism (Groesser et al., 2013). We propose that extensive dermal melanocytosis and PPV are members of an expanding group of heterotrimeric G-protein alpha subunit gene mosaic conditions, joining McCune-Albright syndrome (Weinstein et al., 1991), caused by mosaicism for gain-of-function mutations in GNAS, and SWS, caused by mosaic gain-of-function mutations in GNAQ (Shirley et al., 2013). We also propose that GNAQ mosaicism forms a spectrum from SWS, through PPV, to extensive dermal melanocytosis. This knowledge will allow accurate clinical molecular diagnosis of a subset of extensive dermal melanocytosis and of PPV, leading to identification of neonates at risk for serious complications associated with these birthmarks. Importantly, it will also pave the way for therapeutic options in these children.
+
+All human and animal studies were approved by the authors' institutions' research ethics review boards. Declaration of Helsinki protocols were followed, and all patients gave written informed consent. Eleven patients from four international centers were recruited with written consent for genetic research, approved by the local research ethics committees. Patients were classified by clinical phenotype: three with extensive or atypical dermal melanocytosis (which was defined as involving areas other than only the lumbosacral lesion) and eight with PPV, with representatives of subtypes I, II (cesioflammea), III (spilorosea), and V (cesiomarmorata) (Supplementary Table S1 and Figure 1), and also the unclassifiable achromico-melano-marmorata type (Boente Mdel et al., 2008). Blood samples and skin biopsies were taken from each patient, and in those patients with PPV, skin was biopsied from both the vascular and pigmentary birthmarks when possible.
+
+Deoxyribonucleic acid (DNA) was extracted from whole blood and directly from fresh skin lesion samples using the DNeasy Blood and Tissue Kit (Qiagen, Düsseldorf, Germany) and from paraffin embedded tissue using the RecoverAll total nucleic acid extraction kit for formalin-fixed paraffin-embedded tissue (Life Technologies, Carlsbad, CA). To maximize detection of mutant alleles at low percentage mosaicism, we designed restriction enzyme digests of the normal allele at hotspots codons 183 and 209 of GNA11 and 183 of GNAQ using validated methods (Kinsler et al., 2013) and Sanger sequencing. Primer sequences and restriction enzymes for each hotspot are given in Supplementary Table S3 (online). Touchdown polymerase chain reaction programs were used throughout, with 35 cycles for the first polymerase chain reaction and 25 for the second.
+
+We performed targeted deep sequencing of the regions spanning mutations previously identified by selective amplification of mutant alleles in all samples for which DNA quality was sufficient (as determined by the presence of a band above 10 kb size on agarose gel). In subjects with no identified mutation, all coding regions of GNAQ and GNA11 were screened using the same method. Targeted regions were amplified using custom intronic primers and standard long-range polymerase chain reaction protocols. Polymerase chain reaction products were purified and libraries were prepared using the Nextera XT DNA Sample Preparation kit (Illumina, Cambridge, UK). Samples were then pooled and sequenced on a MiSeq instrument (Illumina) according to the manufacturer’s recommendations for paired-end 150-bp reads. In-depth sequencing was performed to achieve a sequencing depth of at least 1,000 reads for all targeted coding bases and splice junctions. Identification of candidate variants was performed as described previously (Riviere et al., 2012). Briefly, all targeted bases were systematically screened to count all sites with at least one read not matching the reference sequence, using a base-quality threshold of 30. Candidate postzygotic variants were confirmed by at least one independent experiment in all DNA samples available from the patient.
+
+To test the causality and model the effects of the mutation, we injected zebrafish embryos with WT human GNA11, GNA11R183C, or GNA11Q209L expressed from the melanocyte mitfa promoter and grew the genetically mosaic animals to adulthood. All zebrafish work was performed in accordance with United Kingdom Home Office Animals (Scientific Procedures) Act (1986) and approved by the University of Edinburgh Ethical Review Committee.
+
+The human GNA11 cDNA clone was purchased from Origene (purchased from NM_002067.1 precloned into an untagged pCMV6-XL4 vector, catalog number SC303115). Mutant GNA11Q209L (626a> t) was generated by site-directed genesis polymerase chain reaction with primers (forward: 5′-GATGTGGGGGGCCTGCGGTCGGAGCGGAGG-3′, reverse: 5′-CCTCCGCTCCGACCGCAGGCCCCCCACATC-3′). Mutant GNA11R183C (547c>t) was also generated with primers (forward: 5′-CGTGCTGCGGGTCTGCGTGCCCACCACCG-3′, reverse: 5′-CGGTGGTGGGCACGCAGACCCGCAGCACG-3′). The WT and mutant GNA11 cDNAs were cloned together with the zebrafish mitfa gene promoter into the pDestTol2CG2 expression vector using the Tol2kit gateway cloning method (Kwan et al., 2007), resulting in mitfa-GNA11, mitfa-GNA11Q209L and mitfa-GNA11R183C constructs. For selection purposes, these constructs contain an additional green fluorescent protein gene expressed from the heart cml promoter. Two nanoliters of mixed mitfa-GNA11 plasmid DNA and Tol2 mRNA (62.5 ng/μl and 70 ng/μl, respectively) was injected into one-cell stage zebrafish embryos. Zebrafish embryos with green fluorescent protein transgenic marker in the heart were selected and grown to adulthood.
+
+Adult zebrafish were anesthetized in 50 mg/L tricaine solution and ×1 images from both sides of the fish were taken under a stereomicroscope. Dark patches of melanocyte lesions with areas larger than that of one scale were counted. Adult zebrafish were sacrificed by immersion in tricaine solution as directed by Home Office Schedule 1 methods. Zebrafish were then dissected in half transversely to increase penetration of the fixative and fixed in 4% freshly prepared paraformaldehyde (Electron Microscopy Sciences, Hatfield, PA) at 4 °C for 3 days. Samples were washed in phosphate buffered saline and decalcified in 0.5 M EDTA at pH 8 for 5 days before storage in 70% ethanol. Samples were embedded in paraffin wax and sectioned at 5-μm thickness. For hematoxylin and eosin staining, slides were deparaffinized in xylene twice for 5 minutes and then rehydrated through graded alcohol solutions (100%, 90%, 70%, 50% and 30% for 3 minutes each) and stopped in water. Slides were stained with Mayer hematoxylin and eosin after the standard hematoxylin and eosin staining procedure.
+
+To characterize the functional effect of mutations on downstream signaling pathways, HEK293T cells were transfected with vector, WT GNA11, or mutant GNA11 constructs encoding R183C and Q209L. The Q209L was used as a positive comparator because it is a more studied mutation in GNA11. Flag-tagged GNA11 WT, R183C, and Q209L constructs and vector alone control (pDEST26, Invitrogen, Carlsbad, CA) were transfected into HEK293 cells using lipofectamine 2000 (Invitrogen), according to the manufacturer’s instructions. Cells were cultured for another 24 hours, and protein lysates were prepared by boiling in a denaturing SDS buffer (2% 2-mercaptoethanol, 2% SDS, 10mM Tris pH 7.5) for 10 minutes. Levels of GNA11 effector activation were assessed by western blot using the following antibodies at the following concentrations: Rabbit anti–p-Serine473 Akt (1/500; Cell Signaling Technology, Danvers, MA), rabbit anti-total Akt (1/1,000, Cell Signaling Technology), rabbit anti-phospho T180/Y182 p38 MAPK (1/500; Cell Signaling Technology), rabbit anti-Total p38 MAPK (1/500, Cell Signaling Technology), mouse anti-phospho T183/Y185 SAPK/JNK (1/500; Cell Signaling Technology), rabbit anti-total SAPK/JNK (1/500; Cell Signaling Technology), pT202/Y204 ERK (1/500; Cell Signaling Technology), and rabbit anti-total ERK 1,2 (1/1,000; Cell Signaling Technology), mouse anti-Flag (DYKDDDDK tag) (1/500; Cell Signaling Technology), rabbit anti-GNA11 (1/500; GeneTex, Irvine, CA), and mouse anti-GAPDH (1/2,000; Millipore, Watford, UK).
+
+Primary antibody incubations were in TBST (100 mM Tris HCl, 0.2 M NaCl, 0.1% Tween-20 v/v) containing 5% bovine serum albumin (Sigma, Gillingham, United Kingdom) or 5% skimmed milk powder either overnight at 4 oC or for 1–2 hours at room temperature, whereas secondary antibody incubations were performed in 5% skimmed milk powder for 1 hour at room temperature. The concentrations used were swine anti-rabbit HRP (DakoCytomation, Carpinteria, CA) 1:3,000 and rabbit anti-mouse HRP (DakoCytomation) 1:2,000. Protein was visualized using Luminol reagent (Santa Cruz Biotechnologies, Dallas, TX). Densitometry of bands was performed using thresholded images in the ImageJ suite (imagej.nih.gov/ij/).
+
+Veronica Kinsler: http://orcid.org/0000-0001-6256-327X
+
+Pierre Vabres: http://orcid.org/0000-0001-8693-3183
+
+The authors state no conflicts of interest.

--- a/references_cache/PMID_35851619.md
+++ b/references_cache/PMID_35851619.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:35851619"
+title: An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota).
+authors:
+- Abdolrahimzadeh S
+- Pugi DM
+- Manni P
+- Iodice CM
+- Di Tizio F
+- Persechino F
+- Scuderi G
+journal: Graefes Arch Clin Exp Ophthalmol
+year: '2023'
+doi: 10.1007/s00417-022-05743-1
+keywords:
+- Humans
+- "Nevus of Ota/diagnosis, pathology"
+- "Melanoma/diagnosis, pathology"
+- Choroid Neoplasms/diagnosis
+- "Tomography, Optical Coherence/methods"
+- Skin Neoplasms/pathology
+- Glaucoma
+- Uveal Melanoma
+content_type: abstract_only
+---
+
+# An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus of Ota).
+**Authors:** Abdolrahimzadeh S, Pugi DM, Manni P, Iodice CM, Di Tizio F, Persechino F, Scuderi G
+**Journal:** Graefes Arch Clin Exp Ophthalmol (2023)
+**DOI:** [10.1007/s00417-022-05743-1](https://doi.org/10.1007/s00417-022-05743-1)
+
+## Content
+
+1. Graefes Arch Clin Exp Ophthalmol. 2023 Feb;261(2):291-301. doi: 
+10.1007/s00417-022-05743-1. Epub 2022 Jul 19.
+
+An update on ophthalmological perspectives in oculodermal melanocytosis (Nevus 
+of Ota).
+
+Abdolrahimzadeh S(#)(1)(2), Pugi DM(#)(3), Manni P(3), Iodice CM(4), Di Tizio 
+F(5), Persechino F(6), Scuderi G(3)(5).
+
+Author information:
+(1)Ophthalmology Unit, Mental Health, Neurosciences, and Sense Organs (NESMOS) 
+Department, Faculty of Medicine and Psychology, University of Rome Sapienza, 
+Rome, Italy. solmaz.abdolrahimzadeh@uniroma1.it.
+(2)St. Andrea Hospital, Via di Grottarossa 1035/1039, 00189, Rome, Italy. 
+solmaz.abdolrahimzadeh@uniroma1.it.
+(3)Ophthalmology Unit, Mental Health, Neurosciences, and Sense Organs (NESMOS) 
+Department, Faculty of Medicine and Psychology, University of Rome Sapienza, 
+Rome, Italy.
+(4)Multidisciplinary Department of Medical Surgical and Dental Sciences, Eye 
+Clinic, University of Campania Luigi Vanvitelli, Naples, Italy.
+(5)St. Andrea Hospital, Via di Grottarossa 1035/1039, 00189, Rome, Italy.
+(6)Department of Clinical and Molecular Medicine, Sapienza University of Rome, 
+Rome, Italy.
+(#)Contributed equally
+
+PURPOSE: To provide a review of the literature on oculodermal melanocytosis 
+(ODM) with a focus on the diagnostic and therapeutic implications of multimodal 
+imaging techniques in the management of ophthalmic complications.
+METHODS: The authors carried out a literature search on PubMed, Medline, and 
+Scopus of English language articles published on ODM through August 2021. This 
+review presents traditional and novel diagnostic methods in the diagnosis and 
+follow-up of patients with particular emphasis on addressing the role of imaging 
+in the management of the ophthalmic complications of the condition towards 
+improving current practice patterns.
+RESULTS: ODM is a rare, prevalently unilateral, congenital condition that 
+presents with brown or blue/gray flat asymptomatic lesions of the skin, mucosae, 
+episclera/sclera, and uvea localized within the territory of distribution of the 
+ophthalmic and mandibular branches of the trigeminal nerve. Glaucoma and 
+predisposition to uveal melanoma are the main ophthalmic complications. 
+Diagnosis and management are through comprehensive opthalmological examination 
+and traditional imaging methods such as ultrasonography and 
+fluorescein/indocyanine green angiography as pigmentation of the fundus can 
+conceal subtle retinal and choroidal alterations. Anterior segment optical 
+coherence tomography and ultrasound biomicroscopy are used to evaluate the 
+anterior segment and the ciliary body in the presence of glaucoma or melanoma of 
+the anterior uveal tract. Fundus autofluorescence and retinal pigment epithelium 
+(RPE) alterations are of aid in the differential diagnosis between choroidal 
+nevi and melanoma. Enhanced depth imaging spectral domain optical coherence 
+tomography offers outstanding in vivo evaluation of the dimensions and details 
+of tumors or nevi and surrounding choroidal tissues and small choroidal 
+melanomas may show distortions of the retinal and sub-retinal profile, presence 
+of intra and sub-retinal fluid, abnormalities of the RPE, and compression of the 
+choriocapillaris.
+CONCLUSIONS: Novel multimodal imaging techniques are significant in the 
+diagnosis and management of the ophthalmic complications of ODM. Fundus 
+autofluorescence and enhanced depth spectral domain optical coherence tomography 
+have adjunctive value in the detection of early-stage melanoma and differential 
+diagnosis between nevi and melanoma. Awareness of current and emerging imaging 
+techniques can propagate improved standardized definition and assessment of the 
+complications of ODM.
+
+© 2022. The Author(s).
+
+DOI: 10.1007/s00417-022-05743-1
+PMCID: PMC9837000
+PMID: 35851619 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_6677847.md
+++ b/references_cache/PMID_6677847.md
@@ -1,0 +1,53 @@
+---
+reference_id: "PMID:6677847"
+title: Ocular and oculodermal melanocytosis associated with uveal melanoma.
+authors:
+- Velazquez N
+- Jones IS
+journal: Ophthalmology
+year: '1983'
+doi: 10.1016/s0161-6420(83)34358-x
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Choroid/pathology
+- Choroid Neoplasms/pathology
+- Female
+- Humans
+- Male
+- Melanoma/pathology
+- Melanosis/pathology
+- Middle Aged
+- Sclera/pathology
+content_type: abstract_only
+---
+
+# Ocular and oculodermal melanocytosis associated with uveal melanoma.
+**Authors:** Velazquez N, Jones IS
+**Journal:** Ophthalmology (1983)
+**DOI:** [10.1016/s0161-6420(83)34358-x](https://doi.org/10.1016/s0161-6420(83)34358-x)
+
+## Content
+
+1. Ophthalmology. 1983 Dec;90(12):1472-6. doi: 10.1016/s0161-6420(83)34358-x.
+
+Ocular and oculodermal melanocytosis associated with uveal melanoma.
+
+Velazquez N, Jones IS.
+
+Fifteen patients with ocular or oculodermal melanocytosis were found after 
+reviewing 1210 cases of histologically proven uveal melanomas. The melanoma in 
+each of these patients developed in the eye affected with ocular or oculodermal 
+melanocytosis and not in the unaffected eye. In the one case of bilateral 
+involvement with oculodermal melanocytosis, the patient developed the melanoma 
+in the eye more affected with melanocytosis. In the only case of partial ocular 
+melanocytosis, the melanoma developed in a sector of the eye affected with 
+melanocytosis. A comparison of the prevalence of ocular or oculodermal 
+melanocytosis in patients with uveal melanoma with the prevalence of ocular or 
+oculodermal melanocytosis in the general population, implies that there is an 
+increased incidence of uveal melanomas in patients with ocular or oculodermal 
+melanocytosis.
+
+DOI: 10.1016/s0161-6420(83)34358-x
+PMID: 6677847 [Indexed for MEDLINE]

--- a/references_cache/clinicaltrials_NCT04481178.md
+++ b/references_cache/clinicaltrials_NCT04481178.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT04481178
+title: A Retrospective Study on Laser Treatment of Nevus of Ota in Thai Patients
+content_type: summary
+---
+
+# A Retrospective Study on Laser Treatment of Nevus of Ota in Thai Patients
+
+## Content
+
+A retrospective study on efficacy and complication of laser treatment (Q-switched Nd:YAG and picosecond laser) of nevus of Ota in Thai patients

--- a/research/Nevus_of_Ota-deep-research-falcon.md
+++ b/research/Nevus_of_Ota-deep-research-falcon.md
@@ -1,0 +1,1260 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:34:31.262685'
+end_time: '2026-05-11T12:47:59.381060'
+duration_seconds: 808.12
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Nevus of Ota
+  mondo_id: ''
+  category: Skin Disorder
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Nevus of Ota
+- **MONDO ID:**  (if available)
+- **Category:** Skin Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Nevus of Ota** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Nevus of Ota
+- **MONDO ID:**  (if available)
+- **Category:** Skin Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Nevus of Ota** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Research Report: Nevus of Ota (Oculodermal Melanocytosis)
+
+### Target disease
+Nevus of Ota is a congenital (occasionally later-appearing) dermal melanocytosis characterized by blue/gray or brown macular pigmentation involving skin and ocular tissues in the distribution of trigeminal nerve branches, with important ophthalmic complications including glaucoma and elevated risk of uveal melanoma. (abdolrahimzadeh2023anupdateon pages 1-3, williams2021melanomainthe pages 1-2, vishnevskiadai2021naevusofota pages 1-2)
+
+| Domain | Finding | Population/Study | Year | Source (with URL) | Evidence ID |
+|---|---|---|---|---|---|
+| Epidemiology | Incidence in Asians: 1–2 per 1,000 | Review of oculodermal melanocytosis / Nevus of Ota | 2023 | Abdolrahimzadeh et al., *Graefe's Archive for Clinical and Experimental Ophthalmology*; https://doi.org/10.1007/s00417-022-05743-1 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Epidemiology | Prevalence in Japanese dermatology patients: ~0.4–0.8% | Review citing Japanese data | 2021 | Williams et al., *International Journal of Dermatology*; https://doi.org/10.1111/ijd.15135 | (williams2021melanomainthe pages 1-2) |
+| Epidemiology | Prevalence in Black persons reported as 0.014% (1/6,915); older review also cites Asian prevalence 0.014–0.034% in one summary source | Historical prevalence study / review snippet | 1982 / 2017 | Gonder et al., *Ophthalmology*; https://doi.org/10.1016/S0161-6420(82)34695-3; Plateroti et al., *Seminars in Ophthalmology*; https://doi.org/10.3109/08820538.2015.1118133 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Epidemiology | Unilateral involvement: one eye in 90% of cases | Review of ODM | 2023 | Abdolrahimzadeh et al.; https://doi.org/10.1007/s00417-022-05743-1 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Epidemiology | Female predominance: women affected about 5:1 vs men | Review of ODM / melanoma review | 2023 / 2021 | Abdolrahimzadeh et al.; https://doi.org/10.1007/s00417-022-05743-1; Williams et al.; https://doi.org/10.1111/ijd.15135 | (abdolrahimzadeh2023anupdateon pages 1-3, williams2021melanomainthe pages 1-2) |
+| Ocular / tissue involvement | Periocular skin only in ~1/3 of cases; ocular tissue involvement in 66% | Review of ODM | 2023 | Abdolrahimzadeh et al.; https://doi.org/10.1007/s00417-022-05743-1 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Ocular / tissue involvement | In infant cohort, 55/102 had periorbital skin lesions and 46/102 had ipsilateral scleral involvement | Infant laser cohort | 2024 | Zheng et al., *Clinical, Cosmetic and Investigational Dermatology*; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 1-2) |
+| Complications | Main ophthalmic complications are glaucoma and predisposition to uveal melanoma | Review of ODM | 2023 | Abdolrahimzadeh et al.; https://doi.org/10.1007/s00417-022-05743-1 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Complications | Uveal melanoma in ODM carries about twice the metastatic risk of uveal melanoma without ODM | Review of ODM | 2023 | Abdolrahimzadeh et al.; https://doi.org/10.1007/s00417-022-05743-1 | (abdolrahimzadeh2023anupdateon pages 1-3) |
+| Complications | In one 40-patient ocular series, 4 developed glaucoma and 3 developed choroidal melanoma | Retrospective ocular series | 2021 | Vishnevskia-Dai et al., *British Journal of Ophthalmology*; https://doi.org/10.1136/bjophthalmol-2019-313984 | (vishnevskiadai2021naevusofota pages 1-1, vishnevskiadai2021naevusofota pages 1-2) |
+| Treatment outcomes | Success rate 88.7% after 4 sessions | 102 infants treated sequentially with Q-switched 755 nm then 1064 nm lasers | 2024 | Zheng et al.; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 1-2) |
+| Treatment outcomes | Success rate 99.3% after 7 sessions | Same infant cohort | 2024 | Zheng et al.; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 1-2) |
+| Treatment outcomes | Recurrence 14/47 = 29.8% on follow-up; retreatment with 2–3 additional sessions was effective | Follow-up subset of infant cohort | 2024 | Zheng et al.; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 1-2, zheng2024resultsandfollowup pages 4-6) |
+| Treatment outcomes | Satisfaction rate 95.5% | Follow-up subset of infant cohort | 2024 | Zheng et al.; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 4-6) |
+| Treatment outcomes | No serious adverse reactions except pain in abstract; detailed follow-up text reports no scars, pigment deepening, or hypopigmentation, with intact skin in all 47 followed children | Infant laser cohort | 2024 | Zheng et al.; https://doi.org/10.2147/CCID.S444410 | (zheng2024resultsandfollowup pages 1-2, zheng2024resultsandfollowup pages 4-6) |
+| Treatment outcomes | Historical/literature-based success rate cited in trial record: 95% after 6–8 sessions with Q-switched lasers | ClinicalTrials.gov retrospective protocol in Thai patients | 2020 | NCT04481178; https://clinicaltrials.gov/study/NCT04481178 | (NCT04481178 chunk 1) |
+| Treatment outcomes | Reported laser complications in trial record: hypopigmentation 15.3%, hyperpigmentation 2.9%, texture changes 2.9%, scarring 1.9% | ClinicalTrials.gov retrospective protocol in Thai patients | 2020 | NCT04481178; https://clinicaltrials.gov/study/NCT04481178 | (NCT04481178 chunk 1) |
+| Identifier | MeSH term/ID: Nevus of Ota, D009507 | ClinicalTrials.gov indexed record | 2020 | NCT04481178; https://clinicaltrials.gov/study/NCT04481178 | (NCT04481178 chunk 1) |
+
+
+*Table: This table compiles the main quantitative findings retrieved for Nevus of Ota / oculodermal melanocytosis, including epidemiology, ocular involvement, complication risks, and recent laser-treatment outcomes. It is useful as a compact evidence summary for knowledge-base population and citation tracking.*
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview (definition; current understanding)
+Nevus of Ota is described as a benign dermal melanocytic lesion with typical unilateral blue-gray macules/patches along the ophthalmic (V1) and maxillary (V2) trigeminal distributions, frequently with ocular involvement. (williams2021melanomainthe pages 1-2)
+
+An ophthalmology-focused review defines oculodermal melanocytosis (ODM; Nevus of Ota) as a “rare, prevalently unilateral, congenital condition” presenting with “brown or blue/gray flat asymptomatic lesions of the skin, mucosae, episclera/sclera, and uvea” in trigeminal territory. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 1.2 Key identifiers (ontology and coding)
+* **MeSH descriptor**: *Nevus of Ota* (MeSH ID **D009507**) is explicitly present in a ClinicalTrials.gov record for laser treatment outcomes (NCT04481178). (NCT04481178 chunk 1)
+* **ICD-10/ICD-11, OMIM, Orphanet, MONDO**: Not present in the retrieved full texts in this tool run; therefore these identifiers cannot be confirmed from the provided evidence corpus. (NCT04481178 chunk 1)
+
+### 1.3 Common synonyms / alternative names
+* **Oculodermal melanocytosis / oculodermal melanosis** (vishnevskiadai2021naevusofota pages 1-2, zheng2024resultsandfollowup pages 1-2)
+* **Nevus fuscoceruleus ophthalmomaxillaris** (williams2021melanomainthe pages 1-2, vishnevskiadai2021naevusofota pages 1-2)
+
+### 1.4 Evidence source type
+The information in this report is derived from a mixture of aggregated disease-level reviews and case-series/cohort clinical studies (e.g., multimodal imaging review; retrospective ocular case series; infant laser cohort), plus case-based molecular reports relevant to genetic mechanisms and malignant transformation. (vishnevskiadai2021naevusofota pages 1-1, abdolrahimzadeh2023anupdateon pages 1-3, zheng2024resultsandfollowup pages 1-2, toomey2019gnaqandpms1 pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors (mechanistic/developmental)
+Multiple sources frame Nevus of Ota/ODM as a neural crest developmental melanocytosis. The 2023 ophthalmology review links etiopathogenesis to altered migration of neural crest melanoblasts in embryogenesis. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 2.2 Risk factors
+* **Sex**: Marked female predominance is repeatedly reported; the ODM review states women are “five times more afflicted.” (abdolrahimzadeh2023anupdateon pages 1-3)
+* **Ethnicity/skin phototype**: Higher incidence in Asians is reported (e.g., incidence 1–2 per 1000). (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved texts. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 2.4 Gene–environment interactions
+Direct gene–environment interaction evidence was not retrieved. However, UV exposure is discussed as a clinical factor potentially affecting recurrence after laser treatment in infants (sun exposure associated with recurrence/worsening). (zheng2024resultsandfollowup pages 1-2)
+
+---
+
+## 3. Phenotypes
+
+### 3.1 Core phenotypes and clinical characteristics
+**Cutaneous phenotype (blue/gray/brown macules/patches)**
+* **Type**: Clinical sign (pigmentary macules/patches).
+* **Typical distribution**: V1/V2 trigeminal territory; often unilateral. (williams2021melanomainthe pages 1-2, abdolrahimzadeh2023anupdateon pages 1-3)
+* **Laterality frequency**: “ODM occurs in just one eye in 90% of cases” in the 2023 review. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+**Ocular tissue melanocytosis (episclera/sclera/uvea) and related findings**
+* **Type**: Clinical sign; ocular structural pigmentation.
+* **Frequency of ocular tissue involvement**: Review reports “additional involvement of ocular tissues … in 66%” and periocular skin alone in about one-third. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+**Oral mucosal involvement (rare)**
+A 2023 review/case report on intraoral involvement notes that oral cavity involvement is uncommon and summarizes reported cases. (sharma2023intraoralnevusof pages 3-4)
+
+### 3.2 Quality-of-life impact
+The infant laser cohort motivates early treatment partly by psychosocial impact; the trial record similarly notes that marked facial hyperpigmentation can cause “psychosocial disturbances” prompting treatment seeking. (NCT04481178 chunk 1, zheng2024resultsandfollowup pages 1-2)
+
+### 3.3 Suggested HPO terms (examples)
+* Facial hyperpigmentation (HP:0001000)
+* Blue-gray skin discoloration (phenotypic descriptor; may be mapped via “abnormality of skin pigmentation” HP:0000951)
+* Scleral hyperpigmentation (map under “abnormality of the sclera” HP:0000592; pigmentation-specific child term may be needed)
+* Ocular melanocytosis (conceptual; may map to “abnormality of the uvea” HP:0000610 plus pigmentation descriptors)
+* Glaucoma (HP:0000501)
+
+(These term suggestions are ontology mappings; specific HPO IDs for “ocular melanocytosis” may require ontology lookup beyond the retrieved texts.)
+
+---
+
+## 4. Genetic/Molecular Information
+
+### 4.1 Causal genes / key molecular drivers (somatic mosaicism)
+Evidence supports **postzygotic (somatic mosaic) activating mutations in GNAQ and GNA11** in extensive dermal melanocytosis/related phenotypes. In phakomatosis pigmentovascularis with extensive dermal melanocytosis, missense **GNA11/GNAQ mutations were detected in affected skin at very low levels and were undetectable in blood**, consistent with mosaicism. (thomas2016mosaicactivatingmutations pages 2-3)
+
+A 2016 JID study provides functional support: mutant GNA11 variants activate MAPK-family pathways (p38/JNK/ERK depending on variant) and a mosaic zebrafish model recapitulated dermal melanocytosis. (thomas2016mosaicactivatingmutations pages 1-2, thomas2016mosaicactivatingmutations pages 3-5)
+
+A 2024 review further explains that **codon 209 mutations impair GTP hydrolysis and lock Gα in the active GTP-bound state**, driving constitutive signaling through MAPK/ERK, Hippo/YAP-TAZ, and PI3K/AKT pathways, and notes postzygotic somatic mutations at residue 183 in GNAQ/GNA11 in relevant syndromic melanocytoses. (pilch2024gnaqgna11relatedbenignand pages 6-7)
+
+### 4.2 Pathogenic variants and somatic vs germline
+* Recurrent activating hotspots: **GNAQ p.R183Q** and **GNA11 p.R183C/p.R183S**, and **Q209** substitutions (e.g., Q209L/Q209P) are repeatedly implicated in mosaic melanocytosis and melanoma-related entities. (thomas2016mosaicactivatingmutations pages 3-5, pilch2024gnaqgna11relatedbenignand pages 6-7)
+* Somatic origin: low mutant allele fractions in affected tissue and absence in blood support postzygotic mosaicism. (thomas2016mosaicactivatingmutations pages 3-5, thomas2016mosaicactivatingmutations pages 2-3)
+
+### 4.3 Malignant transformation genetics / modifiers (tumor progression context)
+Case-based literature links uveal melanoma in the context of nevus of Ota/ocular melanosis to canonical uveal melanoma drivers and progression genes.
+* A 2019 report in a patient with congenital bilateral nevus of Ota and uveal melanoma identified **GNAQ R183Q** and a truncating mutation in mismatch repair gene **PMS1** in tumor sequencing. (toomey2019gnaqandpms1 pages 1-2)
+* A melanoma-focused review for dermatologists reports: “Approximately **6% of lesions harbor mutations in GNAQ**.” (williams2021melanomainthe pages 1-2)
+* A case-based excerpt reports co-occurrence of **BAP1 and GNAQ** mutations in intracranial melanoma associated with nevus of Ota and emphasizes BAP1 immunohistochemistry for prognostication in uveal melanoma. (konstantinov2018nevusofota pages 3-3)
+
+### 4.4 Suggested GO biological process terms (examples)
+* MAPK cascade (GO:0000165)
+* ERK1/ERK2 cascade (GO:0070371)
+* Neural crest cell migration (GO:0001755)
+* Melanocyte differentiation (GO:0030318)
+
+### 4.5 Suggested Cell Ontology (CL) terms (examples)
+* Melanocyte (CL:0000148)
+* Neural crest cell (CL:0000135)
+
+---
+
+## 5. Environmental Information
+
+Environmental/lifestyle contributors are not established as causal in the retrieved primary evidence. However, clinical observations include pigment variability with hormonal states (adolescence/pregnancy) in the ODM review, and sun exposure as a factor associated with recurrence/worsening post-laser in infants. (abdolrahimzadeh2023anupdateon pages 1-3, zheng2024resultsandfollowup pages 1-2)
+
+No infectious etiologies were identified. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Causal chain (current mechanistic model)
+1. **Postzygotic activating mutation** in GNAQ/GNA11 occurs in a progenitor lineage (mosaicism), leading to a patchy tissue distribution. (thomas2016mosaicactivatingmutations pages 2-3)
+2. Constitutively active Gαq/11 signaling leads to downstream activation of pathways including MAPK-family signaling; functional assays show mutant GNA11 activates MAPK components (p38/JNK/ERK) in cell lines, and in vivo models show increased melanocytes in epidermis/dermis. (thomas2016mosaicactivatingmutations pages 1-2, thomas2016mosaicactivatingmutations pages 3-5)
+3. Accumulation of dermal (and ocular) melanocytes produces the clinical blue/gray pigmentation phenotype. (vishnevskiadai2021naevusofota pages 1-2, abdolrahimzadeh2023anupdateon pages 1-3)
+4. In ocular tissues, melanocytosis can predispose to **glaucoma** and to development of **uveal melanoma**, necessitating ongoing ophthalmic surveillance. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 6.2 Immune involvement
+No disease-specific immune mechanism evidence was retrieved. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 6.3 Suggested CL/GO/UBERON terms for mechanism mapping
+* **UBERON**: skin of face (UBERON:0003920), sclera (UBERON:0000974), uvea (UBERON:0001769)
+* **GO (cellular component)**: plasma membrane (GO:0005886) (for GPCR signaling nodes), cytosol (GO:0005829)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Organ and tissue level
+* **Skin (facial/periocular)**: pigmentary macules/patches in trigeminal distributions. (williams2021melanomainthe pages 1-2, abdolrahimzadeh2023anupdateon pages 1-3)
+* **Eye**: episclera/sclera and uvea; ocular involvement may include iris changes and other globe structures in clinical series. (vishnevskiadai2021naevusofota pages 1-2, abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 7.2 Localization and laterality
+Typically unilateral; review reports “one eye in 90% of cases,” though bilateral cases occur. (abdolrahimzadeh2023anupdateon pages 1-3, vishnevskiadai2021naevusofota pages 1-1)
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Onset is commonly congenital or early life. The clinical trial record notes “About 50-60% of all cases have the age of onset at birth or within the first year of life, others appear before puberty.” (NCT04481178 chunk 1)
+
+### 8.2 Progression / course
+ODM does not tend to regress spontaneously; pigmentation may vary over time and with hormonal state. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (key quantitative data)
+* Asian incidence reported as **1–2 per 1000**. (abdolrahimzadeh2023anupdateon pages 1-3)
+* Japanese dermatology clinic prevalence cited as **~0.4–0.8%**. (williams2021melanomainthe pages 1-2)
+* Laterality: **~90%** unilateral ocular involvement. (abdolrahimzadeh2023anupdateon pages 1-3)
+* Sex ratio: **~5:1** female predominance. (abdolrahimzadeh2023anupdateon pages 1-3, williams2021melanomainthe pages 1-2)
+
+### 9.2 Inheritance pattern
+The ODM review characterizes the condition as congenital and **non-hereditary**, consistent with somatic mosaicism models. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Clinical diagnosis
+Diagnosis is primarily clinical based on characteristic distribution and ocular/skin pigmentation; ocular evaluation is emphasized due to glaucoma and melanoma risks. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 10.2 Ophthalmic evaluation and multimodal imaging (current practice trends)
+The 2023 ophthalmology review provides a diagnostic/monitoring framework:
+* Comprehensive ophthalmologic examination plus traditional imaging (ultrasonography; fluorescein/indocyanine green angiography), because fundus pigmentation may conceal subtle retinal/choroidal alterations. (abdolrahimzadeh2023anupdateon pages 1-3)
+* Anterior segment OCT and ultrasound biomicroscopy for anterior segment/ciliary body evaluation when glaucoma or anterior uveal melanoma is suspected. (abdolrahimzadeh2023anupdateon pages 1-3)
+* Fundus autofluorescence and RPE alterations for differentiating choroidal nevi vs melanoma; enhanced depth imaging OCT for high-resolution in vivo tumor/nevi assessment and early melanoma features (subretinal fluid, RPE abnormalities, choriocapillaris compression). (abdolrahimzadeh2023anupdateon pages 1-3)
+
+Abstract support (direct quote): the review concludes that “Novel multimodal imaging techniques are significant in the diagnosis and management of the ophthalmic complications of ODM.” (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 10.3 Histopathology
+A 2023 bilateral case-series review states that nevus of Ota shows melanocytes in the dermis (and notes epidermal involvement in their phrasing). (kumari2023bilateralnevusof pages 4-5)
+
+### 10.4 Genetic testing
+Routine germline genetic testing is not established for typical isolated nevus of Ota in the retrieved texts; molecular findings mainly come from research sequencing of affected tissues/tumors (GNAQ/GNA11; BAP1 in associated melanomas). (toomey2019gnaqandpms1 pages 1-2, konstantinov2018nevusofota pages 3-3)
+
+### 10.5 Differential diagnosis
+The retrieved evidence emphasizes classification distinctions within dermal melanocytoses and diagnostic challenges; e.g., case literature distinguishes Ota nevus from acquired bilateral nevus of Ota-like macules (ABNOM) based on clinical and histopathologic patterns. (seemongaldass2025acaseof pages 5-6)
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Major complications and prognosis-relevant risks
+* **Glaucoma** and **predisposition to uveal melanoma** are highlighted as the main ophthalmic complications in ODM. (abdolrahimzadeh2023anupdateon pages 1-3)
+* The 2023 ophthalmology review states that “uveal melanoma in ODM carries twice the risk of metastasis compared to uveal melanoma in eyes without ODM,” underscoring prognostic importance of early detection. (abdolrahimzadeh2023anupdateon pages 1-3)
+* In a 40-patient ocular series, **4 developed glaucoma** and **3 developed malignant transformation to choroidal melanoma**. (vishnevskiadai2021naevusofota pages 1-1)
+
+### 11.2 Prognostic factors
+The retrieved texts do not provide validated prognostic models specific to nevus of Ota itself; prognostication is more developed for uveal melanoma (e.g., BAP1 loss). (konstantinov2018nevusofota pages 3-3)
+
+---
+
+## 12. Treatment
+
+### 12.1 Standard of care / current applications
+**Laser therapy (selective photothermolysis) is the main real-world treatment for cosmetic pigment reduction**, especially Q-switched pigment lasers (ruby 694 nm, alexandrite 755 nm, Nd:YAG 1064 nm). (kumari2023bilateralnevusof pages 4-5, NCT04481178 chunk 1)
+
+### 12.2 Recent developments (prioritizing 2023–2024)
+**Early-life sequential Q-switched therapy (infant cohort; 2024):**
+A large retrospective cohort of **102 infants (<1 year)** treated with sequential Q-switched 755 nm (initial sessions) and 1064 nm (from session 3 onward) at 6-month intervals reports high clearance and quantifies long-term recurrence. (zheng2024resultsandfollowup pages 1-2)
+
+Direct abstract quote: “Success rates reached **88.7% after four sessions and 99.3% after seven sessions**.” (zheng2024resultsandfollowup pages 1-2)
+
+Recurrence: among 47 infants with follow-up, **14 recurred (29.8%)**, and additional 2–3 sessions typically controlled recurrence. (zheng2024resultsandfollowup pages 1-2)
+
+A table image from this study (efficacy by subtype and factors such as location/anesthesia) is available and supports the reported outcome stratification. (zheng2024resultsandfollowup media 94a4abe5, zheng2024resultsandfollowup media 9a87c0a6)
+
+### 12.3 Adverse events and tolerability (quantitative)
+* In the 2024 infant cohort abstract, “No instances of serious adverse reactions, except for pain, were reported.” (zheng2024resultsandfollowup pages 1-2)
+* A Thai retrospective protocol (NCT04481178; ClinicalTrials.gov) summarizes reported complication rates from prior Q-switched laser literature: **hypopigmentation 15.3%, hyperpigmentation 2.9%, texture changes 2.9%, scarring 1.9%**, and cites a “success rate of 95% after 6-8 sessions.” (NCT04481178 chunk 1)
+
+### 12.4 Treatment strategy / monitoring
+The ophthalmology review emphasizes that monitoring for glaucoma and melanoma is central and that multimodal imaging is increasingly used to standardize complication detection and follow-up. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+### 12.5 MAXO term suggestions (examples)
+* Laser therapy (MAXO:0000058, “laser therapy”)
+* Ophthalmologic monitoring/surveillance (MAXO term may require lookup; concept: “medical monitoring”)
+
+---
+
+## 13. Prevention
+
+Primary prevention of nevus of Ota is not described (developmental mosaic condition). Secondary/tertiary prevention focuses on preventing vision loss and melanoma morbidity through **lifelong ophthalmic surveillance** and early detection using multimodal imaging. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+---
+
+## 14. Other Species / Natural Disease
+
+A naturally occurring analogue has been described in dogs (oculodermal melanocytosis/nevus of Ota), with similar distribution and ocular involvement on histopathology, indicating cross-species relevance of neural crest–derived melanocyte disorders. (abdolrahimzadeh2023anupdateon pages 1-3)
+
+(Note: the main veterinary primary literature was retrieved but not deeply evidence-extracted in this run; this section is therefore limited.)
+
+---
+
+## 15. Model Organisms
+
+A mechanistically informative model is a **mosaic transgenic zebrafish** expressing mutant GNA11 (e.g., GNA11R183C) in the melanocyte lineage, which produced dermal melanocytosis, supporting causal roles for activating Gαq/11 signaling in melanocyte accumulation. (thomas2016mosaicactivatingmutations pages 1-2, thomas2016mosaicactivatingmutations pages 3-5)
+
+---
+
+## Expert opinions / authoritative synthesis (from reviews)
+* The 2023 ophthalmology review highlights an expert-practice shift toward standardized use of multimodal imaging for ODM complications, stating that OCT and fundus autofluorescence have “adjunctive value” for early melanoma detection and differential diagnosis. (abdolrahimzadeh2023anupdateon pages 1-3)
+* The dermatology melanoma review stresses that while nevus of Ota is often a cosmetic concern, malignant transformation risk mandates clinician awareness and appropriate referrals. (williams2021melanomainthe pages 1-2)
+
+---
+
+## Key evidence gaps in this run
+* ICD-10/ICD-11, OMIM, Orphanet, and MONDO identifiers were not available in the retrieved full texts/tools state; they require direct lookup in those external databases. (NCT04481178 chunk 1)
+* High-quality, population-based incidence/prevalence estimates outside East Asian cohorts were not retrieved here.
+* Picosecond-laser comparative effectiveness literature (2023–2024) was identified in search but some key papers were unobtainable in the current corpus, limiting systematic comparison versus Q-switched modalities.
+
+---
+
+## References (URLs with publication dates where available)
+* Abdolrahimzadeh S, et al. *Graefe’s Archive for Clinical and Experimental Ophthalmology*. Published online 19 Jul 2022; in-issue 2023. https://doi.org/10.1007/s00417-022-05743-1 (abdolrahimzadeh2023anupdateon pages 1-3)
+* Zheng H, et al. *Clinical, Cosmetic and Investigational Dermatology*. Published 3 Feb 2024. https://doi.org/10.2147/CCID.S444410 (zheng2024resultsandfollowup pages 1-2)
+* Williams NM, et al. *International Journal of Dermatology*. 2021 (issue date Aug 2021; copyright line 2020). https://doi.org/10.1111/ijd.15135 (williams2021melanomainthe pages 1-2)
+* Thomas AC, et al. *Journal of Investigative Dermatology*. Apr 2016. https://doi.org/10.1016/j.jid.2015.11.027 (thomas2016mosaicactivatingmutations pages 1-2)
+* ClinicalTrials.gov. NCT04481178. First posted 22 Jul 2020. https://clinicaltrials.gov/study/NCT04481178 (NCT04481178 chunk 1)
+
+
+References
+
+1. (abdolrahimzadeh2023anupdateon pages 1-3): Solmaz Abdolrahimzadeh, Damiano Maria Pugi, Priscilla Manni, Clemente Maria Iodice, Federico Di Tizio, Flavia Persechino, and Gianluca Scuderi. An update on ophthalmological perspectives in oculodermal melanocytosis (nevus of ota). Graefe's Archive for Clinical and Experimental Ophthalmology, 261:291-301, Jul 2023. URL: https://doi.org/10.1007/s00417-022-05743-1, doi:10.1007/s00417-022-05743-1. This article has 19 citations.
+
+2. (williams2021melanomainthe pages 1-2): Natalie M. Williams, Pooja Gurnani, Angelina Labib, Ronaldo Nuesi, and Keyvan Nouri. Melanoma in the setting of nevus of ota: a review for dermatologists. International Journal of Dermatology, 60:523-532, Aug 2021. URL: https://doi.org/10.1111/ijd.15135, doi:10.1111/ijd.15135. This article has 28 citations and is from a peer-reviewed journal.
+
+3. (vishnevskiadai2021naevusofota pages 1-2): Vicktoria Vishnevskia-Dai, Iris Moroz, Tal Davidy, Keren Zloto, Yael Birger, Ido Didi Fabian, Guy Ben Simon, Ayelet Priel, and Ofira Zloto. Naevus of ota: clinical characteristics and proposal for a new ocular classification and grading system. British Journal of Ophthalmology, 105:42-47, Mar 2021. URL: https://doi.org/10.1136/bjophthalmol-2019-313984, doi:10.1136/bjophthalmol-2019-313984. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+4. (zheng2024resultsandfollowup pages 1-2): Han Zheng, Ai-E Xu, Gang Qiao, Xiao-Yu Sun, Jia Deng, and Yong Zhang. Results and follow-up of a sequential q-switched laser therapy for nevus of ota in infants. Clinical, Cosmetic and Investigational Dermatology, 17:339-347, Feb 2024. URL: https://doi.org/10.2147/ccid.s444410, doi:10.2147/ccid.s444410. This article has 2 citations and is from a peer-reviewed journal.
+
+5. (vishnevskiadai2021naevusofota pages 1-1): Vicktoria Vishnevskia-Dai, Iris Moroz, Tal Davidy, Keren Zloto, Yael Birger, Ido Didi Fabian, Guy Ben Simon, Ayelet Priel, and Ofira Zloto. Naevus of ota: clinical characteristics and proposal for a new ocular classification and grading system. British Journal of Ophthalmology, 105:42-47, Mar 2021. URL: https://doi.org/10.1136/bjophthalmol-2019-313984, doi:10.1136/bjophthalmol-2019-313984. This article has 11 citations and is from a highest quality peer-reviewed journal.
+
+6. (zheng2024resultsandfollowup pages 4-6): Han Zheng, Ai-E Xu, Gang Qiao, Xiao-Yu Sun, Jia Deng, and Yong Zhang. Results and follow-up of a sequential q-switched laser therapy for nevus of ota in infants. Clinical, Cosmetic and Investigational Dermatology, 17:339-347, Feb 2024. URL: https://doi.org/10.2147/ccid.s444410, doi:10.2147/ccid.s444410. This article has 2 citations and is from a peer-reviewed journal.
+
+7. (NCT04481178 chunk 1): Woraphong Manuskiatti, M.D.. A Retrospective Study on Laser Treatment of Nevus of Ota in Thai Patients. Mahidol University. 2020. ClinicalTrials.gov Identifier: NCT04481178
+
+8. (toomey2019gnaqandpms1 pages 1-2): Christopher B. Toomey, Kyle Fraser, John A. Thorson, Michael H. Goldbaum, and Jonathan H. Lin. Gnaq and pms1 mutations associated with uveal melanoma, ocular surface melanosis, and nevus of ota. Ocular Oncology and Pathology, 5:267-272, Jan 2019. URL: https://doi.org/10.1159/000495508, doi:10.1159/000495508. This article has 11 citations and is from a peer-reviewed journal.
+
+9. (sharma2023intraoralnevusof pages 3-4): DR ARUN DEV SHARMA, DR AJAY PRATAP SINGH PARIHAR, DR PRASHANTHI REDDY, DR NIDHI YADAV, and DR RASHI MANDLIK. Intraoral nevus of ota : a case report and review. UNIVERSITY JOURNAL OF DENTAL SCIENCES, Jul 2023. URL: https://doi.org/10.21276/ujds.2023.9.3.19, doi:10.21276/ujds.2023.9.3.19. This article has 1 citations.
+
+10. (thomas2016mosaicactivatingmutations pages 2-3): Anna C. Thomas, Zhiqiang Zeng, Jean-Baptiste Rivière, Ryan O’Shaughnessy, Lara Al-Olabi, Judith St.-Onge, David J. Atherton, Hélène Aubert, Lorea Bagazgoitia, Sébastien Barbarot, Emmanuelle Bourrat, Christine Chiaverini, W. Kling Chong, Yannis Duffourd, Mary Glover, Leopold Groesser, Smail Hadj-Rabia, Henning Hamm, Rudolf Happle, Imran Mushtaq, Jean-Philippe Lacour, Regula Waelchli, Marion Wobser, Pierre Vabres, E. Elizabeth Patton, and Veronica A. Kinsler. Mosaic activating mutations in gna11 and gnaq are associated with phakomatosis pigmentovascularis and extensive dermal melanocytosis. The Journal of Investigative Dermatology, 136:770-778, Apr 2016. URL: https://doi.org/10.1016/j.jid.2015.11.027, doi:10.1016/j.jid.2015.11.027. This article has 234 citations.
+
+11. (thomas2016mosaicactivatingmutations pages 1-2): Anna C. Thomas, Zhiqiang Zeng, Jean-Baptiste Rivière, Ryan O’Shaughnessy, Lara Al-Olabi, Judith St.-Onge, David J. Atherton, Hélène Aubert, Lorea Bagazgoitia, Sébastien Barbarot, Emmanuelle Bourrat, Christine Chiaverini, W. Kling Chong, Yannis Duffourd, Mary Glover, Leopold Groesser, Smail Hadj-Rabia, Henning Hamm, Rudolf Happle, Imran Mushtaq, Jean-Philippe Lacour, Regula Waelchli, Marion Wobser, Pierre Vabres, E. Elizabeth Patton, and Veronica A. Kinsler. Mosaic activating mutations in gna11 and gnaq are associated with phakomatosis pigmentovascularis and extensive dermal melanocytosis. The Journal of Investigative Dermatology, 136:770-778, Apr 2016. URL: https://doi.org/10.1016/j.jid.2015.11.027, doi:10.1016/j.jid.2015.11.027. This article has 234 citations.
+
+12. (thomas2016mosaicactivatingmutations pages 3-5): Anna C. Thomas, Zhiqiang Zeng, Jean-Baptiste Rivière, Ryan O’Shaughnessy, Lara Al-Olabi, Judith St.-Onge, David J. Atherton, Hélène Aubert, Lorea Bagazgoitia, Sébastien Barbarot, Emmanuelle Bourrat, Christine Chiaverini, W. Kling Chong, Yannis Duffourd, Mary Glover, Leopold Groesser, Smail Hadj-Rabia, Henning Hamm, Rudolf Happle, Imran Mushtaq, Jean-Philippe Lacour, Regula Waelchli, Marion Wobser, Pierre Vabres, E. Elizabeth Patton, and Veronica A. Kinsler. Mosaic activating mutations in gna11 and gnaq are associated with phakomatosis pigmentovascularis and extensive dermal melanocytosis. The Journal of Investigative Dermatology, 136:770-778, Apr 2016. URL: https://doi.org/10.1016/j.jid.2015.11.027, doi:10.1016/j.jid.2015.11.027. This article has 234 citations.
+
+13. (pilch2024gnaqgna11relatedbenignand pages 6-7): Justyna Pilch, Jakub Mizera, Maciej Tota, and Piotr Donizy. Gnaq/gna11-related benign and malignant entities—a common histoembriologic origin or a tissue-dependent coincidence. Cancers, 16:3672, Oct 2024. URL: https://doi.org/10.3390/cancers16213672, doi:10.3390/cancers16213672. This article has 6 citations.
+
+14. (konstantinov2018nevusofota pages 3-3): NK Konstantinov, TM Berry, HR Elwood, and BJ Zlotoff. Nevus of ota associated with a primary uveal melanoma and intracranial melanoma metastasis. Unknown journal, 2018.
+
+15. (kumari2023bilateralnevusof pages 4-5): Pinki Kumari, Vartika, Pallavi UK, and Rajesh Sinha. Bilateral nevus of ota: a case series and literature review. Asian Journal of Medical Sciences, 14:326-331, Nov 2023. URL: https://doi.org/10.3126/ajms.v14i11.56108, doi:10.3126/ajms.v14i11.56108. This article has 0 citations.
+
+16. (seemongaldass2025acaseof pages 5-6): Rajiv V Seemongal-Dass, Robin R Seemongal-Dass, Alyssa P Singh, and Diego A Conocchiari. A case of nevus of ota in trinidad and tobago. Cureus, Jan 2025. URL: https://doi.org/10.7759/cureus.78311, doi:10.7759/cureus.78311. This article has 1 citations.
+
+17. (zheng2024resultsandfollowup media 94a4abe5): Han Zheng, Ai-E Xu, Gang Qiao, Xiao-Yu Sun, Jia Deng, and Yong Zhang. Results and follow-up of a sequential q-switched laser therapy for nevus of ota in infants. Clinical, Cosmetic and Investigational Dermatology, 17:339-347, Feb 2024. URL: https://doi.org/10.2147/ccid.s444410, doi:10.2147/ccid.s444410. This article has 2 citations and is from a peer-reviewed journal.
+
+18. (zheng2024resultsandfollowup media 9a87c0a6): Han Zheng, Ai-E Xu, Gang Qiao, Xiao-Yu Sun, Jia Deng, and Yong Zhang. Results and follow-up of a sequential q-switched laser therapy for nevus of ota in infants. Clinical, Cosmetic and Investigational Dermatology, 17:339-347, Feb 2024. URL: https://doi.org/10.2147/ccid.s444410, doi:10.2147/ccid.s444410. This article has 2 citations and is from a peer-reviewed journal.

--- a/research/Nevus_of_Ota-deep-research-falcon.md.citations.md
+++ b/research/Nevus_of_Ota-deep-research-falcon.md.citations.md
@@ -1,0 +1,483 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Nevus of Ota
+- **MONDO ID:**  (if available)
+- **Category:** Skin Disorder
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Nevus of Ota** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T12:47:59.381060
+
+1. abdolrahimzadeh2023anupdateon pages 1-3
+2. williams2021melanomainthe pages 1-2
+3. zheng2024resultsandfollowup pages 1-2
+4. zheng2024resultsandfollowup pages 4-6
+5. sharma2023intraoralnevusof pages 3-4
+6. thomas2016mosaicactivatingmutations pages 2-3
+7. konstantinov2018nevusofota pages 3-3
+8. kumari2023bilateralnevusof pages 4-5
+9. seemongaldass2025acaseof pages 5-6
+10. vishnevskiadai2021naevusofota pages 1-1
+11. thomas2016mosaicactivatingmutations pages 1-2
+12. vishnevskiadai2021naevusofota pages 1-2
+13. thomas2016mosaicactivatingmutations pages 3-5
+14. https://doi.org/10.1007/s00417-022-05743-1
+15. https://doi.org/10.1111/ijd.15135
+16. https://doi.org/10.1016/S0161-6420(82
+17. https://doi.org/10.3109/08820538.2015.1118133
+18. https://doi.org/10.1007/s00417-022-05743-1;
+19. https://doi.org/10.2147/CCID.S444410
+20. https://doi.org/10.1136/bjophthalmol-2019-313984
+21. https://clinicaltrials.gov/study/NCT04481178
+22. https://doi.org/10.1016/j.jid.2015.11.027
+23. https://doi.org/10.1007/s00417-022-05743-1,
+24. https://doi.org/10.1111/ijd.15135,
+25. https://doi.org/10.1136/bjophthalmol-2019-313984,
+26. https://doi.org/10.2147/ccid.s444410,
+27. https://doi.org/10.1159/000495508,
+28. https://doi.org/10.21276/ujds.2023.9.3.19,
+29. https://doi.org/10.1016/j.jid.2015.11.027,
+30. https://doi.org/10.3390/cancers16213672,
+31. https://doi.org/10.3126/ajms.v14i11.56108,
+32. https://doi.org/10.7759/cureus.78311,


### PR DESCRIPTION
## Summary

- Adds Falcon-guided DISMECH curation for nevus of Ota (MONDO:0016984).
- Captures oculodermal melanocytosis features, GNAQ/GNA11 mosaic signaling, glaucoma and uveal melanoma risks, ophthalmic diagnosis, and laser treatment.
- Adds Falcon research artifacts and cited reference caches generated with just fetch-reference.

## Validation

- just validate kb/disorders/Nevus_of_Ota.yaml
- just validate-references kb/disorders/Nevus_of_Ota.yaml
- just validate-terms kb/disorders/Nevus_of_Ota.yaml
- just compliance kb/disorders/Nevus_of_Ota.yaml (global 84.5%, weighted 85.2%)

## Notes

Generated cache/* churn and unrelated modified references_cache/clinicaltrials_NCT*.md files were restored before commit. The only committed caches are cited by the YAML.