### PR TITLE
Add renal tubular acidosis distal 4 curation

### DIFF
--- a/kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml
+++ b/kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml
@@ -1,0 +1,424 @@
+name: Renal Tubular Acidosis Distal 4 with Hemolytic Anemia
+creation_date: "2026-05-11T00:00:00Z"
+updated_date: "2026-05-11T00:00:00Z"
+description: >-
+  Renal tubular acidosis, distal, 4, with hemolytic anemia is an inherited
+  SLC4A1-related disorder that combines impaired renal distal acid secretion
+  with red-cell membrane disease. In the best-described Indian families,
+  homozygous SLC4A1 p.Ala858Asp (A858D) causes autosomal recessive distal renal
+  tubular acidosis coupled with hereditary spherocytosis or hemolytic anemia.
+  The shared AE1/band 3 defect links kidney type A intercalated-cell
+  bicarbonate exchange to erythrocyte membrane stability.
+category: Mendelian
+parents:
+- autosomal recessive distal renal tubular acidosis
+- familial hemolytic anemia
+disease_term:
+  preferred_term: renal tubular acidosis, distal, 4, with hemolytic anemia
+  term:
+    id: MONDO:0012700
+    label: renal tubular acidosis, distal, 4, with hemolytic anemia
+synonyms:
+- Distal renal tubular acidosis 4 with hemolytic anemia
+- Distal renal tubular acidosis with anemia
+- dRTA with anemia
+- Autosomal recessive distal renal tubular acidosis coupled with hereditary spherocytosis
+inheritance:
+- name: Autosomal recessive
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  evidence:
+  - reference: PMID:37448902
+    reference_title: Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This report identifies an autosomal recessive inheritance pattern for
+      SLC4A1 variants in a patient presenting with dRTA and hemolytic anemia.
+    explanation: >-
+      This adult case report explicitly classifies the SLC4A1-associated dRTA
+      with hemolytic anemia presentation as autosomal recessive.
+pathophysiology:
+- name: SLC4A1 Anion Exchanger Dysfunction
+  description: >-
+    Biallelic pathogenic SLC4A1 variants impair anion exchanger 1 function in
+    kidney collecting-duct alpha-intercalated cells and in erythrocytes.
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Familial distal renal tubular acidosis (dRTA) can be caused by mutations
+      in the Cl2/HCO32 exchanger of the renal Type A intercalated cell, kidney
+      AE1/SLC4A1.
+    explanation: >-
+      This mechanistic passage identifies SLC4A1/AE1 as a collecting-duct
+      intercalated-cell exchanger required for distal urinary acidification.
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      AE1 is expressed not only in Type A intercalated cells, but also in late
+      erythroid precursors, reticulocytes, and circulating red cells.
+    explanation: >-
+      This supports the same gene product acting in both kidney acidification
+      cells and erythroid lineages.
+  cell_types:
+  - preferred_term: renal intercalated cell
+    term:
+      id: CL:0005010
+      label: renal intercalated cell
+  - preferred_term: erythrocyte
+    term:
+      id: CL:0000232
+      label: erythrocyte
+  gene:
+    preferred_term: SLC4A1
+    term:
+      id: hgnc:11027
+      label: SLC4A1
+  biological_processes:
+  - preferred_term: bicarbonate transport
+    modifier: DECREASED
+    term:
+      id: GO:0015701
+      label: bicarbonate transport
+  downstream:
+  - target: Distal Urinary Acidification Failure
+    description: Impaired renal anion exchanger function disrupts distal acid secretion.
+  - target: Red Cell Membrane Instability
+    description: Altered erythrocyte anion exchanger function destabilizes red-cell membranes.
+- name: Distal Urinary Acidification Failure
+  description: >-
+    Distal nephron acidification failure prevents appropriate urinary
+    acidification, causing metabolic acidosis and electrolyte complications.
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Additional findings of "metabolic acidosis with alkaline urine pH"
+      (detailed medical records are unavailable) led to the clinical diagnosis
+      of distal renal tubular acidosis.
+    explanation: >-
+      This patient-level observation links metabolic acidosis with inappropriately
+      alkaline urine to the dRTA diagnosis.
+  - reference: PMID:37448902
+    reference_title: Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Distal renal tubular acidosis (dRTA) can be caused by mutations in
+      SLC4A1, which encodes the Cl-/HCO3- exchanger of the renal type A
+      intercalated cell, kidney AE1.
+    explanation: >-
+      This case-report abstract directly links SLC4A1 mutations to dRTA through
+      the renal type A intercalated-cell exchanger.
+  cell_types:
+  - preferred_term: renal intercalated cell
+    term:
+      id: CL:0005010
+      label: renal intercalated cell
+  biological_processes:
+  - preferred_term: bicarbonate transport
+    modifier: DECREASED
+    term:
+      id: GO:0015701
+      label: bicarbonate transport
+  downstream:
+  - target: Distal Renal Tubular Acidosis Phenotype
+    description: Acidification failure produces the clinical distal renal tubular acidosis phenotype.
+- name: Red Cell Membrane Instability
+  description: >-
+    Abnormal erythrocyte membrane anion exchange causes red-cell fragility and
+    chronic hemolysis.
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The presence of band 3-deficient ovalocytic hemolytic anemia together
+      with evidence of distal renal tubular acidosis suggested possible mutation
+      of the SLC4A1 gene encoding erythroid and kidney isoforms of Band
+      3/AE1/SLC4A1.
+    explanation: >-
+      This links band 3-deficient hemolytic red-cell disease to the same SLC4A1
+      lesion causing the renal phenotype.
+  - reference: PMID:18266205
+    reference_title: Hematological abnormalities in patients with distal renal tubular acidosis and hemoglobinopathies.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Mutations of the human SLC4A1 gene encoding erythroid and kidney isoforms
+      of anion exchanger 1 (AE1, band 3) result in erythrocyte abnormalities or
+      distal renal tubular acidosis (dRTA) and such mutations are observed in
+      Southeast Asia, where hemoglobinopathies are prevalent.
+    explanation: >-
+      This cohort-based abstract supports SLC4A1 as a shared erythroid and
+      kidney mechanism for red-cell abnormalities and dRTA.
+  cell_types:
+  - preferred_term: erythrocyte
+    term:
+      id: CL:0000232
+      label: erythrocyte
+  downstream:
+  - target: Hemolytic Anemia Phenotype
+    description: Red-cell membrane instability causes hemolytic anemia.
+phenotypes:
+- name: Distal renal tubular acidosis
+  description: Impaired distal urinary acidification with systemic metabolic acidosis.
+  phenotype_term:
+    preferred_term: Distal renal tubular acidosis
+    term:
+      id: HP:0008341
+      label: Distal renal tubular acidosis
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We report here two unrelated Indian patients with combined hemolytic
+      anemia and dRTA who share homozygous A858D mutations of the AE1/SLC4A1
+      gene.
+    explanation: >-
+      This establishes dRTA as part of the combined homozygous SLC4A1 A858D
+      presentation.
+- name: Hemolytic anemia
+  description: Chronic hemolysis due to red-cell membrane dysfunction.
+  phenotype_term:
+    preferred_term: Hemolytic anemia
+    term:
+      id: HP:0001878
+      label: Hemolytic anemia
+  evidence:
+  - reference: PMID:37448902
+    reference_title: Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In some rare instances, SLC4A1 dRTA can present with hemolytic anemia
+      resulting in marked anemia that is not responsive to standard
+      interventions.
+    explanation: >-
+      This adult case report supports hemolytic anemia as a rare but explicit
+      SLC4A1-dRTA presentation.
+- name: Spherocytosis
+  description: Spherical red-cell morphology can accompany the hemolytic anemia phenotype.
+  phenotype_term:
+    preferred_term: Spherocytosis
+    term:
+      id: HP:0004444
+      label: Spherocytosis
+  evidence:
+  - reference: PMID:37448902
+    reference_title: Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this case study, we report an adult patient presenting with generalized
+      weakness, marked anemia, spherocytosis, and no features of thalassemia.
+    explanation: >-
+      This case report documents spherocytosis in an adult with homozygous
+      SLC4A1-associated dRTA and hemolytic anemia.
+- name: Metabolic acidosis
+  description: Hyperchloremic metabolic acidosis is the biochemical consequence of dRTA.
+  phenotype_term:
+    preferred_term: Metabolic acidosis
+    term:
+      id: HP:0001942
+      label: Metabolic acidosis
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Metabolic acidosis was noted concomitant with spot urine pH of 8 and
+      absence of glucosuria.
+    explanation: >-
+      This supports metabolic acidosis with alkaline urine as a clinical
+      presentation feature.
+- name: Hypokalemia
+  description: Low serum potassium can accompany the distal renal tubular acidosis phenotype.
+  phenotype_term:
+    preferred_term: Hypokalemia
+    term:
+      id: HP:0002900
+      label: Hypokalemia
+  evidence:
+  - reference: PMID:36776909
+    reference_title: "Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The children present with metabolic acidosis with high urinary pH,
+      accompanying hypokalemia, hyperchloremia, nephrocalcinosis, growth
+      retardation and hematological abnormalities should be suspected as dRTA
+      and suggested a genetic testing.
+    explanation: >-
+      This systematic review conclusion lists hypokalemia among the clinical
+      features that should prompt suspicion for SLC4A1-related dRTA.
+- name: Nephrocalcinosis
+  description: Renal medullary calcification/nephrocalcinosis is a reported renal complication.
+  phenotype_term:
+    preferred_term: Nephrocalcinosis
+    term:
+      id: HP:0000121
+      label: Nephrocalcinosis
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Sonography detected hepatosplenomegaly and nephrocalcinosis.
+    explanation: >-
+      This supports nephrocalcinosis as part of the reported patient phenotype.
+- name: Growth delay
+  description: Pediatric cases can present with impaired growth.
+  phenotype_term:
+    preferred_term: Growth delay
+    term:
+      id: HP:0001510
+      label: Growth delay
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patient 1, a 15 year old from Maharasthtra of Kunbi caste born of a
+      non-consanguinous marriage, presented at age 6 years with growth
+      retardation, jaundice and a history of fracture on falling.
+    explanation: >-
+      This supports growth delay in a pediatric homozygous A858D case.
+genetic:
+- name: SLC4A1
+  gene_term:
+    preferred_term: SLC4A1
+    term:
+      id: hgnc:11027
+      label: SLC4A1
+  association: Causative biallelic pathogenic variants
+  relationship_type: CAUSATIVE
+  variant_origin: GERMLINE
+  inheritance:
+  - name: Autosomal recessive
+  features: >-
+    Recurrent homozygous SLC4A1 c.2573C>A (p.Ala858Asp; A858D) has been
+    reported in Indian families with autosomal recessive distal renal tubular
+    acidosis coupled with hereditary spherocytosis or hemolytic anemia.
+  evidence:
+  - reference: PMID:33068675
+    reference_title: Genotypic analysis of SLC4A1 A858D mutation in Indian population associated with distal renal tubular Acidosis (dRTA) coupled with hemolytic anemia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We here described the clinical, hematological and genetic data of 16
+      individuals from 12 families having AR dRTA coupled with HS. All patients
+      carried homozygous SLC4A1 (A858D) mutation, whereas their family members
+      had heterozygous A858D obtained by HRM analysis and confirmed by RFLP and
+      Sanger sequencing.
+    explanation: >-
+      This Indian-family series supports homozygous SLC4A1 A858D as a recurrent
+      causal genotype for autosomal recessive dRTA coupled with hereditary
+      spherocytosis.
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      As shown in Fig. 2C, nominally nonconsanguinous patient 1 was homozygous
+      for the SLC4A1/AE1/Band 3 missense mutation A858D, encoded by a C-to-A
+      transversion changing codon GCC to GAC in exon 19.
+    explanation: >-
+      This original report identifies the homozygous SLC4A1 A858D variant in a
+      patient with combined hemolytic anemia and dRTA.
+epidemiology:
+- name: Published SLC4A1-dRTA case spectrum
+  description: >-
+    A systematic review of published SLC4A1-related dRTA cases found both
+    autosomal dominant and autosomal recessive inheritance, with recessive cases
+    more often reported in Asian patients and more severe biochemical
+    presentation.
+  evidence:
+  - reference: PMID:36776909
+    reference_title: "Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Fifty-three eligible articles involving 169 patients were included and 41
+      mutations were identified totally.
+    explanation: >-
+      This provides the published-case denominator for SLC4A1-related dRTA
+      literature synthesis.
+  - reference: PMID:36776909
+    reference_title: "Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Nephrocalcinosis or kidney stones were found in 72.27%, impairment in
+      renal function in 14.29%, developmental disorders in 61.16%,
+      hematological abnormalities in 33.88%, and muscle weakness in 13.45% of
+      patients.
+    explanation: >-
+      This summarizes the frequency of major renal, developmental, hematologic,
+      and neuromuscular features among published SLC4A1-dRTA patients.
+  - reference: PMID:36776909
+    reference_title: "Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Autosomal recessive inheritance was more often found in Asian patients,
+      and more attentions should be paid to the Asian patients.
+    explanation: >-
+      This supports the report's population observation for recessive
+      SLC4A1-related dRTA.
+treatments:
+- name: Oral alkali supplementation
+  description: >-
+    Oral sodium bicarbonate and potassium citrate correct systemic acidosis in
+    reported patients, although nephrocalcinosis may persist and hematologic
+    severity can vary.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: sodium bicarbonate
+      term:
+        id: CHEBI:32139
+        label: sodium hydrogencarbonate
+    - preferred_term: potassium citrate
+      term:
+        id: CHEBI:64733
+        label: potassium citrate (anhydrous)
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He was transfused and treated with oral sodium bicarbonate and potassium
+      citrate.
+    explanation: >-
+      This supports the specific alkali regimen used in a reported patient.
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both patients responded to oral base supplementation with resolution of
+      acidosis, but without reversal of nephrocalcinosis.
+    explanation: >-
+      This supports alkali responsiveness for acidosis while preserving the
+      limitation that nephrocalcinosis may not reverse.

