### PR TITLE
Add Carney-Stratakis syndrome curation

### DIFF
--- a/kb/disorders/Carney-Stratakis_Syndrome.yaml
+++ b/kb/disorders/Carney-Stratakis_Syndrome.yaml
@@ -1,0 +1,588 @@
+name: Carney-Stratakis syndrome
+creation_date: "2026-05-11T17:02:12Z"
+updated_date: "2026-05-11T17:02:12Z"
+category: Genetic
+description: >-
+  Carney-Stratakis syndrome is a rare hereditary tumor-predisposition syndrome
+  defined by the dyad of paraganglioma or pheochromocytoma and
+  gastrointestinal stromal tumor. Classic molecularly confirmed disease is
+  caused by heterozygous germline loss-of-function variants in succinate
+  dehydrogenase complex genes, especially SDHB, SDHC, and SDHD, with incomplete
+  penetrance and variable expression. SDH-deficient tumor cells lose
+  mitochondrial complex II function, accumulate succinate, activate
+  pseudohypoxic transcriptional programs, and develop epigenetic dysregulation
+  that supports multifocal gastric GIST and paraganglioma formation.
+parents:
+- hereditary neoplastic syndrome
+- multiple polyglandular tumor
+synonyms:
+- Carney dyad
+- Carney-Stratakis dyad
+- GIST-paraganglioma dyad
+- hereditary GIST-paraganglioma syndrome
+- paraganglioma and gastrointestinal stromal tumor
+disease_term:
+  preferred_term: Carney-Stratakis syndrome
+  term:
+    id: MONDO:0011740
+    label: Carney-Stratakis syndrome
+inheritance:
+- name: Autosomal Dominant
+  description: >-
+    Carney-Stratakis syndrome is inherited in an autosomal dominant manner with
+    incomplete penetrance; mutation-positive relatives may be clinically
+    unaffected.
+  evidence:
+  - reference: PMID:31174229
+    reference_title: "Paragangliomas in Carney-Stratakis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CSS has autosomal dominant inheritance, incomplete penetrance, and greater
+      relative frequency of PGL over GISTs.
+    explanation: >-
+      Review abstract explicitly states the inheritance pattern and incomplete
+      penetrance.
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CSS is also known as the dyad of GIST and PGL; it affects both genders
+      equally and is inherited in an autosomal dominant manner with incomplete
+      penetrance.
+    explanation: >-
+      SDH-deficiency review confirms equal sex involvement and autosomal
+      dominant inheritance with incomplete penetrance.
+prevalence:
+- population: Worldwide reported literature
+  percentage: Unknown
+  notes: >-
+    Population prevalence has not been established. Published evidence consists
+    mainly of small family series, case reports, and SDH-deficient GIST/PGL
+    reviews.
+  evidence:
+  - reference: PMID:36387130
+    reference_title: "Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline mutation in a patient with Carney-Stratakis syndrome: A case report and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      BACKGROUND: Carney-Stratakis syndrome (CSS) is a rare dyad of
+      paraganglioma (PGL)/pheochromocytoma (PHEO) and gastrointestinal stromal
+      tumor (GIST).
+    explanation: >-
+      Case-report review supports rarity and defines the syndrome by its tumor
+      dyad.
+pathophysiology:
+- name: Germline SDH complex loss of function
+  description: >-
+    Heterozygous germline pathogenic variants in SDHB, SDHC, or SDHD predispose
+    to SDH-deficient tumors. Tumor suppressor behavior is supported by loss of
+    function of the remaining allele in affected GIST tissue.
+  genes:
+  - preferred_term: SDHB
+    term:
+      id: hgnc:10681
+      label: SDHB
+  - preferred_term: SDHC
+    term:
+      id: hgnc:10682
+      label: SDHC
+  - preferred_term: SDHD
+    term:
+      id: hgnc:10683
+      label: SDHD
+  biological_processes:
+  - preferred_term: mitochondrial electron transport, succinate to ubiquinone
+    modifier: DECREASED
+    term:
+      id: GO:0006121
+      label: mitochondrial electron transport, succinate to ubiquinone
+  - preferred_term: tricarboxylic acid cycle
+    modifier: DECREASED
+    term:
+      id: GO:0006099
+      label: tricarboxylic acid cycle
+  evidence:
+  - reference: PMID:17667967
+    reference_title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We investigated 11 patients with the dyad of 'paraganglioma and gastric
+      stromal sarcoma'; in eight (from seven unrelated families), the GISTs were
+      caused by germline mutations of the genes encoding subunits B, C, or D
+      (the SDHB, SDHC and SDHD genes, respectively).
+    explanation: >-
+      Landmark molecular series identifies germline SDHB, SDHC, and SDHD
+      variants as causes of the Carney-Stratakis dyad.
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CSS is caused by inactivating germline mutations in genes encoding for the
+      SDH subunits, while CT is mostly caused by a specific pattern of
+      methylation of the SDHC gene and may be due to germline mosaicism of the
+      responsible genetic defect.
+    explanation: >-
+      Review distinguishes germline SDH-subunit inactivation in
+      Carney-Stratakis syndrome from Carney triad.
+  downstream:
+  - target: Succinate accumulation and pseudohypoxia
+    description: >-
+      SDH dysfunction blocks succinate oxidation and promotes succinate-driven
+      inhibition of oxygen-sensing enzymes.
+- name: Succinate accumulation and pseudohypoxia
+  description: >-
+    Loss of SDH activity causes succinate accumulation. Succinate inhibits
+    alpha-ketoglutarate-dependent prolyl hydroxylases, stabilizing HIF signaling
+    under normoxic conditions and increasing angiogenic, glycolytic, and
+    proliferative transcriptional programs.
+  biological_processes:
+  - preferred_term: cellular response to hypoxia
+    modifier: INCREASED
+    term:
+      id: GO:0071456
+      label: cellular response to hypoxia
+  - preferred_term: cell population proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: PMID:31773431
+    reference_title: "Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SDH deficiency leads to accumulation of succinate, an oncometabolite that
+      promotes tumorigenesis.
+    explanation: >-
+      Management review directly links SDH deficiency to succinate accumulation
+      and tumorigenesis.
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This mechanism implies that due to SDH deficiency, succinate is
+      accumulated; this inhibits propyl hydroxylases (PHDs) resulting in
+      induction of the hypoxic response despite normoxic conditions
+      (pseudohypoxia)
+    explanation: >-
+      Review explains the succinate-to-pseudohypoxia mechanism underlying
+      SDH-deficient tumor biology.
+  downstream:
+  - target: Epigenetic dysregulation
+    description: >-
+      Succinate also inhibits dioxygenases involved in DNA and histone
+      demethylation.
+  - target: Multifocal SDH-deficient tumor development
+    description: >-
+      Pseudohypoxia supports growth and survival of GIST and paraganglioma
+      precursor cells.
+- name: Epigenetic dysregulation
+  description: >-
+    Succinate accumulation inhibits alpha-ketoglutarate-dependent dioxygenases,
+    including JmjC-domain histone demethylases, producing hypermethylation and
+    altered differentiation programs in SDH-deficient tumors.
+  biological_processes:
+  - preferred_term: cellular response to hypoxia
+    modifier: INCREASED
+    term:
+      id: GO:0071456
+      label: cellular response to hypoxia
+  evidence:
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      this acts as an alpha-ketoglutarate competitor, inhibiting
+      a-KG-dependent dioxygenases, JIp1, which is involved in sulfur metabolism
+      and Jhd1 which belongs to the JmjC-domain-containing histone demethylase
+      (JHDM) enzymes.
+    explanation: >-
+      Review supports the dioxygenase-inhibition branch of SDH-deficient tumor
+      pathogenesis.
+  downstream:
+  - target: Multifocal SDH-deficient tumor development
+    description: >-
+      Pseudohypoxic and epigenetic programs converge on tumor predisposition.
+- name: Multifocal SDH-deficient tumor development
+  description: >-
+    SDH-deficient tumor biology predisposes to multifocal gastric GIST and
+    multicentric paraganglioma or pheochromocytoma. GISTs are usually
+    KIT/PDGFRA-wildtype, often gastric, and show loss of SDHB protein by
+    immunohistochemistry.
+  cell_types:
+  - preferred_term: chromaffin cell
+    term:
+      id: CL:0000166
+      label: chromaffin cell
+  evidence:
+  - reference: PMID:31174229
+    reference_title: "Paragangliomas in Carney-Stratakis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The PGLs in CSS are multicentric and GISTs are multifocal in all the
+      patients, suggesting an inherited susceptibility and associating the two
+      manifestations.
+    explanation: >-
+      Review supports multicentric paraganglioma and multifocal GIST as core
+      Carney-Stratakis tumor behavior.
+  - reference: PMID:21997692
+    reference_title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SDH-deficient GISTs especially include pediatric GISTs and those
+      associated with Carney triad (CT) or Carney-Stratakis syndromes (CSSs);
+      the latter 2 also include paraganglioma as a component.
+    explanation: >-
+      Clinicopathologic series places Carney-Stratakis GISTs in the broader
+      SDH-deficient GIST class and notes paraganglioma as the associated tumor
+      component.
+phenotypes:
+- category: Neoplastic
+  name: Paraganglioma or pheochromocytoma
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Paraganglioma, and less often pheochromocytoma, is one of the two defining
+    tumor classes in the syndrome. Tumors may be multicentric and can occur in
+    head and neck, retroperitoneal, adrenal, pelvic, or other paraganglionic
+    sites.
+  phenotype_term:
+    preferred_term: Paraganglioma
+    term:
+      id: HP:0002668
+      label: Paraganglioma
+  evidence:
+  - reference: PMID:36387130
+    reference_title: "Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline mutation in a patient with Carney-Stratakis syndrome: A case report and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      BACKGROUND: Carney-Stratakis syndrome (CSS) is a rare dyad of
+      paraganglioma (PGL)/pheochromocytoma (PHEO) and gastrointestinal stromal
+      tumor (GIST).
+    explanation: >-
+      Case-report review identifies PGL/PHEO as a defining component of the
+      syndrome.
+  - reference: PMID:31174229
+    reference_title: "Paragangliomas in Carney-Stratakis Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CSS has autosomal dominant inheritance, incomplete penetrance, and greater
+      relative frequency of PGL over GISTs.
+    explanation: >-
+      Review supports the high relative frequency of paraganglioma within
+      Carney-Stratakis syndrome.
+- category: Neoplastic
+  name: Gastrointestinal Stromal Tumor
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    SDH-deficient GIST is the other defining tumor class. Tumors are generally
+    gastric, KIT/PDGFRA-wildtype, may be multifocal, and can recur or metastasize
+    after long intervals.
+  phenotype_term:
+    preferred_term: Gastrointestinal stromal tumor
+    term:
+      id: HP:0100723
+      label: Gastrointestinal stroma tumor
+  evidence:
+  - reference: PMID:17667967
+    reference_title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In a subset of patients with GISTs, the lesions are associated with
+      paragangliomas; the condition is familial and transmitted as an
+      autosomal-dominant trait.
+    explanation: >-
+      Landmark series supports GIST plus paraganglioma as a familial tumor dyad.
+  - reference: PMID:21997692
+    reference_title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SDH-deficient GISTs constitute a small subgroup of gastric GISTs; they
+      usually occur in children and young adults, often have a chronic course
+      similar to that of pediatric and CT GISTs, and have potential association
+      with paraganglioma, necessitating long-term follow-up.
+    explanation: >-
+      Clinicopathologic cohort supports gastric location, younger age tendency,
+      chronic course, and paraganglioma association of SDH-deficient GIST.
+- category: Cardiovascular
+  name: Hypertension from catecholamine-secreting paraganglioma
+  frequency: OCCASIONAL
+  description: >-
+    Catecholamine-secreting paragangliomas or pheochromocytomas may cause
+    episodic or sustained hypertension, headache, palpitations, and sweating.
+  phenotype_term:
+    preferred_term: Hypertension
+    term:
+      id: HP:0000822
+      label: Hypertension
+  evidence:
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A patient with any type of PGL will present in any of the following
+      contexts: a) because of signs and/or symptoms of excess catecholamine
+      secretion (e.g. hypertension, headache, palpitations, hyperhidrosis,
+      tremor);
+    explanation: >-
+      Review supports hypertension as a catecholamine-related manifestation of
+      paraganglioma in the SDH-deficiency spectrum.
+- category: Gastrointestinal
+  name: Abdominal pain or gastrointestinal bleeding
+  frequency: OCCASIONAL
+  description: >-
+    Gastric SDH-deficient GIST may present with abdominal pain, ulcer symptoms,
+    or gastrointestinal bleeding, but presentation can be nonspecific.
+  phenotype_term:
+    preferred_term: Abdominal pain
+    term:
+      id: HP:0002027
+      label: Abdominal pain
+  evidence:
+  - reference: PMID:31773431
+    reference_title: "Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Many patients with GIST are diagnosed after presenting with severe
+      epigastric pain or gastrointestinal bleeding due to ulceration
+    explanation: >-
+      Management review supports abdominal pain and bleeding as common
+      presentations for GIST.
+diagnosis:
+- name: SDHB immunohistochemistry
+  description: >-
+    Loss of granular SDHB staining in tumor cells, with retained internal
+    control staining, is a diagnostic hallmark of SDH-deficient GIST and should
+    prompt consideration of Carney-Stratakis syndrome or Carney triad.
+  evidence:
+  - reference: PMID:20890271
+    reference_title: "SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We show that Carney-Stratakis syndrome- and Carney-triad-associated GISTs
+      are negative by immunohistochemistry for SDHB in contrast to KIT- or
+      PDGFRA-mutated GISTs and a majority of sporadic GISTs.
+    explanation: >-
+      Pathology study establishes SDHB immunohistochemistry as a practical
+      discriminator for Carney-Stratakis/Carney-triad-associated GIST.
+  - reference: PMID:20890271
+    reference_title: "SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In case of negative SDHB staining in GISTs, Carney-Stratakis syndrome or
+      Carney triad should be considered and appropriate clinical surveillance
+      should be instituted.
+    explanation: >-
+      Same study provides the diagnostic follow-up implication of negative SDHB
+      staining.
+- name: Germline SDHx testing
+  description: >-
+    Germline testing for SDHB, SDHC, and SDHD, with deletion/duplication testing
+    when sequencing is negative and clinical suspicion remains high, is used to
+    confirm the inherited syndrome and guide family surveillance.
+  evidence:
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Genetic testing for SDHx mutations in any of the above patients,
+      particularly if there are other family members with any of those tumors
+      (do not only include first-degree relatives) should be performed.
+    explanation: >-
+      SDH-deficiency review recommends SDHx genetic testing in relevant tumor
+      contexts and family settings.
+genetic:
+- name: SDHB
+  association: Germline Loss-of-Function Variants
+  inheritance:
+  - name: Autosomal Dominant
+  notes: >-
+    SDHB pathogenic variants are an established cause of Carney-Stratakis
+    syndrome and are particularly important because SDHB-related paraganglioma
+    syndromes have higher metastatic risk in the broader SDHx literature.
+  evidence:
+  - reference: PMID:17667967
+    reference_title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the GISTs were caused by germline mutations of the genes encoding subunits
+      B, C, or D (the SDHB, SDHC and SDHD genes, respectively).
+    explanation: >-
+      Landmark CSS series includes SDHB among causal germline genes.
+- name: SDHC
+  association: Germline Loss-of-Function Variants
+  inheritance:
+  - name: Autosomal Dominant
+  notes: >-
+    SDHC pathogenic variants are an established cause of Carney-Stratakis
+    syndrome; this differs from Carney triad, where SDHC promoter methylation is
+    more typical.
+  evidence:
+  - reference: PMID:17667967
+    reference_title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the GISTs were caused by germline mutations of the genes encoding subunits
+      B, C, or D (the SDHB, SDHC and SDHD genes, respectively).
+    explanation: >-
+      Landmark CSS series includes SDHC among causal germline genes.
+- name: SDHD
+  association: Germline Loss-of-Function Variants
+  inheritance:
+  - name: Autosomal Dominant
+  notes: >-
+    SDHD pathogenic variants are an established cause of Carney-Stratakis
+    syndrome and should be evaluated as part of SDHx testing.
+  evidence:
+  - reference: PMID:17667967
+    reference_title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      the GISTs were caused by germline mutations of the genes encoding subunits
+      B, C, or D (the SDHB, SDHC and SDHD genes, respectively).
+    explanation: >-
+      Landmark CSS series includes SDHD among causal germline genes.
+treatments:
+- name: Complete surgical resection
+  description: >-
+    Complete resection is the main treatment for localized SDH-deficient GIST or
+    paraganglioma when feasible, with attention to multifocal, nodal, and
+    recurrent disease.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  evidence:
+  - reference: PMID:36387130
+    reference_title: "Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline mutation in a patient with Carney-Stratakis syndrome: A case report and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The unique mechanism of tumorigenesis including hypoxia and
+      hypermethylation caused by SDH deficiency renders target therapy with
+      tyrosine kinase inhibitors ineffective, therefore complete surgical
+      resection is the optimal treatment in the absence of tumor metastases.
+    explanation: >-
+      Case-report review supports surgery as the preferred local treatment and
+      notes limited TKI effectiveness.
+  - reference: PMID:31773431
+    reference_title: "Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Thus, surgical resection is the mainstay of treatment for localized
+      disease, but recurrence is common.
+    explanation: >-
+      Management review supports surgical resection for localized SDH-deficient
+      GIST and cautions that recurrence remains common.
+- name: KIT-directed tyrosine kinase inhibitors
+  description: >-
+    Standard KIT/PDGFRA-directed therapies such as imatinib are often ineffective
+    in SDH-deficient, KIT/PDGFRA-wildtype GIST. Anti-angiogenic TKIs may have
+    limited activity in selected advanced SDH-deficient GIST cases, but evidence
+    remains incomplete.
+  treatment_term:
+    preferred_term: targeted therapy
+    term:
+      id: NCIT:C93352
+      label: Targeted Therapy
+  evidence:
+  - reference: PMID:31773431
+    reference_title: "Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SDH-deficient GISTs are generally resistant to tyrosine-kinase inhibitors,
+      the standard treatment for advanced or metastatic GIST.
+    explanation: >-
+      Supports avoiding over-reliance on standard GIST TKIs in SDH-deficient
+      disease; marked as partial because some non-imatinib TKIs can have limited
+      activity in selected advanced cases.
+- name: Genetic counseling and surveillance
+  description: >-
+    Genetic counseling, cascade testing, and long-term surveillance for
+    paraganglioma, pheochromocytoma, gastric GIST recurrence, and related
+    SDH-deficient tumors are central management components for affected
+    individuals and at-risk relatives.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients and family members should be referred for genetic counseling.
+    explanation: >-
+      Review explicitly recommends genetic counseling for patients and family
+      members in SDH-deficient tumor predisposition contexts.
+  - reference: PMID:31773431
+    reference_title: "Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      For all GIST patients with completely resected disease, follow-up with
+      physical exams and cross sectional imaging (i.e., CT or MRI) of the
+      abdomen/pelvis is recommended every 3-6 months for the first 5 years and
+      then annually.
+    explanation: >-
+      Management review provides an imaging follow-up framework after resection
+      of GIST, relevant to SDH-deficient GIST surveillance.
+differential_diagnoses:
+- name: Carney triad
+  description: >-
+    Carney triad overlaps by including GIST and paraganglioma, but also includes
+    pulmonary chondroma, has a strong female predominance, and is usually linked
+    to SDHC promoter hypermethylation rather than inherited germline SDHB, SDHC,
+    or SDHD variants.
+  evidence:
+  - reference: PMID:34012423
+    reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CT is a very rare disease; PGL, GIST and pulmonary chondromas constitute
+      CT which shows female predilection and may be a mosaic disorder.
+    explanation: >-
+      Review defines the triad and differentiates it from the inherited dyad.
+- name: Sporadic KIT/PDGFRA-mutant gastrointestinal stromal tumor
+  description: >-
+    Sporadic KIT/PDGFRA-mutant GIST is usually SDHB-positive by
+    immunohistochemistry and lacks the inherited PGL/GIST dyad.
+  evidence:
+  - reference: PMID:20890271
+    reference_title: "SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The five GISTs with a KIT or PDGFRA gene mutation were all
+      immunohistochemically positive for SDHB.
+    explanation: >-
+      Pathology study supports SDHB staining as a distinction between
+      KIT/PDGFRA-mutant sporadic GIST and SDH-deficient syndromic GIST.

--- a/kb/disorders/Carney-Stratakis_Syndrome.yaml
+++ b/kb/disorders/Carney-Stratakis_Syndrome.yaml
@@ -140,11 +140,11 @@ pathophysiology:
     under normoxic conditions and increasing angiogenic, glycolytic, and
     proliferative transcriptional programs.
   biological_processes:
-  - preferred_term: cellular response to hypoxia
-    modifier: INCREASED
+  - preferred_term: chromatin organization
+    modifier: DYSREGULATED
     term:
-      id: GO:0071456
-      label: cellular response to hypoxia
+      id: GO:0006325
+      label: chromatin organization
   - preferred_term: cell population proliferation
     modifier: INCREASED
     term:
@@ -245,6 +245,73 @@ pathophysiology:
       Clinicopathologic series places Carney-Stratakis GISTs in the broader
       SDH-deficient GIST class and notes paraganglioma as the associated tumor
       component.
