### PR TITLE
[codex] Link FGFR1 testosterone endpoint

### DIFF
--- a/kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+++ b/kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
@@ -240,6 +240,39 @@ genetic:
     evidence_source: HUMAN_CLINICAL
     snippet: "Pathogenic variants in more than 25 genes account for about half of all IGD; the genetic cause for the remaining cases of IGD is unknown."
     explanation: FGFR1 is one of more than 25 genes established to cause IGD.
+biochemical:
+- name: Serum Testosterone
+  presence: Decreased
+  context: Low in affected males due to absent or partial GnRH-mediated LH and FSH release.
+  readouts:
+  - target: GnRH deficiency and hypogonadism
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-112
+    interpretation: >-
+      Higher serum testosterone indicates correction of the low-sex-steroid
+      component of hypogonadism in affected males.
+    evidence:
+    - reference: PMID:20301509
+      reference_title: "Isolated Gonadotropin-Releasing Hormone (GnRH) Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        IGD is typically diagnosed in adolescents presenting with absent or
+        partial puberty using biochemical testing that reveals low serum
+        testosterone or estradiol (hypogonadism) that results from complete or
+        partial absence of GnRH-mediated release of LH and FSH
+      explanation: >-
+        GeneReviews directly links low serum testosterone to hypogonadism in
+        isolated GnRH deficiency, supporting serum testosterone as a disease
+        and treatment-response readout in affected males.
+  biomarker_term:
+    preferred_term: testosterone
+    term:
+      id: CHEBI:17347
+      label: testosterone
 treatments:
 - name: Testosterone replacement therapy
   description: >-

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2790,8 +2790,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Testosterone deficiency; population: Men with primary or hypogonadotropic
     hypogonadism; endpoint: Serum testosterone; approval context: traditional; drug mechanism: Androgen,
     GnRH analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - FGFR1-Related Hypogonadotropic Hypogonadism
+  mapped_disease_files:
+  - kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+  mapping_notes: >-
+    Manually reviewed for FGFR1-related hypogonadotropic hypogonadism serum
+    testosterone biomarker integration. The FDA row is broader than the disease
+    page because it covers men with primary or hypogonadotropic hypogonadism.
 - row_id: FDA-SE-adult-noncancer-113
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- Add serum testosterone as a biochemical marker for FGFR1-related hypogonadotropic hypogonadism.
- Link the marker to the `GnRH deficiency and hypogonadism` pathophysiology node with pharmacodynamic endpoint context.
- Mark the FDA serum-testosterone surrogate endpoint row as a candidate DisMech mapping because the FDA context covers primary and hypogonadotropic hypogonadism broadly.

## Validation

- `just validate kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`