--- a/kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml
+++ b/kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml
@@ -300,6 +300,59 @@ phenotypes:
       retardation, jaundice and a history of fracture on falling.
     explanation: >-
       This supports growth delay in a pediatric homozygous A858D case.
+- name: Rickets
+  description: Skeletal mineralization defects can accompany pediatric distal renal tubular acidosis.
+  phenotype_term:
+    preferred_term: Rickets
+    term:
+      id: HP:0002748
+      label: Rickets
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Physical exam revealed a weight of 13 kg (<5th %ile for age) and rickets.
+    explanation: >-
+      This directly documents rickets in a pediatric patient with homozygous
+      SLC4A1 A858D-associated dRTA and hemolytic anemia.
+- name: Hepatosplenomegaly
+  description: Combined liver and spleen enlargement was documented in the severe pediatric case.
+  phenotype_term:
+    preferred_term: Hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Physical examination revealed hepatosplenomegaly.
+    explanation: >-
+      This directly supports hepatosplenomegaly as a documented clinical
+      finding in a reported patient.
+- name: Jaundice
+  description: Hyperbilirubinemia from hemolysis can present clinically as jaundice.
+  phenotype_term:
+    preferred_term: Jaundice
+    term:
+      id: HP:0000952
+      label: Jaundice
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patient 1, a 15 year old from Maharasthtra of Kunbi caste born of a
+      non-consanguinous marriage, presented at age 6 years with growth
+      retardation, jaundice and a history of fracture on falling.
+    explanation: >-
+      This supports jaundice as part of the hemolytic presentation in a
+      homozygous A858D case.
 genetic:
 - name: SLC4A1
   gene_term:
@@ -422,3 +475,35 @@ treatments:
     explanation: >-
       This supports alkali responsiveness for acidosis while preserving the
       limitation that nephrocalcinosis may not reverse.
+- name: Blood transfusion
+  description: >-
+    Red blood cell transfusion may be required for marked or transfusion-dependent
+    hemolytic anemia in severe reported cases.
+  treatment_term:
+    preferred_term: blood transfusion
+    term:
+      id: MAXO:0000756
+      label: blood transfusion
+  evidence:
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      He was transfused and treated with oral sodium bicarbonate and potassium
+      citrate.
+    explanation: >-
+      This documents transfusion as part of clinical management for the severe
+      pediatric presentation.
+  - reference: PMID:20799361
+    reference_title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      However, patient 2 is severely anemic with dependence on frequent
+      transfusion, and is at risk for progressive nephrotoxicity from renal
+      hemosiderosis (8) and chronic scarring (9) in the setting of
+      nephrocalcinosis.
+    explanation: >-
+      This supports transfusion dependence as an important management context in
+      the severe hemolytic anemia phenotype.