+histopathology:
+- name: SDHB-negative gastric epithelioid GIST
+  diagnostic: true
+  description: >-
+    Carney-Stratakis-associated GISTs are SDH-deficient gastric tumors with loss
+    of SDHB immunostaining, epithelioid morphology, and absence of KIT or PDGFRA
+    driver mutations.
+  evidence:
+  - reference: PMID:20890271
+    reference_title: "SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All SDHB-negative GISTs were located in the stomach, had an epithelioid
+      morphology, and had no KIT or PDGFRA mutations.
+    explanation: >-
+      Pathology study supports gastric location, epithelioid morphology, and
+      KIT/PDGFRA-wildtype status as diagnostic features of SDHB-negative
+      Carney-Stratakis/Carney-triad-associated GIST.
+- name: Microplexiform muscularis propria involvement
+  description: >-
+    SDH-deficient gastric GISTs often grow as multiple separate nodules in the
+    muscularis propria, producing a microplexiform or multinodular pattern.
+  evidence:
+  - reference: PMID:21997692
+    reference_title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The tumors commonly involved muscularis propria as multiple apparently
+      separate nodules, creating a "microplexiform" pattern
+    explanation: >-
+      Clinicopathologic cohort directly describes the characteristic
+      microplexiform muscularis propria growth pattern.
+- name: Epithelioid hypercellular morphology
+  description: >-
+    Epithelioid cytology and epithelioid hypercellular morphology are common
+    microscopic features of SDH-deficient GISTs.
+  evidence:
+  - reference: PMID:21997692
+    reference_title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Epithelioid cytology dominated in 37 cases, 20 tumors had mixed
+      epithelioid and spindle cell, 7 spindle cell, and 1 had extensively
+      pleomorphic cytology.
+    explanation: >-
+      Cohort histology supports epithelioid cytology as the dominant morphology
+      among SDH-deficient GISTs.
+- name: Lymphovascular invasion
+  description: >-
+    Lymphovascular invasion can be common in SDH-deficient gastric GIST, although
+    in the cited cohort it was not independently associated with adverse
+    outcome.
+  evidence:
+  - reference: PMID:21997692
+    reference_title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Lymph node metastases were detected in 5 patients, but lymphovascular
+      invasion was present in >50% of cases studied; these 2 were not related to
+      adverse outcome.
+    explanation: >-
+      Cohort evidence supports lymphovascular invasion as a frequent
+      histopathologic feature in SDH-deficient GIST.
 phenotypes:
 - category: Neoplastic
   name: Paraganglioma or pheochromocytoma

--- a/kb/disorders/Carney-Stratakis_Syndrome.yaml
+++ b/kb/disorders/Carney-Stratakis_Syndrome.yaml
@@ -140,11 +140,11 @@ pathophysiology:
     under normoxic conditions and increasing angiogenic, glycolytic, and
     proliferative transcriptional programs.
   biological_processes:
-  - preferred_term: chromatin organization
-    modifier: DYSREGULATED
+  - preferred_term: cellular response to hypoxia
+    modifier: INCREASED
     term:
-      id: GO:0006325
-      label: chromatin organization
+      id: GO:0071456
+      label: cellular response to hypoxia
   - preferred_term: cell population proliferation
     modifier: INCREASED
     term:
@@ -188,11 +188,11 @@ pathophysiology:
     including JmjC-domain histone demethylases, producing hypermethylation and
     altered differentiation programs in SDH-deficient tumors.
   biological_processes:
-  - preferred_term: cellular response to hypoxia
-    modifier: INCREASED
+  - preferred_term: chromatin organization
+    modifier: DYSREGULATED
     term:
-      id: GO:0071456
-      label: cellular response to hypoxia
+      id: GO:0006325
+      label: chromatin organization
   evidence:
   - reference: PMID:34012423
     reference_title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."

