### PR TITLE
[codex] Link methemoglobinemia methemoglobin endpoints

### DIFF
--- a/kb/disorders/Hereditary_Methemoglobinemia.yaml
+++ b/kb/disorders/Hereditary_Methemoglobinemia.yaml
@@ -1,7 +1,7 @@
 name: Hereditary methemoglobinemia
 category: Mendelian
 creation_date: "2026-05-09T13:01:56Z"
-updated_date: "2026-05-09T13:01:56Z"
+updated_date: "2026-05-11T00:00:00Z"
 synonyms:
 - Autosomal recessive congenital methemoglobinemia
 - Recessive congenital methemoglobinemia
@@ -624,6 +624,18 @@ biochemical:
   notes: >
     Affected individuals have elevated blood methemoglobin; levels in a Yakutia
     pediatric registry ranged from mild to markedly elevated values.
+  readouts:
+  - target: Methemoglobin accumulation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-076
+    - FDA-SE-pediatric-noncancer-053
+    interpretation: >
+      Blood methemoglobin level reports the ferric hemoglobin accumulation
+      node; reduction after redox-directed therapy indicates lower impaired
+      oxygen-binding hemoglobin burden.
   evidence:
   - reference: PMID:27879543
     reference_title: Enzymopenic Congenital Methemoglobinemia in Children of the Republic of Sakha (Yakutia).

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1881,8 +1881,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with methemoglobinemia;
     endpoint: Serum methemoglobin; approval context: accelerated; drug mechanism: Oxidation-reduction
     agent.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hereditary methemoglobinemia
+  mapped_disease_files:
+  - kb/disorders/Hereditary_Methemoglobinemia.yaml
+  mapping_notes: >
+    Curated partial disease mapping; FDA row applies broadly to patients with
+    methemoglobinemia and is biologically applicable to the hereditary
+    methemoglobinemia entry through the methemoglobin-accumulation node.
 - row_id: FDA-SE-adult-noncancer-077
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4978,8 +4985,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with methemoglobinemia;
     endpoint: Serum methemoglobin; approval context: accelerated; drug mechanism: Oxidation-reduction
     agent; age range: All pediatric age groups.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Hereditary methemoglobinemia
+  mapped_disease_files:
+  - kb/disorders/Hereditary_Methemoglobinemia.yaml
+  mapping_notes: >
+    Curated partial disease mapping; FDA row applies broadly to pediatric
+    patients with methemoglobinemia and is biologically applicable to the
+    hereditary methemoglobinemia entry through the methemoglobin-accumulation
+    node.
 - row_id: FDA-SE-pediatric-noncancer-054
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Adds serum/blood methemoglobin as a pharmacodynamic readout of the `Methemoglobin accumulation` pathograph node in `Hereditary_Methemoglobinemia.yaml`.
- Maps the adult and pediatric FDA serum methemoglobin surrogate endpoint rows to the hereditary methemoglobinemia disease file.
- Splits the non-overlapping methemoglobinemia portion out of the older broad inborn-lab draft PR so it can be reviewed independently.

## Validation

- `just validate kb/disorders/Hereditary_Methemoglobinemia.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_regulatory_endpoint_refs.py tests/test_graph_model_links.py -q`
- `git diff --check`