--- a/references_cache/PMID_18266205.md
+++ b/references_cache/PMID_18266205.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:18266205"
+title: Hematological abnormalities in patients with distal renal tubular acidosis and hemoglobinopathies.
+authors:
+- Khositseth S
+- Sirikanaerat A
+- Khoprasert S
+- Opastirakul S
+- Kingwatanakul P
+- Thongnoppakhun W
+- Yenchitsomanus PT
+journal: Am J Hematol
+year: '2008'
+doi: 10.1002/ajh.21151
+keywords:
+- "Acidosis, Renal Tubular/blood, genetics"
+- Adolescent
+- "Anion Exchange Protein 1, Erythrocyte/genetics"
+- Child
+- "Child, Preschool"
+- DNA Mutational Analysis
+- "Elliptocytosis, Hereditary"
+- "Erythrocytes, Abnormal/pathology"
+- Female
+- Genotype
+- "Hematologic Diseases/genetics, pathology"
+- "Hemoglobinopathies/genetics, pathology"
+- Humans
+- Infant
+- Male
+- "Mutation, Missense"
+- Reticulocytosis
+- Thailand
+content_type: abstract_only
+---
+
+# Hematological abnormalities in patients with distal renal tubular acidosis and hemoglobinopathies.
+**Authors:** Khositseth S, Sirikanaerat A, Khoprasert S, Opastirakul S, Kingwatanakul P, Thongnoppakhun W, Yenchitsomanus PT
+**Journal:** Am J Hematol (2008)
+**DOI:** [10.1002/ajh.21151](https://doi.org/10.1002/ajh.21151)
+
+## Content
+
+1. Am J Hematol. 2008 Jun;83(6):465-71. doi: 10.1002/ajh.21151.
+
+Hematological abnormalities in patients with distal renal tubular acidosis and 
+hemoglobinopathies.
+
+Khositseth S(1), Sirikanaerat A, Khoprasert S, Opastirakul S, Kingwatanakul P, 
+Thongnoppakhun W, Yenchitsomanus PT.
+
+Author information:
+(1)Department of Pediatrics, Faculty of Medicine, Thammasat University, 
+Thailand.
+
+Mutations of the human SLC4A1 gene encoding erythroid and kidney isoforms of 
+anion exchanger 1 (AE1, band 3) result in erythrocyte abnormalities or distal 
+renal tubular acidosis (dRTA) and such mutations are observed in Southeast Asia, 
+where hemoglobinopathies are prevalent. Genetic and hematological studies in 18 
+Thai patients with dRTA have shown that 12 of them (67%) carried SLC4A1 
+mutations (7 G701D/G701D, 3 SAO/G701D, and 2 G701D/A858D). Of these 12 patients, 
+three had homozygous G701D/G701D and heterozygous Hb E; one compound 
+heterozygous SAO/G701D and heterozygous alpha(+)-thalassemia; and one compound 
+heterozygous G701D/A858D and heterozygous Hb E. Of 6 patients without SLC4A1 
+mutation, two each carried heterozygous or homozygous Hb E and one of the latter 
+also had Hb H disease (--(SEA)/-alpha(4.2)). The blood smears of patients with 
+homozygous G701D/G701D showed approximately 25% ovalocytes. Strikingly, the 
+patients with coexistence of homozygous G701D/G701D and heterozygous Hb E had 
+58% ovalocytes. Similarly, the patients who had compound heterozygous SAO/G701D 
+showed 49% ovalocytes, but the patient with coexistence of compound heterozygous 
+SAO/G701D and heterozygous alpha(+)-thalassemia had 70% ovalocytes. Our previous 
+study has shown that under metabolic acidosis, the patients with homozygous 
+G701D/G701D or compound heterozygous SAO/G701D had reticulocytosis, indicating 
+compensated hemolysis. A patient with compound heterozygous SAO/G701D and 
+heterozygous alpha(+)-thalassemia presented with hemolytic anemia and 
+hepatosplenomegaly which was alleviated by alkaline therapy. Taken together, the 
+coexistence of both homozygous or compound heterozygous SLC4A1 mutations and 
+hemoglobinopathy has a combined effect on red cell morphology and degree of 
+hemolytic anemia, which is aggravated by acidosis.
+
+Copyright 2008 Wiley-Liss, Inc.
+
+DOI: 10.1002/ajh.21151
+PMID: 18266205 [Indexed for MEDLINE]

--- a/references_cache/PMID_20799361.md
+++ b/references_cache/PMID_20799361.md
@@ -1,0 +1,114 @@
+---
+reference_id: "PMID:20799361"
+title: Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+authors:
+- Shmukler BE
+- Kedar PS
+- Warang P
+- Desai M
+- Madkaikar M
+- Ghosh K
+- Colah RB
+- Alper SL
+journal: Am J Hematol
+year: '2010'
+doi: 10.1002/ajh.21836
+keywords:
+- "Acidosis, Renal Tubular/complications, genetics"
+- Amino Acid Substitution
+- "Anemia, Hemolytic, Congenital/complications, genetics"
+- "Anemia, Macrocytic/complications, drug therapy"
+- "Anion Exchange Protein 1, Erythrocyte/genetics, physiology"
+- Child
+- Codon/genetics
+- Consanguinity
+- Ethnicity/genetics
+- Homozygote
+- Humans
+- India/epidemiology
+- Infant
+- Introns/genetics
+- "Mutation, Missense"
+- Pedigree
+- Point Mutation
+- "Polymorphism, Restriction Fragment Length"
+- "Tuberculosis, Multidrug-Resistant/complications"
+content_type: full_text_xml
+---
+
+# Hemolytic anemia and distal renal tubular acidosis in two Indian patients homozygous for SLC4A1/AE1 mutation A858D.
+**Authors:** Shmukler BE, Kedar PS, Warang P, Desai M, Madkaikar M, Ghosh K, Colah RB, Alper SL
+**Journal:** Am J Hematol (2010)
+**DOI:** [10.1002/ajh.21836](https://doi.org/10.1002/ajh.21836)
+
+## Content
+
+1. Am J Hematol. 2010 Oct;85(10):824-8. doi: 10.1002/ajh.21836.
+
+Hemolytic anemia and distal renal tubular acidosis in two Indian patients 
+homozygous for SLC4A1/AE1 mutation A858D.
+
+Shmukler BE, Kedar PS, Warang P, Desai M, Madkaikar M, Ghosh K, Colah RB, Alper 
+SL.
+
+Familial distal renal tubular acidosis (dRTA) can be caused by mutations in the 
+Cl2/HCO32 exchanger of the renal Type A intercalated cell, kidney AE1/SLC4A1. 
+dRTA-associated AE1 mutations have been reported in families from North America, 
+Europe, Thailand, Malaysia, Papua-New Guinea, Taiwan, and the Philippines, but 
+not India. The dRTA mutation AE1 A858D has been detected only in the context of 
+compound heterozygosity. We report here two unrelated Indian patients with 
+combined hemolytic anemia and dRTA who share homozygous A858D mutations of the 
+AE1/SLC4A1 gene. The mutation creates a novel restriction site that is validated 
+for diagnostic screening.
+
+DOI: 10.1002/ajh.21836
+PMCID: PMC3517738
+PMID: 20799361 [Indexed for MEDLINE]
+
+Distal urinary acidification requires coordinated function of several proteins in the Type A intercalated cell of the renal collecting duct: the multi-subunit, vacuolar (v)H+-ATPase of the apical membrane, cytoplasmic carbonic anhydrase II, and the SLC4A1/AE1 Cl−/HCO3− exchanger (kidney Band 3, kAE1). Mutations in any one of these genes can cause dRTA, and AE1 mutations have been linked to both recessive and dominant forms of dRTA (1). AE1 is expressed not only in Type A intercalated cells, but also in late erythroid precursors, reticulocytes, and circulating red cells. AE1 mutations associated with dominant hereditary spherocytic and stomatocytic anemias are generally unassociated with a renal phenotype. Conversely, dRTA mutations associated with dominant and recessive dRTA were long believed to be without associated erythroid phenotype (1). However, compound heterozygotes have been described with combined spherostomatocytic anemia and dRTA (2). More recently, subclinical cation-leak stomatocytosis has been associated with AE1 mutation-associated dRTA (3).
+
+Case reports of non-sporadic dRTA have appeared from India. Among 40 pediatric nephrocalcinosis cases from New Delhi, 50% presented with dRTA between ages 3 and 6 years (4). However, molecular diagnoses of dRTA have only recently begun to appear from India. A 12 year old with osteopetrosis, renal tubular acidosis, and cerebral calcifications was homozygous for the carbonic anhydrase II mutation S29P (5), and siblings with dRTA and sensorineural deafness were homozygous for R31X truncations in the B1 subunit of vacuolar H+-ATPase (6).
+
+We report here the first two cases of dRTA from India associated with mutations in the SLC4A1/AE1 gene. Two unrelated patients from Maharashtra with combined hemolytic anemia and dRTA were found to be homozygous for the AE1 A858D mutation, previously detected only in the heterozygous or compound heterozygous state.
+
+Patient 1, a 15 year old from Maharasthtra of Kunbi caste born of a non-consanguinous marriage, presented at age 6 years with growth retardation, jaundice and a history of fracture on falling. Physical exam revealed a weight of 13 kg (<5th %ile for age) and rickets. Abdominal sonogram revealed splenomegaly, bilateral renal medullary calcification, and two simple left renal cortical cysts (unchanged 3 years later). Additional findings of “metabolic acidosis with alkaline urine pH” (detailed medical records are unavailable) led to the clinical diagnosis of distal renal tubular acidosis. Treatment with oral sodium bicarbonate and potassium citrate reportedly resolved the acidosis.
+
+In May 2009, the patient presented with jaundice and history of a recent blood transfusion. Exam revealed normal stature and weight with persistent splenomegaly. Peripheral blood smear revealed ovalocytes and tear drop cells without stomatocytes (Figure 1A). Hematological indices revealed macrocytic anemia with Hct 13.2%, Hgb 4.9 g/dL, reticulocyte count 7%, mean corpuscular volume 129 fL, mean corpuscular hemoglobin concentration 37.1 g/dL, and relative density width 27.2. E5M mean channel fluorescence (MCF) indicating AE1/Band3 surface abundance was 850 au (normal range 1080-1300 au). Serum Vitamin B12 was low at 110 pg/mL (normal range 211 - 911 pg /mL). Total bilirubin was 4.9 mg/dL with indirect bilirubin 4.7 mg/dL, and serum alkaline phosphatase was elevated at 530 IU/L. Serum K+ was normal at 4.1 mM. Serum bicarbonate was 26.7 mM with blood pH 7.41 while on continued oral supplementation with bicarbonate and citrate. Blood urea nitrogen of 9 mg% and serum creatinine of 0.4 mg% indicated normal renal glomerular function. 24 hr urinary calcium excretion was normal at 2.2 mmol per 5.3 mmol creatinine. The patient’s parents and one older sib had no clinical history of hematological or renal disease. The patient’s mother had normal hematological indices, but E5M MCF was reduced (847 au vs. normal control 1103 au).
+
+After transfusion, the patient was treated with intravenous vitamin B12 and with chronic oral folate supplementation. 13 months later, splenomegaly persisted, but hematological indices showed improvement: Hgb 12.0 g/dL, Hct 31.2 %, MCV 81.3 fL, MCHC 38.5 mg/dL, reticulocyte count 2%. Total bilirubin was 3.7 mg/dL (direct 0.5 mg/dL), and alkaline phosphatase 238 U/L. The smear at that time revealed that resolution of macrocytosis was accompanied by more prominent elliptocytosis and stomatocytosis and acanthocytosis (Figure 1B). Both parents have been asymptomatic, and hematologic indices of the mother were unremarkable.
+
+The clinical diagnosis was treated dRTA with ovalocytic, hemolytic anemia and ineffective erythropoiesis complicated by folate/B12 deficiency responsive to supplementation. The combined anemia and dRTA suggested evaluation of erythroid band 3/AE1. Reduced E5M MCF further supported moderate erythroid Band 3 deficiency.
+
+Patient 2, a 6 year old male from Maharashtra, of Kunbi caste born to first cousin parents (Figure 2A), presented at age 16 months with sudden onset hypotonia without diarrhea or vomiting. Physical examination revealed hepatosplenomegaly. Hb was 4.4 g/dL with reticulocytosis, and peripheral blood smear showed spherocytes, ovalocytes, acanthocytes, and schizocytes (not shown). Sonography detected hepatosplenomegaly and nephrocalcinosis. Metabolic acidosis was noted concomitant with spot urine pH of 8 and absence of glucosuria. The patient was diagnosed with hemolytic anemia and dRTA (detailed medical records not available). He was transfused and treated with oral sodium bicarbonate and potassium citrate. From 3 years of age, the tranfusion requirement gradually increased to a current frequency of every 30-45 days. At age 4 ½ years the patient developed multi-drug resistant pulmonary tuberculosis, initially treated with kanamycin, ethionamide, pyrazinamide, capreomycin, clofazimine, and ofloxacin, and more recently switched to a regimen of ethionamide, cycloserine, sodium aminosalicylate, moxifloxacin, and clofazermine.
+
+Recent evaluation of patient 2 revealed continued growth retardation, hepatosplenomegaly, and nephrocalcinosis. Peripheral blood smear was remarkable for spherostomatocytosis, anisopoikilocytosis, acanthocytosis, and elliptocytes. Hematological indices revealed Hgb 4.9 g/dL, Hct 15.9%, MCV 80.7 fL, MCHC 30.8 g/dL, reticulocyte count 5%. Alkaline phosphatase was elevated at 273 IU/L. Serum K+ was 3.4 mM. On oral bicarbonate/citrate supplementation, blood pH was 7.38 and serum bicarbonate was 23.4 mM, Blood urea nitrogen was 8 mg/dL and serum creatinine was 0.3 mg/dL Spot urine revealed pH 8.0, trace proteinuria, and no glucosuria. Analysis of red cell AE1/Band 3 surface abundance by E5M flow-cytometry revealed MCF of 710 a.u. (normal 1070-1300; Fig. 2B). Erythroid osmotic fragility was slightly increased (0.52% vs control 0.42 - 0.48%). Both parents were asymptomatic. The patient’s father had normal hematological indices, but moderate reduction in red cell E5M MCF of 896 a.u. The patient’s mother had mild microcytic anemia (Hb 10.7, Hct 32.2, MCV 73). No further family history or laboratory workup was available.
+
+The presence of band 3-deficient ovalocytic hemolytic anemia together with evidence of distal renal tubular acidosis suggested possible mutation of the SLC4A1 gene encoding erythroid and kidney isoforms of Band 3/AE1/SLC4A1. The entire coding region and all splice junctions and flanking sequences of the AE1 gene were sequenced. Complete DNA sequences were also obtained for introns 2, 5, 7, 8, 10-12, 14, 15, 18, and 19 from both patients. In addition, introns 3 and 6 were sequenced completely from patient 1, and partially from patient 2.
+
+As shown in Fig. 2C, nominally nonconsanguinous patient 1 was homozygous for the SLC4A1/AE1/Band 3 missense mutation A858D, encoded by a C-to-A transversion changing codon GCC to GAC in exon 19. The same homozygous mutation was found in consanguinous patient 2 genomic DNA (not shown). The A858D mutation has been reported previously only in heterozygous or compound heterozygous states. Neither patient exhibited the Southeast Asian ovalocytosis deletion mutation, Δ400-408, or the tightly linked Band 3 Memphis I polymorphism, E56K.
+
+The C-to-A nucleotide substitution encoding the AE1 A858D mutation introduces a novel AvaII restriction site not present in the wildtype AE1 gene. The presence of the AvaII site can be used diagnostically to confirm the presence of the A858D mutation in appropriate PCR amplification products, as shown in Fig. 2D. The PCR product of 482 bp (lane 3) remains uncut in wildtype genomic DNA (lane 2), whereas the PCR product from A858D/A858D genomic DNA is cleaved at a single site, giving rise to two AvaII fragments of 345 and 137 bp (lane 1). Fig. 2D also shows that the C-to-A nucleotide substitution of the A858D mutation also abolishes a BglI site in the same PCR product, such that wildtype BglI fragments of 134 and 38 bp (lane 5) are contained in a single 172 bp fragment in A858D/A858D genomic DNA (lane 4).
+
+Several intronic sequence variants were detected in both patients. Patients 1 and 2 each were homozygous for intron 3 substitutions c.11079G>A (SNP rs999716) and the apparently novel c.11200C>A, both within the putative kAE1 promoter region. Both patients were also homozygous for intron 17 substitutions c.20332T>G (SNP rs2857078) and c.20381G>A (SNP rs1476512). Genomic DNA was unavailable from either set of nominally obligate heterozygote parents or from the sib of patient 1. The two dRTA patients with hemolytic anemia described in this paper are the first dRTA patients from India with defined mutations in the SLC4A1/AE1 gene encoding kAE1 of the Type A intercalated cell basolateral membrane and eAE1 or the erythocyte. These patients are also the first reported with with homozygous AE1 A858D mutations. This substitution mutation introduces a novel AvaII restriction site easily diagnosed by restriction digest of a genomic PCR product.
+
+Both patients are also homozygous for identical, linked, intronic polymorphisms. Though nominally unrelated, both patients are of the same Maratha ethnic group from the Mumbai region. The allele frequency of the A858D mutation or other dRTA-associated mutations among Marathas or other Indians is presently unknown. The A858D mutation was not found among 206 healthy individuals from Southern Thailand (7). Neither patient exhibited the Southeast Asian Ovalocytosis (SAO) mutation AE1 Δ400-408 or its tightly linked Memphis I polymorphism E56K.
+
+Patient 1 presented with paradoxical macrocytosis which turned out to be coincident vitamin B12 deficiency, possibly compounded with folate deficiency. The macrocytosis resolved after repletion of cobalamin and folate, but the smear remained atypical. The course of patient 2 was complicated by multidrug-resistant tuberculosis, requiring treatment with nephrotoxic antibiotics, including aminoglycosides and some drugs previously associated with inflammatory intersitial nephritis. Both patients responded to oral base supplementation with resolution of acidosis, but without reversal of nephrocalcinosis. Patient 1 remains moderately anemic, requiring only occasional tranfusion. However, patient 2 is severely anemic with dependence on frequent transfusion, and is at risk for progressive nephrotoxicity from renal hemosiderosis (8) and chronic scarring (9) in the setting of nephrocalcinosis.
+
+The AE1 A858D mutation has been described in compound heterozygosity with AE1 SAO in a Malay family, with AE1 ΔV850 in a family from Papua New Guinea (2), and with AE1 G701D in two Thais (10). All of these compound heterozygous patients exhibited complete dRTA. Both compound heterozygous and homozygous A858D dRTA patients responded to oral base supplementation with normalization of acidosis and resumption of normal growth.
+
+The homozygous A858D patients presented with severe anemia. Anemia was also moderate-to-severe for A858D/SAO and A858D/ΔV850 patients, but A858D/G701D patients and A858D/+ heterozygotes had minimal if any anemia, with slight reticulocytosis. Most A858D/SAO red cells were small atypical elliptocytes. The more frequently elliptocytic A858D/ΔV850 red cells included microcytes, poikilocytes, and schizocytes (2), while A858D/G701D red cells included xerocytes, pincer cells, echinocytes, and acanthocytes (11). The smears of homozygous A858D patients resembled those of compound heterozygotes with Δ850 and G701D (Fig. 1), but A858D/+ red cells were normal or acanthocytic (2). The mechanism by which particular AE1 mutations give rise to specific morphologies of circulating erythrocytes remains unclear.
+
+A858D/+ red cells were of normal rigidity, but A858D/SAO red cells exhibited greater rigidity than SAO/+ red cells. In the A858D/SAO red cell membrane, AE1 A858D polypeptide was less abundant than AE1 SAO polypeptide. DIDS-sensitive sulfate influx, was 80% of normal in intact A858D/+ red cells, but only 30% of normal in A858D/ΔV850 cells (2).
+
+Recombinant kAE1 A858D expressed in Xenopus oocytes exhibited 28% of wildtype activity, a value increased to 64% by coexpression of human glycophorin A (GPA) through increased surface expression. AE1 SAO polypeptide coexpression exerted a dominant negative effect on AE1 A858D even in the presence of glycophorin A (2). AE1 A858D coexpressed with GPA also conferred on Xenopus oocytes low level cation leak activity, a property shared by other AE1 mutants associated with dRTA (3), and with apparently isolated stomatocytosis (12, 13).
+
+In polarized MDCK cell monolayers, kAE1 A858D polypeptide was only slightly impaired in exit from endoplasmic reticulum, and trafficked normally to the basolateral membrane, where it exhibited some Cl−/HCO3− exchange activity, despite altered SITS-agarose binding of the detergent-solubilized mutant protein (14). kAE1 A858D coexpression with kAE1 SAO (15) or with kAE1 G701D polypeptides (16) promoted intracellular retention of both mutants with decreased surface expression. The Cys 858 residue is located near the exofacial surface of AE1 (17).
+
+The two patients described in the current report are the first patients from India in whom dRTA has been linked to mutations in the SLC4A1/AE1 gene. They also represent the first reported cases of homozygous AE1 A858D mutations. The associated combined syndrome of hemolytic anema and distal renal tubular acidosis provides another example of an AE1 mutation in which hematologic and renal phenotypes are not segregated.
+
+Blood samples were obtained during normal clinical care at Mumbai’s B. J. Wadia Children’s Hospital. Non-routine diagnostic studies were performed according to protocols approved by the Institutional Review Boards of the National Institute of Immunohematology (Mumbai) and Beth Israel Deaconess Medical Center (Boston). Hematological indices were measured in Mumbai with Sysmex automated cell counters (KX 21 or XS 800i, Kobe). Eosin-5′-maleimide (E5M) flow cytometry measured red cell surface abundance of Band 3/AE1/SLC4A1 polypeptide (18).
+
+Genomic DNA was isolated from whole blood samples (Qiagen Blood and Tissue Dneasy Mini Kit) . The SLC4A1/AE1/Band 3 gene was PCR-amplified in 5 fragments encompassing all 20 exons with their splice junctions and flanking regions, and the putative kAE1 promoter in intron 3. Reaction mixes containing 100-500 ng of human genomic DNA and HotStart DNA Polymerase (Qiagen), made up to 50 μL reaction volume with the suppliers’ recommended buffer, were incubated at 95°C for 15 min, then subjected to 36 cycles of PCR (45 sec denaturation at 94°C, 2 min annealing at 60°C, 3-5 min elongation at 72°C). A 7 min final extension at 72°C was terminated by rapid cooling to room temperature. PCR products were separated in 1% agarose gels, visualized by ethidium bromide staining, excised, purified (QIAquick Gel Extraction Kit), and sequenced. Table 1 lists the oligonucleotides used to amplify and sequence AE1 genomic DNA.
+
+For diagnostic restriction digestion, genomic DNA of patients and normal controls was subjected to PCR-amplification (conditions as above, except for 2 min elongation time) with this oligonucleotide pair: hAE1.I18F2: 5′-AGGGTGCTGGGGTGTGATAGG-3′ and hAE1.I19R2: 5′-CTCACTCACAGCACACCCTGTC-3′. The amplicon was purified (QIAquick PCR purification Kit, Qiagen), digested with AvaII or BglI (New England Biolabs, Beverley, MA), then analyzed by agarose gel electrophroesis. (Informative restriction digestion did not require amplicon purification from the PCR reaction.)

--- a/references_cache/PMID_33068675.md
+++ b/references_cache/PMID_33068675.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:33068675"
+title: Genotypic analysis of SLC4A1 A858D mutation in Indian population associated with distal renal tubular Acidosis (dRTA) coupled with hemolytic anemia.
+authors:
+- More TA
+- Kedar PS
+journal: Gene
+year: '2021'
+doi: 10.1016/j.gene.2020.145241
+keywords:
+- "Acidosis, Renal Tubular/complications, genetics"
+- Adolescent
+- "Anion Exchange Protein 1, Erythrocyte/genetics"
+- Child
+- "Child, Preschool"
+- Female
+- Humans
+- India
+- Infant
+- Male
+- "Mutation, Missense"
+- Pedigree
+- "Spherocytosis, Hereditary/complications"
+- Young Adult
+content_type: abstract_only
+---
+
+# Genotypic analysis of SLC4A1 A858D mutation in Indian population associated with distal renal tubular Acidosis (dRTA) coupled with hemolytic anemia.
+**Authors:** More TA, Kedar PS
+**Journal:** Gene (2021)
+**DOI:** [10.1016/j.gene.2020.145241](https://doi.org/10.1016/j.gene.2020.145241)
+
+## Content
+
+1. Gene. 2021 Feb 15;769:145241. doi: 10.1016/j.gene.2020.145241. Epub 2020 Oct
+15.
+
+Genotypic analysis of SLC4A1 A858D mutation in Indian population associated with 
+distal renal tubular Acidosis (dRTA) coupled with hemolytic anemia.
+
+More TA(1), Kedar PS(2).
+
+Author information:
+(1)Department of Hematogenetics, ICMR-National Institute of Immunohematology, 
+KEM Hospital Campus, Parel, Mumbai 40012, India.
+(2)Department of Hematogenetics, ICMR-National Institute of Immunohematology, 
+KEM Hospital Campus, Parel, Mumbai 40012, India. Electronic address: 
+kedarps2002@yahoo.com.
+
+INTRODUCTION: Although distinctive, distal renal tubular acidosis (dRTA) and 
+Hereditary Spherocytosis (HS) shares a common protein, the anion exchanger1 
+(AE1) encoded by SLC4A1gene. In spite of this, the co-existence of dRTA and HS 
+has rarely been observed. To date, 23 mutations have been identified in SLC4A1 
+gene causing both autosomal recessive (AR) and autosomal dominant (AD) forms of 
+dRTA.
+METHODS: We have assessed the applicability of the High Resolution Melting curve 
+(HRM) method for the detection of SLC4A1 (A858D) mutation in 12 Indian families 
+having AR dRTA coupled with HS. The reliability of the HRM analysis was verified 
+by comparing the results of the HRM method with those of conventional methods 
+such as Polymerase Chain Reaction-Restriction Fragment-Length Polymorphism 
+(PCR-RFLP) and Sanger sequencing thereby confirming the diagnosis.
+RESULTS: We here described the clinical, hematological and genetic data of 16 
+individuals from 12 families having AR dRTA coupled with HS. All patients 
+carried homozygous SLC4A1 (A858D) mutation, whereas their family members had 
+heterozygous A858D obtained by HRM analysis and confirmed by RFLP and Sanger 
+sequencing.
+CONCLUSION: Our data indicates that a missense mutation of A858D in SLC4A1 gene 
+is the most common cause of dRTA coupled with HS in the Indian population. HRM 
+analysis can be used as a rapid screening method for common SLC4A1 mutations 
+that cause AR dRTA in the Indian population.
+
+Copyright © 2020 Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.gene.2020.145241
+PMID: 33068675 [Indexed for MEDLINE]

--- a/references_cache/PMID_36776909.md
+++ b/references_cache/PMID_36776909.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:36776909"
+title: "Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients."
+authors:
+- Yang M
+- Sheng Q
+- Ge S
+- Song X
+- Dong J
+- Guo C
+- Liao L
+journal: Front Pediatr
+year: '2023'
+doi: 10.3389/fped.2023.1077120
+content_type: abstract_only
+---
+
+# Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: Analysis based on published patients.
+**Authors:** Yang M, Sheng Q, Ge S, Song X, Dong J, Guo C, Liao L
+**Journal:** Front Pediatr (2023)
+**DOI:** [10.3389/fped.2023.1077120](https://doi.org/10.3389/fped.2023.1077120)
+
+## Content
+
+1. Front Pediatr. 2023 Jan 26;11:1077120. doi: 10.3389/fped.2023.1077120. 
+eCollection 2023.
+
+Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations: 
+Analysis based on published patients.
+
+Yang M(1)(2), Sheng Q(3), Ge S(1), Song X(4), Dong J(3), Guo C(1)(4), Liao 
+L(1)(2)(4).
+
+Author information:
+(1)Department of Endocrinology and Metabology, The First Affiliated Hospital of 
+Shandong First Medical University & Shandong Provincial Qianfoshan Hospital, 
+Ji-nan, China.
+(2)Cheeloo College of Medicine, Shandong University, Department of Endocrinology 
+and Metabology, Shandong Provincial Qianfoshan Hospital, Shandong Key Laboratory 
+of Rheumatic Disease and Translational Medicine, Shandong Institute of 
+Nephrology, Ji-nan, China.
+(3)Division of Endocrinology, Department of Internal Medicine, Qilu Hospital of 
+Shandong University, Ji-nan, China.
+(4)College of Traditional Chinese Medicine, Shandong University of Traditional 
+Chinese Medicine, Ji-nan, China.
+
+BACKGROUND AND AIMS: The genetic and clinical characteristics of patients with 
+distal renal tubular acidosis (dRTA) caused by SLC4A1 mutations have not been 
+systematically recorded before. Here, we summarized the SLC4A1 mutations and 
+clinical characteristics associated with dRTA.
+METHODS: Database was searched, and the mutations and clinical manifestations of 
+patients were summarized from the relevant articles.
+RESULTS: Fifty-three eligible articles involving 169 patients were included and 
+41 mutations were identified totally. Fifteen mutations involving 100 patients 
+were autosomal dominant inheritance, 21 mutations involving 61 patients were 
+autosomal recessive inheritance. Nephrocalcinosis or kidney stones were found in 
+72.27%, impairment in renal function in 14.29%, developmental disorders in 
+61.16%, hematological abnormalities in 33.88%, and muscle weakness in 13.45% of 
+patients. The age of onset was younger (P < 0.01), urine pH was higher 
+(P < 0.01), and serum potassium was lower (P < 0.001) in recessive patients than 
+patients with dominant SLC4A1 mutations. Autosomal recessive inheritance was 
+more often found in Asian patients (P < 0.05).
+CONCLUSIONS: The children present with metabolic acidosis with high urinary pH, 
+accompanying hypokalemia, hyperchloremia, nephrocalcinosis, growth retardation 
+and hematological abnormalities should be suspected as dRTA and suggested a 
+genetic testing. The patients with recessive dRTA are generally more severely 
+affected than that with dominant SLC4A1 mutations. Autosomal recessive 
+inheritance was more often found in Asian patients, and more attentions should 
+be paid to the Asian patients.
+
+© 2023 Yang, Sheng, Ge, Song, Dong, Guo and Liao.
+
+DOI: 10.3389/fped.2023.1077120
+PMCID: PMC9910804
+PMID: 36776909
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_37448902.md
+++ b/references_cache/PMID_37448902.md
@@ -1,0 +1,54 @@
+---
+reference_id: "PMID:37448902"
+title: Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+authors:
+- Shaikh W
+- Suratkal L
+- Bhave A
+journal: Indian J Nephrol
+year: '2023'
+doi: 10.4103/ijn.ijn_210_21
+content_type: abstract_only
+---
+
+# Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due to Homozygous SLC4A1 Mutation.
+**Authors:** Shaikh W, Suratkal L, Bhave A
+**Journal:** Indian J Nephrol (2023)
+**DOI:** [10.4103/ijn.ijn_210_21](https://doi.org/10.4103/ijn.ijn_210_21)
+
+## Content
+
+1. Indian J Nephrol. 2023 May-Jun;33(3):209-212. doi: 10.4103/ijn.ijn_210_21.
+Epub  2023 Feb 21.
+
+Rare Case of Hemolytic Anemia and Distal Renal Tubular Acidosis in an adult due 
+to Homozygous SLC4A1 Mutation.
+
+Shaikh W(1), Suratkal L(1), Bhave A(2).
+
+Author information:
+(1)Department of Nephrology, Lilavati Hospital and Research Center, Mumbai, 
+Maharashtra, India.
+(2)Department of Hematology, Lilavati Hospital and Research Center, Mumbai, 
+Maharashtra, India.
+
+In this case study, we report an adult patient presenting with generalized 
+weakness, marked anemia, spherocytosis, and no features of thalassemia. The 
+patient was treated for suspicion of autoimmune hemolytic anemia but was 
+recalcitrant to treatment. Genetic analysis revealed the patient to be 
+homozygous for SLC4A1 c.2573C>A (p.Ala858Asp). Distal renal tubular acidosis 
+(dRTA) can be caused by mutations in SLC4A1, which encodes the Cl-/HCO3- 
+exchanger of the renal type A intercalated cell, kidney AE1. SLC4A1 variants 
+have been reported in dRTA patients from North America, Europe, and Southeast 
+Asia. In some rare instances, SLC4A1 dRTA can present with hemolytic anemia 
+resulting in marked anemia that is not responsive to standard interventions. 
+This report identifies an autosomal recessive inheritance pattern for SLC4A1 
+variants in a patient presenting with dRTA and hemolytic anemia.
+
+Copyright: © 2023 Indian Journal of Nephrology.
+
+DOI: 10.4103/ijn.ijn_210_21
+PMCID: PMC10337233
+PMID: 37448902
+
+Conflict of interest statement: There are no conflicts of interest.

--- a/research/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia-deep-research-falcon.md
+++ b/research/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia-deep-research-falcon.md
@@ -1,0 +1,1323 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T12:37:25.452223'
+end_time: '2026-05-11T13:08:32.511740'
+duration_seconds: 1867.06
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Renal Tubular Acidosis Distal 4 with Hemolytic Anemia
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 41
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Renal Tubular Acidosis Distal 4 with Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Renal Tubular Acidosis Distal 4 with Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Renal Tubular Acidosis Distal 4 with Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Renal Tubular Acidosis Distal 4 with Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Comprehensive Disease Characteristics Research Report
+
+### Target disease
+**Renal Tubular Acidosis, Distal, 4 with Hemolytic Anemia** (Mendelian, typically AR)
+
+---
+
+## 1. Disease Information
+
+### Disease overview
+Renal tubular acidosis (RTA) comprises disorders of renal acid handling that cause **chronic, normal-anion-gap (hyperchloremic) metabolic acidosis**. **Distal RTA (dRTA; type 1)** is defined by the **failure to acidify urine below pH ~5.5** despite systemic acidosis and is primarily a disorder of **type A (α-) intercalated cells** in the collecting duct. In the subset “dRTA with hemolytic anemia,” the renal phenotype co-occurs with **hereditary hemolytic anemia and red-cell morphological abnormalities**, most often due to **biallelic SLC4A1 (AE1/band 3) variants**, linking kidney and erythrocyte pathology. (batlle2012geneticcausesand pages 1-2, a2023thepathophysiologyof pages 1-5, alexander2025hereditarydistalrenal pages 5-7)
+
+### Key identifiers
+- **OMIM phenotype:** **611590** (reported in the literature as distal RTA; also used in genetic discussions of AR dRTA with hematologic involvement) (deejai2022impairedtraffickingand pages 1-2)
+- **OMIM gene:** **SLC4A1 / AE1 / band 3**: **+109270** (deejai2022impairedtraffickingand pages 1-2)
+
+**Other requested identifiers (Orphanet, MONDO, MeSH, ICD-10/ICD-11):** not retrievable from the available full-text evidence in this run; would require direct database lookup. 
+
+### Synonyms / alternative names (used in literature)
+- Distal renal tubular acidosis (dRTA), type 1 RTA (watanabe2018improvingoutcomesfor pages 1-2, batlle2012geneticcausesand pages 1-2)
+- SLC4A1-related distal renal tubular acidosis (watanabe2018improvingoutcomesfor pages 1-2, yang2023mutationsandclinical pages 1-2)
+- dRTA with hereditary spherocytosis (dRTA/HS) or with Southeast Asian ovalocytosis (dRTA/SAO) used to denote the combined renal+hematologic phenotype in case compilations (yang2023mutationsandclinical pages 3-4)
+
+### Evidence source type
+Evidence for this entity is largely derived from **aggregated disease-level resources and reviews** (e.g., Nature Reviews Nephrology 2023; systematic review Frontiers in Pediatrics 2023) plus **primary case reports/series and functional studies** (Thailand pediatric cohort; HEK293T trafficking work; mouse models). (a2023thepathophysiologyof pages 1-5, yang2023mutationsandclinical pages 1-2, khositseth2007distalrenaltubular pages 1-2, deejai2022impairedtraffickingand pages 6-9, stehberger2007distalrenaltubular pages 1-3)
+
+---
+
+## 2. Etiology
+
+### Primary causal factors (genetic)
+The core causal factor for “distal RTA with hemolytic anemia” is **pathogenic variation in SLC4A1**, encoding the **anion exchanger 1 (AE1)** (band 3), with the combined renal+hematologic phenotype most often arising from **autosomal recessive (biallelic) loss-of-function / inactivating or compound alleles**. (alexander2025hereditarydistalrenal pages 5-7, deejai2022impairedtraffickingand pages 1-2)
+
+Broader hereditary dRTA can also be caused by **ATP6V1B1** and **ATP6V0A4** (V-ATPase subunits), among other genes, but these are typically associated with renal phenotype (and often hearing loss) rather than hemolytic anemia. (batlle2012geneticcausesand pages 1-2, watanabe2018improvingoutcomesfor pages 1-2)
+
+### Risk factors
+- **Genetic:** carrying **biallelic SLC4A1 pathogenic variants**, including compound heterozygosity with the **SAO deletion allele** and another pathogenic allele, is a key risk factor for developing dRTA with hemolysis. (deejai2022impairedtraffickingand pages 1-2, yang2023mutationsandclinical pages 3-4)
+- **Physiologic/clinical modifier:** metabolic acidosis itself can exacerbate hemolysis in SLC4A1-related disease, consistent with clinical observations that RBCs can be more “vulnerable to hemolysis under conditions of metabolic acidosis.” (alexander2025hereditarydistalrenal pages 5-7, khositseth2007distalrenaltubular pages 1-2)
+
+### Protective factors / gene–environment interaction
+No specific protective variants or clear gene–environment interaction data for this specific Mendelian entity were found in the available evidence. Clinically, **adequate alkali therapy** is repeatedly associated with improved systemic acid-base status and can reduce hemolytic manifestations, effectively acting as a protective clinical modifier. (alexander2025hereditarydistalrenald pages 5-7, khositseth2007distalrenaltubular pages 1-2)
+
+---
+
+## 3. Phenotypes
+
+### Core phenotype set (renal + hematologic)
+**Distal RTA phenotype (renal acidification failure)**
+- Hyperchloremic metabolic acidosis with normal anion gap; inappropriately **alkaline urine** (urine pH >5.5) in the presence of systemic acidosis (watanabe2018improvingoutcomesfor pages 1-2, batlle2012geneticcausesand pages 1-2, khositseth2007distalrenaltubular pages 1-2)
+- **Hypokalemia** is common (watanabe2018improvingoutcomesfor pages 1-2, yang2023mutationsandclinical pages 3-4)
+- **Nephrocalcinosis and/or nephrolithiasis**, often with hypercalciuria and hypocitraturia (watanabe2018improvingoutcomesfor pages 1-2, stehberger2007distalrenaltubular pages 1-3)
+- Growth delay/failure to thrive; rickets/osteomalacia (watanabe2018improvingoutcomesfor pages 1-2, yang2023mutationsandclinical pages 1-2)
+
+**Hematologic phenotype**
+- Hemolytic anemia with RBC morphological abnormalities (e.g., hereditary spherocytosis, SAO/ovalocytosis; acanthocytosis in some reports) (watanabe2018improvingoutcomesfor pages 1-2, alexander2025hereditarydistalrenal pages 5-7, yang2023mutationsandclinical pages 3-4)
+
+### Quantitative phenotype frequencies (recent systematic review)
+A 2023 systematic review of published SLC4A1-dRTA cases (169 patients; 53 articles) reported: 
+- Nephrocalcinosis or kidney stones: **72.27%** 
+- Developmental disorders: **61.16%** 
+- Hematological abnormalities: **33.88%** 
+- Impaired renal function: **14.29%** 
+- Muscle weakness: **13.45%** (yang2023mutationsandclinical pages 1-2)
+
+More granular counts from extracted datasets in the same work include: 
+- Nephrocalcinosis: **65/121 (53.72%)**; kidney stones **23/121 (19.01%)** 
+- Renal impairment: **17/121 (14.29%)** 
+- Hematologic abnormalities: **41/121 (33.88%)** 
+- Alkaline urine pH >6.5: **64/79 (81.01%)** 
+- Hypokalemia: **72/109 (66.06%)** 
+- Hyperchloremia: **50/53 (94.34%)** (yang2023mutationsandclinical pages 3-4)
+
+**AR enrichment of hematologic findings:** hematologic abnormalities were particularly common among AR patients (**30/61; 49.18%**) in this synthesis. (yang2023mutationsandclinical pages 3-4)
+
+### Onset/severity/progression
+AR SLC4A1-dRTA cases tend to have **earlier onset** and **more severe biochemical phenotype** than AD SLC4A1-dRTA, with earlier age at onset, higher urine pH, and lower serum potassium in AR cases. (yang2023mutationsandclinical pages 1-2)
+
+### Suggested HPO terms (non-exhaustive)
+- Distal renal tubular acidosis: **HP:0001947** (dRTA) (term suggestion; not directly evidenced in text)
+- Metabolic acidosis: **HP:0001942** (watanabe2018improvingoutcomesfor pages 1-2)
+- Hypokalemia: **HP:0002900** (yang2023mutationsandclinical pages 3-4)
+- Nephrocalcinosis: **HP:0000121** (watanabe2018improvingoutcomesfor pages 1-2)
+- Nephrolithiasis: **HP:0000787** (watanabe2018improvingoutcomesfor pages 1-2)
+- Hyperchloremia: **HP:0011421** (yang2023mutationsandclinical pages 3-4)
+- Hemolytic anemia: **HP:0001878** (alexander2025hereditarydistalrenal pages 5-7)
+- Hereditary spherocytosis: **HP:0004444** (watanabe2018improvingoutcomesfor pages 1-2)
+- Ovalocytosis: **HP:0004426** (yang2023mutationsandclinical pages 3-4)
+- Growth delay / short stature: **HP:0004322 / HP:0001510** (yang2023mutationsandclinical pages 1-2)
+- Rickets / osteomalacia: **HP:0002748 / HP:0000938** (watanabe2018improvingoutcomesfor pages 1-2)
+
+(Notes: HPO IDs are suggested for ontology mapping; the evidence supports the phenotypes, not the specific IDs.)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### Causal gene(s)
+- **SLC4A1 (AE1; band 3)** is the key gene linking renal and erythrocyte phenotypes; it encodes the basolateral **Cl−/HCO3− exchanger** in kidney α-intercalated cells and the dominant RBC membrane anion exchanger/structural protein in erythrocytes. (guo2023geneticdiagnosisand pages 1-3, batlle2012geneticcausesand pages 3-4)
+
+### Inheritance patterns
+- The combined phenotype “dRTA with hemolytic anemia” is typically **autosomal recessive** with **biallelic SLC4A1 pathogenic variants**. (alexander2025hereditarydistalrenal pages 5-7, alexander2025hereditarydistalrenal pages 1-3)
+- SLC4A1 can also cause **autosomal dominant dRTA** via dominant-negative mechanisms, usually without prominent hemolysis. (batlle2012geneticcausesand pages 3-4, alexander2025hereditarydistalrenal pages 1-3)
+
+### Pathogenic variants (examples; not exhaustive)
+A 2023 synthesis of published cases identified **41 distinct SLC4A1 mutations** with both AD and AR forms. (yang2023mutationsandclinical pages 1-2)
+
+Variant examples explicitly appearing in compiled evidence include:
+- **p.Ala858Asp (A858D)** (recurrent; associated with dRTA and hemolytic anemia in some biallelic contexts) (alexander2025hereditarydistalrenalc pages 5-7, yang2023mutationsandclinical pages 3-4)
+- **p.Gly701Asp (G701D)** (frequent in AR Southeast Asian cases; reported with hemolytic anemia in some genotypes) (deejai2022impairedtraffickingand pages 1-2, yang2023mutationsandclinical pages 3-4)
+- **SAO deletion p.Ala400_Ala408del** (c.1199_1225del) (deejai2022impairedtraffickingand pages 1-2)
+- **p.Thr444Asn (T444N)** in compound genotype with SAO deletion (deejai2022impairedtraffickingand pages 1-2)
+- **p.Ser477\*** (truncating) listed in case compilations (yang2023mutationsandclinical pages 3-4)
+- **p.Ser725Arg** described as abolishing transport and producing anemia + RTA (as cited within broader AE1/dRTA mechanistic discussions) (batlle2012geneticcausesand pages 3-4)
+
+Compound heterozygous patterns repeatedly associated with dRTA plus hematologic abnormalities include **SAO/G701D**, **SAO/Q759H**, **SAO/A858D**, **G701D/A858D**, and others. (deejai2022impairedtraffickingand pages 1-2)
+
+### Functional consequence classes
+Mechanisms described across reviews and functional studies include: 
+- **Trafficking defects / intracellular retention** (ER/Golgi), reduced stability/shorter half-life of mutant kAE1 (deejai2022impairedtraffickingand pages 6-9, fry2007inheritedrenalacidoses. pages 3-4)
+- **Mistargeting** (e.g., apical mislocalization in polarized epithelia) (batlle2012geneticcausesand pages 3-4)
+- **Transport loss-of-function** for some variants (batlle2012geneticcausesand pages 3-4)
+
+### Population frequency
+No gnomAD or population allele-frequency values were available in the retrieved evidence.
+
+### Modifier genes / epigenetics
+No validated modifier genes or epigenetic mechanisms specific to this disease were identified in the retrieved evidence.
+
+---
+
+## 5. Environmental Information
+
+This is primarily a genetic disease. Environmental contributions are mainly relevant as **clinical modifiers** (e.g., acid–base status affecting hemolysis risk), rather than primary causes. (alexander2025hereditarydistalrenal pages 5-7)
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### Current understanding (renal)
+In kidney **type A (α-) intercalated cells**, **apical H+-ATPase** secretes protons into the tubular lumen; this process is functionally coupled to basolateral bicarbonate extrusion via **AE1 (SLC4A1)**, a **Cl−/HCO3− exchanger**. Cytosolic carbonic anhydrase provides intracellular H+ and HCO3− substrates. Therefore, AE1 dysfunction disrupts the basolateral bicarbonate exit step needed for sustained proton secretion, producing distal acidification failure. (batlle2012geneticcausesand pages 1-2, batlle2012geneticcausesand pages 2-3, batlle2012geneticcausesand pages 3-4)
+
+### Current understanding (hematologic)
+In erythrocytes, AE1/band 3 contributes both to anion exchange and to **membrane skeleton anchoring**; mutations can cause red-cell morphological disorders (HS, SAO/ovalocytosis) and hemolysis. In the combined phenotype, RBCs can be especially susceptible to hemolysis during systemic acidosis. (parker2018mousemodelsof pages 2-3, alexander2025hereditarydistalrenal pages 5-7)
+
+### Trafficking/processing mechanism (key expert consensus)
+Several authoritative discussions emphasize that many AE1 mutations have near-normal anion exchange in heterologous systems, and that **trafficking and targeting defects** are a major disease mechanism (intracellular retention in nonpolarized cells; apical mistargeting/retention in polarized renal epithelia). (fry2007inheritedrenalacidoses. pages 3-4, batlle2012geneticcausesand pages 3-4)
+
+A 2022 mechanistic study of AR dRTA with mild hemolytic anemia identified compound heterozygous **SAO deletion + T444N** and demonstrated: 
+- WT and T444N kAE1 localized at the cell surface, whereas SAO and SAO/T444N were intracellularly retained
+- Mutant kAE1 proteins had shorter half-lives than WT, supporting impaired trafficking and instability as pathogenic mechanisms. (deejai2022impairedtraffickingand pages 1-2, deejai2022impairedtraffickingand pages 6-9)
+
+**Visual evidence supporting this mechanism:** immunofluorescence localization of WT vs mutant kAE1 (cell-surface vs intracellular retention) and structural modeling were retrieved from Deejai et al. (deejai2022impairedtraffickingand media 9d60dc11, deejai2022impairedtraffickingand media 94347afb)
+
+### Model organism evidence
+**Slc4a1-null mice** recapitulate core dRTA features: spontaneous hyperchloremic metabolic acidosis with inappropriate urine alkalinity, nephrocalcinosis and related urinary abnormalities, supporting AE1’s causal role in distal acidification. (stehberger2007distalrenaltubular pages 1-3)
+
+### Pathway/ontology mappings (suggested)
+**Key cell types (CL):**
+- α-intercalated cell (collecting duct): **CL:0000653** (suggested)
+- Erythrocyte: **CL:0000232** (suggested)
+
+**Key anatomical structures (UBERON):**
+- Kidney collecting duct: **UBERON:0001230** (suggested)
+- Renal cortical collecting duct / distal nephron segments (suggested; evidence supports collecting duct localization) (batlle2012geneticcausesand pages 3-4)
+
+**Key GO Biological Process terms (suggested):**
+- Renal acid secretion / urinary acidification (supported conceptually by coupling described) (batlle2012geneticcausesand pages 1-2)
+- Bicarbonate transport; chloride transport; anion exchange (batlle2012geneticcausesand pages 3-4)
+- Protein targeting to membrane; intracellular protein transport; ER retention/quality control (fry2007inheritedrenalacidoses. pages 3-4, deejai2022impairedtraffickingand pages 6-9)
+
+(Notes: ontology IDs are suggested; supporting mechanistic statements are cited.)
+
+---
+
+## 7. Anatomical Structures Affected
+
+### Primary organs
+- **Kidney** (collecting duct α-intercalated cells) (batlle2012geneticcausesand pages 3-4)
+- **Blood / red blood cells** (erythroid AE1/band 3) (batlle2012geneticcausesand pages 3-4)
+
+### Secondary involvement/complications
+- Bone (rickets/osteomalacia) secondary to chronic acidosis and mineral handling issues (watanabe2018improvingoutcomesfor pages 1-2)
+
+---
+
+## 8. Temporal Development
+
+- **Typical onset:** often infancy/childhood in AR disease; AD disease can present later and may be milder (yang2023mutationsandclinical pages 1-2, batlle2012geneticcausesand pages 3-4)
+- **Course:** chronic lifelong disease; long-term risk includes nephrocalcinosis and potential progression to CKD in dRTA cohorts (watanabe2018improvingoutcomesfor pages 1-2, a2023thepathophysiologyof pages 1-5)
+
+---
+
+## 9. Inheritance and Population
+
+### Inheritance
+- Most characteristic “dRTA with hemolytic anemia” presentations: **autosomal recessive, biallelic SLC4A1 variants**. (alexander2025hereditarydistalrenal pages 5-7, alexander2025hereditarydistalrenal pages 1-3)
+
+### Epidemiology and prevalence
+Disease-specific prevalence for the *hemolytic anemia subset* was not found in the retrieved evidence.
+
+For dRTA overall, a 2023 Nature Reviews Nephrology synthesis reported prevalence estimates from administrative datasets: 
+- UK database: ~**0.46 recorded** and **1.60 suspected/recorded per 10,000** 
+- US insurance data: ~**0.38 primary** and **3.88 acquired dRTA per 100,000** (a2023thepathophysiologyof pages 1-5)
+
+### Geographic distribution
+AR SLC4A1-dRTA is disproportionately reported in Asian populations in systematic synthesis, and many dRTA/hemolysis cases are reported from Southeast Asia and India. (yang2023mutationsandclinical pages 1-2, alexander2025hereditarydistalrenal pages 5-7)
+
+---
+
+## 10. Diagnostics
+
+### Clinical/laboratory diagnosis
+Key diagnostic pattern for dRTA includes:
+- **Normal anion gap (hyperchloremic) metabolic acidosis**
+- **Inappropriately high urine pH (>5.5)** during systemic acidosis
+- Frequent **hypokalemia**
+- Evidence of hypercalciuria/hypocitraturia and imaging evidence of nephrocalcinosis/nephrolithiasis (watanabe2018improvingoutcomesfor pages 1-2, khositseth2007distalrenaltubular pages 1-2)
+
+### Genetic testing
+For suspected hereditary dRTA with or without hemolysis, reviews recommend genetic testing of known genes including **SLC4A1** (and ATP6V1B1, ATP6V0A4, FOXI1, WDR72 in broader dRTA). (yang2023mutationsandclinical pages 1-2, alexander2025hereditarydistalrenal pages 1-3)
+
+### Differential diagnosis
+Differential diagnosis includes other genetic and acquired causes of dRTA (autoimmune disease, drug-induced) as well as other causes of hemolytic anemia; the specific co-occurrence suggests SLC4A1 involvement. (a2023thepathophysiologyof pages 1-5, watanabe2018improvingoutcomesfor pages 1-2)
+
+---
+
+## 11. Outcome / Prognosis
+
+With appropriate alkali therapy, prognosis is often described as generally good, but long-term follow-up studies indicate risk of chronic kidney disease (CKD) in dRTA cohorts, and nephrocalcinosis can persist despite therapy. (watanabe2018improvingoutcomesfor pages 1-2, a2023thepathophysiologyof pages 1-5, bertholetthomas20256yeartreatmentfollowup pages 7-10)
+
+---
+
+## 12. Treatment
+
+### Standard of care
+**Oral alkali therapy** (bicarbonate and/or citrate) is central; early and sufficient dosing is emphasized to support growth, bone health, and reduce kidney complications. (watanabe2018improvingoutcomesfor pages 1-2)
+
+Clinical principles summarized in expert guidance include: 
+- Maintain bicarbonate and potassium to reduce acute symptoms and long-term complications
+- Avoid sodium salts when possible because sodium can worsen hypercalciuria
+- Citrate provides bicarbonate equivalents in vivo and can reduce required dosing. (alexander2025hereditarydistalrenald pages 10-12, alexander2025hereditarydistalrenalc pages 10-12)
+
+**For hemolytic anemia:** supportive transfusion and iron therapy as needed; correction of systemic acidosis may improve anemia/reticulocytosis in SLC4A1-related hemolysis. (alexander2025hereditarydistalrenald pages 5-7)
+
+### Recent therapeutic development / real-world implementation: ADV7103 (Sibnayal®)
+ADV7103 is a prolonged-release, twice-daily combination of potassium bicarbonate and potassium citrate.
+
+**Real-world pediatric implementation (2024):** At a UK center after Oct 2022 availability, 20 children with RTA were prescribed Sibnayal; **14/20 (70%)** preferred and tolerated it; **6/20 (30%)** reverted due to refusal or texture issues, especially in younger/developmentally affected children. Efficacy was comparable to standard therapy with maintenance of normal plasma bicarbonate; dosing was similar between standard vs Sibnayal. (tan2024treatmentofpaediatric pages 1-5)
+
+**Long-term outcomes (peer-reviewed 2025):** In a 6-year open-label follow-up (B22CS; n=30; mean age 10.6 years), plasma bicarbonate control was sustained (22.0→22.6 mmol/L), growth improved (height Z −0.6→−0.3), eGFR remained stable (105→104 mL/min/1.73m²) with no progression to CKD stage 3–5, and lumbar spine BMD Z-score improved (−1.1→−0.8). Nephrocalcinosis remained common (86% at baseline; 92% at end), illustrating prevention/stabilization rather than reversal. (bertholetthomas20256yeartreatmentfollowup pages 7-10, bertholetthomas20256yeartreatmentfollowup pages 1-2)
+
+**Preprint (Dec 2024):** A preprint describing the same long-term B22CS dataset reports similar outcomes and describes the formulation as prolonged-release, tasteless granules providing ~12-hour effect with twice-daily dosing. (bertholetthomas2024longtermclinicaloutcomes pages 1-5)
+
+### Clinical trials
+- **NCT03644706** (ClinicalTrials.gov): phase 3 randomized withdrawal study of ADV7103 in primary dRTA; record notes **TERMINATED**, enrollment 3, completion 2023-12-20; primary endpoint focused on preventing metabolic acidosis during withdrawal. (NCT03644706 chunk 1)
+
+### Suggested MAXO terms (examples; suggested)
+- Alkali therapy / bicarbonate supplementation
+- Potassium citrate supplementation
+- Blood transfusion
+- Iron supplementation
+
+(Notes: MAXO IDs not retrieved in evidence; terms suggested for mapping.)
+
+---
+
+## 13. Prevention
+
+Primary prevention is not applicable for most Mendelian cases beyond **genetic counseling** and reproductive options. Clinically, tertiary prevention focuses on preventing nephrocalcinosis progression and growth/bone complications through sustained alkali therapy and adherence. (watanabe2018improvingoutcomesfor pages 1-2, alexander2025hereditarydistalrenalc pages 10-12)
+
+---
+
+## 14. Other Species / Natural Disease
+
+No natural disease in other species specific to SLC4A1-related dRTA with hemolytic anemia was retrieved in the available evidence.
+
+---
+
+## 15. Model Organisms
+
+- **Mouse (Slc4a1-null):** exhibits a robust dRTA phenotype with hyperchloremic metabolic acidosis and nephrocalcinosis, supporting causal biology and enabling mechanistic investigation. (stehberger2007distalrenaltubular pages 1-3)
+- Additional Slc4 model discussion contextualizes AE1 isoforms and how mutations can cause both kidney and RBC phenotypes. (parker2018mousemodelsof pages 2-3)
+
+---
+
+## Expert synthesis / key takeaways
+1. The disorder is best conceptualized as a **shared-molecule syndrome**: a single gene (**SLC4A1/AE1**) expressed in **kidney α-intercalated cells** and **erythrocytes** produces combined defects in urinary acidification and RBC integrity. (batlle2012geneticcausesand pages 3-4, guo2023geneticdiagnosisand pages 1-3)
+2. The most typical “dRTA + hemolytic anemia” cases are **autosomal recessive**, often involving **compound alleles including SAO** or other inactivating variants; systematic synthesis shows hematologic abnormalities are common in AR SLC4A1-dRTA. (yang2023mutationsandclinical pages 1-2, deejai2022impairedtraffickingand pages 1-2)
+3. A major mechanistic theme is **protein mistrafficking/instability** (not just loss of exchanger activity), supported by cellular studies and kidney epithelial targeting biology. (deejai2022impairedtraffickingand pages 6-9, fry2007inheritedrenalacidoses. pages 3-4)
+4. 2023–2024 literature emphasizes improved characterization (systematic review statistics) and improved real-world treatment options (prolonged-release alkali therapy) supporting adherence and long-term outcomes. (yang2023mutationsandclinical pages 1-2, tan2024treatmentofpaediatric pages 1-5)
+
+---
+
+## Evidence table (summary)
+| Topic | Key evidence | Citation |
+|---|---|---|
+| Causal gene | The combined phenotype is chiefly linked to **SLC4A1** (encoding **AE1/band 3**), expressed in both **erythrocytes** and **type A intercalated cells** of the distal nephron, providing the molecular basis for coexisting renal acidification failure and red-cell disease. | (guo2023geneticdiagnosisand pages 1-3, a2023thepathophysiologyof pages 1-5) |
+| Disease mechanism | In kidney, mutant **kAE1** impairs basolateral **Cl-/HCO3- exchange**, disrupting distal acid secretion and causing **distal renal tubular acidosis**; in red cells, AE1 defects alter membrane/cytoskeletal anchoring and can increase erythrocyte fragility, especially during acidosis, producing **hemolytic anemia** or RBC morphologic abnormalities. | (alexander2025hereditarydistalrenala pages 5-7, a2023thepathophysiologyof pages 1-5) |
+| Inheritance and hemolytic-anemia association | **Autosomal recessive (AR)** SLC4A1 disease is the form most strongly associated with **hemolytic anemia / hereditary spherocytosis / ovalocytosis**; **autosomal dominant (AD)** SLC4A1 dRTA more often causes isolated renal disease, though rare AD families with hematologic involvement exist. | (batlle2012geneticcausesand pages 3-4, watanabe2018improvingoutcomesfor pages 1-2) |
+| AR vs AD distribution in published cases | 2023 systematic review of **169 patients** identified **41 SLC4A1 mutations**: **15 mutations / 100 patients AD** and **21 mutations / 61 patients AR**; AR patients had **younger onset**, **higher urine pH**, and **lower serum K+** than AD patients. | (yang2023mutationsandclinical pages 1-2) |
+| Key reported variants linked to dRTA ± hemolysis | Reported pathogenic/likely pathogenic SLC4A1 variants associated with this spectrum include **p.Ala858Asp (A858D)**, **p.Gly701Asp (G701D)**, **SAO deletion p.Ala400_Ala408del**, **p.Thr444Asn**, **p.Ser477\***, **p.Ser725Arg**, plus combinations such as **SAO/G701D**, **SAO/R602H**, **SAO/Q759H**, **SAO/A858D**, and **G701D/A858D**. | (yang2023mutationsandclinical pages 3-4, deejai2022impairedtraffickingand pages 1-2) |
+| A858D-specific evidence | **Biallelic p.Ala858Asp (A858D)** is a recurrent variant in Indian families with the combined phenotype; reported with **hemolytic anemia/acanthocytosis** plus dRTA, and heterozygous parents may show only mild erythrocyte changes. | (alexander2025hereditarydistalrenalc pages 5-7, alexander2025hereditarydistalrenalb pages 5-7) |
+| SAO/T444N evidence | A 2022 case identified **compound heterozygous SAO deletion (p.Ala400_Ala408del) + p.Thr444Asn**, causing **AR dRTA with mild hemolytic anemia**; functional work showed **intracellular retention** of SAO-containing kAE1 and reduced protein stability. | (deejai2022impairedtraffickingand pages 1-2) |
+| Truncating / severe variants | The 2023 review includes **p.Ser477\*** among reported SLC4A1 dRTA alleles, and severe truncating disease has been described with marked hemolysis and complete dRTA; these support loss-of-function/trafficking-defect mechanisms. | (yang2023mutationsandclinical pages 3-4) |
+| Transport-null missense variant | **p.Ser725Arg** was reported to **abolish AE1 transport function** and cause **anemia plus renal tubular acidosis**, illustrating that some variants directly impair exchanger activity in addition to trafficking defects. | (batlle2012geneticcausesand pages 3-4) |
+| Core clinical/laboratory phenotype | Typical findings are **hyperchloremic normal-anion-gap metabolic acidosis**, inability to acidify urine (**urine pH >5.5** despite acidosis), **hypokalemia**, **nephrocalcinosis/nephrolithiasis**, **growth failure**, **rickets/osteomalacia**, and **hemolysis / RBC morphology abnormalities**. | (watanabe2018improvingoutcomesfor pages 1-2, batlle2012geneticcausesand pages 1-2) |
+| Quantitative phenotype statistics (2023 systematic review) | Across published SLC4A1-dRTA patients, **nephrocalcinosis or kidney stones 72.27%**, **developmental disorders 61.16%**, **hematological abnormalities 33.88%**, **renal impairment 14.29%**, **muscle weakness 13.45%**. | (yang2023mutationsandclinical pages 1-2) |
+| More detailed phenotype frequencies | In the subset with data: **nephrocalcinosis 65/121 (53.72%)**, **kidney stones 23/121 (19.01%)**, **renal impairment 17/121 (14.29%)**, **hematologic abnormalities 41/121 (33.88%)**; **alkaline urine pH >6.5 in 64/79 (81.01%)**, **hypokalemia 72/109 (66.06%)**, **hyperchloremia 50/53 (94.34%)**. | (yang2023mutationsandclinical pages 3-4) |
+| AR hematologic burden | Hematologic abnormalities were particularly enriched in AR disease: **30/61 (49.18%)** in AR cases in the 2023 review; AR inheritance was also more common in **Asian** patients. | (yang2023mutationsandclinical pages 3-4, yang2023mutationsandclinical pages 1-2) |
+| Prevalence estimates (recent authoritative review) | 2023 *Nature Reviews Nephrology* reported dRTA prevalence estimates of about **0.46 recorded** and **1.60 suspected/recorded per 10,000** in a UK database, and about **0.38 primary** and **3.88 acquired dRTA per 100,000** in US insurance data; these are for dRTA overall, not specifically the hemolytic-anemia subset. | (a2023thepathophysiologyof pages 1-5) |
+| Diagnostic clues | Suspect SLC4A1-related disease in a child with **metabolic acidosis + high urine pH + hypokalemia + hyperchloremia + nephrocalcinosis/growth delay**, especially if there is **hemolytic anemia or abnormal RBC morphology**; **genetic testing** is recommended. | (yang2023mutationsandclinical pages 1-2, khositseth2007distalrenaltubular pages 1-2) |
+| Treatment and outcomes | **Alkali therapy** is the core treatment; studies/reviews report that adequate alkalinization improves acidosis, growth, bone disease, and may reduce or correct **reticulocytosis/anemia** in SLC4A1-related hemolytic cases. | (alexander2025hereditarydistalrenald pages 5-7, khositseth2007distalrenaltubular pages 1-2) |
+
+
+*Table: This table condenses the main genetic, mechanistic, phenotypic, and epidemiologic evidence for renal tubular acidosis distal 4 with hemolytic anemia. It emphasizes how SLC4A1/AE1 variants connect distal acidification failure with erythrocyte pathology and highlights recent quantitative data.*
+
+---
+
+## Key references (URLs and publication dates where available)
+- Wagner CA et al. *Nature Reviews Nephrology* (Apr 2023). “The pathophysiology of distal renal tubular acidosis.” https://doi.org/10.1038/s41581-023-00699-9 (a2023thepathophysiologyof pages 1-5)
+- Yang M et al. *Frontiers in Pediatrics* (Jan 2023). “Mutations and clinical characteristics of dRTA caused by SLC4A1 mutations…” https://doi.org/10.3389/fped.2023.1077120 (yang2023mutationsandclinical pages 1-2)
+- Deejai N et al. *BMC Medical Genomics* (Oct 2022). “Impaired trafficking and instability of mutant kidney anion exchanger 1…” https://doi.org/10.1186/s12920-022-01381-y (deejai2022impairedtraffickingand pages 1-2)
+- Tan HL et al. *Pediatric Nephrology* (May 2024). “Treatment of paediatric renal tubular acidosis with a prolonged-release alkali supplementation.” https://doi.org/10.1007/s00467-024-06411-8 (tan2024treatmentofpaediatric pages 1-5)
+- Bertholet-Thomas A et al. *Orphanet Journal of Rare Diseases* (Aug 2025). “6-year treatment follow-up…” https://doi.org/10.1186/s13023-025-03953-4 (bertholetthomas20256yeartreatmentfollowup pages 1-2)
+- ClinicalTrials.gov NCT03644706 (record includes dates/status). (NCT03644706 chunk 1)
+
+---
+
+## Limitations of this run
+- Direct Orphanet/MONDO/MeSH/ICD identifiers were not found in the retrieved full-text evidence; OMIM identifiers (611590; SLC4A1 +109270) were supported by primary literature excerpts. (deejai2022impairedtraffickingand pages 1-2)
+- Not all variant-level details and PMIDs for every cited paper could be extracted from the current tool outputs; however, the cited sources provide DOIs and journal metadata, and include a 2023 systematic review covering 53 primary reports. (yang2023mutationsandclinical pages 1-2)
+
+
+References
+
+1. (batlle2012geneticcausesand pages 1-2): D. Batlle and Syed K. Haque. Genetic causes and mechanisms of distal renal tubular acidosis. Nephrology, dialysis, transplantation : official publication of the European Dialysis and Transplant Association - European Renal Association, 27 10:3691-704, Oct 2012. URL: https://doi.org/10.1093/ndt/gfs442, doi:10.1093/ndt/gfs442. This article has 257 citations.
+
+2. (a2023thepathophysiologyof pages 1-5): Carsten A Wagner, Robert Unwin, Sergio C Lopez-Garcia, Robert Kleta, Detlef Bockenhauer, and Stephen Walsh. The pathophysiology of distal renal tubular acidosis. Nature Reviews Nephrology, 19:384-400, Apr 2023. URL: https://doi.org/10.1038/s41581-023-00699-9, doi:10.1038/s41581-023-00699-9. This article has 78 citations and is from a domain leading peer-reviewed journal.
+
+3. (alexander2025hereditarydistalrenal pages 5-7): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+4. (deejai2022impairedtraffickingand pages 1-2): Nipaporn Deejai, Nunghathai Sawasdee, Choochai Nettuwakul, Wanchai Wanachiwanawin, Suchai Sritippayawan, Pa-thai Yenchitsomanus, and Nanyawan Rungroj. Impaired trafficking and instability of mutant kidney anion exchanger 1 proteins associated with autosomal recessive distal renal tubular acidosis. BMC Medical Genomics, Oct 2022. URL: https://doi.org/10.1186/s12920-022-01381-y, doi:10.1186/s12920-022-01381-y. This article has 3 citations and is from a peer-reviewed journal.
+
+5. (watanabe2018improvingoutcomesfor pages 1-2): Toru Watanabe. Improving outcomes for patients with distal renal tubular acidosis: recent advances and challenges ahead. Pediatric Health, Medicine and Therapeutics, 9:181-190, Dec 2018. URL: https://doi.org/10.2147/phmt.s174459, doi:10.2147/phmt.s174459. This article has 56 citations.
+
+6. (yang2023mutationsandclinical pages 1-2): Mengge Yang, Qiqi Sheng, Shenghui Ge, Xinxin Song, Jianjun Dong, Congcong Guo, and Lin Liao. Mutations and clinical characteristics of drta caused by slc4a1 mutations: analysis based on published patients. Frontiers in Pediatrics, Jan 2023. URL: https://doi.org/10.3389/fped.2023.1077120, doi:10.3389/fped.2023.1077120. This article has 11 citations.
+
+7. (yang2023mutationsandclinical pages 3-4): Mengge Yang, Qiqi Sheng, Shenghui Ge, Xinxin Song, Jianjun Dong, Congcong Guo, and Lin Liao. Mutations and clinical characteristics of drta caused by slc4a1 mutations: analysis based on published patients. Frontiers in Pediatrics, Jan 2023. URL: https://doi.org/10.3389/fped.2023.1077120, doi:10.3389/fped.2023.1077120. This article has 11 citations.
+
+8. (khositseth2007distalrenaltubular pages 1-2): Sookkasem Khositseth, Apiwan Sirikanerat, Kulruedee Wongbenjarat, Sauwalak Opastirakul, Siri Khoprasert, Ratikorn Peuksungnern, Duangrurdee Wattanasirichaigoon, Wanna Thongnoppakhun, Vip Viprakasit, and Pa-thai Yenchitsomanus. Distal renal tubular acidosis associated with anion exchanger 1 mutations in children in thailand. American journal of kidney diseases : the official journal of the National Kidney Foundation, 49 6:841-850.e1, Jun 2007. URL: https://doi.org/10.1053/j.ajkd.2007.03.002, doi:10.1053/j.ajkd.2007.03.002. This article has 40 citations.
+
+9. (deejai2022impairedtraffickingand pages 6-9): Nipaporn Deejai, Nunghathai Sawasdee, Choochai Nettuwakul, Wanchai Wanachiwanawin, Suchai Sritippayawan, Pa-thai Yenchitsomanus, and Nanyawan Rungroj. Impaired trafficking and instability of mutant kidney anion exchanger 1 proteins associated with autosomal recessive distal renal tubular acidosis. BMC Medical Genomics, Oct 2022. URL: https://doi.org/10.1186/s12920-022-01381-y, doi:10.1186/s12920-022-01381-y. This article has 3 citations and is from a peer-reviewed journal.
+
+10. (stehberger2007distalrenaltubular pages 1-3): Paul A. Stehberger, Boris E. Shmukler, Alan K. Stuart-Tilley, Luanne L. Peters, Seth L. Alper, and Carsten A. Wagner. Distal renal tubular acidosis in mice lacking the ae1 (band3) cl−/hco3 − exchanger (slc4a1). Journal of the American Society of Nephrology, 18:1408-1418, May 2007. URL: https://doi.org/10.1681/asn.2006101072, doi:10.1681/asn.2006101072. This article has 161 citations and is from a highest quality peer-reviewed journal.
+
+11. (alexander2025hereditarydistalrenald pages 5-7): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+12. (guo2023geneticdiagnosisand pages 1-3): Wenkai Guo, Pengcheng Ji, and Yuansheng Xie. Genetic diagnosis and treatment of inherited renal tubular acidosis. Kidney Diseases, 9:371-383, Jun 2023. URL: https://doi.org/10.1159/000531556, doi:10.1159/000531556. This article has 6 citations and is from a peer-reviewed journal.
+
+13. (batlle2012geneticcausesand pages 3-4): D. Batlle and Syed K. Haque. Genetic causes and mechanisms of distal renal tubular acidosis. Nephrology, dialysis, transplantation : official publication of the European Dialysis and Transplant Association - European Renal Association, 27 10:3691-704, Oct 2012. URL: https://doi.org/10.1093/ndt/gfs442, doi:10.1093/ndt/gfs442. This article has 257 citations.
+
+14. (alexander2025hereditarydistalrenal pages 1-3): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+15. (alexander2025hereditarydistalrenalc pages 5-7): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+16. (fry2007inheritedrenalacidoses. pages 3-4): Andrew C. Fry and Fiona E. Karet. Inherited renal acidoses. Physiology, 22:202-11, Jun 2007. URL: https://doi.org/10.1152/physiol.00044.2006, doi:10.1152/physiol.00044.2006. This article has 132 citations and is from a peer-reviewed journal.
+
+17. (batlle2012geneticcausesand pages 2-3): D. Batlle and Syed K. Haque. Genetic causes and mechanisms of distal renal tubular acidosis. Nephrology, dialysis, transplantation : official publication of the European Dialysis and Transplant Association - European Renal Association, 27 10:3691-704, Oct 2012. URL: https://doi.org/10.1093/ndt/gfs442, doi:10.1093/ndt/gfs442. This article has 257 citations.
+
+18. (parker2018mousemodelsof pages 2-3): Mark D. Parker. Mouse models of <i>slc4</i>-linked disorders of hco<sub>3</sub><sup>−</sup>-transporter dysfunction. American Journal of Physiology-Cell Physiology, 314:C569-C588, May 2018. URL: https://doi.org/10.1152/ajpcell.00301.2017, doi:10.1152/ajpcell.00301.2017. This article has 25 citations.
+
+19. (deejai2022impairedtraffickingand media 9d60dc11): Nipaporn Deejai, Nunghathai Sawasdee, Choochai Nettuwakul, Wanchai Wanachiwanawin, Suchai Sritippayawan, Pa-thai Yenchitsomanus, and Nanyawan Rungroj. Impaired trafficking and instability of mutant kidney anion exchanger 1 proteins associated with autosomal recessive distal renal tubular acidosis. BMC Medical Genomics, Oct 2022. URL: https://doi.org/10.1186/s12920-022-01381-y, doi:10.1186/s12920-022-01381-y. This article has 3 citations and is from a peer-reviewed journal.
+
+20. (deejai2022impairedtraffickingand media 94347afb): Nipaporn Deejai, Nunghathai Sawasdee, Choochai Nettuwakul, Wanchai Wanachiwanawin, Suchai Sritippayawan, Pa-thai Yenchitsomanus, and Nanyawan Rungroj. Impaired trafficking and instability of mutant kidney anion exchanger 1 proteins associated with autosomal recessive distal renal tubular acidosis. BMC Medical Genomics, Oct 2022. URL: https://doi.org/10.1186/s12920-022-01381-y, doi:10.1186/s12920-022-01381-y. This article has 3 citations and is from a peer-reviewed journal.
+
+21. (bertholetthomas20256yeartreatmentfollowup pages 7-10): A. Bertholet-Thomas, Aurélie de Mul, J. Bernardor, G. Roussey-Kesler, Ludmila Podracká, R. Novo, F. Nobili, Bertrand Knebelmann, J. Harambat, Emilija Golubović, Olivia Boyer, Massimo Di Maio, M. Cailliez, V. Baudouin, Laure Chidler, Véronique Leblanc, and Justine Bacchetta. 6-year treatment follow-up with an extended-release alkaline formulation (sibnayal®) in primary distal renal tubular acidosis. Orphanet Journal of Rare Diseases, Aug 2025. URL: https://doi.org/10.1186/s13023-025-03953-4, doi:10.1186/s13023-025-03953-4. This article has 0 citations and is from a peer-reviewed journal.
+
+22. (alexander2025hereditarydistalrenald pages 10-12): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+23. (alexander2025hereditarydistalrenalc pages 10-12): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+24. (tan2024treatmentofpaediatric pages 1-5): Hai Liang Tan, Matko Marlais, Faidra Veligratli, Sarit Shah, Wesley Hayes, and Detlef Bockenhauer. Treatment of paediatric renal tubular acidosis with a prolonged-release alkali supplementation. Pediatric nephrology, 39:3373-3375, May 2024. URL: https://doi.org/10.1007/s00467-024-06411-8, doi:10.1007/s00467-024-06411-8. This article has 7 citations and is from a domain leading peer-reviewed journal.
+
+25. (bertholetthomas20256yeartreatmentfollowup pages 1-2): A. Bertholet-Thomas, Aurélie de Mul, J. Bernardor, G. Roussey-Kesler, Ludmila Podracká, R. Novo, F. Nobili, Bertrand Knebelmann, J. Harambat, Emilija Golubović, Olivia Boyer, Massimo Di Maio, M. Cailliez, V. Baudouin, Laure Chidler, Véronique Leblanc, and Justine Bacchetta. 6-year treatment follow-up with an extended-release alkaline formulation (sibnayal®) in primary distal renal tubular acidosis. Orphanet Journal of Rare Diseases, Aug 2025. URL: https://doi.org/10.1186/s13023-025-03953-4, doi:10.1186/s13023-025-03953-4. This article has 0 citations and is from a peer-reviewed journal.
+
+26. (bertholetthomas2024longtermclinicaloutcomes pages 1-5): Aurelia Bertholet-Thomas, Aurelie de-mul, Gwenaëlle Roussey-Kesler, Ludmila Podracka, Robert Novo, Francois Nobili, Bertrand Knebelmann, Jerome Harambat, Emilija Golubovic, Olivia Boyer, Massimo Di Maio, Mathilde Caillez, Veronique Baudouin, Laure Chidler, Veronique Leblanc, and Justine Bacchetta. Long-term clinical outcomes with an average of 6 years follow-up in drta patients treated with adv7103 an oral twice-daily fixed and prolonged-release combination of potassium bicarbonate and potassium citrate (sibnayal®). Unknown journal, Dec 2024. URL: https://doi.org/10.21203/rs.3.rs-4957828/v1, doi:10.21203/rs.3.rs-4957828/v1.
+
+27. (NCT03644706 chunk 1):  Study Evaluating Subjects With Distal Renal Tubular Acidosis. Advicenne Pharma. 2021. ClinicalTrials.gov Identifier: NCT03644706
+
+28. (alexander2025hereditarydistalrenala pages 5-7): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.
+
+29. (alexander2025hereditarydistalrenalb pages 5-7): RT Alexander, H Gil-Peña, and LA Greenbaum. Hereditary distal renal tubular acidosis. Unknown journal, 2025.

--- a/research/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia-deep-research-falcon.md.citations.md
+++ b/research/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia-deep-research-falcon.md.citations.md
@@ -1,0 +1,492 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Renal Tubular Acidosis Distal 4 with Hemolytic Anemia
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Renal Tubular Acidosis Distal 4 with Hemolytic Anemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T13:08:32.511740
+
+1. deejai2022impairedtraffickingand pages 1-2
+2. yang2023mutationsandclinical pages 3-4
+3. yang2023mutationsandclinical pages 1-2
+4. watanabe2018improvingoutcomesfor pages 1-2
+5. alexander2025hereditarydistalrenal pages 5-7
+6. batlle2012geneticcausesand pages 3-4
+7. stehberger2007distalrenaltubular pages 1-3
+8. batlle2012geneticcausesand pages 1-2
+9. a2023thepathophysiologyof pages 1-5
+10. alexander2025hereditarydistalrenald pages 5-7
+11. tan2024treatmentofpaediatric pages 1-5
+12. bertholetthomas2024longtermclinicaloutcomes pages 1-5
+13. parker2018mousemodelsof pages 2-3
+14. khositseth2007distalrenaltubular pages 1-2
+15. deejai2022impairedtraffickingand pages 6-9
+16. guo2023geneticdiagnosisand pages 1-3
+17. alexander2025hereditarydistalrenal pages 1-3
+18. alexander2025hereditarydistalrenalc pages 5-7
+19. batlle2012geneticcausesand pages 2-3
+20. alexander2025hereditarydistalrenald pages 10-12
+21. alexander2025hereditarydistalrenalc pages 10-12
+22. alexander2025hereditarydistalrenala pages 5-7
+23. alexander2025hereditarydistalrenalb pages 5-7
+24. https://doi.org/10.1038/s41581-023-00699-9
+25. https://doi.org/10.3389/fped.2023.1077120
+26. https://doi.org/10.1186/s12920-022-01381-y
+27. https://doi.org/10.1007/s00467-024-06411-8
+28. https://doi.org/10.1186/s13023-025-03953-4
+29. https://doi.org/10.1093/ndt/gfs442,
+30. https://doi.org/10.1038/s41581-023-00699-9,
+31. https://doi.org/10.1186/s12920-022-01381-y,
+32. https://doi.org/10.2147/phmt.s174459,
+33. https://doi.org/10.3389/fped.2023.1077120,
+34. https://doi.org/10.1053/j.ajkd.2007.03.002,
+35. https://doi.org/10.1681/asn.2006101072,
+36. https://doi.org/10.1159/000531556,
+37. https://doi.org/10.1152/physiol.00044.2006,
+38. https://doi.org/10.1152/ajpcell.00301.2017,
+39. https://doi.org/10.1186/s13023-025-03953-4,
+40. https://doi.org/10.1007/s00467-024-06411-8,
+41. https://doi.org/10.21203/rs.3.rs-4957828/v1,


### PR DESCRIPTION
## Summary
- Adds DISMECH curation for renal tubular acidosis, distal, 4, with hemolytic anemia (MONDO:0012700)
- Integrates Falcon deep research and cited PMID reference caches
- Covers SLC4A1/A858D genetics, renal acidification failure, hemolytic anemia/spherocytosis, clinical phenotypes, epidemiology, and alkali treatment

## Validation
- `just validate kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml`
- `just validate-references kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml`
- `just validate-terms kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml`
- `just compliance kb/disorders/Renal_Tubular_Acidosis_Distal_4_with_Hemolytic_Anemia.yaml` -> global 90.5%, weighted 91.5%

## Cache cleanup
- Restored generated `cache/*` churn
- Restored unrelated `references_cache/clinicaltrials_NCT*.md` churn