--- a/references_cache/PMID_17667967.md
+++ b/references_cache/PMID_17667967.md
@@ -1,0 +1,95 @@
+---
+reference_id: "PMID:17667967"
+title: "Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD."
+authors:
+- Pasini B
+- McWhinney SR
+- Bei T
+- Matyakhina L
+- Stergiopoulos S
+- Muchow M
+- Boikos SA
+- Ferrando B
+- Pacak K
+- Assie G
+- Baudin E
+- Chompret A
+- Ellison JW
+- Briere JJ
+- Rustin P
+- Gimenez-Roqueplo AP
+- Eng C
+- Carney JA
+- Stratakis CA
+journal: Eur J Hum Genet
+year: '2008'
+doi: 10.1038/sj.ejhg.5201904
+keywords:
+- Adolescent
+- Adult
+- Alleles
+- Antineoplastic Agents/therapeutic use
+- Base Sequence
+- Benzamides
+- Child
+- DNA Primers/genetics
+- "DNA, Neoplasm/genetics"
+- Female
+- "Gastrointestinal Stromal Tumors/drug therapy, enzymology, genetics, pathology"
+- "Genes, Dominant"
+- Germ-Line Mutation
+- Heterozygote
+- Humans
+- Imatinib Mesylate
+- Iron-Sulfur Proteins/genetics
+- Loss of Heterozygosity
+- Male
+- Membrane Proteins/genetics
+- "Neoplastic Syndromes, Hereditary/drug therapy, enzymology, genetics, pathology"
+- "Paraganglioma/drug therapy, enzymology, genetics, pathology"
+- Piperazines/therapeutic use
+- Pyrimidines/therapeutic use
+- Succinate Dehydrogenase/genetics
+content_type: abstract_only
+---
+
+# Clinical and molecular genetics of patients with the Carney-Stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits SDHB, SDHC, and SDHD.
+**Authors:** Pasini B, McWhinney SR, Bei T, Matyakhina L, Stergiopoulos S, Muchow M, Boikos SA, Ferrando B, Pacak K, Assie G, Baudin E, Chompret A, Ellison JW, Briere JJ, Rustin P, Gimenez-Roqueplo AP, Eng C, Carney JA, Stratakis CA
+**Journal:** Eur J Hum Genet (2008)
+**DOI:** [10.1038/sj.ejhg.5201904](https://doi.org/10.1038/sj.ejhg.5201904)
+
+## Content
+
+1. Eur J Hum Genet. 2008 Jan;16(1):79-88. doi: 10.1038/sj.ejhg.5201904. Epub 2007
+ Aug 1.
+
+Clinical and molecular genetics of patients with the Carney-Stratakis syndrome 
+and germline mutations of the genes coding for the succinate dehydrogenase 
+subunits SDHB, SDHC, and SDHD.
+
+Pasini B(1), McWhinney SR, Bei T, Matyakhina L, Stergiopoulos S, Muchow M, 
+Boikos SA, Ferrando B, Pacak K, Assie G, Baudin E, Chompret A, Ellison JW, 
+Briere JJ, Rustin P, Gimenez-Roqueplo AP, Eng C, Carney JA, Stratakis CA.
+
+Author information:
+(1)Department of Genetics, Biology and Biochemistry, University of Torino, 
+Turin, Italy.
+
+Gastrointestinal stromal tumors (GISTs) may be caused by germline mutations of 
+the KIT and platelet-derived growth factor receptor-alpha (PDGFRA) genes and 
+treated by Imatinib mesylate (STI571) or other protein tyrosine kinase 
+inhibitors. However, not all GISTs harbor these genetic defects and several do 
+not respond to STI571 suggesting that other molecular mechanisms may be 
+implicated in GIST pathogenesis. In a subset of patients with GISTs, the lesions 
+are associated with paragangliomas; the condition is familial and transmitted as 
+an autosomal-dominant trait. We investigated 11 patients with the dyad of 
+'paraganglioma and gastric stromal sarcoma'; in eight (from seven unrelated 
+families), the GISTs were caused by germline mutations of the genes encoding 
+subunits B, C, or D (the SDHB, SDHC and SDHD genes, respectively). In this 
+report, we present the molecular effects of these mutations on these genes and 
+the clinical information on the patients. We conclude that succinate 
+dehydrogenase deficiency may be the cause of a subgroup of GISTs and this offers 
+a therapeutic target for GISTs that may not respond to STI571 and its analogs.
+
+DOI: 10.1038/sj.ejhg.5201904
+PMID: 17667967 [Indexed for MEDLINE]

--- a/references_cache/PMID_20890271.md
+++ b/references_cache/PMID_20890271.md
@@ -1,0 +1,124 @@
+---
+reference_id: "PMID:20890271"
+title: "SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors."
+authors:
+- Gaal J
+- Stratakis CA
+- Carney JA
+- Ball ER
+- Korpershoek E
+- Lodish MB
+- Levy I
+- Xekouki P
+- van Nederveen FH
+- den Bakker MA
+- "O'Sullivan M"
+- Dinjens WN
+- de Krijger RR
+journal: Mod Pathol
+year: '2011'
+doi: 10.1038/modpathol.2010.185
+keywords:
+- "Biomarkers, Tumor/metabolism"
+- "Carney Complex/diagnosis, genetics, metabolism"
+- DNA Mutational Analysis
+- "Epithelioid Cells/metabolism, pathology"
+- "Gastrointestinal Stromal Tumors/diagnosis, genetics, metabolism"
+- Humans
+- Immunohistochemistry
+- Mutation
+- "Proto-Oncogene Proteins c-kit/genetics, metabolism"
+- "Receptor, Platelet-Derived Growth Factor alpha/genetics, metabolism"
+- "Succinate Dehydrogenase/genetics, metabolism"
+- Syndrome
+content_type: full_text_xml
+---
+
+# SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis and Carney triad gastrointestinal stromal tumors.
+**Authors:** Gaal J, Stratakis CA, Carney JA, Ball ER, Korpershoek E, Lodish MB, Levy I, Xekouki P, van Nederveen FH, den Bakker MA, O'Sullivan M, Dinjens WN, de Krijger RR
+**Journal:** Mod Pathol (2011)
+**DOI:** [10.1038/modpathol.2010.185](https://doi.org/10.1038/modpathol.2010.185)
+
+## Content
+
+1. Mod Pathol. 2011 Jan;24(1):147-51. doi: 10.1038/modpathol.2010.185. Epub 2010 
+Oct 1.
+
+SDHB immunohistochemistry: a useful tool in the diagnosis of Carney-Stratakis 
+and Carney triad gastrointestinal stromal tumors.
+
+Gaal J(1), Stratakis CA, Carney JA, Ball ER, Korpershoek E, Lodish MB, Levy I, 
+Xekouki P, van Nederveen FH, den Bakker MA, O'Sullivan M, Dinjens WN, de Krijger 
+RR.
+
+Author information:
+(1)Department of Pathology, Josephine Nefkens Institute, Erasmus MC, University 
+Medical Center Rotterdam, Rotterdam, The Netherlands. j.gaal@erasmusmc.nl
+
+Mutations in the tumor suppressor genes SDHB, SDHC, and SDHD (or collectively 
+SDHx) cause the inherited paraganglioma syndromes, characterized by 
+pheochromocytomas and paragangliomas. However, other tumors have been associated 
+with SDHx mutations, such as gastrointestinal stromal tumors (GISTs) 
+specifically in the context of Carney-Stratakis syndrome. Previously, we have 
+shown that SDHB immunohistochemistry is a reliable technique for the 
+identification of pheochromocytomas and paragangliomas caused by SDHx mutations. 
+We hypothesized that GISTs in patients with SDHx mutations would be negative 
+immunohistochemically for SDHB as well. Four GISTs from patients with 
+Carney-Stratakis syndrome and six from patients with Carney triad were 
+investigated by SDHB immunohistochemistry. Five GISTs with KIT or PDGFRA gene 
+mutations were used as controls. In addition, SDHB immunohistochemistry was 
+performed on 42 apparently sporadic GISTs. In cases in which the SDHB 
+immunohistochemistry was negative, mutational analysis of SDHB, SDHC, and SDHD 
+was performed. All GISTs from patients with Carney-Stratakis syndrome and Carney 
+triad were negative for SDHB immunohistochemically. In one patient with 
+Carney-Stratakis syndrome, a germline SDHB mutation was found (p.Ser92Thr). The 
+five GISTs with a KIT or PDGFRA gene mutation were all immunohistochemically 
+positive for SDHB. Of the 42 sporadic tumors, one GIST was SDHB-negative. 
+Mutational analysis of this tumor did not reveal an SDHx mutation. All 
+SDHB-negative GISTs were located in the stomach, had an epithelioid morphology, 
+and had no KIT or PDGFRA mutations. We show that Carney-Stratakis syndrome- and 
+Carney-triad-associated GISTs are negative by immunohistochemistry for SDHB in 
+contrast to KIT- or PDGFRA-mutated GISTs and a majority of sporadic GISTs. We 
+suggest that GISTs of epithelioid cell morphology are tested for SDHB 
+immunohistochemically. In case of negative SDHB staining in GISTs, 
+Carney-Stratakis syndrome or Carney triad should be considered and appropriate 
+clinical surveillance should be instituted.
+
+DOI: 10.1038/modpathol.2010.185
+PMCID: PMC3415983
+PMID: 20890271 [Indexed for MEDLINE]
+
+Conflict of interest statement: Disclosure/conflict of interest The authors 
+declare no conflict of interest.
+
+Succinate dehydrogenase (SDH) is an enzyme complex that catalyzes the oxidation of succinate to fumarate in the citric acid cycle and participates in the electron transport chain. SDH is located in the mitochondrial inner membrane and consists of four nuclear-encoded subunits: the flavoprotein SDHA, the iron–sulfur protein SDHB, and the integral membrane proteins SDHC, and SDHD.1
+
+Mutations in the different subunits result in very different disorders. Mutations in SDHA cause Leigh’s syndrome, a rare inherited neurometabolic disorder characterized by degeneration of the central nervous system.2 Mutations in the tumor suppressor genes SDHB, SDHC, SDHD from here on collectively referred to as SDHx, occur in patients with the pheochromocytoma–paraganglioma syndromes.3 Diverse additional tumors have been associated with SDHx mutations, including gastrointestinal stromal tumors (GISTs), renal cell carcinomas, renal oncocytomas, and, rarely, papillary thyroid carcinomas, neuroblastomas, and seminomas.4–8
+
+Of these tumors, GISTs occur most frequently in patients with SDHx mutations. The majority of sporadic GIST is caused by mutations in the KIT and PDGFRA genes whereas four different SDHB mutations, two SDHC mutations, and one SDHD mutation have been identified in patients with the familial dyad of paraganglioma and GIST, also known as the Carney–Stratakis syndrome.7 The Carney triad is similar to Carney–Stratakis syndrome, but includes pulmonary chondromas and is apparently infrequently inherited; SDHx mutations have not been described in the Carney triad.9
+
+In a previous report, we showed that SDHB immunohistochemistry is a reliable technique to identify pheochromocytomas and paragangliomas caused by mutations in SDHB, SDHC, and SDHD.10 It seemed likely that other tumors in patients with SDHx mutations would be negative for SDHB immunohistochemistry, as well. In this study, we performed SDHB immunohistochemistry on GISTs that occurred as a component of the Carney–Stratakis syndrome and the Carney triad. In addition, we performed SDHB immunohistochemistry on a series of apparently sporadic GISTs.
+
+Four GISTs from patients with the Carney–Stratakis syndrome and six GISTs from patients with Carney triad were available for this study. Distinguishing Carney triad and Carney–Stratakis syndrome is difficult in individual patients. In this study, we used the familial predisposition and paraganglioma as the first presenting tumor in Carney–Stratakis syndrome and the presence of pulmonary chondroma, female predominance, and GIST as the first presenting tumor in Carney triad as differentiating features, as described by Carney.11 As a control group, we used five GISTs with a mutation in KIT or PDGFRA. GIST diagnosis was made based on histology and verified immunohistochemically using DOG1 (RM-9132-R7) antibody (Thermo Scientific, Cheshire, UK; 1:50) and CD117, c-kit (A4502) antibody (DAKO, Heverlee, Belgium; 1:25).
+
+In addition, we investigated a series of 42 formalin-fixed paraffin-embedded sporadic GISTs that were diagnosed in Erasmus MC between 2001 and 2009. These samples were anonymously used according to the code for adequate secondary use of tissue, code of conduct: ‘Proper Secondary Use of Human Tissue’ established by the Dutch Federation of Medical Scientific Societies (http://www.federa.org).
+
+All GISTs were investigated by SDHB immunohistochemistry as previously described,10 using the rabbit polyclonal antibody HPA002868 (Sigma-Aldrich, St Louis, MO, USA; 1:500). Immunoreactivity was scored independently by two observers (JG and RRdK) who were blinded to all clinical, pathological, and molecular data. Slides with a granular staining in the tumor cell cytoplasm were scored as positive. Slides in which the tumor cells were negative or showed diffuse cytoplasmatic staining, but with granular staining in endothelial cells (internal control), were scored as negative. Samples lacking the internal positive control were considered non-informative and were repeated.
+
+Following SDHB immunohistochemical evaluation, SDHx-gene mutational analysis was performed on the tumors with negative SDHB immunohistochemistry. A region containing at least 70% tumor cells was micro-dissected from the tumor block and DNA was isolated using the Puregene DNA isolation kit (Qiagen, Minneapolis, MN, USA) according to the manufacturer’s protocol. No tumor DNA was available of one sample and germline DNA was used instead. Mutational analysis was performed by direct sequencing of the open reading frames, including the exon–intron boundaries of the SDHB, SDHC, and SDHD genes. In addition, sequence analysis of exons 8, 9, 11, 13, and 17 of the KIT proto-oncogene and exons 12, 14, and 18 of the PDGFRA gene was performed on the SDHB immunonegative tumors.
+
+There was uniform agreement between the two observers in classifying tumors as SDHB-positive or SDHB-negative. Four GISTs from patients with the Carney–Stratakis syndrome were negative for SDHB by immunohistochemistry (Figure 1a). In contrast, all KIT- or PDGFRA-mutated GISTs were SDHB-positive (Figures 1b and c). In one of the Carney–Stratakis syndrome patients, an SDHB germline mutation (p.Ser92Thr) was present. In the other three patients no mutations in SDHB, SDHC, and SDHD were found. The six GISTs from patients with Carney triad were negative for SDHB by immunohistochemistry (Figure 1d). However, no mutations in SDHB, SDHC, and SDHD were found. The GISTs in the Carney–Stratakis syndrome and triad all had an epithelioid morphology. In contrast, the KIT- and PDGFRA-mutated tumors had a spindle-cell morphology. The clinical details of the Carney–Stratakis syndrome and Carney-triad patients are summarized in Table 1.
+
+Among the 42 sporadic GISTs, one GIST (2%) from a 41-year-old woman, located in the stomach, was negative for SDHB immunohistochemically. She developed a medullary thyroid carcinoma at age 45 years with local lymph node and liver metastasis. The medullary thyroid carcinoma was positive for SDHB immunohistochemistry. Microscopy of the GIST showed an epithelioid morphology and the tumor cells were positive for CD117 and DOG1. Mutational analysis revealed no mutations in SDHB, SDHC, SDHD, and SDHAF2 genes. Sequencing analysis of exons 8, 9, 11, 13, and 17 of the KIT proto-oncogene and exons 12, 14, and 18 of the PDGFRA gene did not reveal mutations.
+
+In pheochromocytomas and paragangliomas, absence of SDHB staining is an indicator of Complex II disruption caused by SDHB, SDHC, or SDHD mutations.10 In this study, a GIST from a patient with Carney–Stratakis syndrome had a proven germline SDHB mutation, which confirms our hypothesis that GISTs caused by mutations in SDHB, SDHC, and SDHD would be negative with SDHB immunohistochemistry.
+
+SDHB mutations are also described in different types of renal tumors,6,8,12 usually clear cell carcinomas, but the mutations have also been found in oncocytomas, eosinophilic chromophobe renal cell carcinomas, and papillary renal cell carcinomas. Previously, we reported negative SDHB immunohistochemistry in a renal cell carcinoma.10 This suggests that all tumor types in patients with SDHx mutations are characterized by absent SDHB staining.
+
+The GISTs from Carney–Stratakis syndrome and Carney triad patients in our study were negative for SDHB by immunohistochemistry, results that are concordant with a recent publication of Gill et al,13 in which tumors are described from five Carneytriad patients with negative SDHB immunohistochemistry. However, they did not study any Carney–Stratakis syndrome patients. We found that mutations in SDHB, SDHC, and SDHD were absent in all but one SDHB-immunonegative GIST, which came from a Carney–Stratakis syndrome patient. In addition, we found no proof of loss of heterozygosity of one of the SDH genes in these tumor samples (results not shown). In a previous study of pheochromocytomas and paragangliomas, we found six tumors with negative SDHB immunohistochemistry, but lacking SDHB, SDHC, and SDHD mutations (11%).10,14 This may be due to a <100% sensitivity of the technique of sequence analysis or to the fact that we did not perform systematic multiplex ligation-dependent probe amplification in all our samples, thus probably missing up to 10% of genetic abnormalities. However, it is also possible that epigenetic changes or other genes affect complex II, and that mutations in such additional genes might result in disruption of complex II and subsequently in negative SDHB immunohistochemistry. The question, therefore, remains whether absent SDHB immunostaining implies the presence of SDHx mutations in GISTs, as we have shown with >85% sensitivity in pheochromocytomas and paragangliomas. Although the mechanism of tumorigenesis of the SDHB immunohistochemically-negative GISTs is unknown, several studies have shown that VEGF and HIF1α are relatively overexpressed in GISTs,15,16 as is the case in SDHx-mutated paragangliomas. The negative SDHB immunohistochemistry in Carney–Stratakis syndrome and Carney-triad GISTs indicates the absence of SDHB protein and functional complex II.10 The mammalian mitochondria contain about 1100 proteins of which nearly 300 are uncharacterized, so it can be anticipated that pathogenic mutations or functional abnormalities of other mitochondrial proteins both drive tumorigenesis and account for SDHB negativity in Carney–Stratakis syndrome and Carney-triad-related GISTs.
+
+Among the 42 apparently sporadic GISTs we studied, one tumor (2%) was negative for SDHB by immunohistochemistry. This finding is in agreement with Gill et al13 who found that 3% (3/101) of sporadic GISTs in their series was negative for SDHB immunohistochemically. Interestingly, our patient developed a medullary thyroid carcinoma 4 years after diagnosis of the GIST. This combination of GIST and medullary thyroid carcinoma has been described previously in a patient with multiple endocrine neoplasia type 2A.17 In our case, we found a somatic mutation in RET in the medullary thyroid carcinoma (results not shown). In addition, SDHB immunohistochemistry was positive in this medullary thyroid carcinoma, indicating that the tumor was not caused by complex II disruption.
+
+Gill et al13 divided GISTs into two broad groups: GIST type 1, which includes most GISTs and occurs mainly in adults and KIT- or PDGFRA-mutant tumors. Type I tumors usually show spindled morphology. GIST type 2 occurs predominantly in children and young adults. Type 2 tumors show an epithelioid morphology, occur exclusively in the stomach, and are never associated with KIT or PDGFRA mutations. The one apparently sporadic SDHB-negative GIST in our study, although occurring in an adult, was located in the stomach and had an epithelioid morphology, in line with the observations by Gill et al.
+
+In conclusion, we have shown that Carney–Stratakis syndrome and Carney triad GISTs are negative for SDHB by immunohistochemistry in contrast to KIT- or PDGFRA-mutated GISTs and the majority of apparently sporadic GISTs, which are immunopositive. Our findings suggest that absent SDHB immunostaining in GISTs has a high likelihood of a syndromic diagnosis of either Carney–Stratakis syndrome or the Carney triad. Consequently, SDHx mutational analysis and clinical surveillance for the development of paragangliomas and pulmonary chondromas should be instituted.

--- a/references_cache/PMID_21997692.md
+++ b/references_cache/PMID_21997692.md
@@ -1,0 +1,182 @@
+---
+reference_id: "PMID:21997692"
+title: "Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age."
+authors:
+- Miettinen M
+- Wang ZF
+- Sarlomo-Rikala M
+- Osuch C
+- Rutkowski P
+- Lasota J
+journal: Am J Surg Pathol
+year: '2011'
+doi: 10.1097/PAS.0b013e3182260752
+keywords:
+- Adolescent
+- Adult
+- Age Factors
+- Aged
+- "Aged, 80 and over"
+- "Biomarkers, Tumor/analysis, genetics"
+- Child
+- DNA Mutational Analysis
+- Female
+- Finland
+- "Gastrointestinal Stromal Tumors/chemistry, diagnosis, enzymology, genetics, mortality, secondary"
+- Humans
+- Immunohistochemistry
+- Male
+- Maryland
+- Middle Aged
+- Mitotic Index
+- Neoplasm Invasiveness
+- Poland
+- Prognosis
+- "Stomach Neoplasms/chemistry, diagnosis, enzymology, genetics, mortality, pathology"
+- "Succinate Dehydrogenase/deficiency, genetics"
+- Time Factors
+- Tumor Burden
+- Young Adult
+content_type: full_text_xml
+---
+
+# Succinate dehydrogenase-deficient GISTs: a clinicopathologic, immunohistochemical, and molecular genetic study of 66 gastric GISTs with predilection to young age.
+**Authors:** Miettinen M, Wang ZF, Sarlomo-Rikala M, Osuch C, Rutkowski P, Lasota J
+**Journal:** Am J Surg Pathol (2011)
+**DOI:** [10.1097/PAS.0b013e3182260752](https://doi.org/10.1097/PAS.0b013e3182260752)
+
+## Content
+
+1. Am J Surg Pathol. 2011 Nov;35(11):1712-21. doi: 10.1097/PAS.0b013e3182260752.
+
+Succinate dehydrogenase-deficient GISTs: a clinicopathologic, 
+immunohistochemical, and molecular genetic study of 66 gastric GISTs with 
+predilection to young age.
+
+Miettinen M(1), Wang ZF, Sarlomo-Rikala M, Osuch C, Rutkowski P, Lasota J.
+
+Author information:
+(1)Laboratory of Pathology, National Cancer Institute, Bethesda, 20892, USA. 
+miettinenmm@mail.nih.gov
+
+Most gastrointestinal stromal tumors (GISTs) are driven by KIT or 
+PDGFRA-activating mutations, but a small subset is associated with loss of 
+function of the succinate dehydrogenase (SDH) complex of mitochondrial inner 
+membrane proteins. This occurs by germline mutations of the SDH subunit genes 
+and hitherto unknown mechanisms. SDH-deficient GISTs especially include 
+pediatric GISTs and those associated with Carney triad (CT) or Carney-Stratakis 
+syndromes (CSSs); the latter 2 also include paraganglioma as a component. 
+SDH-deficient GISTs were identified in this study on the basis of 
+immunohistochemical loss of succinate dehydrogenase subunit B (SDHB), which 
+signals functional loss of the SDH complex. We found 66 SDH-deficient GISTs 
+among 756 gastric GISTs, with an estimated frequency of 7.5% of unselected 
+cases. Nearly, all gastric GISTs in patients <20 years, and a substantial 
+percentage of those in patients <40 years, but only rare GISTs in older adults 
+were SDH deficient. There was a female predominance of over 2:1. Two patients 
+each had either pulmonary chondroma or paraganglioma (CT), but none of the 
+examined cases had SDH germline mutations (CSS) or somatic KIT/PDGFRA or BRAF 
+mutations. SDH-deficient GISTs were often multiple and typically showed 
+plexiform muscularis propria involvement and epithelioid hypercellular 
+morphology. They were consistently KIT-positive and DOG1/Ano 1-positive and 
+almost always smooth muscle actin negative. Tumor size and mitotic activity 
+varied, and the tumors were somewhat unpredictable with low mitotic rates 
+developing metastases. Gastric recurrences occurred in 11 patients, and 
+peritoneal and liver metastases occurred in 8 and 10 patients, respectively. 
+Lymph node metastases were detected in 5 patients, but lymphovascular invasion 
+was present in >50% of cases studied; these 2 were not related to adverse 
+outcome. Seven patients died of disease, but many had long survivals, even with 
+peritoneal or liver metastases. All 378 nongastric GISTs and 34 gastric non-GIST 
+mesenchymal tumors were SDHB positive. SDH-deficient GISTs constitute a small 
+subgroup of gastric GISTs; they usually occur in children and young adults, 
+often have a chronic course similar to that of pediatric and CT GISTs, and have 
+potential association with paraganglioma, necessitating long-term follow-up.
+
+DOI: 10.1097/PAS.0b013e3182260752
+PMCID: PMC3193596
+PMID: 21997692 [Indexed for MEDLINE]
+
+Most gastrointestinal stromal tumors (GISTs) occur in older adults and are driven by alternative KIT or PDGFRA receptor signaling activating mutations. However, 10–15% GISTs lack such mutations (are wild type in relation to those mutations). 12,14,20 These include three clinicopathologic subgroups: pediatric GISTs, those associated with neurofibromatosis type 1, and sporadic wild-type GISTs. 19,25,32 Rare examples of wild-type GISTs, mostly intestinal ones, have been reported to harbor BRAF mutations.2,16
+
+A newly described pathogenetic mechanism for GIST is the intratumoral loss- of-function of the succinate dehydrogenase (SDH) complex.17 In Carney-Stratakis syndrome (GIST and paraganglioma) and familial paraganglioma syndromes, loss-of-function SDHB, C, or D germline mutations are associated with a somatic loss of function alteration causing bi-allelic inactivation of SDH in tumor cells typical of classic tumor suppressor genes.22,28,35 In the non-hereditary Carney triad (GIST, paraganglioma and pulmonary chondroma) and most pediatric GISTs, the same end result occurs via currently unknown mechanisms. 35 Activation of pseudohypoxia signaling by overexpression of hypoxia inducible factor 1 alpha (HIF1α) is understood to be among the central events in the pathogenesis of SDH-deficient tumors. 17,18,31 It has also been shown that silencing of SDHB expression induces tumor-like phenotypic traits in cell cultures. 6
+
+Succinate dehydrogenase (succinate-coenzyme Q reductase or mitochondrial complex 2) consists of four subunit proteins: SDHA, SDHB, SDHC, and SDHD localized in the inner mitochondrial membrane. This complex acts at the interphase of the tricarboxylic acid cycle and electron transport chain. One of the subunits, SDHB, is a hydrophilic iron-sulphur protein, encoded by chromosomal DNA. 34
+
+SDHB is normally ubiquitously expressed with granular cytoplasmic immunostaining reflecting its mitochondrial location. 9,10 However, GISTs from patients with hereditary paraganglioma syndromes, Carney-Stratakis syndrome, Carney triad, and pediatric GISTs in general, have been found to be SDHB deficient based on small number of cases studied. 8,10,17 Loss of any subunit protein leads to the loss of SDHB expression due to destabilization of the SDH complex, and therefore SDHB loss is a marker for any bi-allelic loss of function of the succinate dehydrogenase complex (SDH-deficient GIST). 11,17 A similar role for SDH loss was previously discovered in paragangliomas. Many of them are also SDHB-negative generally reflecting loss-of-function germline mutations in one of the SDH-genes, which in combination with somatic loss-of-function of the other allele lead to silencing of one of the SDH-genes and functional loss of the SDH-complex. 9,26
+
+In this study, we report 66 SDH-deficient gastric GISTs among 1134 GISTs and examine their pathology, prognosis, and genetic background.
+
+Gastrointestinal stromal tumors from stomach (n = 756), small intestine (n = 265), rectum (n = 43), colon (n = 23), esophagus (n = 7), and of extragastrointestinal locations (n = 40), a total 1134 GISTs, were immunohistochemically examined for succinate dehydrogenase subunit B (SDHB) expression (retention or loss). The cases were derived from different institutions and included a major component of second opinion referrals. In most cases, the immunostaining was performed on multitumor blocks containing 5-60 tumors. However, in 10 cases with limited material, unstained slides, hematoxylin and eosin stained slides, or slides with previous negative immunostains were processed for SDHB immunostaining, especially from young patients. Twenty-six SDHB-negative cases were studied with an independent tissue array or conventional section, and the negative result was confirmed in each case. Some of the pediatric GISTs were previously reported 25, as was the cohort of SDHB-positive NF1-associated GISTs. 37
+
+In addition, 34 non-GIST mesenchymal tumors of the GI tract were also studied for SDHB-expression, including inflammatory myofibroblastic tumors, leiomyomas, leiomyosarcomas, schwannomas, plexiform fibromyxomas, and synovial sarcomas.
+
+The primary mouse monoclonal antibody to SDHB, 21A11 (ABCAM, Cambridge, Massachusetts) was used in a dilution of 1:1000. The immunostaining was performed using the Leica BondMax autostainer (Leica Microsystems, Bannockburn, IL) utilizing the BondMax avidin biotin free polymer-based detection system preceded by heat-induced epitope retrieval with Leica retrieval solution (alkaline buffer). Diaminobenzine was used as the chromogen. Only cases with positive internal control (vascular, lymhpohematopoietic, smooth muscle, or epithelial elements) were considered informative. Only 1% of cases were deemed uninformative and eliminated from further analysis.
+
+Immunostaining for KIT (polyclonal antibody A4502, Dako Cytomation, Carpinteria, CA), diluted 1:250, and DOG1/anoctamin1 (monoclonal antibody, clone K9, Leica), diluted 1:100, Desmin (clone D33, Dako), diluted 1:50, and CD34 (clone QBEnd/10), prediluted (Ventana Medical Systems, Tucson, AZ, were performed following similar epitope retrieval and procedure as described above. Smooth muscle actin (clone 1A4, Sigma Chemicals, St. Louis, MO), diluted 1:1600, and S100 protein (polyclonal, Dako Cytomation) diluted 1:1600, immunohistochemistry was performed similarly without epitope retrieval pretreatment.
+
+The gastrointestinal stromal tumors that were immunohistochemically negative for SDHB (all gastric) were analyzed histologically in detail: mitotic count/50 high power fields (corresponding to 5 mm2), plexiform/multinodular architecture, cellular components (epithelioid vs. spindle), cytologic atypia (especially pleomorphism), tumor necrosis, cytoplasmic vacuolization, nuclear palisading, lymphovascular invasion, and nodal metastases. Prognostic groups were assigned as previously described.24
+
+The gross features were recorded from available data, including tumor size, multiplicity, and possible metastases. Clinical follow-up was obtained from tumor registries, treating physicians, or in some cases from patients or family members. Follow-up information was available for 54 patients (range: <1–44 years, median, 14.7 years).
+
+DNA was obtained from formalin-fixed and paraffin-embedded tumor tissue. Mutational analysis of KIT and PDGFRA genes was performed as previously described.18 KIT exons 9, 11, 13 and 17, and PDGFRA exons 12, 14 and 18, mutational hot spots for GISTs, were PCR-amplified, and the products were sequenced directly. BRAF mutation analysis was performed to detect the previously reported exon 15 mutant. 2,16
+
+Molecular studies of SDH-genes were focused on selected coding and intronic sequences reportedly mutated in SDH-deficient GISTs. 17,28 SDHB exons 1, 3, 4, 6 and 7, SDHC exons 1 and 5, and SDHD exon 1, and intronic boundaries of all analyzed exons were PCR amplified and sequenced directly. These primer sequences and PCR conditions are listed in supplementary table available on-line.
+
+A total of 66 GISTs, all gastric, 8.7% of all 756 gastric GISTs studied, were immunohistochemically SDHB-negative (SDHB deficient GISTs). Because 10 patients were selected by age for analysis, we estimate the true frequency among all gastric GISTs as 7.5%. This patient group consisted mainly of children and young adults but included a small number of older adults (Fig. 1). The patient age range was 8–77 years (median, 22 years; mean, 37 years). Thirty three individuals were 21 years or younger. There was a significant overall female predominance: 47 females and 19 males, more prominent in the age groups < 21 years. However, there was an equal gender distribution in the age group ≥ 30 years (Table 1).
+
+The 66 SDHB-negative GISTs showed SDHB immunoreactivity only in non-neoplastic elements, such as vascular endothelial and smooth muscle cells, lymphohistiocytic cells, residual muscularis propria, or epithelial elements, such as hepatocytes. The tumor cells were negative for cytoplasmic granular staining, although they occasionally showed weak focal cytoplasmic blush of positivity (Fig. 2A–D).
+
+Most gastric GISTs, 690 of the total of 756 cases (91.2%), were immunohistochemically positive for SDHB showing granular cytoplasmic staining of various intensities (Fig. 2E–H). While SDHB-positive GISTs were rare in younger age groups, they overwhelmingly predominated in the older age groups (Fig. 1). There were only two patients with SDHB-positive gastric GISTs under the age of 21 years: a 16-year-old male and a 19-year-old female.
+
+All non-gastric GISTs were SDHB-positive (Table 2). This included all small intestinal GISTs (n = 265), sporadic and NF1-associated, regardless of patient age. All esophageal, colorectal, and extragastrointestinal GISTs were also SDHB-positive. With the exception of NF1-associated small intestinal GISTs (which contained a number of younger patients), the median ages in each site-related group were around 60 years or above.
+
+All 34 non-GIST mesenchymal tumors of the GI tract examined were SDHB positive. These included 9 intramural leiomyomas, 8 leiomyosarcomas, 6 inflammatory myofibroblastic tumors, 7 gastric schwannomas, and two each of gastric plexiform fibromyxomas and synovial sarcomas.
+
+Clinicopathologic features of the patients with SDH-deficient GISTs are summarized in Table 1. Most patients came to medical attention for symptoms related to gastrointestinal bleeding, and some were diagnosed based on vague abdominal complaints or ulcer symptoms. In one patient with ulcer symptoms prior to the endoscopy era, the GIST diagnosis was delayed by several years until it was detected as a palpable mass. None of the patients had family history of GIST or neurofibromatosis type 1.
+
+When stated, the tumors were located in the antrum (n= 20), lesser curvature (n=11), posterior wall/lesser sac (n = 2), and one each in the greater curvature/fundus, fundus, cardia or upper stomach. Multiple synchronous tumors were present in at least 12 patients.
+
+Two patients, both children, had pulmonary chondromas diagnosed simultaneously with the GIST in one case and 1 year later in the other case, originally suspected of metastatic disease. Two different patients had paragangliomas. One had an adrenal pheochromocytoma 24 years prior to GIST, and another had a carotid body paraganglioma 25.5 years after the first GIST. One additional patient had renal onkocytoma 40 years after the GIST. None of the patients were diagnosed with adrenal adenoma or esophageal leiomyoma.
+
+Multiple synchronous GISTs were detected in 12 patients. The size of the dominant tumor varied from 1.5–12 cm (median, 5.0 cm). The GISTs were typically described as multinodular or sometimes bilobed masses, often divided by apparent fibrous septa (Fig. 3). At least 7 larger tumors were centrally cystic. On sectioning the tumors varied from yellowish to pale tan to pink and brown, and many examples contained focal areas of hemorrhage.
+
+The tumors commonly involved muscularis propria as multiple apparently separate nodules, creating a “microplexiform” pattern (Fig 4A). Such an arrangement was seen in nearly all cases specifically evaluated for this feature (32/34). Ulceration was present in 19 of 45 cases.
+
+Epithelioid cytology dominated in 37 cases, 20 tumors had mixed epithelioid and spindle cell, 7 spindle cell, and 1 had extensively pleomorphic cytology. Most commonly the tumors featured the epithelioid hypercellular type characterized by high cellularity and back-to-back cells in dense sheets (n = 27). Although most cases showed rather uniform cytology, four tumors showed significant nuclear pleomorphism, and two of them had atypical mitoses (Fig. 4). Features commonly seen in adult GISTs, such as palisaded-vacuolated or sclerosing (spindle cell or epithelioid) morphology were only rarely encountered. Nuclear palisading (typically vague) was seen in only 9 cases, but vacuolization was detectable in most cases, usually focally. Only two tumors had coagulation necrosis; both patients had long survivals. None of the tumors revealed calcification of mucosal invasion.
+
+Two patients had omental/peritoneal micrometastases at presentation (Fig. 5B). Lymph node metastases were encountered in 5 of 12 cases in which lymph nodes where present and re-examined in this study (Fig. 5B). However, lymphovascular invasion around the tumor nodules was common and was seen in 17 of the 31 cases evaluated for this feature (Fig. 5C, D). In some cases, sharply demarcated micronodules in fact were intravascular tumor deposits, similar to those seen in some gastric glomus tumors.
+
+Immumohistochemically nearly all examined cases were extensively positive for KIT (52/53) and DOG1/Ano 1 (31/31), with >50% of tumor cells positive in each case. CD34 was detected in 44/52 cases (usually extensively), but muscle markers only rarely: SMA 1/51 case (focally), and desmin in 1/49 cases (in 3% of tumor cells). None of the 47 examined cases were S100 protein positive.
+
+All samples evaluated for KIT exons 9 (n = 30), 11 (n =31), 13 (n = 30), and 17 (n = 31), and PDGFRA exons 12 (n = 29), exon 14 (n = 24), and exon 18 (n = 29) were wild type. This was also true for BRAF exon 15 (n=16). No mutations were found in SDHB exons 1 (n=22), 3 (n=21), 4 (n=22), 6 (n=20) and 7 (n=22), and SDHC exons 1 (n=24) and 5 (n=23), and SDHD exon 1(n=23) coding sequences. All flanking intronic sequences except exon/intron 6 boundary, were evaluated. The latter could not be examined due to the lack of a compatible primer system for assaying formalin-fixed and paraffin-embedded tissue.
+
+Eleven patients developed one or more gastric recurrences or second primary tumors <1–33 years from presentation and underwent subtotal or total gastrectomy. Only one of these patients had liver metastases. Ten patients had liver metastasis, 3 of them at presentation. The longest interval from primary tumor to liver metastasis was 42 years. Eight patients had abdominal soft tissue metastases. Only one of them, who also had liver metastases, died of disease, but three patients survived for 10–17 years after peritoneal metastases. So far, 7 patients had died, all but one with known liver metastases, but 3 have survived for 10–18 years with liver metastases. Four of the 7 patients who died of tumor were males. Two patients who died of disease had mitotic rates < 5/50 HPFs. Four patients were known having received imatinib mesylate for 6 months to 7 years, and one patient underwent excision of abdominal metastases subsequent to imatinib response. No one was known having received sunitib malate.
+
+In this study we evaluated clinicopathologically 66 succinate dehydrogenase (SDH) deficient gastric GISTs, defined here by immunohistochemical negativity for SDHB, one of the normally ubiquitously expressed subunits of the SDH complex. Based on knowledge of the impact of loss of any SDH – subunits inactivation of the entire SDH complex in other tumors associated with SDH-deficiency, especially paragangliomas 11,17 – it is appropriate to designate this group as SDH-deficient GISTs.
+
+We found SDH-deficient GISTs exclusively among gastric GISTs (66/756, 8.7%). However, this overestimates the true frequency, as the analysis was in part targeted to GISTs of young patients. Based on an unselected sample, we estimate that the true frequency of SDHB-deficient GISTs among all gastric GISTs is 7.5%. While most GISTs in young patients (≤21 years of age) were SDH-deficient, approximately half of them in patients at ages 21–30 years were SDH-deficient, whereas this was only rarely the case in GISTs of older adults. Previous studies have found SDH-deficient (SDHB-negative) pediatric, Carney Triad or Carney Stratakis syndrome-associated GISTs 8,10,17 along with rare examples of similar adult GISTs (3%) in one study.10 While there was an overall female predominance, the gender distribution was equal in age groups > 30 years in our study.
+
+There are a number of histologic clues to SDH-negative status. These include epithelial hypercellular histology, plexiform growth pattern in the muscularis propria, and lymphovascular invasion and lymph node metastases that are otherwise rare in gastric GISTs. In fact, the “plexiform” muscularis propria involvement resembles that often seen in gastric glomus tumors, in some of the nodules may be intravascular.23 Similar patterns were recently also reported in rare adult GISTs resembling pediatric GISTs, but their SDHB-status was not known.33
+
+Immunohistochemically SDH-deficient GISTs are distinctive for strong KIT expression, in contrast to many gastric epithelioid GISTs that show weaker KIT expression. They also are more often CD34-positive than gastric epithelioid GISTs but almost never express alpha smooth muscle actin that is present in 23% gastric GISTs, at least focally. 24
+
+A molecular genetic clue to SDH-deficient GIST is lack of KIT and PDGFRA mutations (wild type), found here in all analyzed SDH-deficient GISTS, similar to previous observations on a smaller number of cases. 17 Also, these tumors seem to be unrelated to the rare KIT/PDGFRA-wild type GISTs carrying BRAF mutations found in adult patients, more often with intestinal GISTs. 2,16
+
+Clinical behavior of SDH-deficient GISTs largely mirrors pediatric and Carney triad GISTs due to their predominant occurrence at a young age. In our study cohort, 10 of 54 patients with follow-up (19%) developed liver metastases and 7 patients died of disease. Many patients were alive with disease during long-term follow-up. Long latency from primary tumor to metastasis is common, and the longest interval from primary tumor to liver metastasis was 42 years in our study, illustrating the chronic course and need for life-long follow-up. Gastric recurrences, very rare in adult gastric GISTs, are common in SDH-deficient GISTs often ultimately leading to subtotal gastrectomy; they do not seem to have adverse prognostic significance. Neither are lymphovascular invasion, lymph node metastases, or peritoneal micrometastases ominous signs in this group, as many patients with them survived for long times.
+
+SDH-deficient GISTs are unpredictable and metastatic disease may occur in tumors with favorable histologic parameters; two such patients died of disease. In our experience, many patients with metastatic GISTs ≤ 5 cm with mitotic counts ≤ 5/50 HPFs (group 2 GISTs) are SDH-deficient GISTs. On other hand, some patients with SDH-deficient GISTs with mitotic activity in excess of 10/50 HPFs, have uneventful survival again illustrating their unpredictability. The fact that 4 of 7 patients who died of tumor were male in this heavily female dominated group, may suggest that male patients have more aggressive course of disease. The very small number of older adults with SDH-deficient GISTs limits prognostic conclusions, although, with one exception, all patients had a favorable outcome. In many ways: tumor multiplicity, predilection to gastric antrum, potential occurrence of nodal metastases, chronic, somewhat unpredictable course but ultimately low long-term tumor mortality, SDH-deficient GISTs resemble Carney triad-associated and pediatric GISTs in general.5,25,32,38
+
+Carney triad (gastric GIST, pulmonary chondroma, and paraganglioma) is a non-hereditary tumor syndrome including at least of the following: gastric GIST, pulmonary chondroma, and paraganglioma, at varying time intervals. It has a strong predilection to young females.5,38 In this study, we identified only 2 patients with pulmonary chondroma and 2 other patients with paraganglioma. Even if the frequency of Carney triad may be underestimated in our series, the findings suggest that Carney triad is not very common among the SDH-deficient GISTs. Carney triad patients do not have SDH germline mutations, but SDH-deficiency may be mediated by allelic losses in SDH, and losses in chromosome 1p36, the locus of SDHB, may be the alternative mechanism for loss of function of the SDH complex. 21
+
+Carney-Stratakis syndrome (CSS) is a rare hereditary syndrome combining gastric GIST and paraganglioma. In contrast to Carney triad, it has a more equal gender distribution. The pathogenesis is based on a loss-of-function germline mutation in SDH subunits B, C, or D, and functional loss of the other allele based on currently poorly understood mechanisms. 28,29 Lack of familial tumor history and SDHB, C, or D (germline) mutations (analyzed in 10 patients in this study) suggests that SDHB-deficient GISTs are not commonly associated with CSS. However, we were not able to analyze DNA from two male patients with GIST and paraganglioma, good candidates for CSS. However, 54% of patients with paragangliomas, commonly SDH-deficient tumors, were found to have germline SDH mutations in one study. 3 In their rarity of SDH germline mutations, despite SDH-deficient status, GISTs differ from paragangliomas, for which SDH-deficiency generally signals a germline mutation. 26
+
+Very recently, loss-of-function SDHA germline mutations were reported in two gastric KIT/PDGFRA wildtype GISTs 27 indicating that mutations of this subunit should also be screened in SDH-negative GISTs. SDHA mutations have been previously found in one patient with a cathecholamine-secreting adrenal paraganglioma. 4 Previously SDHA loss-of function mutation was reported in Leigh syndrome featuring a severe neurodegenerative disorder. 15
+
+Renal onkocytoma was diagnosed in one patient with an SDH-deficient GIST. Renal cell carcinoma has been reported to be associated with SDHB paraganglioma syndrome, and this tumor is also otherwise known to be associated with pseodohypoxia pathway.36 Esophageal leiomyoma or adrenal adenoma, other tumors seen in Carney Triad, 5 were not encountered in our patients.
+
+The pathogenesis-based definition, SDH-deficient GIST, common to GISTs of Carney triad, Carney-Stratakis syndrome and pediatric GISTs in general, obtained by a single immunostain for SDHB, seems to be more efficient than the identification of a syndrome based on the accompanying tumors, paragangliomas and pulmonary chondromas, or young age only. First, different components of these syndromes can present over a long period of time making life-long follow-up necessary to observe the complete syndrome phenotype. Secondly, based knowledge on the related paraganglioma syndromes also associated with SDH-deficiency, these syndromes may have incomplete to low penetrance, perhaps in only 30%, making it more difficult to observe familial disease without germline mutation analysis. 13 Thirdly, there are pediatric GISTs other than SDH-deficient GISTs; these comprise the very rare non-gastric GISTs at a young age. Similar gene expression profiles reported in CT, CSS, pediatric GISTs, and a small number of adult GISTs also seem to support the unifying concept of SDH-deficient GIST. 1
+
+SDHB-deficient GISTs seem to exclusively occur in the stomach, and none of the GISTs from other locations were SDHB-negative. This included the rare non-gastric GISTs in young populations, NF1-associated GISTs, and sporadic, non-gastric wild-type GISTs, whose pathogenesis remains poorly understood. However, one report described two small intestinal (jejunal) GISTs in paraganglioma patients. 30 Although these cases were negative for SDH subunit mutations, immunohistochemical testing for SDHB was not yet available, leaving it open whether these jejunal GISTs were SDH-deficient.
+
+For treatment, patients with SDH-deficient GISTs should undergo complete tumor resection with attention to secondary lesions and peritoneal and nodal metastases. For adjuvant therapy, they may require different approach than KIT/PDGFRA mutated GISTs that typically respond to imatinib mesylate, the first line KIT tyrosine kinase inhibitor. Instead, second generation tyrosine kinase inhibitors, such as sunitib malate, may be more effective, as noted for pediatric GISTs.1 Lifelong follow-up is necessary for the potential of liver metastases and accompanying tumors, especially paragangliomas, for which also radiologic screening might be indicated. In this retrospective study, only a few patients received imatinib for some periods of time and no one sunitinib, so that data are insufficient for further comments on effectiveness of tyrosine kinase inhibitor treatment, especially in view of generally slow natural course of disease.
+
+In conclusion, we analyzed a series of 66 gastric SDH-deficient GISTs. Most patients were young, with a small population of older adults. Only 4 patients had accompanying tumors defining Carney triad, and none of the patients was found to have germline mutations of SDH subunits defining Carney-Stratakis syndrome. SDH-deficient GISTs are KIT/PDGFRA wild type, typically have plexiform muscularis propria involvement, epithelioid morphology, lymphovascular invasion, and some also have lymph node metastases. Multiple synchronous or asynchronous tumors are common leading to gastric recurrences. Potential, somewhat unpredictable development of liver metastases (in 20% of patients) after long latency and asynchronous paragangliomas necessitate long-term follow-up.

--- a/references_cache/PMID_31174229.md
+++ b/references_cache/PMID_31174229.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:31174229"
+title: Paragangliomas in Carney-Stratakis Syndrome.
+authors:
+- Khurana A
+- Mei L
+- Faber AC
+- Smith SC
+- Boikos SA
+journal: Horm Metab Res
+year: '2019'
+doi: 10.1055/a-0918-8340
+keywords:
+- Adult
+- "Chondroma/diagnosis, genetics, metabolism, pathology"
+- Female
+- "Gastrointestinal Stromal Tumors/diagnosis, genetics, metabolism, pathology"
+- Germ-Line Mutation
+- Humans
+- "Leiomyosarcoma/diagnosis, genetics, metabolism, pathology"
+- "Lung Neoplasms/diagnosis, genetics, metabolism, pathology"
+- Male
+- "Paraganglioma/diagnosis, genetics, metabolism, pathology"
+- "Paraganglioma, Extra-Adrenal/diagnosis, genetics, metabolism, pathology"
+- "Stomach Neoplasms/diagnosis, genetics, metabolism, pathology"
+content_type: abstract_only
+---
+
+# Paragangliomas in Carney-Stratakis Syndrome.
+**Authors:** Khurana A, Mei L, Faber AC, Smith SC, Boikos SA
+**Journal:** Horm Metab Res (2019)
+**DOI:** [10.1055/a-0918-8340](https://doi.org/10.1055/a-0918-8340)
+
+## Content
+
+1. Horm Metab Res. 2019 Jul;51(7):437-442. doi: 10.1055/a-0918-8340. Epub 2019
+Jun  7.
+
+Paragangliomas in Carney-Stratakis Syndrome.
+
+Khurana A(1), Mei L(1), Faber AC(2), Smith SC(3), Boikos SA(1).
+
+Author information:
+(1)VCU Massey Cancer Center - Hematology Oncology, Richmond, Virginia, USA.
+(2)Virginia Commonwealth University - Philips Institute for Oral Health 
+Research, Richmond, Virginia, USA.
+(3)Virginia Commonwealth University - Pathology, Richmond, Virginia, USA.
+
+Carney-Stratakis Syndrome (CSS) comprises of paragangliomas (PGLs) and 
+gastrointestinal stromal tumors (GISTs). Several of its features overlap with 
+Carney Triad (CT) - PGLs, GISTs, and pulmonary chondromas. CSS has autosomal 
+dominant inheritance, incomplete penetrance, and greater relative frequency of 
+PGL over GISTs. The PGLs in CSS are multicentric and GISTs are multifocal in all 
+the patients, suggesting an inherited susceptibility and associating the two 
+manifestations. In this review, we highlight the clinical, pathological, and 
+molecular characteristics of CSS, along with its diagnostic and therapeutic 
+implications.
+
+© Georg Thieme Verlag KG Stuttgart · New York.
+
+DOI: 10.1055/a-0918-8340
+PMID: 31174229 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no conflict 
+of interest.

--- a/references_cache/PMID_31773431.md
+++ b/references_cache/PMID_31773431.md
@@ -1,0 +1,139 @@
+---
+reference_id: "PMID:31773431"
+title: Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors.
+authors:
+- Neppala P
+- Banerjee S
+- Fanta PT
+- Yerba M
+- Porras KA
+- Burgoyne AM
+- Sicklick JK
+journal: Cancer Metastasis Rev
+year: '2019'
+doi: 10.1007/s10555-019-09818-0
+keywords:
+- Animals
+- "Gastrointestinal Neoplasms/enzymology, genetics, therapy"
+- "Gastrointestinal Stromal Tumors/enzymology, genetics, therapy"
+- Humans
+- Mutation
+- "Succinate Dehydrogenase/deficiency, genetics, metabolism"
+content_type: full_text_xml
+---
+
+# Current management of succinate dehydrogenase-deficient gastrointestinal stromal tumors.
+**Authors:** Neppala P, Banerjee S, Fanta PT, Yerba M, Porras KA, Burgoyne AM, Sicklick JK
+**Journal:** Cancer Metastasis Rev (2019)
+**DOI:** [10.1007/s10555-019-09818-0](https://doi.org/10.1007/s10555-019-09818-0)
+
+## Content
+
+1. Cancer Metastasis Rev. 2019 Sep;38(3):525-535. doi:
+10.1007/s10555-019-09818-0.
+
+Current management of succinate dehydrogenase-deficient gastrointestinal stromal 
+tumors.
+
+Neppala P(1), Banerjee S(2)(3), Fanta PT(4)(5), Yerba M(2), Porras KA(1), 
+Burgoyne AM(6), Sicklick JK(7)(8).
+
+Author information:
+(1)UC San Diego School of Medicine, University of California, San Diego, La 
+Jolla, CA, USA.
+(2)Division of Surgical Oncology, Department of Surgery, UC San Diego Moores 
+Cancer Center, University of California, San Diego, La Jolla, CA, USA.
+(3)Department of Surgery, David Geffen School of Medicine at UCLA, Los Angeles, 
+CA, USA.
+(4)Center for Personalized Cancer Therapy, UC San Diego Moores Cancer Center, 
+University of California, San Diego, La Jolla, CA, USA.
+(5)Division of Hematology-Oncology, Department of Medicine, UC San Diego Moores 
+Cancer Center, University of California, San Diego, La Jolla, CA, USA.
+(6)Division of Hematology-Oncology, Department of Medicine, UC San Diego Moores 
+Cancer Center, University of California, San Diego, La Jolla, CA, USA. 
+aburgoyne@ucsd.edu.
+(7)Division of Surgical Oncology, Department of Surgery, UC San Diego Moores 
+Cancer Center, University of California, San Diego, La Jolla, CA, USA. 
+jsicklick@ucsd.edu.
+(8)Center for Personalized Cancer Therapy, UC San Diego Moores Cancer Center, 
+University of California, San Diego, La Jolla, CA, USA. jsicklick@ucsd.edu.
+
+Gastrointestinal stromal tumors (GISTs) are increasingly recognized as having 
+diverse biology. With the development of tyrosine kinase inhibitors molecularly 
+matched to oncogenic KIT and PDGFRA mutations, GISTs have become a 
+quintessential model for precision oncology. However, about 5-10% of GIST lack 
+these driver mutations and are deficient in succinate dehydrogenase (SDH), an 
+enzyme that converts succinate to fumarate. SDH deficiency leads to accumulation 
+of succinate, an oncometabolite that promotes tumorigenesis. SDH-deficient GISTs 
+are clinically unique in that they generally affect younger patients and are 
+associated with GIST-paraganglioma hereditary syndrome, also known as 
+Carney-Stratakis Syndrome. SDH-deficient GISTs are generally resistant to 
+tyrosine-kinase inhibitors, the standard treatment for advanced or metastatic 
+GIST. Thus, surgical resection is the mainstay of treatment for localized 
+disease, but recurrence is common. Clinical trials are currently underway 
+investigating systemic agents for treatment of advanced SDH-deficient GIST. 
+However, further studies are warranted to improve our understanding of 
+SDH-deficient GIST disease biology, natural history, surgical approaches, and 
+novel therapeutics.
+
+DOI: 10.1007/s10555-019-09818-0
+PMCID: PMC6903702
+PMID: 31773431 [Indexed for MEDLINE]
+
+Gastrointestinal stromal tumors (GIST) are the most common sarcoma, affecting 6.8 per million people annually in the United States [1]. GIST arise from interstitial cells of Cajal, which are pacemaker cells in the gut that control the slow wave of smooth muscle contraction [2]. GIST can arise anywhere in the gastrointestinal tract but occur most often in the stomach and small bowel [3–5]. They also can have histopathologic heterogeneity ranging from spindeloid to epithelioid to mixed histologies [6–8]. Moreover, GIST are driven by a variety of oncogenic driver or loss of function mutations, making them molecularly diverse [3, 4].
+
+Before the advent of targeted cancer therapies, the prognosis for GIST was poor given their resistance to conventional chemotherapy and radiation [9]. In 1998, gain of function mutations in KIT were identified. These mutations activate the receptor tyrosine kinase c-KIT via ligand-independent receptor dimerization, which promotes downstream signaling. This leads to unchecked tumor cell growth and survival [10]. We now know that 70–80% of GIST have mutations in KIT or another receptor tyrosine kinase, PDGFRA [11, 12]. Tyrosine kinase inhibitors such as imatinib target mutations in KIT and PDGFRA and are the mainstay of treatment. Therefore, GIST have become an important proof-of-principle model for precision therapy in cancer patients [9, 13].
+
+Further studies of the molecular biology of GIST have identified additional GIST subsets caused by mutations of K/H/N-RAS, BRAF, and NF1, as well as gene fusions of FGFR1 and ETV6-NTRK3 [12, 14–17]. Additionally, another 5–10% of GIST have mutations in succinate dehydrogenase (SDH) subunits [18, 19]. Mutations in SDH subunits have been linked to a number of cancers. More importantly, they were first linked to GIST in the setting of hereditary GIST-paraganglioma syndrome, also known as Carney-Stratakis syndrome [20].
+
+The median age of diagnosis of GIST is 64 years old, but SDH-deficient GIST usually first appear in children, adolescents, and young adults [1]. However, patients in their 40s to late 50s also can present with an initial diagnosis of SDH-deficient GIST (Sicklick, unpublished data). Over 80% of pediatric GIST have inactivating mutations in SDH subunits [20–22]. Females are reported to be disproportionately affected [18]. However, in our practice of young adults with GIST, we have observed a higher proportion of male patients with SDH mutations (Fanta, Burgoyne, and Sicklick, unpublished data).
+
+SDH-deficient GIST generally arise in the stomach. The clinical presentation is often non-specific, which leads to a delay in diagnosis. Many patients with GIST are diagnosed after presenting with severe epigastric pain or gastrointestinal bleeding due to ulceration [19, 23]. This is consistent with the indolent biology of these tumors. In fact, often patients present with gastric recurrences and lymph node metastases later in life, a phenomenon that is less common in SDH-competent GIST. Recurrence often leads to repeat partial gastrectomy [19, 24]. Histology often shows epithelial hypercellularity and lymphovascular invasion, as well as multifocality, which is also rarer in KIT/PDGFRA-mutated GIST. Thus, the natural history and biology of these SDH-deficient tumors is distinct from their oncogene-driven counterparts.
+
+The SDH complex is a component of complex II in the Krebs cycle, a process that connects glycolysis in the cytoplasm to oxidative phosphorylation in the mitochondria (Figure 1). This complex resides in the inner mitochondrial membrane and has four subunits, encoded by the SDHA, SDHB, SDHC, and SDHD genes. In mammalian mitochondria, SDHA forms the catalytic core, while SDHB forms an iron sulphur protein, and SDHC/SDHD are integral membrane proteins (Figure 2) [25, 26].
+
+Although SDH is an essential part of normal cellular metabolism, SDH-deficient cancer cells continue to proliferate, suggesting that metabolic variability must exist in these cells. Bioinformatic analysis of SDH mutated pheochromocytomas and paragangliomas (PPGLs) revealed that these cells become highly dependent on aspartate through increased pyruvate carboxylation [27]. In fact, deficiency of SDHB has been shown to lead to a complete block of the Krebs cycle, with cells consuming extracellular pyruvate and deriving most energy needs through glycolysis alone. In these cells, pyruvate carboxylase activity is crucial for continued growth [28].
+
+The SDH complex is involved in the conversion of succinate to fumarate during cellular respiration. Tumors with inactivating mutations in SDHx genes lack a functional SDH complex, losing the ability to convert succinate to fumarate. Thus, they are considered to be SDH-deficient. In 1977, SDH deficiency was first described in a mutant Chinese hamster fibroblast cell line [29]. Lack of SDH in this system resulted in a defect of oxidative phosphorylation, as well increased cellular reliance on glycolysis for energy metabolism. SDHx mutations were first linked to cancer in 2000 when germline mutations in SDHD were reported in hereditary paraganglioma [30]. Since that time, SDHx mutations have been implicated in a number of tumor types including carcinomas (i.e., renal cell, thyroid) and other neuroendocrine tumors (i.e., neuroblastoma, paraganglioma, pheochromocytoma) [31–34], as well as GIST.
+
+Mutations in SDHx result in an accumulation of succinate. Similarly, deficiency of fumarate hydratase (FH) results in an accumulation of fumarate. Both succinate and fumarate have been implicated as oncometabolites, a term used to describe how these metabolites dysregulate oxygen-dependent signaling in the tumor microenvironment [35–37]. Under normoxic conditions, hypoxia-inducible factor 1α (HIF1α) is hydroxylated by prolyl hydroxylase domain (PHD) proteins, via an oxygen-dependent reaction that converts α-ketoglutarate (α-KG) to succinate, which in turn targets HIF1α for proteasome-mediated degradation. In hypoxic conditions such as those within a tumor environment, HIF1α accumulates and translocates into the nucleus where it complexes with HIF1β to promote the transcription of genes involved in angiogenesis, proliferation, and glycolysis [38]. However, deficiency of either SDH or FH leads to the accumulation of succinate or fumarate, respectively, inhibiting PHDs and leading to the stabilization and accumulation of HIF1α in normoxic conditions [37][39]. Such HIF1α activation under normoxic conditions is termed pseudohypoxia. In this setting, HIF1α activation supports increased angiogenesis and glycolysis, processes that enhance tumor growth. Furthermore, the exogenous administration of α-KG allows PHDs to overcome inhibition by succinate in SDH-deficient tumor cells through a concentration-dependent manner [40]. This suggests α-KG may be a potential therapeutic target in SDH-deficient GIST.
+
+Epithelial-to-mesenchymal transition (EMT) describes the process of epithelial cancer cells taking on mesenchymal features. EMT is important for embryonic development and wound healing, but in the setting of tumor biology, it leads to the invasion of cancer cells and eventual metastasis. Over the last decade, there has been emerging knowledge regarding the role of Krebs cycle enzymes and mitochondrial dysfunction in EMT [41].
+
+SDH was first implicated in increased EMT in mouse cancer ovarian cells. Knockdown of SDHB led to increased proliferation and EMT. This was found to occur through transcriptional upregulation of genes involved in methylation, leading to a hypermethylated epigenome. SDHB deficiency also correlated with the downregulation of genes involved in oxidative phosphorylation, as well as an increased utilization of glucose in the pentose phosphate pathway (PPP) and glutamine in the Krebs cycle [42]. Of note, glutamine dependence correlates with invasion potential in ovarian cancer cells [43]. In mouse chromaffin cells, SDHB knockdown led to the activation of transcription factors important in EMT, which are also preferentially expressed in PPGLs. The cells took on an invasive phenotype, appearing to have undergone EMT [44].
+
+The SDHC subunit has also been linked to EMT. In breast cancer tumors, increased expression of EMT genes, such as TWIST and SNAI2 (SLUG), has been correlated with decreased expression of SDHC. Moreover, knockdown of SDHC in breast cancer cells using the CRISPR/Cas9 system induced EMT. SDHC-deficient breast cancer cells had increased expression of mesenchymal markers, such as vimentin and TWIST, as well as decreased expression of the epithelial marker, E-cadherin. Morphologically, these cells had decreased cell-cell adherence and stability in size, which is more in line with a mesenchymal phenotype. Furthermore,, overexpression of TWIST and SNAI2 caused decreased expression of SDH, as well as decreased mitochondrial respiration and biomass [45].
+
+SDHA is the most common mutation leading to SDH-deficient GIST, occurring in up to 30% of cases [46]. Loss of function mutations of SDHA were first identified in an isolated case of abdominal paraganglioma [47]. In 2011, sequencing of sporadic non-KIT/PDGFRA-mutated GIST revealed germline mutations in SDHA [48]. Miettinen and colleagues further classified these SDHA germline mutations using immunohistochemistry. Tumors with SDHA mutations were found to be devoid of mutations in the other SDH subunits. However, these tumors were SDHB-deficient on immunohistochemistry, making this a reliable tool for identifying SDHA-mutant GISTs. Patients with SDHA-mutant tumors tend to have an older median age (34 years old) versus SDH-deficient GIST from other subunit mutations (21 years old) [46].
+
+With the increased use of molecular testing and next generation sequencing (NGS), many SDHA variants of unknown significance (VUS) have been identified. In 2017, Bannon and colleagues reported the creation of a yeast model to determine the functional significance of 22 of these variants on mitochondrial function. Their screen identified pathogenic VUS sequences that resulted in decreased expression of SDH and defective oxidative phosphorylation. They determined that 16 (73%) of the alterations are actually pathogenic, resulting in loss of SDH function. The remaining six (27%) have no effect on SDH function [49]. Thus, we continue to learn about the functional significance and previous underappreciation of these alterations.
+
+Defects of other SDHx genes in non-KIT/PDGFRA mutated GIST were first reported in 2011 by Janeway and colleagues. This group demonstrated germline mutations in SDHB and SDHC lead to deficient SDHB expression, while most KIT-mutated GIST have conserved expression of SDHB protein [18]. Germline mutations in SDHB, SDHC, and SDHD occur in only 20–30% of SDH-deficient GIST [24]. Currently, SDHB immunohistochemistry is used to identify all SDH-deficient GIST.
+
+Almost 50% of SDH-deficient GIST lack mutations in the genomic sequencing of SDHx subunits. However, DNA methylation analyses of SDH-deficient GIST have revealed hypermethylation of the SDHC promoter sequence. The frequency of SDHC hypermethylation in non-KIT/PDGFRA-mutated GIST appears to be similar to that of coding mutations in SDHx subunit sequences. There are no reported simultaneous cases of SDHC genomic mutation and hypermethylation [50].
+
+Epigenetic mutations in SDHx are also seen in the Carney Triad, a GIST syndrome in young females notable for development of gastric GIST, pulmonary chondroma, and paraganglioma [51]. The features of concurrent GIST and paragangliomas, as well as loss of SDHB by immunohistochemistry are shared with Carney-Stratakis Syndrome. However, no germline mutations in SDHx have been identified in Carney Triad patients, suggesting that it is not a heritable condition. Tumors in these patients exhibit hypermethylation of the SDHC promoter sequence, leading to loss of SDHC protein expression and functional SDH deficiency [52, 53]. The identification of this hypermethylation phenomenon raises the hypothesis that demethylating agents may have therapeutic potential in SDH-deficient GIST.
+
+Surgical resection continues to be a mainstay of treatment for all GIST [54]. Generally, surgical resection of primary tumors is considered when the tumor is bleeding, causing obstruction, larger than 2 cm, or is increasing in size [55]. Resection of primary tumor with negative margins is achieved in 85% of patients, but recurrence or progression within 5 years is common. This suggests that surgical resection alone is not adequate for curative treatment of GIST [56]. Currently, guidelines do not exist for surgical management of GIST based on genetic mutations.
+
+Only recently has the population of pediatric GIST patients been identified as a group of patients with genetically-distinct tumors that likely require unique treatment approaches. The majority of pediatric patients have non-KIT/PDGFRA-mutated GIST [57]. Most treatments for pediatric GIST take place in the context of clinical trials and tertiary care centers [58]. Surgical resection is aimed at an organ-sparing resection of primary tumor. Given the increased incidence of lymph node metastases in non-KIT/PDGFRA-mutated GISTs, sampling of draining lymph node basins is recommended [22]. Close follow up after surgery is also necessary due to high recurrence rates [58].
+
+A retrospective study of young adult and adolescents with GIST in the SEER database showed that this population was more likely to receive surgical treatment. Young adults and adolescents had improved overall survival, as well as GIST-specific survival following surgical resection. In the same study, it was found that GIST located in the stomach had poorer outcomes than those found in small intestine [59]. It is noteworthy that SDH-deficient GIST are primarily found in the stomach. However, this study did not include stratification by genetic mutations limiting its application to the treatment for SDH-deficient GIST.
+
+In 2017, the results of a retrospective analysis from the NIH Pediatric and Wild-type GIST clinic were reported [60]. This study was the first to evaluate surgical management of exclusively non-KIT/PDGFRA mutated GISTs. Analysis of 76 patients who underwent surgery found median event-free survival (EFS) to be 2.5 years with 71% of patients experiencing tumor recurrence or disease progression. The EFS was negatively affected by an elevated mitotic index and by the presence of metastases. Interestingly, negative resection margins and neoadjuvant or adjuvant treatment did not appear to affect EFS. SDH-deficient and SDH-competent tumors were only stratified for the outcome of EFS in a limited number of patients, with other variables such as metastases not being evaluated. Taken together, the results suggest that surgical resection of non-KIT/PDGFRA-mutated tumors may not be of benefit to some patients. However, given the inherent limitations of retrospective analysis, it is difficult to make any definitive recommendations for the surgical management of SDH-deficient GIST from the available data. But, with all surgical decision making, the morbidities should be weighed against the benefits of resection on an individualized basis.
+
+The tyrosine kinase inhibitor (TKI) imatinib is used as adjuvant therapy after surgical resection in high risk patients treated with curative intent and as first-line systemic therapy for metastatic patients [54, 61]. Although imatinib is very effective in treating KIT/PDGFRA-mutant GISTs, SDH-deficient GIST are largely resistant to TKIs due to the absence of gain-of-function tyrosine kinase mutations [18, 62]. Sunitinib is a TKI approved for the treatment of imatinib-resistant GIST [63]. Sunitinib inhibits the ATP-binding domains of KIT and PDGFRA, a property shared with imatinib. Unlike imatinib, sunitinib also inhibits VEGFR, which leads to blockade of angiogenesis. Sunitinib has been shown to increase progression-free and overall survival in advanced non-KIT/PDGFRA-mutated GIST after imatinib failure, possibly due to these added anti-angiogenic properties [64]. Unfortunately, primary and secondary resistance to sunitinib develops in almost all GIST patients with a median of 24 months after initiation of first-line treatment and 6–9 months after second-line treatment. The TKI regorafenib is approved for treatment of GIST after failure of imatinib and sunitinib. In a phase II study of third-line regorafenib, 2 out of 6 patients with SDH-deficient GIST had a partial response [65]. In a 2014 phase II study of another TKI targeting VEGFR, pazopanib, the authors describe a patient with SDH-deficient GIST who experienced a 20% reduction of tumor size after failing sixth-line therapy [66]. However, most current studies continue to demonstrate the limited efficacy of TKIs in SDH deficient GIST (Table 1).
+
+Traditional cytotoxic chemotherapy has had limited success in GIST patients. One example is temozolomide, an alkylating agent with demonstrated anti-tumor activity in soft tissue sarcomas [67]. Temozolomide appears to be ineffective in treating unselected GIST patients. Two different studies have evaluated the efficacy of temozolomide in GIST patients, both showing an objective response rate of 0% [68, 69]. However, a 2014 study of 15 patients with paraganglioma and pheochromocytoma demonstrated that 50% of SDHB-mutated patients had a partial response to temozolomide by RECIST 1.1 criteria [70, 71]. On the other hand, 0% of the SDHB wild-type patients had partial responses, with 40% having stable disease and 60% having progressive disease [70]. This suggests that SDHB mutations may be a biomarker for temozolomide sensitivity in paraganglioma and pheochromocytoma. The response of temozolomide has yet to be formally tested in SDH-deficient GIST patients. However, given SDH-deficient GIST and hereditary paragangliomas/pheochromocytomas share genomic mutations and inheritance patterns, we speculate that SDH-deficient GIST may have a response to temozolomide treatment. Our group at UC San Diego has recently opened Phase II clinical trial to investigate this hypothesis (ClinicalTrials.gov identifier ).
+
+As discussed above, hypermethylated promoter sequences in the SDHC gene leads to SDH deficiency. Furthermore, SDH deficiency in paragangliomas has been linked to the hypermethylation of target genes involved in chromaffin cell differentiation [72]. Thus, the use of DNA hypomethylating agents is under investigation for SDH-deficient cancers. A phase II clinical trial of the DNA methyltransferase inhibitor, guadecitabine, is currently recruiting participants with non-KIT/PDGFRA-mutated GIST and SDH-deficient paragangliomas and pheochromocytomas (ClinicalTrials.gov identifier ).
+
+Although the body of literature on the management of SDH-deficient GIST is limited, the increasing fund of knowledge regarding the metabolic role of SDH may lead to novel treatment approaches. A HIF2α small molecule inhibitor, PT2385, has recently been identified and has been shown to act as a transcription factor-specific antagonist, inhibiting the expression of HIF2α specific genes. In mice with renal cell carcinoma, treatment with PT2385 significantly reduced tumor burden [73]. In a recent phase I study of heavily pretreated clear cell renal carcinoma patients, PT2385 showed a favorable side-effect profile and some efficacy, with an observed 14% objective response rate [74]. Given SDH deficiency in implicated in HIF1α stabilization in tumor cells, anti-hypoxics may play a role in SDH-deficient GIST treatment.
+
+According to the 2019 NCCN guidelines for soft tissue sarcomas, KIT and PDGFRA genetic testing should be considered for all patients with GIST that are to be treated with systemic agents. Subsequently, for non-KIT/PDGFRA mutated GISTs, SDHB immunohistochemistry is recommended. Germline testing is recommended for all SDH-deficient GISTs.
+
+Currently, there are no clear surveillance guidelines for follow-up for SDH deficient GIST, but follow-up should parallel that of the general GIST population. For all GIST patients with completely resected disease, follow-up with physical exams and cross sectional imaging (i.e., CT or MRI) of the abdomen/pelvis is recommended every 3–6 months for the first 5 years and then annually.
+
+Given their predisposition to various cancers, there is a question of whether asymptomatic SDHx mutation carriers require surveillance. Recently, the results were reported of an annual surveillance program of 65 asymptomatic SDHB mutation carriers at a tertiary care center in the United Kingdom. All patients underwent annual MRIs of the abdomen with every other year MRIs of the neck, pelvis and thorax. Within 6 years, 25% had developed SDHB-related cancers with 16.6% having an asymptomatic tumor at the time of their first surveillance scan [75]. Of note, SDHB mutations are associated higher rates of pheochromocytoma and paragangliomas (PPGLs) [76, 77]. Patients with SDHD mutations were found to have a younger age of penetrance and were more likely to develop multifocal disease [78, 79]. In addition, SDHB and SDHD mutant PPGLs often secrete norepinephrine and dopamine or secrete only dopamine [80, 81]. Dopamine-only [82, 83]Currently there is no available data regarding surveillance in SDHA and SDHC mutation carriers. However, given the difference in malignancy phenotypes between SDHB and SDHD mutation carriers, the argument can be made that surveillance recommendations should take into account which SDH subunit is mutated [84].
+
+SDH-deficient GIST are largely resistant to tyrosine kinase inhibitor therapy and lack effective treatment options. However, the understanding of the role of succinate dehydrogenase in tumorigenesis continues to expand. This knowledge can be applied to develop novel treatment approaches to SDH-deficient GIST with an emphasis on the use of precision medicine to treat this unique set of cancers.

--- a/references_cache/PMID_34012423.md
+++ b/references_cache/PMID_34012423.md
@@ -1,0 +1,150 @@
+---
+reference_id: "PMID:34012423"
+title: "Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency."
+authors:
+- Pitsava G
+- Settas N
+- Faucz FR
+- Stratakis CA
+journal: Front Endocrinol (Lausanne)
+year: '2021'
+doi: 10.3389/fendo.2021.680609
+keywords:
+- Adrenal Gland Neoplasms/genetics
+- Chondroma/genetics
+- Gastrointestinal Neoplasms/genetics
+- Gastrointestinal Stromal Tumors/genetics
+- Humans
+- Leiomyosarcoma/genetics
+- Lung Neoplasms/genetics
+- Paraganglioma/genetics
+- "Paraganglioma, Extra-Adrenal/genetics"
+- Pheochromocytoma/genetics
+- Stomach Neoplasms/genetics
+- "Succinate Dehydrogenase/deficiency, genetics"
+content_type: full_text_xml
+---
+
+# Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH Deficiency.
+**Authors:** Pitsava G, Settas N, Faucz FR, Stratakis CA
+**Journal:** Front Endocrinol (Lausanne) (2021)
+**DOI:** [10.3389/fendo.2021.680609](https://doi.org/10.3389/fendo.2021.680609)
+
+## Content
+
+1. Front Endocrinol (Lausanne). 2021 May 3;12:680609. doi: 
+10.3389/fendo.2021.680609. eCollection 2021.
+
+Carney Triad, Carney-Stratakis Syndrome, 3PAS and Other Tumors Due to SDH 
+Deficiency.
+
+Pitsava G(1)(2), Settas N(2), Faucz FR(2), Stratakis CA(2).
+
+Author information:
+(1)Division of Intramural Population Health Research, Eunice Kennedy Shriver 
+National Institutes of Child Health and Human Development, National Institutes 
+of Health, Bethesda, MD, United States.
+(2)Section on Endocrinology and Genetics, Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, National Institutes of Health, 
+Bethesda, MD, United States.
+
+Succinate dehydrogenase (SDH) is a key respiratory enzyme that links Krebs cycle 
+and electron transport chain and is comprised of four subunits SDHA, SDHB, SDHC 
+and SDHD. All SDH-deficient tumors are caused by or secondary to loss of SDH 
+activity. As many as half of the familial cases of paragangliomas (PGLs) and 
+pheochromocytomas (PHEOs) are due to mutations of the SDHx subunits. 
+Gastrointestinal stromal tumors (GISTs) associated with SDH deficiency are 
+negative for KIT/PDGFRA mutations and present with distinctive clinical features 
+such as early onset (usually childhood or adolescence) and almost exclusively 
+gastric location. SDH-deficient GISTs may be part of distinct clinical 
+syndromes, Carney-Stratakis syndrome (CSS) or dyad and Carney triad (CT). CSS is 
+also known as the dyad of GIST and PGL; it affects both genders equally and is 
+inherited in an autosomal dominant manner with incomplete penetrance. CT is a 
+very rare disease; PGL, GIST and pulmonary chondromas constitute CT which shows 
+female predilection and may be a mosaic disorder. Even though there is some 
+overlap between CT and CSS, as both are due to SDH deficiency, CSS is caused by 
+inactivating germline mutations in genes encoding for the SDH subunits, while CT 
+is mostly caused by a specific pattern of methylation of the SDHC gene and may 
+be due to germline mosaicism of the responsible genetic defect.
+
+Copyright © 2021 Pitsava, Settas, Faucz and Stratakis.
+
+DOI: 10.3389/fendo.2021.680609
+PMCID: PMC8126684
+PMID: 34012423 [Indexed for MEDLINE]
+
+Conflict of interest statement: CAS holds patent on the PRKAR1A, PDE11A, and 
+GPR101 genes and/or their function and his laboratory has received research 
+funding from Pfizer Inc. FRF holds patent on the GPR101 gene and/or its 
+function. CAS is receiving compensation by ELPEN, Inc. Neither Pfizer, Inc nor 
+ELPEN, Inc had any role in the study design, data collection and analysis, 
+decision to publish, or preparation of the manuscript. The remaining authors 
+declare that the research was conducted in the absence of any commercial or 
+financial relationships that could be construed as a potential conflict of 
+interest.
+
+Succinate dehydrogenase (SDH - also known as mitochondrial complex II or succinate-ubiquinone oxydoreductase) is the only enzyme that is concurrently both a functional member of both the Krebs cycle (or citric acid or tricarboxylic acid cycle) and the electron transport chain (ETC), where it provides electrons for oxidative phosphorylation (1). It is comprised of four mitochondrial subunit proteins: SDHA, SDHB, SDHC, SDHD encoded by nuclear genes, mapped to 5p15.22, 1p36.13, 1q23.3 and 11q23.1, respectively (Figure 1). SDHA is a flavoprotein and SDHB is an iron-sulfur protein; together they make up the main catalytic component of the complex. The other two subunits, SDHC and SDHD are two integral membrane proteins that anchor the complex to the inner mitochondrial membrane (3, 4). Additionally, the succinate dehydrogenase assembly factor 2 (SDHAF2) is required for the flavination and thus normal function of SDHA (4).
+
+Succinate dehydrogenase (Complex II). Figure modified from Settas et al. (2).
+
+Genetic alterations in any of the four SDHx genes (SDHA, SDHB, SDHC, SDHD) or SDHAF2 lead to SDH complex dysfunction and loss of SDHB expression (5). This loss of SDHB can be detected rapidly by immunohistochemistry (IHC) and thus, loss of immunohistochemical staining for SDHB is used as the hallmark of SDH-deficient tumors (6–9).
+
+It is not completely clear how the dysfunction of SDH leads to neoplasia; several mechanisms have been proposed. One of them is the activation of pseudohypoxia pathway (10). This mechanism implies that due to SDH deficiency, succinate is accumulated; this inhibits propyl hydroxylases (PHDs) resulting in induction of the hypoxic response despite normoxic conditions (pseudohypoxia) (11, 12). At the cellular level, the three α subunits of the hypoxia inducible factor-1 (HIF-1α, HIF2α, HIF3α), are hydroxylated by PHDs 1, 2 and 3 (also known as Egln2, Egln1 and Egln3), which are oxygen-dependent enzymes. The hydroxylated HIFαs are then targeted by von Hippel-Lindau (VHL) protein for degradation in the proteasome. In order for the HIFs to be recognized by the VHL, hydroxylation of two proline residues on HIFα is required by PHDs. In the case that the SHDx genes are mutated, propyl hydroxylases are inhibited by the accumulated succinate, hydroxylation of HIF-1αs is decreased and therefore they escape degradation. As a result, they translocate to the nucleus, they dimerize with HIFβ and create a complex that activates genes that induce angiogenesis, cell proliferation and glycolysis (12, 13). This mechanism was further supported by additional studies (12, 14–17). Additionally, besides succinate, the accumulation of reactive oxygen species (ROS) in mitochondria, leading to loss of function of the SDH enzyme, has also been implicated in tumor pathogenesis. ROS are mainly produced in complex I (NADH-ubiquinone oxidoreductase) and complex III (ubiquinone-cytochrome c oxidoreductase) in ETC (18). Recently, Xiao et al. demonstrate that SDHx knockdown increases intracellular levels of succinate; subsequently, this acts as an alpha-ketoglutarate competitor, inhibiting a-KG-dependent dioxygenases, JIp1, which is involved in sulfur metabolism and Jhd1 which belongs to the JmjC-domain-containing histone demethylase (JHDM) enzymes. That could lead to tumor formation by causing epigenetic changes (11, 19). The corresponding human JHDM, JMJD2D, was shown to be inhibited by accumulation of succinate as well (20).
+
+Mutations in the SDHx subunits have been implicated in familial paragangliomas (PGLs) and pheochromocytomas (PHEOs), gastric stromal tumors (GISTs), Carney-Stratakis syndrome (CSS), and rarely in Carney triad (CT) and a few other tumors (21–30). This review focuses on SDH-deficient tumors, the two relevant genetic conditions, CSS and CT, and an association (3PAS), and their clinical, pathological and molecular characteristics.
+
+Pheochromocytomas and paragangliomas are rare neuroendocrine neoplasms derived from chromaffin cells (31). Tumors arising from the adrenal medulla, which is the largest paraganglion in the body, are termed PHEOs, while those derived from the sympathetic and parasympathetic paraganglia are known as PGLs (31). Extraadrenal locations most commonly include the head and neck, mainly the carotid body, jugular foramen, middle ear, but can also occur in the thorax, abdomen and pelvis (32). PGLs/PHEOs can be either sporadic or hereditary. As many as 35% of them are due to genetic predisposition (33). To date, more than 20 susceptibility genes have been identified (34). Germline mutations of SDHB, SDHC, and SDHD genes are responsible for approximately 50% of hereditary paragangliomas (4, 24, 25, 35–38) and pheochromocytomas (24, 36, 39). Recently, mutations in SDHA (21) and SDHAF2 were also identified in hereditary PHEOs and PGLs (40). In addition, multiple reports have shown that these tumors have high incidence in patients with cyanotic congenital heart disease (41–43).
+
+Depending on the SDHx subunit that is mutated, PGL syndromes have different characteristics (Table 1): SDHD (PGL1) (OMIM#168000)-mutated PGLs are more common in the head and neck and appear to have very high lifetime penetrance as 75% of carriers will have manifestations by 40 years old (44). Mutations in SDHB gene as the susceptibility gene for PGL4 (OMIM#115310) are more likely to be in the abdomen and show very high metastatic risk, but lower penetrance compared to PGL1 (~40% of carriers manifest the disease by age 40) (45). On the other hand, in SDHC (PGL3) (OMIM#605373) gene mutations, much rarer than the previous two, tumors are more commonly located in the carotid body (35, 46, 47) and have a low malignant potential (45). Mutations in SDHA and SDHAF2 are associated with PGL5 (OMIM#614165) and PGL2 (OMIM#601650) respectively and are very rare. A patient with any type of PGL will present in any of the following contexts: a) because of signs and/or symptoms of excess catecholamine secretion (e.g. hypertension, headache, palpitations, hyperhidrosis, tremor); b) because of an incidental finding on an imaging study; c) because of signs and/or symptoms due to a local mass (various signs and/or symptoms depending on the location); and d) after a genetic testing was performed in the case of familial disease. Histologically, SDH-deficient PHEOs/PGLs have a nested architecture with round cells and prominent vasculature (4).
+
+Characteristics of SDH-deficient pheochromocytoma and paraganglioma.
+
+AD, autosomal dominant; GIST, gastrointestinal stromal tumor; PCH, pulmonary chondroma; PGL, paraganglioma; RCC, renal cell carcinoma.
+
+PHEOs can occur as part of PGL1 and PGL4 and about 3% of them are attributed to SDH deficiency (6). The rest of them are either sporadic or they are associated with other familial syndromes such as VHL, MEN2 and NF. What could differentiate SDH-deficient PHEOs is the negative SDHB IHC and the secretion solely of noradrenaline (and/or dopamine) in contrast to the others that secret both adrenaline and noradrenaline (47). In addition, PHEOs caused by SDHB mutations show higher malignancy risk (47).
+
+Family history is not always helpful in predicting hereditary PHEOs/PGLs because of phenotypic heterogeneity, incomplete penetrance and in the case of PGL1 and PGL2, maternal imprinting (5, 25, 48). It is interesting that in PHEOs/PGLs that appear to be sporadic based on family history, germline mutations were found in up to 25% of cases (49–51). Therefore, all patients with PHEOs/PGLs (sporadic and hereditary cases) should undergo genetic testing and counseling after IHC is performed (5, 6).
+
+GISTs are the most common neoplasms of the gastrointestinal tract of mesenchymal origin and more than 5000 cases are diagnosed each year in the US alone (52). They originate from the interstitial cells of Cajal (53), the pacemaker cells that regulate peristalsis in the digestive tract (54). Most GISTs occurring in adults are driven by activating mutations in KIT proto-oncogene receptor tyrosine kinase (KIT) (75-80% of cases) or platelet-derived growth factor receptor A (PDGFRA) (5-15%) genes (55–58). The rest (10-15%), that lack KIT and PDGFRA gene mutations, are described as ‘wild type GISTs’ (WT GISTs) and comprise most of pediatric GISTs (59, 60). SDH-deficient GISTs are the majority of WT GISTs (50% of these tumors are associated with hypermethylation of the SDHC promoter locus (CT), 30% with germline SDHA mutations (4), while 20% is associated with mutations in SDHB, SDHC, SDHD (Table 2) (61). The rest harbor mutations in NF-1, BRAF, ARID1A, ARID1B, CBL, NRAS, HRAS, KRAS, EGFR1, MAX, MEN1, PIK3CA and ETV6-NTRK3 fusion genes; these patients are usually older (same as KIT/PDGFRA + tumors) and they have more aggressive disease (62–72) (Figure 2). It is important to identify these mutations as it can be useful in the treatment plan.
+
+Comparison of SDH-deficient GISTs and SDH-competent GISTs.
+
+GIST, gastrointestinal stromal tumor; GIT, gastrointestinal tract; IHC, immunohistochemistry; SDH, succinate dehydrogenase.
+
+Classification of gastrointestinal stromal tumors (GISTs).
+
+SDH- deficient GISTs exhibit unique features which are summarized in Table 2. Briefly, they manifest predominantly in females, at a young age. They arise almost exclusively in the stomach (61, 73–79) and they frequently have early lymphovascular invasion and consequent involvement of the lymph nodes (76), and less frequently of the liver (61), and do not frequently respond to imatinib (80). However, even in the setting of metastatic disease, they have an indolent clinical course. Histologically, these tumors exhibit multinodular growth pattern with epithelioid cells and they are multifocal. In addition, it was found that SDH-deficient GISTs overexpress insulin-like growth factor receptor (IGF1R) (81), and that this upregulation is highly specific of SDH-deficient GISTs (61, 78, 82, 83). The underlying molecular mechanism is unknown, but it could possibly be due to genetic amplification (61). Stratakis and his group also showed that immunohistochemistry that is negative for SDHB can be used to identify SDH-deficient GISTs caused by SDHB, SDHC or SDHD mutations (75). SDH-deficient GISTs can be sporadic or may present as part of two syndromes, CT (84) and CSS (26, 85).
+
+Going back, in 1977 Dr. J. Aidan Carney described the association of three uncommon tumors- GISTs, PGLs and pulmonary chondroma (PCH) (86). Among other characteristics, the young age (median 18 years old), the female predilection, the multifocality and the concurrence of rare tumors suggested a genetic etiology (87). This association was later referred to as CT (OMIM #604287). Afterwards, adrenocortical adenoma and esophageal leiomyoma were added as components of the triad (88). The etiology of CT is not yet clear but recent data have implicated SDHC. In a cohort of 37 patients, comparative genomic hybridization demonstrated no mutations of any of the SDHx subunits. Instead, it revealed the most frequent and largest genomic change to be the deletion of 1q12-q21, a region where SDHC gene resides (84). Later, Haller et al. demonstrated that aberrant DNA hypermethylation is present at specific sequences of the SDHC gene (in the promoter and first exon) in patients with CT; this methylation leads to reduced SDHC mRNA expression (89). A genome-wide DNA study confirmed the SDHC gene promoter hypermethylation in both CT and WT-GISTs (90). Today, SDHC-specific methylation is considered the molecular signature of CT and is used as simple diagnostic test to identify lesions that may be part of CT in patients that are suspected to be affected by the condition.
+
+In 2002, Dr Carney and Dr Stratakis, described a new condition, that is today known as Carney-Stratakis syndrome (CSS) (OMIM #606864) (also reported as the “paraganglioma and gastric stromal sarcoma syndrome” or Carney-Stratakis dyad) (91). This newly described genetic disorder included only two types of tumors, PGLs/PHEOs and GISTs and is inherited in an autosomal dominant manner with incomplete penetrance. It affects both males and females during childhood and adolescence. Later, in 2007, Dr. Stratakis and his group identified inactivating mutations in the SDHB, SDHC and SDHD subunits as responsible for CSS (26, 92), with subunits B and D being mutated in higher frequency. Pasini et al. studied patients with CSS who developed GIST and they identified germline mutations in SDHB, SDHC and SDHD (26). Hemizygosity/homozygosity for the mutant allele was found in the GISTs of the affected individuals which is consistent with the tumor suppressor activity of SDHx genes (26). SDHA loss-of-function mutations have also been identified in patients with CSS (74). Surprisingly, patients harboring SDHA mutations demonstrated impressively long survival (93).
+
+Over the years, the co-existence of PHEOs/PGLs and pituitary adenomas (PAs) was thought to be a coincidence due to the rarity of those endocrine tumors (23). However, in some cases, they may have a common pathogenic mechanism. The first case of a patient with PHEO and acromegaly was described in 1952 (94). Since then, more than 80 such cases have been published (95). In 2012, Xekouki et al. described an individual within a family history with multiple PGLs and PHEOs caused by a germline SDHD mutation; in addition, the individual had an aggressive growth hormone (GH)-secreting PA, and loss of heterozygosity at the SDHD locus in the pituitary tumor along with increased levels of HIF-1α (96). Since then, the co-existence of those tumors, not recognized as a distinct entity before, has been known as 3PAs. More cases of PAs in patients with SDH mutations have been described, supporting the evidence that SDH deficiency plays a role in pituitary tumors (97–99).
+
+SDH-deficient PAs that are part of 3PAs are more commonly macroadenomas and they frequently exhibit different phenotypes within the same family, such as prolactinomas, somatotropinomas and non-functional adenomas (95). Most of the time they respond poorly to somatostatin analogues and they require multiple treatments (95). In addition, PHEOs/PGLs in patients with 3PAs are often bilateral and/or multiple and tend to recur (95). In a cohort study of 19 patients with PHEO/PGL and PA, 9 of them had SDHx mutations. In PAs caused by mutations in any of the SDHx subunits intracytoplasmic vacuoles were present, a histological characteristic specific to those kinds of tumors (100). One could speculate that those vacuoles could possibly be autophagic bodies, as it is known that activation of autophagy is related to hypoxia-related pathways (101, 102); moreover, autophagy has been found to contribute to chemo- and radio-therapy resistance (103, 104).
+
+SDH-deficient renal carcinoma was first recognized in 2004 (22) and later was accepted as a distinct type of renal cell carcinoma (RCC) (4, 105). It is rare, as it is estimated to account for 0.05-0.2% of all renal carcinomas (106). The mean age is 38 to 40 years (107) and there is a slight male predisposition (106, 108). In most of them, SDHB (83%) germline mutation is present (80), but few cases with SDHC and SDHD mutations have been reported as well (106–109). SDHA mutation in RCC was reported for the first time recently by Yakirevich et al. (110), followed by other reports (111, 112). In a cohort study, 36 SDH-deficient RCCs from 27 patients were studied; all of them were negative for SDHB and positive for SDHA by IHC. In addition, genetic testing was performed in 17 of these patients and they all harbored a germline SDHx mutation (16 SDHB, 1 SDHC) (106). In another study, 37 tumors exhibiting morphologic features of SDH-deficient RCC were evaluated; of them 11 showed immunohistochemical loss of SDHB and 1 out of 11 cases loss of SDHA (in this case no SDHB gene mutation was detected by sequencing and SDHA gene was not evaluated) (108).
+
+Morphologically, SHD-deficient RCCs exhibit distinctive features, being made of cuboidal cells with variable cysts and ‘bubbly’ eosinophilic cytoplasm with flocculent inclusions. They also exhibit a solid, nested or tubular growth pattern (80, 106–108, 110, 113, 114). The hallmark of these tumors is loss of SDH immunohistochemical expression. Therefore, in renal tumors with morphology suggestive of SDH-deficient RCC or syndromic disease (younger age, family history of RCC, personal or family history of other SDH-deficient tumors) IHC for SDHB should be performed (106, 112). It is possible that SDHA-deficient RCCs may exhibit slightly different morphologic features such as papillary, cribiform-like architecture, higher nuclear grade and areas of solid growth pattern (110–112). However, very few cases have been reported so far and it is difficult to make any definitive associations.
+
+In addition, this distinct type of RCCs is negative for c-kit, cytokeratin 7 (CK7), carbonic anhydrase IX (CAIX), CD117 and vimentin, while it is immunoreactive for PAX8 and kidney-specific cadherin. These markers can be useful in the case that IHC is unavailable (106–108).
+
+Although most SHD-deficient RCCs have a good prognosis, and the risk of metastasis is estimated to be 11%, some of them- those with high-grade nuclear atypia, tumor necrosis or sarcomatoid differentiation- may behave aggressively reaching metastatic rates as high as 70% (106, 108, 115).
+
+Apart from PGLs/PHEOs, GISTs, PAs and renal cell carcinomas discussed above, there is not much evidence that SDHx deficiency contributes significantly to other neoplasms. Thyroid carcinoma associated with either SDHB or SDHD has been reported in a few individuals (46, 51). Patients with PTEN-negative Cowden and Cowden-like syndromes, have also been reported in association with either SDHB or SDHD variants (27). Neuroblastoma (28) and bilateral adrenal medullary hyperplasia (29) have been linked to SDHB mutations. Moreover, a case of testicular seminoma has been reported in association with SDHD mutation (30). While a variety of tumors has been reported in association with SDH mutations we cannot say for sure if there is a causal relationship between them due to the very limited number of cases.
+
+SDHx genes act as tumor suppressor genes (116). SDHx germline heterozygous inactivating mutations affect the protein function and predispose to hereditary neoplasms; subsequently, loss of heterozygosity (LOH) in the tumor level results in complete loss of SDH activity (14). Loss of immunohistochemical staining for SDHB has been proved to be a robust and reliable marker for syndromic disease resulting from germline mutation of SDHA, SDHB, SDHC or SDHD (6–9). In addition, in the case of double-hit inactivation of SDHA, IHC for SDHA becomes negative as well (9, 21). Thus, tumors associated with bi-allelic inactivation of SDHA stain negative for SDHB and SDHA, while tumors caused by inactivating mutations in SDHB, SDHC or SDHD show negative staining only for SDHB. In every case, caution should be taken when interpreting the results and further clinical and genetic assessment should ensue.
+
+Clinical features of the tumors discussed above should be taken into careful consideration. It is very important, in the case of PGLs/PHEOs, to be aware of any catecholamine excess symptoms (such as hypertension, hyperhidrosis, palpitations, headache) as well as signs and/or symptoms of a local mass. Depending on the tumor location they may vary. Tumors located in the carotid body may present with voice hoarseness, neck fullness, cough, dysphagia or clinically palpable mass in the lateral upper neck. When located in the middle ear (glomus tympanicum) patients may present with palsies of the cranial nerves VII, IX, X, XI and/or XII (117). It is recommended that these patients undergo imaging in order to detect metastatic disease or new tumors (118–120). In the case of SDHA, SDHC and SDHD mutations, because of the slow-growing tumors, MRI screening is suggested every three to five years (120). In individuals with SDHB mutations, due to the rapidly growing nature of these tumors, it should be performed every two years (120). A recent study demonstrated that the most optimal diagnostic imaging included MRI/CT and 111In-octreotide scintigraphy (121). Other studies showed higher sensitivity and more detailed imaging (regardless of genetic mutation and familial or sporadic cases) using 68Ga-DOTA-peptides PET/CT, which targets the abundantly expressed somatostatin receptors in those tumors, compared to conventional CT or MRI (122–128); in addition, more lesions were identified in the case of head and neck paragangliomas (HNPGLs) using that compared to all other imaging techniques (126) (including [18F]-fluorohydroyphenylalanine ([18F]-FDOPA) PET/CT, currently the gold standard for head and neck paragangliomas) (119, 129, 130). Patients with PA should be carefully examined for any symptoms of prolactin (PRL) or GH hypersecretion or visual disturbances, as most PAs that occur in the context of 3PAs are PRL- or GH- secreting macroadenomas or non-functional PAs. Complete pituitary hormone evaluation should also be performed to rule out other pituitary tumors. Hormonal testing should also be performed in the case of concurrent PGLs/PHEOs either in the index case or any family member. If there are no abnormal findings, based on the most recent recommendations, biochemical tests, including testing for PGLs/PHEOs, should be performed annually (118, 119). Pituitary MRI is indicated in the case of abnormal biochemistry or clinical findings. SDH-deficient PAs are treated the same as sporadic (131–134). In the case of renal cancer, patients may complain about flank pain and/or hematuria, whereas in GISTs abdominal pain or fullness may be the main issue.
+
+It could be suggested that in the presence of SDH deficiency a careful and detailed medical and family history should be obtained even in patients with apparently ‘sporadic’ PGLs/PHEOs, GISTs or PAs due to the variable expression and decreased penetrance of those conditions. Patients and family members should be referred for genetic counseling. Genetic testing for SDHx mutations in any of the above patients, particularly if there are other family members with any of those tumors (do not only include first-degree relatives) should be performed. Doctors should be aware of CT or CSS especially in the case of a KIT or PDFGRA negative GIST. In the case that genetic testing is unavailable or cannot be performed, SDHB IHC could be performed.
+
+SDH-deficient tumors are often an indicator of a genetic, tumor-predisposition syndrome, associated with germline mutations in any of the SDHx subunits: SDHA, SDHB, SDHC, SDHD or rarely SDHAF2. In the case of CT, epimutation of SDHC promoter locus is the cause. Identifying the genetic basis of SDH-deficient tumors has helped in identifying individuals in high risk and introduce screening to them and their families. Thus, better clinical care can be provided as early detection and treatment have become more feasible.
+
+GP contributed to writing the draft of the paper, to writing the final version of the paper, and critically revised it. FF and NS contributed to writing the final version of the paper and critically revised it. CS conceived the study and contributed to writing the final version of the paper and critically revised it. All authors contributed to the article and approved the submitted version.
+
+This study was supported by the Intramural Research Program, Eunice Kennedy Shriver National Institute of Child Health & Human Development (NICHD), Bethesda, Md 20892, USA.
+
+CAS holds patent on the PRKAR1A, PDE11A, and GPR101 genes and/or their function and his laboratory has received research funding from Pfizer Inc. FRF holds patent on the GPR101 gene and/or its function. CAS is receiving compensation by ELPEN, Inc. Neither Pfizer, Inc nor ELPEN, Inc had any role in the study design, data collection and analysis, decision to publish, or preparation of the manuscript.
+
+The remaining authors declare that the research was conducted in the absence of any commercial or financial relationships that could be construed as a potential conflict of interest.

--- a/references_cache/PMID_36387130.md
+++ b/references_cache/PMID_36387130.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:36387130"
+title: "Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline mutation in a patient with Carney-Stratakis syndrome: A case report and literature review."
+authors:
+- Shi Y
+- Ding L
+- Mo C
+- Luo Y
+- Huang S
+- Cai S
+- Xia Y
+- Zhang X
+journal: Front Oncol
+year: '2022'
+doi: 10.3389/fonc.2022.1030092
+content_type: abstract_only
+---
+
+# Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline mutation in a patient with Carney-Stratakis syndrome: A case report and literature review.
+**Authors:** Shi Y, Ding L, Mo C, Luo Y, Huang S, Cai S, Xia Y, Zhang X
+**Journal:** Front Oncol (2022)
+**DOI:** [10.3389/fonc.2022.1030092](https://doi.org/10.3389/fonc.2022.1030092)
+
+## Content
+
+1. Front Oncol. 2022 Oct 28;12:1030092. doi: 10.3389/fonc.2022.1030092.
+eCollection  2022.
+
+Bladder paraganglioma, gastrointestinal stromal tumor, and SDHB germline 
+mutation in a patient with Carney-Stratakis syndrome: A case report and 
+literature review.
+
+Shi Y(1), Ding L(2), Mo C(3), Luo Y(4), Huang S(1), Cai S(1), Xia Y(5), Zhang 
+X(1).
+
+Author information:
+(1)Department of Gastrointestinal Surgery, The First Affiliated Hospital of Sun 
+Yat-sen University, Guangzhou, China.
+(2)Department of Pathology, The First Affiliated Hospital of Sun Yat-sen 
+University, Guangzhou, China.
+(3)Department of Pharmacy, The First Affiliated Hospital of Sun Yat-sen 
+University, Guangzhou, China.
+(4)Department of Urology Surgery, The First Affiliated Hospital of Sun Yat-sen 
+University, Guangzhou, China.
+(5)Department of Radiology, The First Affiliated Hospital of Sun Yat-sen 
+University, Guangzhou, China.
+
+BACKGROUND: Carney-Stratakis syndrome (CSS) is a rare dyad of paraganglioma 
+(PGL)/pheochromocytoma (PHEO) and gastrointestinal stromal tumor (GIST). PGLs 
+are neuroendocrine tumors of neural crest origin which are mostly found in the 
+head, neck, and retroperitoneal space. GISTs are the most common mesenchymal 
+tumors of the digestive tract, usually caused by KIT/PDGFRA mutations. Here, we 
+reported a case of CSS with unusual bladder PGL and succinate dehydrogenase 
+(SDH) deficient GIST due to a germline mutation in SDH-subunit B (SDHB) gene.
+CASE PRESENTATION: A 39-year-old female patient initially diagnosed with gastric 
+GIST and isolated pelvic metastasis was eventually found to be CSS with bladder 
+PGL and SDH-deficient GIST after surgery. This patient underwent resection of 
+gastric and bladder tumors, and postoperative pathology confirmed the diagnosis 
+of CSS. According to the next-generation sequencing (NGS), the patient carried a 
+germline mutation in the SDHB gene, which was the cause of the disorder. The 
+patient had no tumor recurrence with regular follow-up in 10 months.
+CONCLUSIONS: CSS is an autosomal genetic disorder with no gender difference in 
+incidence, and PGLs are more frequent than GISTs. SDH germline mutation is the 
+molecular biological mechanism of CSS while the most common type is SDHB 
+mutation. The unique mechanism of tumorigenesis including hypoxia and 
+hypermethylation caused by SDH deficiency renders target therapy with tyrosine 
+kinase inhibitors ineffective, therefore complete surgical resection is the 
+optimal treatment in the absence of tumor metastases.
+
+Copyright © 2022 Shi, Ding, Mo, Luo, Huang, Cai, Xia and Zhang.
+
+DOI: 10.3389/fonc.2022.1030092
+PMCID: PMC9650230
+PMID: 36387130
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/research/Carney-Stratakis_Syndrome-deep-research-falcon.md
+++ b/research/Carney-Stratakis_Syndrome-deep-research-falcon.md
@@ -1,0 +1,1197 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:38:04.321862'
+end_time: '2026-05-11T12:52:13.276499'
+duration_seconds: 848.95
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Carney-Stratakis syndrome
+  mondo_id: ''
+  category: Genetic
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 31
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Carney-Stratakis syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Genetic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Carney-Stratakis syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Carney-Stratakis syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Genetic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Carney-Stratakis syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Carney–Stratakis Syndrome (CSS) — Disease Characteristics Research Report
+
+## 1. Disease information
+
+### Overview / definition
+Carney–Stratakis syndrome (CSS) is a rare hereditary tumor-predisposition syndrome defined by the *dyad* of paraganglioma (PGL) and/or pheochromocytoma (PCC) together with gastrointestinal stromal tumor (GIST), typically a KIT/PDGFRA-wildtype, succinate dehydrogenase (SDH)-deficient GIST. (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2)
+
+**Synonyms / alternative names** include “Carney–Stratakis dyad,” “dyad of paraganglioma and GIST,” and “hereditary GIST–paraganglioma syndrome.” (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 1-2)
+
+**Evidence type**: The syndrome definition and genotype–phenotype associations are derived from aggregated disease-level resources (reviews, guidelines) and from small family series/case reports due to rarity. (pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2)
+
+### Key identifiers (requested: OMIM/Orphanet/ICD/MeSH/MONDO)
+Using the available tools in this run, I was not able to directly retrieve authoritative database identifiers (OMIM, Orphanet, MeSH, ICD-10/11, MONDO) for CSS; therefore these identifiers are not reported here to avoid uncited or incorrect mapping.
+
+## 2. Etiology
+
+### Primary causes
+**Genetic (germline) SDH complex loss-of-function** is the established cause of classic CSS. Multiple sources describe CSS as autosomal dominant with incomplete penetrance and as being caused by germline heterozygous loss-of-function pathogenic variants in SDH subunit genes, especially **SDHB, SDHC, SDHD**. (pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2, pasini2008clinicalandmolecular pages 4-6)
+
+*Abstract-supported definition (example quote)*: Lobato et al. state, “Carney-Stratakis syndrome (CSS) is an autosomal dominant rare syndrome, with incomplete penetrance, characterized by the association of paragangliomas and/or pheochromocytomas and gastrointestinal stromal tumors (GISTs).” (lobato2023threecasesof pages 1-2)
+
+### Risk factors
+- **Family history / inherited SDHx pathogenic variants** are the main risk factors; CSS cases can still occur with limited family history due to incomplete penetrance and variable expressivity. (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 4-6)
+- **Parent-of-origin effects** are noted in SDH-related paraganglioma syndromes (especially SDHD) and can obscure family history patterns (more prominent in the broader SDH-PGL literature than in CSS-specific cohorts). (pitsava2021carneytriadcarneystratakis pages 3-4)
+
+### Protective factors / gene–environment interactions
+No protective factors or gene–environment interactions specific to CSS were identified in the retrieved sources.
+
+## 3. Phenotypes (clinical spectrum)
+
+### Core phenotypes
+CSS manifests as combinations of:
+1) **Paragangliomas (PGLs)** and/or **pheochromocytomas (PCCs)**, often multicentric/multifocal. (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 1-2)
+2) **Gastrointestinal stromal tumors (GISTs)** that are **SDH-deficient** and usually **KIT/PDGFRA-wildtype**; in CSS, GISTs are frequently multifocal and preferentially gastric. (khurana2019paragangliomasincarney–stratakis pages 3-4, pasini2008clinicalandmolecular pages 1-2, khurana2019paragangliomasincarney–stratakis pages 2-3)
+
+Khurana et al. emphasize that CSS has “greater relative frequency of PGL over GISTs,” and that “PGLs in CSS are multicentric and GISTs are multifocal.” (khurana2019paragangliomasincarney–stratakis pages 1-2)
+
+### Phenotype characteristics
+- **Age of onset**: CSS and SDH-deficient GISTs are enriched in younger patients; in the landmark CSS genetic series, affected individuals were young (e.g., earlier series average age reported as ~23 years). (pasini2008clinicalandmolecular pages 1-2)
+- **GIST anatomy and pathology**: SDH-deficient GISTs are described as predominantly gastric, often epithelioid or mixed morphology, multinodular/plexiform growth, multiple tumors, lymphovascular invasion, and occasional lymph node metastasis. (khurana2019paragangliomasincarney–stratakis pages 3-4, kim2024pathologicdiagnosisand pages 3-4, kim2024pathologicdiagnosisand pages 1-3)
+- **PGL/PCC**: PGLs are neuroendocrine tumors of neural crest origin and are commonly in head/neck or retroperitoneal regions; CSS can present with unusual locations (e.g., bladder PGL described in a CSS case report). (shi2022bladderparagangliomagastrointestinal pages 1-2)
+
+### Suggested HPO terms (non-exhaustive)
+- Paraganglioma: **HP:0002666**
+- Pheochromocytoma: **HP:0002667**
+- Gastrointestinal stromal tumor: **HP:0031275** (term name varies by HPO version; use nearest GIST term)
+- Gastrointestinal hemorrhage (if present): **HP:0002239**
+- Abdominal pain: **HP:0002027**
+- Gastrointestinal neoplasm (broad): **HP:0007378**
+
+*Note*: Exact HPO IDs for “GIST” should be verified against the current HPO release when implementing.
+
+## 4. Genetic / molecular information
+
+### Causal genes (CSS)
+Classic CSS is most consistently linked to germline loss-of-function variants in:
+- **SDHB** (HGNC:10681)
+- **SDHC** (HGNC:10682)
+- **SDHD** (HGNC:10683)
+
+These genes encode subunits of mitochondrial complex II (SDH), and germline disruption predisposes to the CSS dyad. (pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2, pasini2008clinicalandmolecular pages 4-6)
+
+**SDHA** is frequently mutated in SDH-deficient GIST overall, but recent review synthesis indicates SDHA germline cases more often present as isolated SDH-deficient GIST rather than classic CSS; co-occurrence with PGL is described as rare. (schipani2023sdhagermlinemutations pages 8-9)
+
+### Pathogenic variants (representative examples)
+In the landmark CSS series, Pasini et al. studied 11 patients and reported that in eight (from seven unrelated families) GISTs were caused by germline mutations in SDHB, SDHC, or SDHD, with autosomal-dominant inheritance and incomplete penetrance. (pasini2008clinicalandmolecular pages 1-2)
+
+Reported variants from the Pasini cohort include (examples; not exhaustive):
+- **SDHB**: c.72+1G>T, c.423+1G>C, c.45_46insCC, large deletions. (pasini2008clinicalandmolecular pages 4-6, pasini2008clinicalandmolecular pages 1-2)
+- **SDHC**: c.43C>T (p.Arg15X), c.405+1G>A (splice), and later a germline SDHC exon 3 deletion reported in a 2023 case series. (pasini2008clinicalandmolecular pages 4-6, lobato2023threecasesof pages 1-2)
+- **SDHD**: c.57delG. (pasini2008clinicalandmolecular pages 1-2)
+
+### Inheritance pattern and penetrance
+CSS is described as **autosomal dominant with incomplete penetrance**, supported by unaffected mutation carriers in pedigrees (e.g., SDHB/SDHC splice variants inherited from clinically unaffected mothers). (pasini2008clinicalandmolecular pages 4-6, pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2)
+
+Quantitative penetrance estimates are more available for SDHx carrier cohorts broadly (PPGL predisposition) than for CSS specifically. For example, SDH-related syndromes have subunit-specific penetrance features; one synthesis notes SDHB has lower penetrance but higher metastatic risk, while SDHD often has higher penetrance and head/neck predominance. (pitsava2021carneytriadcarneystratakis pages 3-4)
+
+### Variant type and mechanism
+Most CSS variants are consistent with **loss of function** (splice-site, nonsense, frameshift, or large deletion), consistent with tumor-suppressor biology and frequent “second-hit” loss of the wild-type allele (LOH) in tumors. (pasini2008clinicalandmolecular pages 4-6)
+
+## 5. Environmental information
+No consistent non-genetic environmental triggers, lifestyle determinants, or infectious agents specific to CSS were identified in the retrieved literature. CSS is primarily genetic. (pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2)
+
+## 6. Mechanism / pathophysiology
+
+### Core causal chain (from germline SDHx loss to tumors)
+1) **Germline SDHx loss-of-function** → reduced SDH (mitochondrial complex II) activity in susceptible tissues. (pasini2008clinicalandmolecular pages 1-2, khurana2019paragangliomasincarney–stratakis pages 2-3)
+2) **Succinate accumulation** (oncometabolite) due to impaired conversion of succinate to fumarate. (pitsava2021carneytriadcarneystratakis pages 3-4, khurana2019paragangliomasincarney–stratakis pages 2-3)
+3) **Pseudohypoxia**: succinate inhibits prolyl hydroxylases, stabilizing **HIF-1α**, driving hypoxia-like transcriptional programs. (khurana2019paragangliomasincarney–stratakis pages 2-3)
+4) **Epigenetic reprogramming**: succinate inhibits TET/JmjC demethylases, promoting DNA/histone hypermethylation and altered differentiation programs. (pitsava2021carneytriadcarneystratakis pages 3-4, khurana2019paragangliomasincarney–stratakis pages 2-3)
+5) Downstream signaling changes in SDH-deficient GIST can include VEGF/IGF2 upregulation and activation of PI3K/AKT and MAPK signaling as summarized in a 2024 mini-review. (kim2024pathologicdiagnosisand pages 3-4)
+
+### GO and CL term suggestions (mechanism anchoring)
+- GO:0006121 **mitochondrial electron transport, succinate to ubiquinone**
+- GO:0006099 **tricarboxylic acid cycle**
+- GO:0001666 **response to hypoxia**
+- GO:0071559 **response to hypoxia-inducible factor** (or related HIF terms depending on GO version)
+- GO:0006325 **chromatin organization**; GO:0043044 **ATP-dependent chromatin remodeling** (as downstream)
+- CL (cell types relevant to lesions):
+  - Chromaffin cell (adrenal medulla) / paraganglionic cells (CL term mapping should be validated)
+  - Interstitial cells of Cajal (cell-of-origin for GIST; CL mapping requires validation)
+
+## 7. Anatomical structures affected
+
+### Primary organs / structures
+- **Stomach** (predominant site for SDH-deficient GIST). (khurana2019paragangliomasincarney–stratakis pages 3-4, kim2024pathologicdiagnosisand pages 1-3)
+- **Paraganglia** along the paravertebral axis; **adrenal medulla** for PCC. (khurana2019paragangliomasincarney–stratakis pages 1-2, khurana2019paragangliomasincarney–stratakis pages 2-3)
+
+### UBERON term suggestions
+- Stomach: **UBERON:0000945**
+- Adrenal gland: **UBERON:0002369** (adrenal medulla is a substructure)
+- Paraganglion: UBERON mapping should be validated for “paraganglion” specific class
+
+### Subcellular localization
+SDH is localized to the **mitochondrial inner membrane** (complex II); dysfunction is therefore a mitochondrial metabolic defect. (khurana2019paragangliomasincarney–stratakis pages 2-3)
+
+## 8. Temporal development
+
+### Onset and course
+CSS often presents in **childhood/adolescence/young adulthood**, particularly for SDH-deficient GIST, and can show multifocal tumors and metastatic potential but with variable/indolent clinical courses in some cases. (khurana2019paragangliomasincarney–stratakis pages 3-4, pasini2008clinicalandmolecular pages 1-2)
+
+## 9. Inheritance and population
+
+### Epidemiology
+CSS is rare; no robust prevalence/incidence estimates were retrieved in the available texts for this run.
+
+### Sex ratio
+Reviews describe CSS as affecting both genders (in contrast to Carney triad, which has female predilection). (pitsava2021carneytriadcarneystratakis pages 3-4)
+
+### Tumor risk statistics (from SDHB carrier surveillance cohorts; not CSS-specific)
+A surveillance series summarized in a 2019 SDH-deficient GIST management review reported that among **65 asymptomatic SDHB mutation carriers** undergoing annual abdominal MRI-based surveillance, **25% developed SDHB-related cancers within 6 years**, and **16.6% had an asymptomatic tumor detected on the first surveillance scan**. (neppala2019currentmanagementof pages 6-7)
+
+## 10. Diagnostics
+
+### Pathology and immunohistochemistry
+**Loss of SDHB immunohistochemical staining** is a validated surrogate marker of SDH deficiency and helps distinguish SDH-deficient GIST (including CSS-associated tumors) from KIT/PDGFRA-mutant GIST. (gaal2011sdhbimmunohistochemistrya pages 6-8)
+
+A representative example of this real-world diagnostic pattern is shown in Gaal et al. Figure 1 panel (a): a CSS-associated GIST demonstrates **negative SDHB staining in tumor cells**, with endothelial cells serving as internal positive control. (gaal2011sdhbimmunohistochemistrya media 9958076a)
+
+### Molecular testing
+- CSS workup commonly includes tumor and germline testing of SDHx genes by **NGS**, with **copy-number analysis (e.g., MLPA)** when sequencing is negative but suspicion remains. A 2023 case series illustrates that NGS/MLPA may be negative in clinically consistent CSS, highlighting genetic heterogeneity and potential underdiagnosis; they also report an SDHC exon 3 deletion not previously reported. (lobato2023threecasesof pages 1-2)
+- In CSS-associated tumors, GISTs typically lack common **KIT**/**PDGFRA** driver mutations. (pasini2008clinicalandmolecular pages 1-2)
+
+### Biochemical testing (PPGL)
+Biochemical evaluation for catecholamine excess (e.g., plasma metanephrines/normetanephrines) is used in real-world CSS/PCC evaluation and perioperative planning (α-blockade). (lobato2023threecasesof pages 1-2)
+
+### Imaging
+Cross-sectional imaging (CT/MRI) and functional imaging (e.g., PET/CT) are used for tumor localization and staging in CSS cases and broader SDHx syndromes. (lobato2023threecasesof pages 1-2, khurana2019paragangliomasincarney–stratakis pages 2-3)
+
+### Differential diagnosis
+Key distinctions include:
+- **Carney triad** (PGL + GIST + pulmonary chondroma), often associated with SDHC promoter hypermethylation and female predominance, and frequently non-hereditary/mosaic rather than classic autosomal dominant inheritance. (pitsava2021carneytriadcarneystratakis pages 3-4)
+- Sporadic KIT/PDGFRA-mutant GIST (typically SDHB-positive by IHC). (gaal2011sdhbimmunohistochemistrya pages 6-8)
+
+## 11. Outcome / prognosis
+No CSS-specific survival rates were identified in retrieved sources. SDH-deficient GIST can metastasize (including nodal metastasis) yet may have relatively indolent behavior compared with other GIST subsets, with clinical course varying substantially. (khurana2019paragangliomasincarney–stratakis pages 3-4, kim2024pathologicdiagnosisand pages 3-4)
+
+## 12. Treatment
+
+### Surgical management (current standard)
+For localized CSS-associated tumors, **complete surgical resection** is a primary approach, particularly because SDH-deficient GIST is often not responsive to standard KIT-directed tyrosine kinase inhibitors. (shi2022bladderparagangliomagastrointestinal pages 1-2, neppala2019currentmanagementof pages 1-2)
+
+### Systemic therapy considerations
+- **Imatinib**: SDH-deficient GISTs are generally described as poorly responsive, which is clinically important in CSS because these tumors are frequently KIT/PDGFRA-wildtype. (khurana2019paragangliomasincarney–stratakis pages 4-4, neppala2019currentmanagementof pages 1-2)
+- **Anti-angiogenic TKIs** (e.g., sunitinib, regorafenib, pazopanib) and other systemic options are discussed in reviews for SDH-deficient tumors, but evidence remains limited and often extrapolated from broader SDH-deficient GIST/PPGL experiences. (khurana2019paragangliomasincarney–stratakis pages 3-4, schipani2023sdhagermlinemutations pages 8-9)
+
+### Surveillance / follow-up (real-world implementation)
+For completely resected SDH-deficient GIST, a commonly cited follow-up framework includes physical exams and cross-sectional abdominal/pelvic imaging **every 3–6 months for 5 years, then annually**, as summarized in a management review discussing guideline-consistent practices. (neppala2019currentmanagementof pages 6-7)
+
+### Relevant clinical trials
+- **Guadecitabine (SGI-110) DNMT inhibitor** for SDH-deficient tumors: Phase II trial **NCT03165721** (ClinicalTrials.gov; first posted 2017; start date 2017-08-16; primary completion 2020-02-24) evaluated guadecitabine in wt/SDH-deficient GIST and SDH-mutant PPGL strata; the study was **terminated due to low accrual**. URL: https://clinicaltrials.gov/study/NCT03165721 (NCT03165721 chunk 1, NCT03165721 chunk 2)
+- **Natural history / biospecimen study**: **NCT03739827** (recruiting; sponsor NCI; primary completion 2028-05-31) includes “SDH deficient GIST” and “Paraganglioma,” enrolling germline variant carriers and relatives to collect biospecimens, imaging, and longitudinal clinical data. URL: https://clinicaltrials.gov/study/NCT03739827 (NCT03739827 chunk 1)
+
+### Suggested MAXO terms
+- Surgical resection: **MAXO:0000011** (surgery; verify exact child term)
+- Genetic counseling: **MAXO:0000075** (verify)
+- Tumor surveillance / screening: **MAXO:0000127** (verify)
+- α-adrenergic blockade for PCC: MAXO mapping should be validated
+
+## 13. Prevention
+
+Primary prevention is not established for CSS because it is an inherited tumor predisposition syndrome. Secondary/tertiary prevention relies on **genetic counseling**, **cascade testing**, and **surveillance imaging/biochemical monitoring** for early tumor detection and management in SDHx variant carriers. (neppala2019currentmanagementof pages 6-7, lobato2023threecasesof pages 1-2)
+
+## 14. Other species / natural disease
+No naturally occurring CSS analog in non-human species was identified in retrieved sources.
+
+## 15. Model organisms
+The retrieved sources for this run did not provide explicit descriptions of CSS-specific model organisms (e.g., SDHx mouse models reproducing the dyad phenotype). Mechanistic descriptions strongly implicate mitochondrial metabolism and epigenetic dysregulation in SDH-deficient tumors, but dedicated model-system evidence should be curated from additional experimental literature beyond the documents retrieved here. (pitsava2021carneytriadcarneystratakis pages 3-4, khurana2019paragangliomasincarney–stratakis pages 2-3)
+
+---
+
+## High-level synthesis (2023–2024 emphasis)
+Recent case-based and pathology-focused literature reinforces that CSS should be considered when encountering **SDH-deficient, KIT/PDGFRA-wildtype gastric GIST** and/or **PGL/PCC**, and that SDHx testing should include deletion/duplication analysis when sequencing is negative. (lobato2023threecasesof pages 1-2, kim2024pathologicdiagnosisand pages 3-4)
+
+A 2024 mini-review summarizes modern diagnostic practice for molecularly diverse GIST, emphasizing that ancillary testing (IHC, NGS) is essential because some epithelioid/mixed tumors may lose canonical KIT/DOG1 signals, and that SDH-deficient GIST (including CSS-associated) behaves as a distinct subgroup with TKI resistance. (kim2024pathologicdiagnosisand pages 3-4)
+
+---
+
+## Summary table
+
+| Domain | Core fact | Recent source(s) with DOI/URL and publication date | Key evidence source (author-year) |
+|---|---|---|---|
+| Definition / synonyms | Carney–Stratakis syndrome (CSS) is a rare hereditary tumor-predisposition syndrome defined by the dyad of paraganglioma/pheochromocytoma and gastrointestinal stromal tumor (GIST); synonyms include **Carney–Stratakis dyad**, **dyad of paraganglioma and GIST**, and **hereditary GIST-paraganglioma syndrome**. It is distinct from Carney triad. (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2) | Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139; Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467 | Pasini-2008; Lobato-2023 |
+| Causal genes | Canonical causal genes are germline loss-of-function variants in **SDHB, SDHC, and SDHD**; these explain most molecularly confirmed CSS families. **SDHA** is part of the SDH-deficient GIST spectrum, but recent reviews emphasize SDHA more often causes isolated SDH-deficient GIST rather than classic CSS. (pasini2008clinicalandmolecular pages 1-2, schipani2023sdhagermlinemutations pages 8-9, lobato2023threecasesof pages 1-2, pasini2008clinicalandmolecular pages 4-6) | Schipani et al., *Genes* (Mar 2023), DOI: 10.3390/genes14030646, https://doi.org/10.3390/genes14030646; Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139 | Pasini-2008; Schipani-2023 |
+| Representative reported variants | Reported CSS-associated variants include **SDHB c.72+1G>T, c.423+1G>C, c.45_46insCC, large deletions; SDHC c.43C>T, c.405+1G>A, exon 3 deletion; SDHD c.57delG**. Variable family expression and unaffected carriers have been documented. (pasini2008clinicalandmolecular pages 4-6, pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2) | Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139 | Pasini-2008; Lobato-2023 |
+| Inheritance / penetrance | CSS is generally described as **autosomal dominant with incomplete penetrance** and variable expressivity. Family studies show mutation-positive but clinically unaffected relatives, supporting reduced penetrance. (khurana2019paragangliomasincarney–stratakis pages 1-2, pasini2008clinicalandmolecular pages 1-2, lobato2023threecasesof pages 1-2) | Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139 | Pasini-2008; Khurana-2019; Lobato-2023 |
+| Key tumor types | Hallmark tumors are **paragangliomas/pheochromocytomas (often multicentric/multifocal)** and **SDH-deficient wild-type GISTs (often multifocal, usually gastric)**. PGL may be more frequent than GIST in CSS cohorts/reviews. (shi2022bladderparagangliomagastrointestinal pages 1-2, khurana2019paragangliomasincarney–stratakis pages 1-2, khurana2019paragangliomasincarney–stratakis pages 3-4, lobato2023threecasesof pages 1-2, schipani2023sdhagermlinemutations pages 1-2) | Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467; Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139 | Khurana-2019; Shi-2022; Kim-2024 |
+| Typical clinicopathologic pattern | CSS-associated GISTs are usually **KIT/PDGFRA-wildtype**, gastric, often epithelioid or mixed, multinodular/plexiform, with lymphovascular invasion and occasional nodal/liver metastases; despite metastatic potential, some cases behave relatively indolently. (khurana2019paragangliomasincarney–stratakis pages 4-4, khurana2019paragangliomasincarney–stratakis pages 3-4, kim2024pathologicdiagnosisand pages 3-4, schipani2023sdhagermlinemutations pages 1-2, kim2024pathologicdiagnosisand pages 1-3) | Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467; Schipani et al., *Genes* (Mar 2023), DOI: 10.3390/genes14030646, https://doi.org/10.3390/genes14030646 | Khurana-2019; Kim-2024; Schipani-2023 |
+| Diagnostic hallmarks | Key hallmarks are **loss of SDHB expression by immunohistochemistry** (marker of SDH deficiency) and **absence of KIT/PDGFRA driver mutations**. SDHA IHC loss can point to SDHA-mutant GIST, while retained SDHB is typical of KIT/PDGFRA-mutant GIST. (khurana2019paragangliomasincarney–stratakis pages 2-3, gaal2011sdhbimmunohistochemistrya pages 6-8, kim2024pathologicdiagnosisand pages 3-4, schipani2023sdhagermlinemutations pages 1-2, gaal2011sdhbimmunohistochemistrya media 9958076a) | Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467; Schipani et al., *Genes* (Mar 2023), DOI: 10.3390/genes14030646, https://doi.org/10.3390/genes14030646 | Gaal-2011; Kim-2024; Schipani-2023 |
+| Mechanistic concepts | SDH loss causes **succinate accumulation**, which inhibits **prolyl hydroxylases** and stabilizes **HIF-1α** (pseudohypoxia), and inhibits **TET/JmjC demethylases**, promoting **global DNA/histone hypermethylation**. These mechanisms help explain CSS tumorigenesis and reduced sensitivity of SDH-deficient GIST to standard KIT-directed therapy. (shi2022bladderparagangliomagastrointestinal pages 1-2, pitsava2021carneytriadcarneystratakis pages 3-4, khurana2019paragangliomasincarney–stratakis pages 2-3, kim2024pathologicdiagnosisand pages 3-4) | Schipani et al., *Genes* (Mar 2023), DOI: 10.3390/genes14030646, https://doi.org/10.3390/genes14030646; Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467 | Pitsava-2021; Khurana-2019; Kim-2024 |
+| Molecular testing / workup | Current practice-oriented reviews and guidelines support **SDHB IHC in wild-type GIST**, followed by **germline SDHx testing** and consideration of copy-number analysis (e.g., **MLPA**) when NGS is negative but clinical suspicion remains high. Ancillary tests may include CT/MRI, PET/CT, catecholamine/metanephrine testing, and pathology review. (neppala2019currentmanagementof pages 6-7, florou2025areviewof pages 4-4, lobato2023threecasesof pages 1-2) | Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139; Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467 | Lobato-2023; Kim-2024 |
+| Recent clinical relevance (2023–2024) | 2023–2024 literature reinforces that CSS belongs within the **SDH-deficient GIST / PPGL spectrum**, that **imatinib is generally ineffective** in SDH-deficient GIST, and that **genetic counseling/surveillance** are important because syndromic disease may be missed if only tumor sequencing is performed. (schipani2023sdhagermlinemutations pages 8-9, kim2024pathologicdiagnosisand pages 3-4, neppala2019currentmanagementof pages 6-7, lobato2023threecasesof pages 1-2) | Schipani et al., *Genes* (Mar 2023), DOI: 10.3390/genes14030646, https://doi.org/10.3390/genes14030646; Lobato et al., *JCEM Case Reports* (Nov 2023), DOI: 10.1210/jcemcr/luad139, https://doi.org/10.1210/jcemcr/luad139; Kim & Lee, *Front Oncol* (Nov 2024), DOI: 10.3389/fonc.2024.1487467, https://doi.org/10.3389/fonc.2024.1487467 | Schipani-2023; Lobato-2023; Kim-2024 |
+
+
+*Table: This table condenses the key definitional, genetic, mechanistic, and diagnostic facts about Carney–Stratakis syndrome for rapid knowledge-base entry. It highlights the SDHx basis of the syndrome, classic tumor dyad, hallmark pathology, and the most relevant 2023–2024 sources.*
+
+---
+
+## Key visual evidence
+
+- SDHB-negative immunohistochemistry pattern in CSS-associated GIST (diagnostic hallmark): (gaal2011sdhbimmunohistochemistrya media 9958076a)
+
+
+References
+
+1. (khurana2019paragangliomasincarney–stratakis pages 1-2): Arushi Khurana, Lin Mei, Anthony C. Faber, Steven C. Smith, and Sosipatros A. Boikos. Paragangliomas in carney–stratakis syndrome. Hormone and Metabolic Research, 51:437-442, Jun 2019. URL: https://doi.org/10.1055/a-0918-8340, doi:10.1055/a-0918-8340. This article has 6 citations and is from a peer-reviewed journal.
+
+2. (pasini2008clinicalandmolecular pages 1-2): Barbara Pasini, Sarah R McWhinney, Thalia Bei, Ludmila Matyakhina, Sotirios Stergiopoulos, Michael Muchow, Sosipatros A Boikos, Barbara Ferrando, Karel Pacak, Guillaume Assie, Eric Baudin, Agnes Chompret, Jay W Ellison, Jean-Jacques Briere, Pierre Rustin, Anne-Paule Gimenez-Roqueplo, Charis Eng, J Aidan Carney, and Constantine A Stratakis. Clinical and molecular genetics of patients with the carney–stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits sdhb, sdhc, and sdhd. European Journal of Human Genetics, 16:79-88, Aug 2008. URL: https://doi.org/10.1038/sj.ejhg.5201904, doi:10.1038/sj.ejhg.5201904. This article has 581 citations and is from a domain leading peer-reviewed journal.
+
+3. (lobato2023threecasesof pages 1-2): Eduardo C Lobato, Felipe F Castro, Lucas S Santana, Ibere C Soares, Gustavo F C Fagundes, and Madson Q Almeida. Three cases of carney-stratakis syndrome: a genetically heterogeneous disease. JCEM Case Reports, Nov 2023. URL: https://doi.org/10.1210/jcemcr/luad139, doi:10.1210/jcemcr/luad139. This article has 2 citations.
+
+4. (pasini2008clinicalandmolecular pages 4-6): Barbara Pasini, Sarah R McWhinney, Thalia Bei, Ludmila Matyakhina, Sotirios Stergiopoulos, Michael Muchow, Sosipatros A Boikos, Barbara Ferrando, Karel Pacak, Guillaume Assie, Eric Baudin, Agnes Chompret, Jay W Ellison, Jean-Jacques Briere, Pierre Rustin, Anne-Paule Gimenez-Roqueplo, Charis Eng, J Aidan Carney, and Constantine A Stratakis. Clinical and molecular genetics of patients with the carney–stratakis syndrome and germline mutations of the genes coding for the succinate dehydrogenase subunits sdhb, sdhc, and sdhd. European Journal of Human Genetics, 16:79-88, Aug 2008. URL: https://doi.org/10.1038/sj.ejhg.5201904, doi:10.1038/sj.ejhg.5201904. This article has 581 citations and is from a domain leading peer-reviewed journal.
+
+5. (pitsava2021carneytriadcarneystratakis pages 3-4): Georgia Pitsava, Nikolaos Settas, Fabio R. Faucz, and Constantine A. Stratakis. Carney triad, carney-stratakis syndrome, 3pas and other tumors due to sdh deficiency. Frontiers in Endocrinology, May 2021. URL: https://doi.org/10.3389/fendo.2021.680609, doi:10.3389/fendo.2021.680609. This article has 54 citations.
+
+6. (khurana2019paragangliomasincarney–stratakis pages 3-4): Arushi Khurana, Lin Mei, Anthony C. Faber, Steven C. Smith, and Sosipatros A. Boikos. Paragangliomas in carney–stratakis syndrome. Hormone and Metabolic Research, 51:437-442, Jun 2019. URL: https://doi.org/10.1055/a-0918-8340, doi:10.1055/a-0918-8340. This article has 6 citations and is from a peer-reviewed journal.
+
+7. (khurana2019paragangliomasincarney–stratakis pages 2-3): Arushi Khurana, Lin Mei, Anthony C. Faber, Steven C. Smith, and Sosipatros A. Boikos. Paragangliomas in carney–stratakis syndrome. Hormone and Metabolic Research, 51:437-442, Jun 2019. URL: https://doi.org/10.1055/a-0918-8340, doi:10.1055/a-0918-8340. This article has 6 citations and is from a peer-reviewed journal.
+
+8. (kim2024pathologicdiagnosisand pages 3-4): Younghoon Kim and Sung Hak Lee. Pathologic diagnosis and molecular features of gastrointestinal stromal tumors: a mini-review. Frontiers in Oncology, Nov 2024. URL: https://doi.org/10.3389/fonc.2024.1487467, doi:10.3389/fonc.2024.1487467. This article has 10 citations.
+
+9. (kim2024pathologicdiagnosisand pages 1-3): Younghoon Kim and Sung Hak Lee. Pathologic diagnosis and molecular features of gastrointestinal stromal tumors: a mini-review. Frontiers in Oncology, Nov 2024. URL: https://doi.org/10.3389/fonc.2024.1487467, doi:10.3389/fonc.2024.1487467. This article has 10 citations.
+
+10. (shi2022bladderparagangliomagastrointestinal pages 1-2): Yihang Shi, Li Ding, Chengqiang Mo, Yanji Luo, Shaoqing Huang, Shirong Cai, Yanzhe Xia, and Xinhua Zhang. Bladder paraganglioma, gastrointestinal stromal tumor, and sdhb germline mutation in a patient with carney-stratakis syndrome: a case report and literature review. Frontiers in Oncology, Oct 2022. URL: https://doi.org/10.3389/fonc.2022.1030092, doi:10.3389/fonc.2022.1030092. This article has 6 citations.
+
+11. (schipani2023sdhagermlinemutations pages 8-9): Angela Schipani, Margherita Nannini, Annalisa Astolfi, and Maria A. Pantaleo. Sdha germline mutations in sdh-deficient gists: a current update. Genes, 14:646, Mar 2023. URL: https://doi.org/10.3390/genes14030646, doi:10.3390/genes14030646. This article has 24 citations.
+
+12. (neppala2019currentmanagementof pages 6-7): Pushpa Neppala, Sudeep Banerjee, Paul T. Fanta, Mayra Yerba, Kevin A. Porras, Adam M. Burgoyne, and Jason K. Sicklick. Current management of succinate dehydrogenase–deficient gastrointestinal stromal tumors. Cancer and Metastasis Reviews, 38:525-535, Sep 2019. URL: https://doi.org/10.1007/s10555-019-09818-0, doi:10.1007/s10555-019-09818-0. This article has 62 citations and is from a peer-reviewed journal.
+
+13. (gaal2011sdhbimmunohistochemistrya pages 6-8): José Gaal, Constantine A Stratakis, J Aidan Carney, Evan R Ball, Esther Korpershoek, Maya B Lodish, Isaac Levy, Paraskevi Xekouki, Francien H van Nederveen, Michael A den Bakker, Maureen O'Sullivan, Winand NM Dinjens, and Ronald R de Krijger. Sdhb immunohistochemistry: a useful tool in the diagnosis of carney–stratakis and carney triad gastrointestinal stromal tumors. Modern Pathology, 24:147-151, Jan 2011. URL: https://doi.org/10.1038/modpathol.2010.185, doi:10.1038/modpathol.2010.185. This article has 252 citations and is from a domain leading peer-reviewed journal.
+
+14. (gaal2011sdhbimmunohistochemistrya media 9958076a): José Gaal, Constantine A Stratakis, J Aidan Carney, Evan R Ball, Esther Korpershoek, Maya B Lodish, Isaac Levy, Paraskevi Xekouki, Francien H van Nederveen, Michael A den Bakker, Maureen O'Sullivan, Winand NM Dinjens, and Ronald R de Krijger. Sdhb immunohistochemistry: a useful tool in the diagnosis of carney–stratakis and carney triad gastrointestinal stromal tumors. Modern Pathology, 24:147-151, Jan 2011. URL: https://doi.org/10.1038/modpathol.2010.185, doi:10.1038/modpathol.2010.185. This article has 252 citations and is from a domain leading peer-reviewed journal.
+
+15. (neppala2019currentmanagementof pages 1-2): Pushpa Neppala, Sudeep Banerjee, Paul T. Fanta, Mayra Yerba, Kevin A. Porras, Adam M. Burgoyne, and Jason K. Sicklick. Current management of succinate dehydrogenase–deficient gastrointestinal stromal tumors. Cancer and Metastasis Reviews, 38:525-535, Sep 2019. URL: https://doi.org/10.1007/s10555-019-09818-0, doi:10.1007/s10555-019-09818-0. This article has 62 citations and is from a peer-reviewed journal.
+
+16. (khurana2019paragangliomasincarney–stratakis pages 4-4): Arushi Khurana, Lin Mei, Anthony C. Faber, Steven C. Smith, and Sosipatros A. Boikos. Paragangliomas in carney–stratakis syndrome. Hormone and Metabolic Research, 51:437-442, Jun 2019. URL: https://doi.org/10.1055/a-0918-8340, doi:10.1055/a-0918-8340. This article has 6 citations and is from a peer-reviewed journal.
+
+17. (NCT03165721 chunk 1): John Glod. A Phase II Trial of the DNA Methyl Transferase Inhibitor, Guadecitabine (SGI-110), in Children and Adults With Wild Type GIST,Pheochromocytoma and Paraganglioma Associated With Succinate Dehydrogenase Deficiency and HLRCC-associated Kidney Cancer. National Cancer Institute (NCI). 2017. ClinicalTrials.gov Identifier: NCT03165721
+
+18. (NCT03165721 chunk 2): John Glod. A Phase II Trial of the DNA Methyl Transferase Inhibitor, Guadecitabine (SGI-110), in Children and Adults With Wild Type GIST,Pheochromocytoma and Paraganglioma Associated With Succinate Dehydrogenase Deficiency and HLRCC-associated Kidney Cancer. National Cancer Institute (NCI). 2017. ClinicalTrials.gov Identifier: NCT03165721
+
+19. (NCT03739827 chunk 1):  Natural History and Biospecimen Acquisition for Children and Adults With Rare Solid Tumors. National Cancer Institute (NCI). 2019. ClinicalTrials.gov Identifier: NCT03739827
+
+20. (schipani2023sdhagermlinemutations pages 1-2): Angela Schipani, Margherita Nannini, Annalisa Astolfi, and Maria A. Pantaleo. Sdha germline mutations in sdh-deficient gists: a current update. Genes, 14:646, Mar 2023. URL: https://doi.org/10.3390/genes14030646, doi:10.3390/genes14030646. This article has 24 citations.
+
+21. (florou2025areviewof pages 4-4): Vaia Florou, Michelle F. Jacobs, Ruth Casey, Denisse Evans, Becky Owens, Margarita Raygada, Sara Rothschild, and Samantha E. Greenberg. A review of genomic testing and sdh‐ deficiency in gastrointestinal stromal tumors: getting to the gist. Cancer Medicine, Feb 2025. URL: https://doi.org/10.1002/cam4.70669, doi:10.1002/cam4.70669. This article has 8 citations and is from a peer-reviewed journal.

--- a/research/Carney-Stratakis_Syndrome-deep-research-falcon.md.citations.md
+++ b/research/Carney-Stratakis_Syndrome-deep-research-falcon.md.citations.md
@@ -1,0 +1,482 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Carney-Stratakis syndrome
+- **MONDO ID:**  (if available)
+- **Category:** Genetic
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Carney-Stratakis syndrome** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T12:52:13.276499
+
+1. lobato2023threecasesof pages 1-2
+2. pitsava2021carneytriadcarneystratakis pages 3-4
+3. pasini2008clinicalandmolecular pages 1-2
+4. shi2022bladderparagangliomagastrointestinal pages 1-2
+5. schipani2023sdhagermlinemutations pages 8-9
+6. pasini2008clinicalandmolecular pages 4-6
+7. kim2024pathologicdiagnosisand pages 3-4
+8. neppala2019currentmanagementof pages 6-7
+9. gaal2011sdhbimmunohistochemistrya pages 6-8
+10. kim2024pathologicdiagnosisand pages 1-3
+11. neppala2019currentmanagementof pages 1-2
+12. schipani2023sdhagermlinemutations pages 1-2
+13. florou2025areviewof pages 4-4
+14. https://clinicaltrials.gov/study/NCT03165721
+15. https://clinicaltrials.gov/study/NCT03739827
+16. https://doi.org/10.1210/jcemcr/luad139;
+17. https://doi.org/10.3389/fonc.2024.1487467
+18. https://doi.org/10.3390/genes14030646;
+19. https://doi.org/10.1210/jcemcr/luad139
+20. https://doi.org/10.3389/fonc.2024.1487467;
+21. https://doi.org/10.3390/genes14030646
+22. https://doi.org/10.1055/a-0918-8340,
+23. https://doi.org/10.1038/sj.ejhg.5201904,
+24. https://doi.org/10.1210/jcemcr/luad139,
+25. https://doi.org/10.3389/fendo.2021.680609,
+26. https://doi.org/10.3389/fonc.2024.1487467,
+27. https://doi.org/10.3389/fonc.2022.1030092,
+28. https://doi.org/10.3390/genes14030646,
+29. https://doi.org/10.1007/s10555-019-09818-0,
+30. https://doi.org/10.1038/modpathol.2010.185,
+31. https://doi.org/10.1002/cam4.70669,


### PR DESCRIPTION
## Summary

- Add a new Carney-Stratakis syndrome disorder page from the Falcon deep research report.
- Curate SDHB/SDHC/SDHD germline etiology, SDH-deficient GIST/paraganglioma phenotypes, pseudohypoxia and epigenetic mechanisms, SDHB IHC diagnosis, differential diagnoses, and treatment/surveillance notes.
- Add only the PMID reference caches cited by the YAML plus the Falcon report and citation artifact.

## Validation

- `just validate kb/disorders/Carney-Stratakis_Syndrome.yaml` passed.
- `just validate-references kb/disorders/Carney-Stratakis_Syndrome.yaml` passed; validator reported 0 checks.
- `just validate-terms kb/disorders/Carney-Stratakis_Syndrome.yaml` passed.
- `just compliance kb/disorders/Carney-Stratakis_Syndrome.yaml` reported 89.5% global / 90.3% weighted compliance.

## Cache cleanup

Generated `cache/*` churn and uncited `references_cache/clinicaltrials_NCT*.md` churn were restored before commit. I did not hand-edit reference cache files.
