### PR TITLE
[codex] Triage vaccine immunogenicity endpoint rows

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -363,8 +363,9 @@ surrogate_endpoints:
     Age; endpoint: Full-length S-binding IgG (for COVID-19) and Hemagglutination inhibition (HAI) antibodies
     (for influenza); approval context: traditional; drug mechanism: Induction of antibodies against the
     S protein of SARS-CoV-2 and the hemagglutinin (HA) protein of influenza virus.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-015
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1027,8 +1028,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Human Papillomavirus; population: Persons (18 through 45 years of age)
     to be immunized against human papillomavirus; endpoint: Cervical intraepithelial neoplasia; approval
     context: traditional; drug mechanism: Induction of immunity.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-042
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1299,8 +1301,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Influenza A virus subtypes and influenza type B virus; population: Persons
     to be immunized against influenza; endpoint: Seroconversion rate; approval context: traditional; drug
     mechanism: Induction of Immunity.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-054
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1375,8 +1378,9 @@ surrogate_endpoints:
     Y; endpoint: Serum bactericidal activity (SBA) determined by endogenous complement preserved in the
     serum samples collected from study participants (enc hSBA) and SBA determined by an exogenous source
     of human complement (hSBA); approval context: traditional; drug mechanism: Induction of Immunity.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-057
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1404,8 +1408,9 @@ surrogate_endpoints:
     20A, 22F, 23A, 23B, 24F, 31, 33F, and 35B.; population: Persons to be immunized against S. pneumoniae
     18 years of age and older; endpoint: Opsonophagocytic activity (OPA); approval context: traditional;
     drug mechanism: Induction of Immunity.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-058
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1429,8 +1434,9 @@ surrogate_endpoints:
     disease; Adults ≥18 years of age living with HIV; endpoint: Opsonophagocytosis assay titers; approval
     context: traditional; drug mechanism: Induction of immunity; Induces OPA against 22 S. pneumoniae
     serotypes.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-059
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2139,8 +2145,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Pertussis (in combination vaccines); population: Persons (18 through 64
     years of age) to be immunized against pertussis; endpoint: Serum antibody concentrations; approval
     context: traditional; drug mechanism: Induction of immunity.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-087
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2544,8 +2551,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Respiratory Syncytial Virus, Lower Respiratory Tract Disease; population:
     Pateints with Respiratory Syncytial Virus, Lower Respiratory Tract Disease; endpoint: Neutralizing
     antibodies to RSV A and B; approval context: traditional; drug mechanism: active immunization.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-103
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2569,8 +2577,9 @@ surrogate_endpoints:
     caused by Respiratory Syncytial Virus; endpoint: Hemagglutination inhibition titers for Flu A/B influenza
     vaccine strains; approval context: traditional; drug mechanism: Induction of immunity with concomitant
     administration of AREXVY and a quadrivalent influenza vaccine.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-104
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2842,8 +2851,9 @@ surrogate_endpoints:
     age and older who are at increased risk of exposure to CHIKV; endpoint: CHIKV-specific neutralizing
     antibody; approval context: accelerated; drug mechanism: The exact mechanism of protection has not
     been determined. VIMKUNYA elicits CHIKV specific immune responses..'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-115
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4376,8 +4386,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Human papillomavirus; population: Persons to be immunized against human
     papillomavirus; endpoint: Cervical intraepithelial neoplasia; approval context: traditional; drug
     mechanism: Induction of immunity; age range: 9 through 17 years.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-030
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4585,8 +4596,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Influenza A H5N1; population: Persons to be immunized against influenza;
     endpoint: Hemagglutination inhibition antibody; approval context: traditional; drug mechanism: Induction
     of Immunity; age range: 6 months and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-039
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4609,8 +4621,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Influenza A virus subtypes and influenza type B virus; population: Individuals
     9 years of age and older; endpoint: Seroconversion rate; approval context: traditional; drug mechanism:
     Induction of Immunity; age range: 9 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-040
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4664,8 +4677,9 @@ surrogate_endpoints:
     collected from study participants (enc hSBA) and SBA determined by an exogenous source of human complement
     (hSBA); approval context: traditional; drug mechanism: Induction of Immunity; age range: 6 weeks and
     older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-042
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5064,8 +5078,9 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Pertussis (in combination vaccines); population: Persons to be immunized
     against pertussis; endpoint: Serum antibody concentrations; approval context: traditional; drug mechanism:
     Induction of immunity; age range: 6 weeks and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-057
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5172,8 +5187,9 @@ surrogate_endpoints:
     clinical benefit); approval context: accelerated; drug mechanism: The exact mechanism of protection
     has not been determined. VIMKUNYA elicits CHIKV specific immune responses.; age range: 12 years and
     older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: FDA row is a product-use, prevention, or broad regulatory context rather than a directly
+    mapped dismech disease entry.
 - row_id: FDA-SE-pediatric-noncancer-061
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Marks 16 vaccine, prevention, and immunogenicity FDA rows as `NOT_DISEASE_SPECIFIC`.
- Keeps this as FDA table triage only: these rows describe product-use or prevention contexts and should not create disease biomarkers/pathograph readouts.
- Covers COVID/influenza combination immunogenicity, HPV immunization contexts, influenza seroconversion/HAI rows, meningococcal and pneumococcal immunogenicity rows, pertussis antibody rows, RSV immunogenicity rows, and CHIKV prevention neutralizing antibody rows.

## Validation

- `uv run pytest tests/test_fda_surrogate_endpoints.py -q`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `git diff --check`