### PR TITLE
Add aggressive NK-cell leukemia curation

### DIFF
--- a/kb/disorders/Aggressive_NK-cell_Leukemia.yaml
+++ b/kb/disorders/Aggressive_NK-cell_Leukemia.yaml
@@ -1,0 +1,738 @@
+name: Aggressive NK-cell Leukemia
+creation_date: "2026-05-11T17:49:12Z"
+updated_date: "2026-05-11T18:33:54Z"
+description: >-
+  Aggressive NK-cell leukemia is a rare, fulminant mature NK-cell hematologic
+  malignancy. It commonly presents as an acute systemic inflammatory and
+  leukemic illness with fever, constitutional symptoms, hepatosplenomegaly,
+  coagulopathy, hemophagocytic syndrome or HLH-like disease, and rapid
+  multiorgan complications. Most cases are Epstein-Barr virus-associated, but
+  EBV-negative cases are recognized. Molecular evidence supports recurrent
+  JAK-STAT activation, TP53/DNA-repair impairment, epigenetic dysregulation,
+  and additional RAS-MAPK/DDX3X lesions. Treatment usually requires urgent
+  asparaginase/pegaspargase-containing chemotherapy with consideration of
+  allogeneic hematopoietic stem cell transplantation in responding eligible
+  patients, but outcomes remain poor.
+categories:
+- Hematologic Malignancy
+- Mature NK-Cell Neoplasm
+- EBV-Associated Neoplasm
+- Rare Cancer
+synonyms:
+- ANKL
+- aggressive NK-cell leukemia/lymphoma
+- aggressive natural killer cell leukemia
+- NK-cell large granular lymphocyte leukemia
+disease_term:
+  preferred_term: aggressive NK-cell leukemia
+  term:
+    id: MONDO:0019470
+    label: aggressive NK-cell leukemia
+parents:
+- mature T-cell and NK-cell non-Hodgkin lymphoma
+- chronic leukemia
+infectious_agent:
+- name: Epstein-Barr Virus
+  infectious_agent_term:
+    preferred_term: Epstein-Barr virus
+    term:
+      id: NCBITaxon:10376
+      label: human gammaherpesvirus 4
+  description: >-
+    EBV is the central infectious association in aggressive NK-cell leukemia.
+    Tumor or marrow EBER positivity supports EBV-associated ANKL, while
+    EBV-HLH is an important overlapping presentation and differential context.
+  evidence:
+  - reference: DOI:10.3389/frhem.2024.1413794
+    reference_title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Aggressive natural killer cell leukemia (ANKL) is a rare, aggressive
+      hematologic malignancy which often presents as fulminant Epstein-Barr
+      virus (EBV)- driven hemophagocytic lymphohistiocytosis (HLH).
+    explanation: >-
+      This human case report explicitly frames ANKL as an EBV-driven HLH-like
+      malignancy presentation.
+pathophysiology:
+- name: EBV-Associated NK-Cell Transformation
+  description: >-
+    EBV-associated ANKL arises in the mature NK-cell lineage and can present as
+    EBV-HLH before the malignant NK-cell population is recognized. EBV positivity
+    should be interpreted with morphology and immunophenotyping because EBV-HLH
+    without neoplasia can clinically overlap.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  locations:
+  - preferred_term: bone marrow
+    term:
+      id: UBERON:0002371
+      label: bone marrow
+  - preferred_term: blood
+    term:
+      id: UBERON:0000178
+      label: blood
+  biological_processes:
+  - preferred_term: cytokine-mediated signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0019221
+      label: cytokine-mediated signaling pathway
+  evidence:
+  - reference: DOI:10.3389/frhem.2024.1413794
+    reference_title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Here we present a case of ANKL in a patient presenting with EBV-HLH.
+    explanation: >-
+      This supports EBV-HLH as a clinically important presentation context for
+      ANKL and anchors EBV-associated transformation in a human patient.
+  downstream:
+  - target: Malignant NK-Cell Expansion
+    description: EBV-associated NK-lineage transformation precedes systemic malignant NK-cell expansion.
+- name: Malignant NK-Cell Expansion
+  description: >-
+    The neoplastic cells retain NK-lineage markers, particularly CD56 and CD94,
+    while lacking surface T-cell markers such as surface CD3, CD5, and CD57.
+    Expansion in marrow and blood produces the leukemic presentation and drives
+    tissue involvement in hematopoietic and reticuloendothelial organs.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  locations:
+  - preferred_term: bone marrow
+    term:
+      id: UBERON:0002371
+      label: bone marrow
+  - preferred_term: blood
+    term:
+      id: UBERON:0000178
+      label: blood
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  - preferred_term: spleen
+    term:
+      id: UBERON:0002106
+      label: spleen
+  biological_processes:
+  - preferred_term: cell population proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The neoplastic cells were positive for CD56 and CD94, and negative for
+      surface CD3, CD5, and CD57 in all cases assessed.
+    explanation: >-
+      This 12-case clinicopathologic series supports NK-lineage malignant-cell
+      expansion with the characteristic diagnostic immunophenotype.
+  downstream:
+  - target: JAK-STAT and Survival Signaling
+    description: Expanded malignant NK cells frequently harbor pathway lesions that promote growth and survival.
+  - target: HLH-Like Systemic Inflammation and Coagulopathy
+    description: Malignant NK-cell disease can trigger fulminant inflammatory and coagulation complications.
+- name: JAK-STAT and Survival Signaling
+  description: >-
+    Recurrent somatic lesions converge on JAK-STAT signaling, epigenetic
+    modifiers, TP53/DNA-repair impairment, RAS-MAPK signaling, and DDX3X.
+    These alterations provide a mechanism for malignant NK-cell proliferation,
+    survival, and therapeutic vulnerability to pathway-directed approaches.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  biological_processes:
+  - preferred_term: cell surface receptor signaling pathway via JAK-STAT
+    modifier: INCREASED
+    term:
+      id: GO:0007259
+      label: cell surface receptor signaling pathway via JAK-STAT
+  - preferred_term: regulation of apoptotic process
+    modifier: ABNORMAL
+    term:
+      id: GO:0042981
+      label: regulation of apoptotic process
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Molecular abnormalities that occur in ANKL can be divided into three
+      major groups: JAK/STAT pathway activation, epigenetic dysregulation, and
+      impairment of TP53 and DNA repair.
+    explanation: >-
+      This review summarizes the main recurrent pathway classes driving ANKL
+      pathogenesis.
+  - reference: DOI:10.1038/s41467-018-03987-2
+    reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We study 14 ANKL patients using whole-exome sequencing (WES) and identify
+      mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as
+      inDDX3X(29%) and epigenetic modifiers (50%).
+    explanation: >-
+      This human tumor genomic study supports recurrent STAT3, RAS-MAPK, DDX3X,
+      and epigenetic-modifier lesions in ANKL.
+  downstream:
+  - target: Malignant NK-Cell Expansion
+    description: JAK-STAT and survival signaling sustain proliferation of malignant NK cells.
+- name: HLH-Like Systemic Inflammation and Coagulopathy
+  description: >-
+    ANKL often manifests as a severe systemic inflammatory syndrome with fever,
+    hemophagocytic syndrome or HLH, hepatosplenomegaly, and disseminated
+    intravascular coagulation. These complications contribute to early organ
+    failure and mortality.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  locations:
+  - preferred_term: blood
+    term:
+      id: UBERON:0000178
+      label: blood
+  - preferred_term: liver
+    term:
+      id: UBERON:0002107
+      label: liver
+  - preferred_term: spleen
+    term:
+      id: UBERON:0002106
+      label: spleen
+  biological_processes:
+  - preferred_term: cytokine-mediated signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0019221
+      label: cytokine-mediated signaling pathway
+  - preferred_term: coagulation
+    modifier: ABNORMAL
+    term:
+      id: GO:0050817
+      label: coagulation
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Patients commonly present acutely with fever, constitutional symptoms,
+      hepatosplenomegaly, and often disseminated intravascular coagulation or
+      hemophagocytic syndrome.
+    explanation: >-
+      This review directly links the acute ANKL presentation to fever,
+      hepatosplenomegaly, DIC, and hemophagocytic syndrome.
+phenotypes:
+- category: Constitutional
+  name: Fever and Constitutional Symptoms
+  severity: SEVERE
+  description: >-
+    Acute fever and systemic constitutional symptoms are part of the typical
+    fulminant presentation.
+  phenotype_term:
+    preferred_term: Fever
+    term:
+      id: HP:0001945
+      label: Fever
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Patients commonly present acutely with fever, constitutional symptoms,
+      hepatosplenomegaly, and often disseminated intravascular coagulation or
+      hemophagocytic syndrome.
+    explanation: >-
+      The abstract explicitly includes fever and constitutional symptoms in the
+      common acute presentation.
+- category: Organomegaly
+  name: Hepatosplenomegaly
+  severity: SEVERE
+  description: >-
+    Concurrent liver and spleen enlargement reflects reticuloendothelial organ
+    involvement in the systemic leukemic process.
+  phenotype_term:
+    preferred_term: Hepatosplenomegaly
+    term:
+      id: HP:0001433
+      label: Hepatosplenomegaly
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Patients commonly present acutely with fever, constitutional symptoms,
+      hepatosplenomegaly, and often disseminated intravascular coagulation or
+      hemophagocytic syndrome.
+    explanation: >-
+      The review abstract directly names hepatosplenomegaly as a common ANKL
+      presentation feature.
+- category: Hematologic
+  name: Disseminated Intravascular Coagulation
+  severity: SEVERE
+  description: >-
+    DIC is a life-threatening coagulopathy reported in the acute ANKL
+    presentation and can contribute to organ failure.
+  phenotype_term:
+    preferred_term: Disseminated intravascular coagulation
+    term:
+      id: HP:0005521
+      label: Disseminated intravascular coagulation
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Patients commonly present acutely with fever, constitutional symptoms,
+      hepatosplenomegaly, and often disseminated intravascular coagulation or
+      hemophagocytic syndrome.
+    explanation: >-
+      The abstract directly supports DIC as a feature of the acute ANKL
+      presentation.
+- category: Immune
+  name: HLH-Like Hemophagocytic Syndrome
+  severity: SEVERE
+  description: >-
+    ANKL can initially mimic or present as EBV-driven HLH, with hemophagocytic
+    syndrome reflecting severe macrophage activation and systemic inflammation.
+  phenotype_term:
+    preferred_term: Hemophagocytosis
+    term:
+      id: HP:0012156
+      label: Hemophagocytosis
+  evidence:
+  - reference: DOI:10.3389/frhem.2024.1413794
+    reference_title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Aggressive natural killer cell leukemia (ANKL) is a rare, aggressive
+      hematologic malignancy which often presents as fulminant Epstein-Barr
+      virus (EBV)- driven hemophagocytic lymphohistiocytosis (HLH).
+    explanation: >-
+      The case report directly supports EBV-HLH as a frequent and clinically
+      important presentation mode for ANKL.
+  - reference: DOI:10.24953/turkjpediatr.2024.5072
+    reference_title: "Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      HLH can serve as the initial manifestation of ANKL.
+    explanation: >-
+      The pediatric case series and literature review supports HLH as an initial
+      manifestation.
+genetic:
+- name: STAT3
+  gene_term:
+    preferred_term: STAT3
+    term:
+      id: hgnc:11364
+      label: STAT3
+  association: Recurrent somatic mutation and JAK-STAT pathway activation in ANKL
+  relationship_type: SOMATIC_DRIVER
+  variant_origin: SOMATIC
+  evidence:
+  - reference: DOI:10.1038/s41467-018-03987-2
+    reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We study 14 ANKL patients using whole-exome sequencing (WES) and identify
+      mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as
+      inDDX3X(29%) and epigenetic modifiers (50%).
+    explanation: >-
+      Whole-exome sequencing of human ANKL tumors identified recurrent STAT3
+      mutations.
+- name: TP53
+  gene_term:
+    preferred_term: TP53
+    term:
+      id: hgnc:11998
+      label: TP53
+  association: Recurrent TP53 alteration and p53 overexpression in ANKL
+  relationship_type: SOMATIC_DRIVER
+  variant_origin: SOMATIC
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 mutations were detected in 3 of 6 cases, whereas ASXL1 and TET2
+      mutations were each detected in 2 of 6 cases.
+    explanation: >-
+      This clinicopathologic series supports recurrent TP53 mutations in ANKL.
+- name: DDX3X
+  gene_term:
+    preferred_term: DDX3X
+    term:
+      id: hgnc:2745
+      label: DDX3X
+  association: Recurrent somatic mutation in ANKL genomic profiling
+  relationship_type: SOMATIC_DRIVER
+  variant_origin: SOMATIC
+  evidence:
+  - reference: DOI:10.1038/s41467-018-03987-2
+    reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We study 14 ANKL patients using whole-exome sequencing (WES) and identify
+      mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as
+      inDDX3X(29%) and epigenetic modifiers (50%).
+    explanation: >-
+      Whole-exome sequencing of ANKL identified recurrent DDX3X mutation.
+- name: ASXL1
+  gene_term:
+    preferred_term: ASXL1
+    term:
+      id: hgnc:18318
+      label: ASXL1
+  association: Epigenetic modifier mutation in ANKL
+  relationship_type: SOMATIC_DRIVER
+  variant_origin: SOMATIC
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 mutations were detected in 3 of 6 cases, whereas ASXL1 and TET2
+      mutations were each detected in 2 of 6 cases.
+    explanation: >-
+      This clinicopathologic series supports ASXL1 mutation as a recurrent
+      epigenetic modifier lesion in ANKL.
+- name: TET2
+  gene_term:
+    preferred_term: TET2
+    term:
+      id: hgnc:25941
+      label: TET2
+  association: Epigenetic modifier mutation in ANKL
+  relationship_type: SOMATIC_DRIVER
+  variant_origin: SOMATIC
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 mutations were detected in 3 of 6 cases, whereas ASXL1 and TET2
+      mutations were each detected in 2 of 6 cases.
+    explanation: >-
+      This clinicopathologic series supports TET2 mutation as a recurrent
+      epigenetic modifier lesion in ANKL.
+progression:
+- phase: Fulminant Presentation and Early Mortality
+  duration: often weeks to months
+  notes: >-
+    ANKL frequently progresses rapidly despite intensive therapy, with very
+    short median survival reported in clinicopathologic series.
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Patients had very poor outcomes despite intensive chemotherapy, with a
+      median survival of 2 months.
+    explanation: >-
+      The 12-case series directly supports very poor prognosis and short median
+      survival.
+diagnosis:
+- name: NK-Cell Flow Cytometry and Immunophenotyping
+  description: >-
+    Diagnosis requires identifying an abnormal NK-cell population and excluding
+    T-cell lineage by immunophenotyping. A typical pattern is CD56/CD94-positive
+    and surface CD3/CD5/CD57-negative, with cytoplasmic CD3epsilon and cytotoxic
+    marker evaluation when available.
+  diagnosis_term:
+    preferred_term: flow cytometry immunophenotyping
+  results: >-
+    An atypical CD3-/CD56+ or CD56+/CD94+ NK-cell population in marrow or blood
+    supports ANKL in the appropriate clinicopathologic context.
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The neoplastic cells were positive for CD56 and CD94, and negative for
+      surface CD3, CD5, and CD57 in all cases assessed.
+    explanation: >-
+      This case series supports the core diagnostic immunophenotype.
+  - reference: DOI:10.3389/frhem.2024.1413794
+    reference_title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      bone marrow biopsy demonstrated an atypical CD3-/CD56+ natural killer
+      (NK) cell population with diminished CD7 expression consistent with EBV+
+      ANKL.
+    explanation: >-
+      The case report demonstrates diagnostic recognition of ANKL by marrow
+      biopsy and NK-cell immunophenotyping.
+- name: EBER In Situ Hybridization
+  description: >-
+    EBER testing helps establish EBV-associated ANKL and distinguish malignant
+    NK/T disease from EBV-HLH without an identifiable neoplastic population.
+  diagnosis_term:
+    preferred_term: EBER in situ hybridization
+  results: EBER positivity in malignant NK cells supports EBV-associated ANKL.
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      They were also positive for CD2 (10/12), c-MYC (6/8), BCL2 (6/8), CD16
+      (5/7), EBER (9/12), CD7 (6/11), pSTAT3Tyr705 (3/8), CD8 (2/6), PD-L1
+      (2/8), CD4 (2/11), CD8 (2/6), and CD158 (1/5).
+    explanation: >-
+      The 12-case series reports EBER positivity in most ANKL cases assessed.
+treatments:
+- name: Asparaginase- or Pegaspargase-Containing Chemotherapy
+  description: >-
+    Asparaginase-based regimens, including pegaspargase-containing intensive
+    combinations and modified SMILE-like approaches, are commonly considered
+    for rapid induction. Evidence remains limited because ANKL is rare and
+    outcomes are poor even when responses occur.
+  treatment_term:
+    preferred_term: chemotherapy
+    term:
+      id: MAXO:0000647
+      label: chemotherapy
+  target_mechanisms:
+  - target: Malignant NK-Cell Expansion
+    treatment_effect: INHIBITS
+    description: Cytotoxic induction chemotherapy attempts to reduce the malignant NK-cell burden.
+  evidence:
+  - reference: DOI:10.24953/turkjpediatr.2024.5072
+    reference_title: "Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Intensive combination chemotherapy based on pegaspargase and
+      anthracyclines may be considered for ANKL.
+    explanation: >-
+      The pediatric case series and literature review supports pegaspargase-
+      based chemotherapy as a considered treatment while preserving uncertainty
+      in the wording.
+  - reference: clinicaltrials:NCT03719105
+    reference_title: Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cohort 1: dexamethasone, methotrexate, ifosfamide, pegaspargase, and
+      etoposide (modified SMILE) chemotherapy regimen alone and pembrolizumab in
+      children, adolescents, and young adults with advanced stage NK lymphoma
+      and leukemia
+    explanation: >-
+      The active trial summary supports a modified SMILE pegaspargase-containing
+      regimen for advanced NK lymphoma/leukemia.
+- name: Allogeneic Hematopoietic Stem Cell Transplantation
+  description: >-
+    Allogeneic hematopoietic stem cell transplantation is considered as
+    consolidation for eligible patients who achieve disease response after
+    induction therapy.
+  treatment_term:
+    preferred_term: hematopoietic stem cell transplantation
+    term:
+      id: MAXO:0000747
+      label: hematopoietic stem cell transplantation
+  target_mechanisms:
+  - target: Malignant NK-Cell Expansion
+    treatment_effect: INHIBITS
+    description: Transplantation aims to consolidate remission after cytoreduction of the malignant NK-cell clone.
+  evidence:
+  - reference: DOI:10.24953/turkjpediatr.2024.5072
+    reference_title: "Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Case-2 underwent hematopoietic stem cell transplantation and is currently
+      alive and disease-free.
+    explanation: >-
+      This human case series supports HSCT as a potential consolidation
+      strategy, but the single-case nature warrants partial support.
+  - reference: clinicaltrials:NCT03719105
+    reference_title: Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both groups proceed to allogeneic stem cell transplant with disease
+      response.
+    explanation: >-
+      The trial summary supports HSCT consolidation after disease response.
+- name: JAK and BCL2 Inhibition
+  description: >-
+    JAK inhibitors and BCL2 inhibitors are emerging rational therapies rather
+    than established ANKL standards. Their rationale comes from ANKL genomic and
+    drug sensitivity profiling showing JAK-STAT pathway involvement and NK-cell
+    sensitivity to JAK and BCL2 inhibition.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_mechanisms:
+  - target: JAK-STAT and Survival Signaling
+    treatment_effect: INHIBITS
+    description: JAK inhibition targets recurrent JAK-STAT signaling activity in NK-cell malignancies.
+  evidence:
+  - reference: DOI:10.1038/s41467-018-03987-2
+    reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: >-
+      Drug sensitivity profiling further demonstrates the role of the JAK-STAT
+      pathway in the pathogenesis of NK-cell malignancies, identifying NK cells
+      to be highly sensitive to JAK and BCL2 inhibition compared to other
+      hematopoietic cell lineages.
+    explanation: >-
+      This ex vivo/in vitro drug profiling supports a targeted-therapy
+      rationale, but not an established clinical standard for ANKL.
+clinical_trials:
+- name: NCT03719105
+  description: >-
+    Pilot chemoimmunotherapy study using modified SMILE-style induction for
+    advanced NK lymphoma/leukemia followed by allogeneic stem cell transplant
+    for responders.
+  evidence:
+  - reference: clinicaltrials:NCT03719105
+    reference_title: Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Cohort 1: dexamethasone, methotrexate, ifosfamide, pegaspargase, and
+      etoposide (modified SMILE) chemotherapy regimen alone and pembrolizumab in
+      children, adolescents, and young adults with advanced stage NK lymphoma
+      and leukemia
+    explanation: >-
+      The trial summary directly describes the ANKL-relevant induction regimen
+      for advanced NK lymphoma/leukemia.
+- name: NCT03623087
+  description: >-
+    SIMPLE chemotherapy study for NK/T-cell malignancies, derived from a
+    PIGLETS chemotherapy protocol used in extranodal NK/T-cell lymphoma and
+    aggressive NK leukemia.
+  evidence:
+  - reference: clinicaltrials:NCT03623087
+    reference_title: "Combination Chemotherapy Using Cisplatin, Gemcitabine, Ifosfamide, Etoposide, L-asparaginase and Dexamethasone (SIMPLE) for Newly Diagnosed and Relapsed/Refractory NK/T Cell Malignancies"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      NK malignancies consist of two different clinical entities, extranodal
+      NK/T cell lymphoma and aggressive NK leukaemia.
+    explanation: >-
+      The trial summary explicitly includes aggressive NK leukemia in the NK
+      malignancy population targeted by the chemotherapy study.
+- name: NCT05863234
+  description: >-
+    Phase I/II dose-escalation clinical trial evaluating repeated continuous
+    intravenous PPMX-T003 in aggressive NK-cell leukemia.
+  evidence:
+  - reference: clinicaltrials:NCT05863234
+    reference_title: Multicenter, Open-label, Dose-escalation Phase I/II Study to Evaluate the Tolerability, Safety, Efficacy and Pharmacokinetics of Repeated Continuous Intravenous PPMX-T003 in Patients With Aggressive NK Cell Leukaemia (ANKL) (Physician-initiated Clinical Trial)
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This is Phase I/II Dose-Escalation Study to evaluate the tolerability,
+      safety, efficacy and pharmacokinetics of PPMX-T003 in aggressive NK-cell
+      leukemia.
+    explanation: >-
+      The trial summary directly supports an ANKL-specific PPMX-T003 clinical
+      trial.
+differential_diagnoses:
+- name: EBV-Driven Hemophagocytic Lymphohistiocytosis Without Neoplasia
+  description: >-
+    EBV-HLH can be the initial presentation of ANKL, but EBV-HLH without a
+    malignant NK/T-cell population is a key differential diagnosis during early
+    evaluation.
+  distinguishing_features:
+  - Detection of an atypical CD3-/CD56+ NK-cell population in marrow or blood supports ANKL rather than isolated EBV-HLH.
+  evidence:
+  - reference: DOI:10.3389/frhem.2024.1413794
+    reference_title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This case highlights the diagnostic challenges of ANKL given the lack of
+      standardized diagnostic criteria, the importance of considering T/NK cell
+      malignancies in the differential diagnosis of EBV-HLH, and adds to the
+      literature on this rare disease.
+    explanation: >-
+      This case report explicitly states that T/NK malignancies must be
+      considered in the differential diagnosis of EBV-HLH.
+- name: Extranodal NK/T-Cell Lymphoma
+  description: >-
+    Extranodal NK/T-cell lymphoma is another EBV-associated NK/T malignancy with
+    overlapping immunophenotypic and clinical features, especially when
+    disseminated. Leukemic blood and marrow involvement support ANKL.
+  distinguishing_features:
+  - Primary extranodal mass-forming disease favors extranodal NK/T-cell lymphoma; systemic leukemic marrow and blood involvement favors ANKL.
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      This acute clinical presentation and the variable pathologic and
+      immunophenotypic features of ANKL overlap with other diagnostic entities,
+      making it challenging to establish a timely and accurate diagnosis of
+      ANKL.
+    explanation: >-
+      The review supports clinically important diagnostic overlap with other
+      NK/T-cell entities.
+references:
+- reference: DOI:10.3390/cancers12102900
+  title: "Aggressive NK Cell Leukemia: Current State of the Art"
+  findings: []
+- reference: DOI:10.3389/frhem.2024.1413794
+  title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+  findings: []
+- reference: DOI:10.1097/pas.0000000000001518
+  title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+  findings: []
+- reference: DOI:10.24953/turkjpediatr.2024.5072
+  title: "Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review"
+  findings: []
+- reference: DOI:10.1038/s41467-018-03987-2
+  title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+  findings: []
+- reference: clinicaltrials:NCT03623087
+  title: "Combination Chemotherapy Using Cisplatin, Gemcitabine, Ifosfamide, Etoposide, L-asparaginase and Dexamethasone (SIMPLE) for Newly Diagnosed and Relapsed/Refractory NK/T Cell Malignancies"
+  findings: []
+- reference: clinicaltrials:NCT03719105
+  title: Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study
+  findings: []
+- reference: clinicaltrials:NCT05863234
+  title: Multicenter, Open-label, Dose-escalation Phase I/II Study to Evaluate the Tolerability, Safety, Efficacy and Pharmacokinetics of Repeated Continuous Intravenous PPMX-T003 in Patients With Aggressive NK Cell Leukaemia (ANKL) (Physician-initiated Clinical Trial)
+  findings: []
+notes: >-
+  Falcon deep research was completed on 2026-05-11. Final curation emphasized
+  sources with generated reference-cache abstracts, PMID full text, or
+  ClinicalTrials.gov summaries so evidence snippets can be validated exactly.
+  The Tang 2017 cohort and Ishida/Sumbly reviews were retained in the research
+  artifact but not promoted to YAML evidence because they were not needed for
+  the final supported assertions.

--- a/kb/disorders/Aggressive_NK-cell_Leukemia.yaml
+++ b/kb/disorders/Aggressive_NK-cell_Leukemia.yaml
@@ -1,6 +1,6 @@
 name: Aggressive NK-cell Leukemia
 creation_date: "2026-05-11T17:49:12Z"
-updated_date: "2026-05-11T18:33:54Z"
+updated_date: "2026-05-11T18:54:27Z"
 description: >-
   Aggressive NK-cell leukemia is a rare, fulminant mature NK-cell hematologic
   malignancy. It commonly presents as an acute systemic inflammatory and
@@ -31,6 +31,54 @@ disease_term:
 parents:
 - mature T-cell and NK-cell non-Hodgkin lymphoma
 - chronic leukemia
+has_subtypes:
+- name: Classic ANKL
+  classification: clinical_course
+  description: >-
+    Fulminant ANKL without a prolonged infectious mononucleosis-like prodrome.
+    In the Tang multicenter cohort, classic ANKL had shorter survival and
+    enrichment for TP53 mutation relative to the subacute subtype.
+  evidence:
+  - reference: PMID:29263371
+    reference_title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      All these data suggested that patients with prolonged prodromal phases,
+      whom we define here as “subacute ANKL”, may represent a clinical subtype
+      of ANKL which differed from the others, whom we define here as “classic
+      ANKL”.
+    explanation: >-
+      The multicenter cohort explicitly distinguishes classic ANKL from the
+      subacute clinical subtype.
+- name: Subacute ANKL
+  classification: clinical_course
+  subtype_frequency: 15.93%
+  description: >-
+    ANKL with a prolonged infectious mononucleosis-like prodrome before the
+    fulminant phase. This subtype was associated with better survival and lower
+    TP53 mutation frequency than classic ANKL in the Tang cohort.
+  evidence:
+  - reference: PMID:29263371
+    reference_title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Intriguingly, a subacute clinical course was demonstrated in 18 ANKL
+      patients (15.93%, 18/113).
+    explanation: >-
+      The multicenter cohort quantified the subacute subtype frequency.
+  - reference: PMID:29263371
+    reference_title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      They manifested infectious mononucleosis (IM)-like symptoms (including
+      fever, lymphocytosis or mononucleosis, lymphadenopathy, and
+      hepatosplenomegaly) for more than 90 days (median: 115 days, range:
+      90–450 days), prior to the fulminant onset (Table 1).
+    explanation: >-
+      This defines the subacute ANKL prodromal clinical course.
 infectious_agent:
 - name: Epstein-Barr Virus
   infectious_agent_term:
@@ -140,16 +188,20 @@ pathophysiology:
       This 12-case clinicopathologic series supports NK-lineage malignant-cell
       expansion with the characteristic diagnostic immunophenotype.
   downstream:
-  - target: JAK-STAT and Survival Signaling
-    description: Expanded malignant NK cells frequently harbor pathway lesions that promote growth and survival.
+  - target: JAK-STAT Pathway Activation
+    description: Expanded malignant NK cells can harbor JAK-STAT lesions that promote growth and survival.
+  - target: TP53 and DNA-Repair Impairment
+    description: Expanded malignant NK cells can acquire TP53 and DNA-repair lesions.
+  - target: Epigenetic Modifier Dysregulation
+    description: Expanded malignant NK cells can harbor recurrent epigenetic-modifier lesions.
   - target: HLH-Like Systemic Inflammation and Coagulopathy
     description: Malignant NK-cell disease can trigger fulminant inflammatory and coagulation complications.
-- name: JAK-STAT and Survival Signaling
+- name: JAK-STAT Pathway Activation
   description: >-
-    Recurrent somatic lesions converge on JAK-STAT signaling, epigenetic
-    modifiers, TP53/DNA-repair impairment, RAS-MAPK signaling, and DDX3X.
-    These alterations provide a mechanism for malignant NK-cell proliferation,
-    survival, and therapeutic vulnerability to pathway-directed approaches.
+    JAK-STAT pathway activation is a major recurrent molecular abnormality in
+    ANKL. STAT3 mutation and additional JAK-STAT copy-gain or phosphatase
+    lesions provide a growth and survival mechanism and a rationale for
+    pathway-directed drug profiling.
   cell_types:
   - preferred_term: natural killer cell
     term:
@@ -161,6 +213,42 @@ pathophysiology:
     term:
       id: GO:0007259
       label: cell surface receptor signaling pathway via JAK-STAT
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Molecular abnormalities that occur in ANKL can be divided into three
+      major groups: JAK/STAT pathway activation, epigenetic dysregulation, and
+      impairment of TP53 and DNA repair.
+    explanation: >-
+      The review identifies JAK/STAT pathway activation as a major molecular
+      abnormality in ANKL.
+  - reference: DOI:10.1038/s41467-018-03987-2
+    reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We study 14 ANKL patients using whole-exome sequencing (WES) and identify
+      mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as
+      inDDX3X(29%) and epigenetic modifiers (50%).
+    explanation: >-
+      This human tumor genomic study supports recurrent STAT3 mutation in ANKL.
+  downstream:
+  - target: Malignant NK-Cell Expansion
+    description: JAK-STAT activation sustains proliferation and survival of malignant NK cells.
+- name: TP53 and DNA-Repair Impairment
+  description: >-
+    TP53 mutation, abnormal p53 expression, and broader DNA-repair impairment
+    form a distinct pathophysiologic axis in ANKL. These alterations are most
+    directly linked to loss of cell-cycle checkpoint and apoptosis control.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  biological_processes:
   - preferred_term: regulation of apoptotic process
     modifier: ABNORMAL
     term:
@@ -176,8 +264,42 @@ pathophysiology:
       major groups: JAK/STAT pathway activation, epigenetic dysregulation, and
       impairment of TP53 and DNA repair.
     explanation: >-
-      This review summarizes the main recurrent pathway classes driving ANKL
-      pathogenesis.
+      The review separates TP53 and DNA-repair impairment from JAK-STAT and
+      epigenetic mechanisms.
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      TP53 mutations were detected in 3 of 6 cases, whereas ASXL1 and TET2
+      mutations were each detected in 2 of 6 cases.
+    explanation: >-
+      This clinicopathologic series supports recurrent TP53 mutation in ANKL.
+  downstream:
+  - target: Malignant NK-Cell Expansion
+    description: TP53 and DNA-repair impairment can permit survival and expansion of genomically abnormal NK cells.
+- name: Epigenetic Modifier Dysregulation
+  description: >-
+    Epigenetic dysregulation is a distinct recurrent molecular class in ANKL,
+    including mutations in epigenetic regulatory genes such as ASXL1 and TET2
+    and broader epigenetic-modifier alterations in sequencing cohorts.
+  cell_types:
+  - preferred_term: natural killer cell
+    term:
+      id: CL:0000623
+      label: natural killer cell
+  evidence:
+  - reference: DOI:10.3390/cancers12102900
+    reference_title: "Aggressive NK Cell Leukemia: Current State of the Art"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Molecular abnormalities that occur in ANKL can be divided into three
+      major groups: JAK/STAT pathway activation, epigenetic dysregulation, and
+      impairment of TP53 and DNA repair.
+    explanation: >-
+      The review identifies epigenetic dysregulation as an independent major
+      molecular abnormality class in ANKL.
   - reference: DOI:10.1038/s41467-018-03987-2
     reference_title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
     supports: SUPPORT
@@ -187,11 +309,11 @@ pathophysiology:
       mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as
       inDDX3X(29%) and epigenetic modifiers (50%).
     explanation: >-
-      This human tumor genomic study supports recurrent STAT3, RAS-MAPK, DDX3X,
-      and epigenetic-modifier lesions in ANKL.
+      Whole-exome sequencing supports frequent epigenetic-modifier mutation in
+      ANKL tumors.
   downstream:
   - target: Malignant NK-Cell Expansion
-    description: JAK-STAT and survival signaling sustain proliferation of malignant NK cells.
+    description: Epigenetic dysregulation can alter malignant NK-cell transcriptional control and survival.
 - name: HLH-Like Systemic Inflammation and Coagulopathy
   description: >-
     ANKL often manifests as a severe systemic inflammatory syndrome with fever,
@@ -239,6 +361,24 @@ pathophysiology:
     explanation: >-
       This review directly links the acute ANKL presentation to fever,
       hepatosplenomegaly, DIC, and hemophagocytic syndrome.
+histopathology:
+- name: Interstitial and Sinusoidal Bone Marrow Involvement
+  diagnostic: true
+  description: >-
+    Bone marrow involvement by ANKL can show interstitial or sinusoidal
+    infiltration patterns, supporting a marrow-based leukemic presentation when
+    interpreted with NK-cell immunophenotyping.
+  evidence:
+  - reference: DOI:10.1097/pas.0000000000001518
+    reference_title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Two distinct patterns of bone marrow involvement were identified:
+      interstitial and sinusoidal.
+    explanation: >-
+      This clinicopathologic series supports the marrow infiltration patterns as
+      a histopathologic feature of ANKL.
 phenotypes:
 - category: Constitutional
   name: Fever and Constitutional Symptoms
@@ -341,6 +481,31 @@ phenotypes:
     explanation: >-
       The pediatric case series and literature review supports HLH as an initial
       manifestation.
+- category: Hematologic
+  name: Pancytopenia
+  severity: SEVERE
+  description: >-
+    Cytopenias, including pancytopenia, can accompany the acute leukemic and
+    HLH-like presentation of ANKL and should prompt marrow and flow-cytometric
+    evaluation when ANKL is suspected.
+  phenotype_term:
+    preferred_term: Pancytopenia
+    term:
+      id: HP:0001876
+      label: Pancytopenia
+  evidence:
+  - reference: DOI:10.1155/crh/7796972
+    reference_title: "Aggressive Natural Killer Cell Leukemia: A Rare and Rapidly Progressive Hematologic Malignancy—Case Report and Literature Review"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We present a case of a 71‐year‐old Caucasian male who developed fever,
+      altered mental status, hepatosplenomegaly, pancytopenia, and
+      hemophagocytic lymphohistiocytosis (HLH) and who was ultimately diagnosed
+      with ANKL.
+    explanation: >-
+      The case report directly supports pancytopenia as part of an ANKL
+      presentation.
 genetic:
 - name: STAT3
   gene_term:
@@ -459,6 +624,17 @@ progression:
     explanation: >-
       The 12-case series directly supports very poor prognosis and short median
       survival.
+  - reference: PMID:29263371
+    reference_title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median OS was only 55 days (Supplementary Tables S2) and 1-year
+      survival rate was only 4.42% (5/113; Supplementary Fig. S1B), which
+      indicated a dismal outcome of ANKL.
+    explanation: >-
+      The 113-patient multicenter cohort supports extremely poor overall
+      survival in ANKL.
 diagnosis:
 - name: NK-Cell Flow Cytometry and Immunophenotyping
   description: >-
@@ -522,6 +698,11 @@ treatments:
     term:
       id: MAXO:0000647
       label: chemotherapy
+    therapeutic_agent:
+    - preferred_term: Pegaspargase
+      term:
+        id: NCIT:C1200
+        label: Pegaspargase
   target_mechanisms:
   - target: Malignant NK-Cell Expansion
     treatment_effect: INHIBITS
@@ -596,7 +777,7 @@ treatments:
       id: MAXO:0000058
       label: pharmacotherapy
   target_mechanisms:
-  - target: JAK-STAT and Survival Signaling
+  - target: JAK-STAT Pathway Activation
     treatment_effect: INHIBITS
     description: JAK inhibition targets recurrent JAK-STAT signaling activity in NK-cell malignancies.
   evidence:
@@ -720,6 +901,12 @@ references:
 - reference: DOI:10.1038/s41467-018-03987-2
   title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
   findings: []
+- reference: PMID:29263371
+  title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+  findings: []
+- reference: DOI:10.1155/crh/7796972
+  title: "Aggressive Natural Killer Cell Leukemia: A Rare and Rapidly Progressive Hematologic Malignancy—Case Report and Literature Review"
+  findings: []
 - reference: clinicaltrials:NCT03623087
   title: "Combination Chemotherapy Using Cisplatin, Gemcitabine, Ifosfamide, Etoposide, L-asparaginase and Dexamethasone (SIMPLE) for Newly Diagnosed and Relapsed/Refractory NK/T Cell Malignancies"
   findings: []
@@ -733,6 +920,7 @@ notes: >-
   Falcon deep research was completed on 2026-05-11. Final curation emphasized
   sources with generated reference-cache abstracts, PMID full text, or
   ClinicalTrials.gov summaries so evidence snippets can be validated exactly.
-  The Tang 2017 cohort and Ishida/Sumbly reviews were retained in the research
-  artifact but not promoted to YAML evidence because they were not needed for
-  the final supported assertions.
+  Tang 2017 was promoted from the research artifact into YAML evidence for
+  clinical subtype and outcome assertions. Ishida/Sumbly reviews were retained
+  in the research artifact but not promoted to YAML evidence because the local
+  DOI cache fetch returned metadata-only records for those sources.

--- a/references_cache/DOI_10.1038_s41467-018-03987-2.md
+++ b/references_cache/DOI_10.1038_s41467-018-03987-2.md
@@ -1,0 +1,45 @@
+---
+reference_id: "DOI:10.1038/s41467-018-03987-2"
+title: Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+authors:
+- Olli Dufva
+- Matti Kankainen
+- Tiina Kelkka
+- Nodoka Sekiguchi
+- Shady Adnan Awad
+- Samuli Eldfors
+- Bhagwan Yadav
+- Heikki Kuusanmäki
+- Disha Malani
+- Emma I Andersson
+- Paavo Pietarinen
+- Leena Saikko
+- Panu E. Kovanen
+- Teija Ojala
+- Dean A. Lee
+- Thomas P. Loughran
+- Hideyuki Nakazawa
+- Junji Suzumiya
+- Ritsuro Suzuki
+- Young Hyeh Ko
+- Won Seog Kim
+- Shih-Sung Chuang
+- Tero Aittokallio
+- Wing C. Chan
+- Koichi Ohshima
+- Fumihiro Ishida
+- Satu Mustjoki
+journal: Nature Communications
+year: '2018'
+doi: 10.1038/s41467-018-03987-2
+content_type: abstract_only
+---
+
+# Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight JAK-STAT signaling as therapeutic target
+**Authors:** Olli Dufva, Matti Kankainen, Tiina Kelkka, Nodoka Sekiguchi, Shady Adnan Awad, Samuli Eldfors, Bhagwan Yadav, Heikki Kuusanmäki, Disha Malani, Emma I Andersson, Paavo Pietarinen, Leena Saikko, Panu E. Kovanen, Teija Ojala, Dean A. Lee, Thomas P. Loughran, Hideyuki Nakazawa, Junji Suzumiya, Ritsuro Suzuki, Young Hyeh Ko, Won Seog Kim, Shih-Sung Chuang, Tero Aittokallio, Wing C. Chan, Koichi Ohshima, Fumihiro Ishida, Satu Mustjoki
+**Journal:** Nature Communications (2018)
+**DOI:** [10.1038/s41467-018-03987-2](https://doi.org/10.1038/s41467-018-03987-2)
+
+## Content
+
+AbstractAggressive natural killer-cell (NK-cell) leukemia (ANKL) is an extremely aggressive malignancy with dismal prognosis and lack of targeted therapies. Here, we elucidate the molecular pathogenesis of ANKL using a combination of genomic and drug sensitivity profiling. We study 14 ANKL patients using whole-exome sequencing (WES) and identify mutations inSTAT3(21%) and RAS-MAPK pathway genes (21%) as well as inDDX3X(29%) and epigenetic modifiers (50%). Additional alterations include JAK-STAT copy gains and tyrosine phosphatase mutations, which we show recurrent also in extranodal NK/T-cell lymphoma, nasal type (NKTCL) through integration of public genomic data. Drug sensitivity profiling further demonstrates the role of the JAK-STAT pathway in the pathogenesis of NK-cell malignancies, identifying NK cells to be highly sensitive to JAK and BCL2 inhibition compared to other hematopoietic cell lineages. Our results provide insight into ANKL genetics and a framework for application of targeted therapies in NK-cell malignancies.

--- a/references_cache/DOI_10.1097_pas.0000000000001518.md
+++ b/references_cache/DOI_10.1097_pas.0000000000001518.md
@@ -1,0 +1,28 @@
+---
+reference_id: "DOI:10.1097/pas.0000000000001518"
+title: Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+authors:
+- Siba El Hussein
+- Keyur P. Patel
+- Hong Fang
+- Beenu Thakral
+- Sanam Loghavi
+- Rashmi Kanagal-Shamanna
+- Sergej Konoplev
+- Elias J. Jabbour
+- L. Jeffrey Medeiros
+- Joseph D. Khoury
+journal: American Journal of Surgical Pathology
+year: '2020'
+doi: 10.1097/pas.0000000000001518
+content_type: abstract_only
+---
+
+# Genomic and Immunophenotypic Landscape of Aggressive NK-Cell Leukemia
+**Authors:** Siba El Hussein, Keyur P. Patel, Hong Fang, Beenu Thakral, Sanam Loghavi, Rashmi Kanagal-Shamanna, Sergej Konoplev, Elias J. Jabbour, L. Jeffrey Medeiros, Joseph D. Khoury
+**Journal:** American Journal of Surgical Pathology (2020)
+**DOI:** [10.1097/pas.0000000000001518](https://doi.org/10.1097/pas.0000000000001518)
+
+## Content
+
+Aggressive natural killer-cell leukemia (ANKL) is a rare, lethal disease with pathologic features that are underdescribed in the literature, particularly in Western nations. In addition, although data on the molecular pathogenesis of ANKL has been reported, evaluation of such data in a clinicopathologic context remains limited. Patients diagnosed with ANKL were identified retrospectively. Detailed demographic and clinicopathologic data were analyzed. We assessed novel markers by immunohistochemistry and performed targeted next-generation sequencing analysis. The study group included 9 men and 3 women with a median age at diagnosis of 47.5 years (range, 20 to 75 y). Two distinct patterns of bone marrow involvement were identified: interstitial and sinusoidal. The neoplastic cells were positive for CD56 and CD94, and negative for surface CD3, CD5, and CD57 in all cases assessed. They were also positive for CD2 (10/12), c-MYC (6/8), BCL2 (6/8), CD16 (5/7), EBER (9/12), CD7 (6/11), pSTAT3Tyr705 (3/8), CD8 (2/6), PD-L1 (2/8), CD4 (2/11), CD8 (2/6), and CD158 (1/5). Aberrant p53 expression was identified in most (7/8) cases; p53 was strongly expressed in 4 cases. Conventional cytogenetic analysis showed clonal abnormalities in 5 of 12 cases. TP53 mutations were detected in 3 of 6 cases, whereas ASXL1 and TET2 mutations were each detected in 2 of 6 cases. Patients had very poor outcomes despite intensive chemotherapy, with a median survival of 2 months. ANKL exhibits 2 distinct patterns of tissue involvement. Neoplastic cells in ANKL are commonly positive for c-MYC and EBER, and they have a high frequency of p53 overexpression, frequently with corresponding TP53 mutations.

--- a/references_cache/DOI_10.1155_crh_7796972.md
+++ b/references_cache/DOI_10.1155_crh_7796972.md
@@ -1,0 +1,24 @@
+---
+reference_id: "DOI:10.1155/crh/7796972"
+title: "Aggressive Natural Killer Cell Leukemia: A Rare and Rapidly Progressive Hematologic Malignancy—Case Report and Literature Review"
+authors:
+- Jennifer Priessnitz
+- Ali Hariri
+- Yuliya Levkiavska
+- Kyle E. Bonner
+- Stephen I. Fisher
+- Joshua M. Sill
+journal: Case Reports in Hematology
+year: '2026'
+doi: 10.1155/crh/7796972
+content_type: abstract_only
+---
+
+# Aggressive Natural Killer Cell Leukemia: A Rare and Rapidly Progressive Hematologic Malignancy—Case Report and Literature Review
+**Authors:** Jennifer Priessnitz, Ali Hariri, Yuliya Levkiavska, Kyle E. Bonner, Stephen I. Fisher, Joshua M. Sill
+**Journal:** Case Reports in Hematology (2026)
+**DOI:** [10.1155/crh/7796972](https://doi.org/10.1155/crh/7796972)
+
+## Content
+
+Aggressive natural killer cell leukemia (ANKL) is a rare, fulminant hematologic malignancy characterized by neoplastic proliferation of mature NK cells. It is frequently associated with Epstein–Barr virus (EBV) infection, although EBV‐negative cases have also been reported. While typically observed in young to middle‐aged adults of East Asian descent, increasing recognition has led to identification of ANKL across diverse age groups and ethnicities. The disease is defined by a rapid clinical course and poor prognosis, underscoring the importance of early diagnosis and effective treatment. We present a case of a 71‐year‐old Caucasian male who developed fever, altered mental status, hepatosplenomegaly, pancytopenia, and hemophagocytic lymphohistiocytosis (HLH) and who was ultimately diagnosed with ANKL. Although he demonstrated initial clinical improvement with chemotherapy, relapse of the ANKL ensued a few months later, and he ultimately succumbed to progressive disease. A review of current literature is provided, focusing on molecular pathogenesis and emerging therapeutic strategies.

--- a/references_cache/DOI_10.24953_turkjpediatr.2024.5072.md
+++ b/references_cache/DOI_10.24953_turkjpediatr.2024.5072.md
@@ -1,0 +1,24 @@
+---
+reference_id: "DOI:10.24953/turkjpediatr.2024.5072"
+title: "Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review"
+authors:
+- Yongan Ni
+- Lei Li
+- Yuping Wang
+- Lirong Sun
+journal: The Turkish Journal of Pediatrics
+year: '2024'
+doi: 10.24953/turkjpediatr.2024.5072
+content_type: abstract_only
+---
+
+# Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review
+**Authors:** Yongan Ni, Lei Li, Yuping Wang, Lirong Sun
+**Journal:** The Turkish Journal of Pediatrics (2024)
+**DOI:** [10.24953/turkjpediatr.2024.5072](https://doi.org/10.24953/turkjpediatr.2024.5072)
+
+## Content
+
+Background. Aggressive natural killer cell leukemia (ANKL) is rare and difficult to diagnose in early stages, with no standard treatment and a poor prognosis.
+Case presentation. Two adolescents with ANKL presented with hemophagocytic lymphohistiocytosis (HLH), with Case-1 presenting as refractory HLH and Case-2 with lung involvement. The morphology of bone marrow showed an increase in unidentified cells, which mainly expressed CD56. Cytogenetic analysis showed complex karyotypes. Both patients received intensive combined chemotherapy based on pegaspargase and anthracyclines. Case-1 died of tumor lysis syndrome. Case-2 underwent hematopoietic stem cell transplantation and is currently alive and disease-free.
+Conclusions. HLH can serve as the initial manifestation of ANKL. Leukemia cells of ANKL have significant variations in the morphology and mainly express CD56. Intensive combination chemotherapy based on pegaspargase and anthracyclines may be considered for ANKL.

--- a/references_cache/DOI_10.3389_frhem.2024.1413794.md
+++ b/references_cache/DOI_10.3389_frhem.2024.1413794.md
@@ -1,0 +1,26 @@
+---
+reference_id: "DOI:10.3389/frhem.2024.1413794"
+title: "Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent"
+authors:
+- Caroline Spaner
+- Jessica Durkee-Shock
+- Andrew Weng
+- Ryan Stubbins
+- Alina S. Gerrie
+- Stefania Pittaluga
+- Jeffrey I. Cohen
+- Luke Y. C. Chen
+journal: Frontiers in Hematology
+year: '2024'
+doi: 10.3389/frhem.2024.1413794
+content_type: abstract_only
+---
+
+# Case report: Aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent
+**Authors:** Caroline Spaner, Jessica Durkee-Shock, Andrew Weng, Ryan Stubbins, Alina S. Gerrie, Stefania Pittaluga, Jeffrey I. Cohen, Luke Y. C. Chen
+**Journal:** Frontiers in Hematology (2024)
+**DOI:** [10.3389/frhem.2024.1413794](https://doi.org/10.3389/frhem.2024.1413794)
+
+## Content
+
+Aggressive natural killer cell leukemia (ANKL) is a rare, aggressive hematologic malignancy which often presents as fulminant Epstein-Barr virus (EBV)- driven hemophagocytic lymphohistiocytosis (HLH). ANKL lacks a distinct immunologic and morphologic signature, making early diagnosis particularly challenging. Here we present a case of ANKL in a patient presenting with EBV-HLH. After poor treatment response to the HLH-2004 protocol (etoposide and dexamethasone), bone marrow biopsy demonstrated an atypical CD3-/CD56+ natural killer (NK) cell population with diminished CD7 expression consistent with EBV+ ANKL. Asparaginase-based chemotherapy was initiated but his disease progressed and he died from multiorgan failure. This case highlights the diagnostic challenges of ANKL given the lack of standardized diagnostic criteria, the importance of considering T/NK cell malignancies in the differential diagnosis of EBV-HLH, and adds to the literature on this rare disease.

--- a/references_cache/DOI_10.3390_cancers12102900.md
+++ b/references_cache/DOI_10.3390_cancers12102900.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.3390/cancers12102900"
+title: "Aggressive NK Cell Leukemia: Current State of the Art"
+authors:
+- Siba El Hussein
+- L. Medeiros
+- Joseph Khoury
+journal: Cancers
+year: '2020'
+doi: 10.3390/cancers12102900
+content_type: abstract_only
+---
+
+# Aggressive NK Cell Leukemia: Current State of the Art
+**Authors:** Siba El Hussein, L. Medeiros, Joseph Khoury
+**Journal:** Cancers (2020)
+**DOI:** [10.3390/cancers12102900](https://doi.org/10.3390/cancers12102900)
+
+## Content
+
+Aggressive natural killer (NK) cell leukemia (ANKL) is a rare disease with a grave prognosis. Patients commonly present acutely with fever, constitutional symptoms, hepatosplenomegaly, and often disseminated intravascular coagulation or hemophagocytic syndrome. This acute clinical presentation and the variable pathologic and immunophenotypic features of ANKL overlap with other diagnostic entities, making it challenging to establish a timely and accurate diagnosis of ANKL. Since its original recognition in 1986, substantial progress in understanding this disease using traditional pathologic approaches has improved diagnostic accuracy. This progress, in turn, has facilitated the performance of recent high-throughput studies that have yielded insights into pathogenesis. Molecular abnormalities that occur in ANKL can be divided into three major groups: JAK/STAT pathway activation, epigenetic dysregulation, and impairment of TP53 and DNA repair. These high-throughput data also have provided potential therapeutic targets that promise to improve therapy and outcomes for patients with ANKL. In this review, we provide a historical context of the conception and evolution of ANKL as a disease entity, we highlight advances in diagnostic criteria to recognize this disease, and we review recent understanding of pathogenesis as well as biomarker discoveries that are providing groundwork for innovative therapies.

--- a/references_cache/PMID_29263371.md
+++ b/references_cache/PMID_29263371.md
@@ -1,0 +1,189 @@
+---
+reference_id: "PMID:29263371"
+title: "Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes."
+authors:
+- Tang YT
+- Wang D
+- Luo H
+- Xiao M
+- Zhou HS
+- Liu D
+- Ling SP
+- Wang N
+- Hu XL
+- Luo Y
+- Mao X
+- Ao QL
+- Huang J
+- Zhang W
+- Sheng LS
+- Zhu LJ
+- Shang Z
+- Gao LL
+- Zhang PL
+- Zhou M
+- Zhou KG
+- Qiu LG
+- Liu QF
+- Zhang HY
+- Li JY
+- Jin J
+- Fu L
+- Zhao WL
+- Chen JP
+- Du X
+- Huang G
+- Wang QF
+- Zhou JF
+- Huang L
+journal: Blood Cancer J
+year: '2017'
+doi: 10.1038/s41408-017-0021-z
+keywords:
+- Adult
+- China
+- Female
+- Humans
+- "Leukemia, Large Granular Lymphocytic/epidemiology, pathology, therapy"
+- Male
+- Retrospective Studies
+- Treatment Outcome
+- Young Adult
+content_type: full_text_xml
+---
+
+# Aggressive NK-cell leukemia: clinical subtypes, molecular features, and treatment outcomes.
+**Authors:** Tang YT, Wang D, Luo H, Xiao M, Zhou HS, Liu D, Ling SP, Wang N, Hu XL, Luo Y, Mao X, Ao QL, Huang J, Zhang W, Sheng LS, Zhu LJ, Shang Z, Gao LL, Zhang PL, Zhou M, Zhou KG, Qiu LG, Liu QF, Zhang HY, Li JY, Jin J, Fu L, Zhao WL, Chen JP, Du X, Huang G, Wang QF, Zhou JF, Huang L
+**Journal:** Blood Cancer J (2017)
+**DOI:** [10.1038/s41408-017-0021-z](https://doi.org/10.1038/s41408-017-0021-z)
+
+## Content
+
+1. Blood Cancer J. 2017 Dec 21;7(12):660. doi: 10.1038/s41408-017-0021-z.
+
+Aggressive NK-cell leukemia: clinical subtypes, molecular features, and
+treatment outcomes.
+
+Tang YT(1), Wang D(1), Luo H(1), Xiao M(1), Zhou HS(2), Liu D(3), Ling SP(3),
+Wang N(1), Hu XL(1), Luo Y(1), Mao X(1), Ao QL(4), Huang J(1), Zhang W(1), Sheng
+LS(1), Zhu LJ(1), Shang Z(1), Gao LL(1), Zhang PL(1), Zhou M(1), Zhou KG(1), Qiu
+LG(5), Liu QF(2), Zhang HY(6), Li JY(7), Jin J(8), Fu L(9), Zhao WL(10), Chen
+JP(11), Du X(12), Huang G(13)(14), Wang QF(3)(5)(15), Zhou JF(1)(5)(16), Huang
+L(17)(18).
+
+Author information:
+(1)Department of Hematology, Tongji Hospital, Tongji Medical College, Huazhong
+University of Science and Technology, Wuhan, China.
+(2)Department of Hematology, Nanfang Hospital, Southern Medical University,
+Guangzhou, China.
+(3)Key Laboratory of Genomic and Precision Medicine, Collaborative Innovation
+Center of Genetics and Development, Beijing Institute of Genomics, Chinese
+Academy of Sciences, Beijing, China.
+(4)Department of Pathology, Tongji Hospital, Tongji Medical College, Huazhong
+University of Science and Technology, Wuhan, China.
+(5)Institute of Hematology and Blood Diseases Hospital, Chinese Academy of
+Medical Sciences and Peking Union Medical College, Tianjing, China.
+(6)Department of Hematology, Peking University Shenzhen Hospital, Shenzhen,
+China.
+(7)Department of Hematology, the First Affiliated Hospital of Nanjing Medical
+University and Jiangsu Province Hospital, Nanjing, China.
+(8)Department of Hematology, the First Affiliated Hospital, Zhejiang University
+College of Medicine, Hangzhou, China.
+(9)Department of Hematology, Beijing Friendship Hospital, Capital Medical
+University, Beijing, China.
+(10)Shanghai Institute of Hematology, State Key Laboratory of Medical Genomics,
+Shanghai Rui Jin Hospital, Shanghai Jiao Tong University School of Medicine,
+Shanghai, China.
+(11)Department of Hematology, Southwest Hospital, Third Military Medical
+University, Chongqing, China.
+(12)Department of Hematology, Guangdong General Hospital and Guangdong Academy
+of Medical Sciences, Guangzhou, China.
+(13)Division of Experimental Hematology and Cancer Biology, Cincinnati
+Children's Hospital Medical Center, Cincinnati, OH, USA.
+(14)Division of Pathology, Cincinnati Children's Hospital Medical Center,
+Cincinnati, OH, USA.
+(15)University of Chinese Academy of Sciences, Beijing, China.
+(16)Cancer Biology Research Center, Tongji Hospital, Tongji Medical College,
+Huazhong University of Science and Technology, Wuhan, China.
+(17)Department of Hematology, Tongji Hospital, Tongji Medical College, Huazhong
+University of Science and Technology, Wuhan, China. lhuang@tjh.tjmu.edu.cn.
+(18)Cancer Biology Research Center, Tongji Hospital, Tongji Medical College,
+Huazhong University of Science and Technology, Wuhan, China.
+lhuang@tjh.tjmu.edu.cn.
+
+DOI: 10.1038/s41408-017-0021-z
+PMCID: PMC5802497
+PMID: 29263371 [Indexed for MEDLINE]
+
+Conflict of interest statement: COMPETING INTERESTS: The authors declare that
+they have no competing interests. PUBLISHER’S NOTE: Springer Nature remains
+neutral with regard to jurisdictional claims in published maps and institutional
+affiliations.
+
+Aggressive NK-cell leukemia (ANKL) is a rare form of NK cell neoplasm sporadically affecting people from Asia and Central and South America. The median overall survival (OS) is less than 2 months, irrespective of treatments. Epstein-Barr virus (EBV) is mostly detected in the leukemia cells and is proposed to contribute to the pathogenesis of ANKL1–3. ANKL represents a distinct disease entity within the continuous spectrum of EBV-associated T/NK-cell lymphoproliferative diseases (EBV-T/NK-LPDs). Patients with ANKL usually manifest a fulminant and extremely aggressive clinical course. However, some clinicopathologic features may be shared with different types of EBV-T/NK-LPDs, which leads to the occurrence of a few cases with features intermediate between two similar disorders4–6. The diagnosis of ANKL largely relies on the identification of morphologically and immunophenotypically aberrant leukemia cells7. Chromosomal gains and losses, activating STAT3 and STAT5 mutations, and HACE1 hypermethylation have only been sporadically detected8–10. Moreover, optimal therapy of ANKL has not yet been established11. To date, less than 350 cases of ANKL have been described in English literature worldwide. Because of the rarity of ANKL, the clinical features, potential pathogenesis, therapeutic strategies, and prognostic factors still lack in understanding. A multicenter study is critically needed for better understanding of this disease.
+
+Here we conducted a 13-year retrospective study with 113 confirmed ANKL patients enrolled in 10 clinical centers located in different geographic regions across China. All cases were centrally reviewed by three hematopathologists and three hematologists. Study design, enrolled clinical centers, and data collection were described in the Supplementary Methods. This study was approved by the institutional review board of Tongji Hospital, Tongji Medical College, Huazhong University of Science and Technology. Informed consent was obtained from each individual in accordance with the principles expressed in the Declaration of Helsinki.
+
+From October 2003 to July 2016, a total of 161 suspected cases were collected, and 113 cases with eligibility consensuses after central review were finally enrolled. All the patients were of the Han nationality living in the mainland China and had no history of chronic active EBV disease (CAEBV), severe mosquito bite allergy, hydroa vacciniforme, or other T/NK-LPDs. Patient eligibility and general characteristics, including immunophenotyping and EBV detection of leukemia cells, were summarized in Supplementary Results and Supplementary Tables S1 and S2. The distribution of onset age was illustrated in Supplementary Fig. S1A showing an incidence peak in patients between 21 and 30 years old (29.20%, 33/113), with a male to female ratio of nearly 2:1 in this decade. The median OS was only 55 days (Supplementary Tables S2) and 1-year survival rate was only 4.42% (5/113; Supplementary Fig. S1B), which indicated a dismal outcome of ANKL.
+
+Intriguingly, a subacute clinical course was demonstrated in 18 ANKL patients (15.93%, 18/113). They manifested infectious mononucleosis (IM)-like symptoms (including fever, lymphocytosis or mononucleosis, lymphadenopathy, and hepatosplenomegaly) for more than 90 days (median: 115 days, range: 90–450 days), prior to the fulminant onset (Table 1). Female predominance (P = 0.007) was revealed in these patients. Alleviated hyperferritinemia (P < 0.001), transaminitis (ALT, P = 0.009), and hypofibrinogenemia (P = 0.038), suggesting alleviated hemophagocytic lymphohistiocytosis (HLH), liver impairment, and coagulopathy, were also noted at diagnosis in these patients (Table 1 and Supplementary Table S3). A marked survival advantage (P < 0.001) was revealed, irrespective of whether or not the patients who received allogeneic hematopoietic stem cell transplantation (allo-HSCT) were excluded (Table 1 and Fig. 1a). After all, allo-HSCT is currently the only treatment modality that can independently improve the survival of ANKL patients11–13. Moreover, even if the prolonged prodromal phases were not included in the estimation of the OS of these patients, this marked survival advantage could still be observed in non-transplant patients (P = 0.042; Supplementary Fig. S2). All these data suggested that patients with prolonged prodromal phases, whom we define here as “subacute ANKL”, may represent a clinical subtype of ANKL which differed from the others, whom we define here as “classic ANKL”.Table 1Comparison of clinical characteristics based on clinical subtypesCharacteristicsSubacute ANKL N=18 (range)Classic ANKL N=95 (range)
+P
+Gender, no. of patients (%)
+0.007
+ Male5 (27.78)59 (62.11) Female13 (72.22)36 (37.89)Median ALT, U/l (range)69.35 (12.00–311.00)108.00 (6.00–933.00)
+0.009
+Median ferritin, mg/l (range)618.00 (184.00–2280.58)4330.00 (99.00–146,000.00)
+<0.001
+Median fibrinogen, g/l (range)2.27 (0.50–5.01)1.51 (0.24–5.48)
+0.038
+TP53 mutation, no. of patients (%)a
+
+0.038
+ Positive0 (0.00)11 (37.93) Negative8 (100.00)18 (62.07)Median prodromal period, days (range)115 (90–450)15 (0–79)
+<0.001
+OS, days (range; all patients)213.5 (98–551)49 (8–1480)
+<0.001
+OS, days (range; non-transplant patients)b
+206 (98–551)44 (8–273)
+<0.001
+
+N number, ALT alanine aminotransferase, OS overall survival
+a
+TP53 mutation screened in eight subacute ANKL patients and 29 classic ANKL patients
+bWhen patients received allo-HSCT were excluded, there were 17 subacute ANKL patients and 89 classic ANKL patients in the studyBold: statistically significant
+Fig. 1Outcomes and mutational patterns of ANKL subtypes
+a Comparison of overall survival (OS) between subacute ANKL patients (N = 18) and classic ANKL patients (N = 95). OS was estimated from the onset of disease to the date of death or the end of the study. A marked survival advantage was revealed in subacute ANKL patients (left, P < 0.001), even if the patients receiving allo-HSCT (N = 7) were excluded (right, P < 0.001). b Somatic mutations identified by targeted sequencing in eight subacute ANKL patients and 29 classic ANKL patients were shown. The custom sequencing panel contained 18 candidate genes, including transcriptional factors (TP53 and MYC), JAK-STAT pathway genes (JAK2, JAK3, STAT3, STAT5A, STAT5B, and STAT6), other signaling pathway genes (PIK3CB, NFKB1, NFKBIA, MAP3K13, MAPK10, NRAS, and FGFR1), and epigenetic regulators (PRDM9, CREBBP, and TET2). Gene mutation patterns were similar between two subtypes, while TP53 gene mutations enriched in classic ANKL patients
+
+
+Comparison of clinical characteristics based on clinical subtypes
+
+
+N number, ALT alanine aminotransferase, OS overall survival
+
+
+a
+TP53 mutation screened in eight subacute ANKL patients and 29 classic ANKL patients
+
+
+bWhen patients received allo-HSCT were excluded, there were 17 subacute ANKL patients and 89 classic ANKL patients in the study
+
+Bold: statistically significant
+
+
+a Comparison of overall survival (OS) between subacute ANKL patients (N = 18) and classic ANKL patients (N = 95). OS was estimated from the onset of disease to the date of death or the end of the study. A marked survival advantage was revealed in subacute ANKL patients (left, P < 0.001), even if the patients receiving allo-HSCT (N = 7) were excluded (right, P < 0.001). b Somatic mutations identified by targeted sequencing in eight subacute ANKL patients and 29 classic ANKL patients were shown. The custom sequencing panel contained 18 candidate genes, including transcriptional factors (TP53 and MYC), JAK-STAT pathway genes (JAK2, JAK3, STAT3, STAT5A, STAT5B, and STAT6), other signaling pathway genes (PIK3CB, NFKB1, NFKBIA, MAP3K13, MAPK10, NRAS, and FGFR1), and epigenetic regulators (PRDM9, CREBBP, and TET2). Gene mutation patterns were similar between two subtypes, while TP53 gene mutations enriched in classic ANKL patients
+
+To clarify the underlying pathogenesis of the two clinical subtypes, genes of interest were screened by Ion Torrent AmpliSeq™ using a custom sequencing panel in 37 ANKL patients, including 8 subacute ANKL patients and 29 classic ANKL patients. The panel contained 18 candidate genes (Fig. 1b) identified in our previous whole-genome sequencing analysis of eight ANKL patients, including transcriptional factors, JAK-STAT pathway genes, other signaling pathway genes, and epigenetic regulators. The sequencing depth of these samples was more than 2000×. Our results showed that the TP53 gene had a significant lower mutation rate in subacute ANKL than that in classic ANKL (P = 0.038; Fig. 1b and Supplementary Table S4). Except for that, the other gene mutation patterns including genes in the JAK-STAT pathway were similar between the two groups, suggesting that the key driving mechanism is still similar between the two subtypes of ANKL. Notably, TP53 mutations were not found in patients of subacute ANKL subtype (Table 1 and Fig. 1b), while enriched in 11 classic ANKL patients (37.93%, 11/29; Supplementary Fig. S3). This result was consistent with the relatively moderate clinical course and improved survival for subacute ANKL patients.
+
+The treatment decision for each patient was made at each clinical center after careful assessment. Since there is no standardized initial treatment for ANKL, chemotherapeutic regimens varied. CHOP-like (containing anthracycline and vincristine), L-ASPA-based (SMILE, AspaMetDex, L-GemOx, and L-ASPA plus dexamethasone)14, 15, and HLH-04 regimens (containing dexamethasone and etoposide) were conducted in this study. Seven patients were subjected to allo-HSCT with myeloablative conditioning regimen when they achieved CR after chemotherapy (CHOP-like, n = 1; L-ASPA-based, n = 6). The median time from diagnosis to allo-HSCT was 73 days (range: 38–128 days). The clinical characteristics of patients in each subgroup were summarized in Supplementary Table S5, and no differences between each subgroups were revealed. The median follow-up time was 55 days (range: 8–1480 days) for the entire cohort and 887 days (range: 384–1480 days) for 3 survivors.
+
+Patients receiving allo-HSCT exhibited significantly superior survivals when compared to the others without allo-HSCT (P < 0.001). The median OS was 300 days (range: 174–1480 days) and 2-year OS rate was 42.86% (3/7; Supplementary Fig. S4A). Further subgroup analysis for patients receiving chemotherapy alone revealed significant OS benefit achieved only in patients treated with L-ASPA-based chemotherapy (n = 19, P = 0.008; Supplementary Fig. S4B). Of the 19 patients with L-ASPA-based chemotherapy alone, 13 patients received a median of two (range: 1–4) cycles of AspaMetDex. The median OS was 115 days (range: 37–450 days). As induction therapy, the CR and overall response rates (ORR) of AspaMetDex in newly diagnosed patients was 30.77% (4/13) and 76.92% (10/13), respectively. Reduction of plasma EBV DNA copies and ferritin levels were observed in nine (69.23%) patients, which was in accordance with the ORR. Grade 3 and Grade 4 hematologic adverse events were common and were recorded in 7 (53.84%) patients. Five of them had severe infection. Meanwhile, damage of liver function was rare (7.69%, 1/13) and no patient died of regimen-related side effects.
+
+We evaluated a variety of clinical features and therapeutic strategies as possible factors that of prognostic significance. Univariate analysis revealed the following clinical factors to be significantly associated with shorter survival: thrombocytopenia (<30 × 109/l), elevated serum LDH level (>800 IU/l), hypoalbuminemia (<35 g/l), hyperferritinemia (>1500 IU/l), classic ANKL, treatment without L-asparagine-based chemotherapy, or allo-HSCT (Supplementary Table S6). Multivariate analysis rendered elevated serum LDH level (>800 IU/l), clinical subtype, treatment (administration of L-asparagine-based chemotherapy, and allo-HSCT) to be valuable predictors of survival (Supplementary Table S7).
+
+In the present study, we systemically explored the features of this deadly type of NK-cell neoplasms. Especially, a subtype of ANKL with clinical and molecular characteristics was depicted. According to the clinicopathological evolution of EBV-T/NK-LPDs5, we propose to define these patients as “subacute ANKL”. Although this subtype resembles CAEBV-transformed ANKL (EBV-T/NK- LPDs category A3)6 in some aspects of clinical presentations, they are different in onset age and clinical course4, 5. CAEBV is an indolent disease primarily affecting children and young adults4. While ANKL usually presents a relatively acute disease mainly occurs in the middle-aged population, even though a subacute clinical course may manifest in a subset of patients. By identifying the group of subacute ANKL patients, clinicians should be alert to those ANKL patients presenting only IM-like symptoms during their prolonged prodromal phases, since early diagnosis and timely treatment before they evolve into aggressive phases is critical for survival. In addition, AspaMetDex was revealed to be an effective and well-tolerated initial treatment in ANKL patients. Multivariate analysis in our study showed that the administration of allo-HSCT was one of the major factors affecting survival (HR = 0.022, 95% CI: 0.005–0.097). Accordingly, the administration of AspaMetDex as induction therapy, SMILE as post-remission consolidation therapy13 and allo-HSCT as finally curative therapy12 could be a promising treatment strategy for ANKL patients. The presence of bias can hardly be avoided, due to the retrospective nature of our study plus the rarity of ANKL. However, these data depicted the clinical features and molecular characteristics of ANKL, and furthermore provided insights into the treatments and outcomes of this deadly type of leukemia.
+
+
+Supplementary Information
+
+
+Supplementary Information

--- a/references_cache/clinicaltrials_NCT03623087.md
+++ b/references_cache/clinicaltrials_NCT03623087.md
@@ -1,0 +1,20 @@
+---
+reference_id: clinicaltrials:NCT03623087
+title: "Combination Chemotherapy Using Cisplatin, Gemcitabine, Ifosfamide, Etoposide, L-asparaginase and Dexamethasone (SIMPLE) for Newly Diagnosed and Relapsed/Refractory NK/T Cell Malignancies"
+content_type: summary
+---
+
+# Combination Chemotherapy Using Cisplatin, Gemcitabine, Ifosfamide, Etoposide, L-asparaginase and Dexamethasone (SIMPLE) for Newly Diagnosed and Relapsed/Refractory NK/T Cell Malignancies
+
+## Content
+
+NK malignancies consist of two different clinical entities, extranodal NK/T cell lymphoma and aggressive NK leukaemia. Queen Mary Hospital (QMH) had started to use PIGLETS chemotherapy for treatment of NK malignancies since 2013, with promising results. The study in QMH had ended because of successful recruitment in the planned number of subjects.
+
+When PIGLETS was used in extranodal NK/T cell lymphoma, patients with stage I/II lymphoma have an overall response rate of nearly 90%, while patients with stage III/IV disease have an overall response rate of around 60%. The figures are comparable to the SMILE chemotherapy previously used. However, PIGLETS regimen carries much lower risk of nephrotoxicity when compared with SMILE. It has since become a standard protocol in management of NK malignancies in our institution.
+
+PIGLETS chemotherapy carries two major problems:
+
+1. the name PIGLETS may appear offensive to some religious populations. (e.g. Muslim)
+2. significant nausea/vomiting was seen in previous studies, and these could at least be partially alleviated with substance P antagonist aprepitant
+
+Thus the investigators decided to start a study, renaming the original PIGLETS regimen into SIMPLE chemotherapy, adding aprepitant as antiemetics and to recruit more patients for evaluation of clinical efficacy. The results of SIMPLE chemotherapy will be compared to SMILE in a non-inferiority trial setting.

--- a/references_cache/clinicaltrials_NCT03719105.md
+++ b/references_cache/clinicaltrials_NCT03719105.md
@@ -1,0 +1,15 @@
+---
+reference_id: clinicaltrials:NCT03719105
+title: "Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study"
+content_type: summary
+---
+
+# Pilot Study Using Induction Chemo-immunotherapy Followed by Consolidation With Reduced Toxicity Conditioning and Allogenic Stem Cell Transplant in Advanced Stage Mature Non-anaplastic T-Cell or NK Lymphoma/Leukemia in Children, Adolescents and Young Adults; A NK/T-Cell Lymphoma/Leukemia Consortium Study
+
+## Content
+
+Patients are in 2 cohorts:
+
+Cohort 1: dexamethasone, methotrexate, ifosfamide, pegaspargase, and etoposide (modified SMILE) chemotherapy regimen alone and pembrolizumab in children, adolescents, and young adults with advanced stage NK lymphoma and leukemia Cohort 2: combining pralatrexate (PRX) (Cycles 1, 2, 4, 6) and brentuximab vedotin (BV) (Cycles 3, 5) to cyclophosphamide, doxorubicin, and prednisone in children, adolescent, and young adults with advanced peripheral T-cell lymphoma (non-anaplastic large cell lymphoma or non-NK lymphoma/leukemia) .
+
+Both groups proceed to allogeneic stem cell transplant with disease response.

--- a/references_cache/clinicaltrials_NCT05863234.md
+++ b/references_cache/clinicaltrials_NCT05863234.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT05863234
+title: "Multicenter, Open-label, Dose-escalation Phase I/II Study to Evaluate the Tolerability, Safety, Efficacy and Pharmacokinetics of Repeated Continuous Intravenous PPMX-T003 in Patients With Aggressive NK Cell Leukaemia (ANKL) (Physician-initiated Clinical Trial)"
+content_type: summary
+---
+
+# Multicenter, Open-label, Dose-escalation Phase I/II Study to Evaluate the Tolerability, Safety, Efficacy and Pharmacokinetics of Repeated Continuous Intravenous PPMX-T003 in Patients With Aggressive NK Cell Leukaemia (ANKL) (Physician-initiated Clinical Trial)
+
+## Content
+
+This is Phase I/II Dose-Escalation Study to evaluate the tolerability, safety, efficacy and pharmacokinetics of PPMX-T003 in aggressive NK-cell leukemia.

--- a/research/Aggressive_NK-cell_Leukemia-deep-research-falcon.md
+++ b/research/Aggressive_NK-cell_Leukemia-deep-research-falcon.md
@@ -1,0 +1,1324 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T13:52:57.324944'
+end_time: '2026-05-11T14:04:19.824446'
+duration_seconds: 682.5
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Aggressive NK-cell Leukemia
+  mondo_id: ''
+  category: ''
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 29
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aggressive NK-cell Leukemia
+- **MONDO ID:**  (if available)
+- **Category:**
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aggressive NK-cell Leukemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aggressive NK-cell Leukemia
+- **MONDO ID:**  (if available)
+- **Category:**
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aggressive NK-cell Leukemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Aggressive NK-cell Leukemia (ANKL) — Comprehensive Disease Characteristics Report
+
+## Target Disease
+- **Disease name:** Aggressive NK-cell leukemia (ANKL)
+- **Category:** Mature NK-cell neoplasm; EBV-associated T/NK-cell neoplasia spectrum
+- **MONDO ID:** Not available from the retrieved sources in this run (needs dedicated ontology lookup outside the current evidence set).
+
+## Evidence summary table
+| Domain | Key points | Quantitative data | Key source (with year, journal) | URL |
+|---|---|---|---|---|
+| Definition / classification | ANKL is a rare, fulminant, systemic mature NK-cell neoplasm with acute presentation and grave prognosis; recent reviews note it remains recognized in modern WHO/ICC-era classification of mature T/NK-cell neoplasms. It is distinct from extranodal NK/T-cell lymphoma, though overlap exists in disseminated disease. (hussein2020aggressivenkcell pages 1-3, spaner2024casereportaggressive pages 1-2, ferry2024maturebt pages 8-10) | Median age around 40 years in review cohorts; fewer than 500 cases reported overall in literature summaries. (hussein2020aggressivenkcell pages 1-3, spaner2024casereportaggressive pages 1-2) | El Hussein et al., 2020, *Cancers*; Spaner et al., 2024, *Frontiers in Hematology*; Ferry et al., 2024, *J Hematol Oncol* | https://doi.org/10.3390/cancers12102900 |
+| EBV association | EBV is strongly associated with ANKL and is detectable in most cases by EBER; however, EBV-negative ANKL exists and can show similar clinicopathologic features. ANKL often sits within the spectrum of EBV-associated T/NK-cell lymphoproliferative diseases. (hussein2020genomicandimmunophenotypic pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 1-2, hussein2020aggressivenkcell pages 3-5) | ~90% EBV-driven in a 2024 case review; ~10% EBV-negative in older review; EBER positive in 9/12 cases in one clinicopathologic series. (spaner2024casereportaggressive pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, hussein2020genomicandimmunophenotypic pages 1-2) | Hussein et al., 2020, *Am J Surg Pathol*; Ishida, 2018, *Front Pediatr*; Spaner et al., 2024, *Front Hematol* | https://doi.org/10.1097/pas.0000000000001518 |
+| Typical presentation / phenotypes | Common features include fever, constitutional symptoms, hepatosplenomegaly, liver dysfunction, leukemic blood picture, cytopenias, HLH/hemophagocytosis, DIC/coagulopathy, and multiorgan failure; nasal/skin lesions are less common than marrow, blood, liver, and spleen involvement. (hussein2020aggressivenkcell pages 1-3, ni2024clinicopathologicalfeaturesand pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, spaner2024casereportaggressive pages 1-2) | HLH reported in ~60–90% in pediatric case literature summary; in one 12-case series, HLH in 2/12; common involved organs include marrow, peripheral blood, liver, spleen, lymph nodes. (ni2024clinicopathologicalfeaturesand pages 1-2, hussein2020genomicandimmunophenotypic pages 1-2) | Ni et al., 2024, *Turkish Journal of Pediatrics*; El Hussein et al., 2020, *Cancers*; Ishida, 2018, *Front Pediatr* | https://doi.org/10.24953/turkjpediatr.2024.5072 |
+| Diagnostic immunophenotype | Characteristic phenotype is NK-lineage with surface CD3 negative and cytoplasmic CD3ε positive; typically CD56+, CD2+, CD94+, cytotoxic marker positive (granzyme B, TIA1, perforin), usually negative for CD4, CD5, CD57, TCR αβ/γδ, and often lacking KIR expression. Bone marrow involvement may be interstitial or sinusoidal/intrasinusoidal. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020aggressivenkcell pages 3-5, hussein2020genomicandimmunophenotypic pages 2-3) | In one 12-case series: CD56+ 12/12, CD94+ 9/9, CD2+ 10/12, EBER+ 9/12; negative in all tested for surface CD3 12/12, CD5 11/11, CD57 9/9, TCRαβ 11/11, TCRγδ 11/11. Marrow ANKL fraction ranged 1.5% to 96.4%, median 22.5%. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020genomicandimmunophenotypic pages 2-3) | El Hussein et al., 2020, *Am J Surg Pathol* | https://doi.org/10.1097/pas.0000000000001518 |
+| Genetics / pathways | Recurrent alterations cluster in JAK/STAT activation, epigenetic dysregulation, TP53/DNA-repair impairment, and RAS/MAPK signaling; IL10-STAT3-MYC biosynthetic axis and HACE1 hypermethylation have been implicated. (hussein2020aggressivenkcell pages 1-3, ishida2018aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 1-2, dufva2018aggressivenaturalkillercell pages 3-4) | Dufva et al.: STAT3 21%, RAS-MAPK genes 21%, DDX3X 29%, epigenetic modifiers 50%; copy-gain/mutation events affecting JAK2/STAT3/STAT5B also reported. Other summaries report TP53 34%, TET2 28%, CREBBP 21%, MLL2/KMT2D 21%, JAK-STAT pathway alterations ~48%, STAT3 mutations ~17%. (dufva2018aggressivenaturalkillercell pages 3-4, ishida2018aggressivenkcellleukemia pages 1-2, sumbly2022aggressivenaturalkiller pages 2-3) | Dufva et al., 2018, *Nat Commun*; Ishida, 2018, *Front Pediatr*; Sumbly et al., 2022, *Cureus* | https://doi.org/10.1038/s41467-018-03987-2 |
+| Epidemiology / demographics | ANKL is very rare, with geographic enrichment in Asian and Central/South American populations; most patients are young to middle-aged adults, though pediatric and older adult cases occur. Male predominance is reported in some cohorts. (hussein2020aggressivenkcell pages 1-3, ishida2018aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 1-2) | Chinese multicenter cohort: age peak 21–30 years was 29.2% (33/113); male:female ratio nearly 2:1 in that decade. Western clinicopathologic series: median age 47.5 years, 9 men/3 women. (tang2017aggressivenkcellleukemia pages 1-2, hussein2020genomicandimmunophenotypic pages 1-2) | Tang et al., 2017, *Blood Cancer Journal*; El Hussein et al., 2020, *Am J Surg Pathol* | https://doi.org/10.1038/s41408-017-0021-z |
+| Prognosis | Prognosis is extremely poor without effective induction and consolidation; many reviews cite median survival under 2–3 months. A subacute subtype with prolonged prodrome may have better outcomes than classic fulminant ANKL. (hussein2020aggressivenkcell pages 1-3, ni2024clinicopathologicalfeaturesand pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 1-2, spaner2024casereportaggressive pages 1-2) | Median OS 55 days and 1-year survival 4.42% (5/113) in a large cohort; median survival 2 months in a 12-case Western series; review summaries report median survival <2 to <3 months. (tang2017aggressivenkcellleukemia pages 1-2, hussein2020genomicandimmunophenotypic pages 1-2, ni2024clinicopathologicalfeaturesand pages 1-2) | Tang et al., 2017, *Blood Cancer Journal*; El Hussein et al., 2020, *Am J Surg Pathol*; Ni et al., 2024, *Turkish Journal of Pediatrics* | https://doi.org/10.1038/s41408-017-0021-z |
+| Treatment: asparaginase-based therapy | Anthracycline-only approaches are generally ineffective; L-asparaginase/pegaspargase-containing regimens are the main active induction strategy. Regimens used include SMILE, AspaMetDex, L-GemOx, and related protocols. (ni2024clinicopathologicalfeaturesand pages 1-2, tang2017aggressivenkcellleukemia pages 1-2) | In Tang et al., among 13 newly diagnosed patients treated with AspaMetDex alone: CR 30.77% (4/13), ORR 76.92% (10/13), median OS 115 days; grade 3–4 hematologic AEs in 53.84% (7/13). Ni et al. summarize chemotherapy CR rate as <36%. (tang2017aggressivenkcellleukemia pages 1-2, ni2024clinicopathologicalfeaturesand pages 1-2) | Tang et al., 2017, *Blood Cancer Journal*; Ni et al., 2024, *Turkish Journal of Pediatrics* | https://doi.org/10.1038/s41408-017-0021-z |
+| Treatment: allo-HSCT / outcomes | Allogeneic HSCT is the only modality consistently associated with durable survival in fit responders and is typically pursued after remission induction with asparaginase-based chemotherapy. (tang2017aggressivenkcellleukemia pages 1-2, ni2024clinicopathologicalfeaturesand pages 1-2) | In Tang et al., 7 patients underwent allo-HSCT after CR; median time to transplant 73 days, median OS 300 days, 2-year OS 42.86% (3/7). Ni et al. summarize ~55.5% relapse/progression within 1 year after allo-HSCT. (tang2017aggressivenkcellleukemia pages 1-2, ni2024clinicopathologicalfeaturesand pages 1-2) | Tang et al., 2017, *Blood Cancer Journal*; Ni et al., 2024, *Turkish Journal of Pediatrics* | https://doi.org/10.1038/s41408-017-0021-z |
+| Emerging / targeted therapy rationale | Genomic profiling and drug sensitivity studies support investigation of JAK inhibitors, BCL2 inhibition, and immune checkpoint blockade in selected cases, especially where JAK/STAT activation or PD-L1 expression is present. These remain emerging rather than standard ANKL therapies. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020aggressivenkcell pages 1-3, dufva2018aggressivenaturalkillercell pages 3-4) | pSTAT3 positivity in 3/8 and PD-L1 positivity in 2/8 in one immunophenotypic series; Dufva et al. found NK malignancies highly sensitive to JAK and BCL2 inhibition in drug profiling. (hussein2020genomicandimmunophenotypic pages 1-2, dufva2018aggressivenaturalkillercell pages 3-4) | El Hussein et al., 2020, *Am J Surg Pathol*; Dufva et al., 2018, *Nat Commun* | https://doi.org/10.1038/s41467-018-03987-2 |
+
+
+*Table: This table condenses core disease facts for aggressive NK-cell leukemia, including classification, EBV association, presentation, diagnostic phenotype, genomics, prognosis, and treatment outcomes. It is useful as a quick evidence-backed reference for building a disease knowledge base entry.*
+
+---
+
+## 1. Disease information
+
+### 1.1 Concise overview (current understanding)
+Aggressive NK-cell leukemia (ANKL) is a rare, fulminant systemic malignancy of mature natural killer (NK) cells with acute presentation, frequent cytokine-driven inflammatory complications (e.g., HLH), and very poor survival without rapid disease control and consolidation. Reviews emphasize that its acute clinical syndrome overlaps with other entities (notably EBV-associated lymphoproliferative disorders and NK/T-cell lymphomas), complicating early recognition and resulting in delayed diagnosis and treatment. (hussein2020aggressivenkcell pages 1-3, spaner2024casereportaggressive pages 1-2)
+
+**Direct abstract quote (example):** “Aggressive natural killer cell leukemia (ANKL) is a rare, aggressive hematologic malignancy which often presents as fulminant Epstein-Barr virus (EBV)- driven hemophagocytic lymphohistiocytosis (HLH).” (spaner2024casereportaggressive pages 1-2)
+
+### 1.2 Key identifiers and ontologies
+- **WHO/ICC framing:** The current hematopathology ecosystem includes WHO-HAEM5 (2022) and ICC (2022); comparative reviews summarize entity families and naming across systems. A classification comparison review provides the context that WHO-HAEM5 and ICC are the operative modern frameworks for mature B/T/NK neoplasms, and that EBV-positive T/NK entities are explicitly treated as a family. (ferry2024maturebt pages 8-10)
+- **ICD/MeSH/OMIM/Orphanet:** Not extractable from the current retrieved evidence set; these require targeted queries to OMIM/Orphanet/MeSH.
+
+### 1.3 Synonyms / alternative names
+- “Aggressive NK-cell leukemia” (most common)
+- “Aggressive NK-cell leukaemia” (UK spelling)
+- Some literature uses “aggressive NK-cell leukemia/lymphoma” in broader discussions of NK-cell malignancies. (ishida2018aggressivenkcellleukemia pages 1-2, NCT03623087 chunk 1)
+
+### 1.4 Evidence source types in this report
+- **Aggregated disease-level resources:** pathology/oncology reviews and classification comparison reviews (hussein2020aggressivenkcell pages 1-3, ferry2024maturebt pages 8-10)
+- **Human clinical primary studies:** multicenter cohort (n=113) (tang2017aggressivenkcellleukemia pages 1-2), clinicopathologic series with IHC/NGS (n=12) (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020genomicandimmunophenotypic pages 2-3)
+- **Human genomic/translational primary studies:** WES + drug profiling (n=14) (dufva2018aggressivenaturalkillercell pages 3-4, dufva2018aggressivenaturalkillercell media 01c6d37e, dufva2018aggressivenaturalkillercell media 2b03bded)
+- **Case-based recent literature (2024):** adolescent/pediatric cases emphasizing HLH and diagnostic delays (ni2024clinicopathologicalfeaturesand pages 1-2, spaner2024casereportaggressive pages 1-2)
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+
+#### Epstein–Barr virus (EBV) association
+ANKL is commonly EBV-associated, with EBER positivity in the majority of cases in multiple series, and many reviews describing EBV as a driver in ~90% of cases (though EBV-negative ANKL exists). (hussein2020genomicandimmunophenotypic pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, spaner2024casereportaggressive pages 1-2)
+
+- **Clinicopathologic series:** EBER was positive in 9/12 ANKL cases. (hussein2020genomicandimmunophenotypic pages 1-2)
+- **Review synthesis:** ~10% EBV-negative in one review; EBV-negative cases may present in middle-aged adults and can resemble EBV-positive ANKL clinically/pathologically. (ishida2018aggressivenkcellleukemia pages 1-2, sumbly2022aggressivenaturalkiller pages 2-3)
+
+### 2.2 Risk factors
+- **Geography/ancestry:** Cohort and review literature repeatedly notes predilection for Asian populations and Central/South America, consistent with EBV-associated NK/T neoplasia geography. (hussein2020aggressivenkcell pages 1-3, tang2017aggressivenkcellleukemia pages 1-2)
+- **Pre-existing EBV-associated immune dysregulation:** Several 2024 reports frame ANKL as arising in/with EBV-driven HLH contexts and discuss overlap with chronic active EBV disease in differential diagnosis. (spaner2024casereportaggressive pages 1-2)
+
+**Note:** Specific germline genetic susceptibility loci or robust environmental risk factors were not retrievable from the current evidence set.
+
+### 2.3 Protective factors
+No protective factors (genetic or environmental) were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+Not established in retrieved evidence; EBV infection is a biological exposure interacting with host immune status and tumor genetics, but formal GxE data were not found here.
+
+---
+
+## 3. Phenotypes (clinical features)
+
+### 3.1 Core phenotype spectrum
+ANKL commonly presents with an acute systemic inflammatory and hematologic syndrome including:
+- **Fever / constitutional symptoms** (symptom)
+- **Hepatosplenomegaly** (clinical sign)
+- **Cytopenias and leukemic blood picture** (laboratory abnormality)
+- **Liver dysfunction / acute liver injury** (laboratory and organ phenotype)
+- **Coagulopathy / DIC** (laboratory abnormality, complication)
+- **Hemophagocytic lymphohistiocytosis (HLH)** (immune dysregulation syndrome)
+- **Multiorgan failure** in severe/refractory disease
+These are repeatedly highlighted across reviews, cohorts, and 2024 case literature. (hussein2020aggressivenkcell pages 1-3, ni2024clinicopathologicalfeaturesand pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, spaner2024casereportaggressive pages 1-2, hussein2020genomicandimmunophenotypic pages 2-3)
+
+**Direct abstract quotes (examples):**
+- “Patients commonly present acutely with fever, constitutional symptoms, hepatosplenomegaly, and often disseminated intravascular coagulation or hemophagocytic syndrome.” (sumbly2022aggressivenaturalkiller pages 2-3)
+- “HLH can serve as the initial manifestation of ANKL.” (ni2024clinicopathologicalfeaturesand pages 1-2)
+
+### 3.2 Age of onset, severity, progression
+- **Typical onset:** young to middle-aged adults; however, pediatric/adolescent cases occur. (ni2024clinicopathologicalfeaturesand pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 1-2)
+- **Course:** fulminant/rapidly progressive in most patients; a “subacute” clinical subtype with prolonged IM-like prodrome (>90 days; median 115 days) was identified in a large cohort. (tang2017aggressivenkcellleukemia pages 2-4)
+
+### 3.3 Frequency (where available)
+- **HLH frequency:** A 2024 pediatric-focused review notes HLH is common; in a separate case-literature preprint, HLH co-occurrence is described as frequent; quantitative, cohort-level HLH prevalence was not consistently extractable from all sources here. (ni2024clinicopathologicalfeaturesand pages 1-2)
+
+### 3.4 Quality of life impact
+Formal QoL instruments (EQ-5D/SF-36/PROMIS) were not identified in retrieved evidence. Clinical impact is inferred from fulminant symptoms, ICU-level complications (DIC, multiorgan failure), and extremely short survival. (hussein2020aggressivenkcell pages 1-3, tang2017aggressivenkcellleukemia pages 1-2)
+
+### 3.5 Suggested HPO terms (non-exhaustive)
+- Fever **HP:0001945**
+- Hepatosplenomegaly **HP:0001433** (or hepatomegaly HP:0002240; splenomegaly HP:0001744)
+- Pancytopenia **HP:0001876**
+- Thrombocytopenia **HP:0001873**
+- Elevated lactate dehydrogenase **HP:0003236**
+- Disseminated intravascular coagulation **HP:0001907**
+- Hemophagocytic lymphohistiocytosis **HP:0031425**
+- Acute liver failure **HP:0006557** / abnormal liver function tests **HP:0002910**
+
+---
+
+## 4. Genetic / molecular information
+
+### 4.1 Causal genes
+ANKL is **not** a monogenic germline disorder in the retrieved evidence. It is characterized by **somatic** alterations and pathway dysregulation.
+
+### 4.2 Recurrently altered genes and pathways (with frequencies)
+Multiple sources converge on three major molecular themes: **JAK/STAT activation**, **epigenetic dysregulation**, and **TP53/DNA repair impairment**, with additional contribution from **RAS/MAPK** signaling. (hussein2020aggressivenkcell pages 1-3, dufva2018aggressivenaturalkillercell pages 3-4)
+
+#### JAK/STAT pathway
+- WES study (n=14): **STAT3 mutations ~21%**; copy-number and other alterations implicating JAK/STAT signaling were emphasized. (dufva2018aggressivenaturalkillercell pages 3-4)
+- Review synthesis: JAK-STAT pathway alterations reported ~48% overall in some summaries. (sumbly2022aggressivenaturalkiller pages 2-3)
+
+Visual evidence from Dufva et al. shows JAK-STAT component alterations and copy-number gains and summarizes frequencies across cohorts (including JAK2/STAT3/STAT5 alterations). (dufva2018aggressivenaturalkillercell media 01c6d37e, dufva2018aggressivenaturalkillercell media 2b03bded)
+
+#### Epigenetic modifiers
+- WES study: epigenetic modifier mutations reported in **~50%**. (dufva2018aggressivenaturalkillercell pages 3-4)
+- Review synthesis lists **TET2 (28%)**, **CREBBP (21%)**, **MLL2/KMT2D (21%)** among recurrent events in a summarized cohort. (sumbly2022aggressivenaturalkiller pages 2-3, ishida2018aggressivenkcellleukemia pages 1-2)
+
+#### TP53 pathway
+- Review synthesis reports **TP53 mutations ~34%**. (sumbly2022aggressivenaturalkiller pages 2-3, ishida2018aggressivenkcellleukemia pages 1-2)
+- A large cohort found TP53 mutations enriched in classic (fulminant) ANKL (37.93%, 11/29 in sequenced classic ANKL), absent in subacute ANKL subtype in that cohort’s sequencing subset. (tang2017aggressivenkcellleukemia pages 2-4)
+- Clinicopathologic series: aberrant p53 expression was common (7/8 by IHC), with TP53 mutations detected in 3/6 in the NGS subset. (hussein2020genomicandimmunophenotypic pages 1-2)
+
+#### DDX3X and RAS/MAPK
+- WES study: **DDX3X ~29%**, **RAS-MAPK pathway genes ~21%**. (dufva2018aggressivenaturalkillercell pages 3-4)
+
+### 4.3 Epigenetics
+ANKL epigenetic dysregulation is supported by recurrent mutations in epigenetic modifiers and literature noting methylation events (e.g., HACE1 hypermethylation mentioned in the large cohort background). (tang2017aggressivenkcellleukemia pages 1-2, hussein2020aggressivenkcell pages 1-3)
+
+### 4.4 Chromosomal abnormalities
+Clonal cytogenetic abnormalities are reported in clinical series (5/12 in one series). (hussein2020genomicandimmunophenotypic pages 1-2)
+
+### 4.5 Mechanistic chain (pathophysiology synthesis)
+A plausible causal chain supported by current evidence is:
+1) EBV infection of NK lineage cells (EBER+) and/or host immune dysregulation contributes to transformation and/or inflammatory phenotype. (hussein2020genomicandimmunophenotypic pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2)
+2) Somatic alterations (JAK/STAT activation; epigenetic modifier and TP53 pathway lesions; RAS/MAPK) promote malignant proliferation, survival, and immune evasion. (dufva2018aggressivenaturalkillercell pages 3-4, tang2017aggressivenkcellleukemia pages 2-4)
+3) NK-cell cytokine programs and pathway-driven transcriptional changes (including IL10–STAT3–MYC axis described in reviews) contribute to “cytokine storm” physiology and HLH-like systemic inflammation. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020aggressivenkcell pages 3-5)
+4) Downstream manifestations include cytopenias, HLH, DIC, liver dysfunction, and multiorgan failure, driving high early mortality. (hussein2020aggressivenkcell pages 1-3, tang2017aggressivenkcellleukemia pages 1-2)
+
+### 4.6 Suggested ontology terms
+- **GO biological process (examples):** JAK-STAT cascade (GO:0007259), cytokine-mediated signaling pathway (GO:0019221), regulation of apoptotic process (GO:0042981), leukocyte proliferation (GO:0070661)
+- **Cell Ontology (CL) (examples):** natural killer cell **CL:0000623**; malignant NK cell (no single CL term; represent as NK cell + neoplastic context)
+
+---
+
+## 5. Environmental information
+
+### Infectious agents
+- **EBV (Epstein–Barr virus)** is the central infectious association; tumor EBER positivity is common. (hussein2020genomicandimmunophenotypic pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2)
+
+Other environmental and lifestyle associations were not identified in retrieved evidence.
+
+---
+
+## 6. Mechanism / pathophysiology
+
+### 6.1 Molecular pathways (high-confidence)
+- **JAK/STAT signaling activation** as a recurring pathway with STAT3/STAT5 and copy-number events. (dufva2018aggressivenaturalkillercell pages 3-4, dufva2018aggressivenaturalkillercell media 01c6d37e, dufva2018aggressivenaturalkillercell media 2b03bded)
+- **Epigenetic dysregulation** (TET2/CREBBP/KMT2D and other epigenetic modifiers). (sumbly2022aggressivenaturalkiller pages 2-3, dufva2018aggressivenaturalkillercell pages 3-4)
+- **TP53 impairment** (mutation and/or aberrant protein expression). (hussein2020genomicandimmunophenotypic pages 1-2, tang2017aggressivenkcellleukemia pages 2-4)
+- **RAS/MAPK activation** subset. (dufva2018aggressivenaturalkillercell pages 3-4)
+
+### 6.2 Immune involvement
+ANKL frequently presents with HLH and systemic inflammation; NK lineage biology (cytokine secretion programs) is implicated as a contributor to cytokine storm physiology in reviews. (hussein2020aggressivenkcell pages 3-5, spaner2024casereportaggressive pages 1-2)
+
+### 6.3 Molecular profiling / multi-omics
+- **Genomics:** WES and targeted sequencing characterize recurrent pathways; Dufva et al. provides integrated genomics + drug sensitivity profiling highlighting pathway vulnerabilities. (dufva2018aggressivenaturalkillercell pages 3-4)
+
+**Not found in retrieved evidence:** single-cell or spatial transcriptomics dedicated to ANKL.
+
+---
+
+## 7. Anatomical structures affected
+
+### 7.1 Organ level
+Commonly involved sites include **bone marrow and peripheral blood**, with frequent involvement of **liver and spleen**; lymph nodes may be involved; less commonly skin/soft tissue/lung are described in recent pediatric case review. (ni2024clinicopathologicalfeaturesand pages 1-2, ishida2018aggressivenkcellleukemia pages 1-2)
+
+### 7.2 Tissue/cell level
+- Targeted population: **neoplastic NK cells** infiltrating marrow and other organs. (hussein2020genomicandimmunophenotypic pages 1-2)
+
+### 7.3 Suggested UBERON terms (examples)
+- Bone marrow: **UBERON:0002371**
+- Spleen: **UBERON:0002106**
+- Liver: **UBERON:0002107**
+- Peripheral blood: **UBERON:0000178**
+
+---
+
+## 8. Temporal development
+
+### 8.1 Onset pattern
+Often **acute** with rapidly progressive systemic illness prompting “acute leukemia” evaluation. (hussein2020genomicandimmunophenotypic pages 2-3)
+
+### 8.2 Progression
+A large cohort distinguished:
+- **Classic ANKL:** fulminant presentation and very short OS.
+- **Subacute ANKL subtype:** prolonged prodromal IM-like phase >90 days (median 115 days) before fulminant onset, with survival advantage and differing TP53 mutation enrichment. (tang2017aggressivenkcellleukemia pages 2-4)
+
+---
+
+## 9. Inheritance and population
+
+### 9.1 Epidemiology
+Robust population incidence/prevalence rates were not found in the retrieved evidence (likely due to rarity and registry limitations). The largest cohort notes extreme rarity (hundreds of cases in the literature) and geographic predilection. (tang2017aggressivenkcellleukemia pages 1-2, hussein2020aggressivenkcell pages 1-3)
+
+### 9.2 Demographics (quantitative)
+- **Age peak:** 21–30 years accounted for 29.2% (33/113) in a multicenter Chinese cohort. (tang2017aggressivenkcellleukemia pages 1-2)
+- **Sex:** male:female ratio nearly 2:1 in that decade in the same cohort. (tang2017aggressivenkcellleukemia pages 1-2)
+- **Western series:** median age 47.5 years; 9 men and 3 women. (hussein2020genomicandimmunophenotypic pages 2-3)
+
+### 9.3 Inheritance
+No germline inheritance pattern is established in retrieved evidence; ANKL is characterized by **somatic** oncogenic alterations.
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Diagnostic approach (real-world)
+ANKL diagnosis is challenging due to variable morphology and lack of a single defining marker; it requires integration of:
+- Peripheral blood and bone marrow morphology
+- Flow cytometry (NK immunophenotype)
+- EBV testing (EBER ISH)
+- IHC and NGS when feasible
+In a clinicopathologic series, the acute presentation triggered marrow sampling with suspicion of acute leukemia. (hussein2020genomicandimmunophenotypic pages 2-3)
+
+### 10.2 Immunophenotype (high-yield diagnostic signature)
+Across series and reviews, a core pattern includes:
+- **Positive:** CD56, CD94, CD2; cytotoxic markers (granzyme B, TIA-1, perforin); often EBER+ (EBV-associated subset)
+- **Negative:** surface CD3, CD4, CD5, CD57; TCRαβ/γδ
+- Bone marrow patterns: **interstitial** or **intrasinusoidal/sinusoidal** infiltration patterns. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020aggressivenkcell pages 3-5, hussein2020genomicandimmunophenotypic pages 2-3)
+
+Quantitative immunophenotype from a 12-case series: CD56+ (12/12), CD94+ (9/9), CD2+ (10/12), EBER+ (9/12); surface CD3− (12/12), CD5− (11/11), CD57− (9/9), TCRαβ− (11/11), TCRγδ− (11/11). (hussein2020genomicandimmunophenotypic pages 1-2)
+
+### 10.3 Differential diagnosis (examples)
+- EBV-driven HLH without neoplasia vs ANKL presenting as EBV-HLH (emphasized in 2024 adolescent case literature). (spaner2024casereportaggressive pages 1-2)
+- Extranodal NK/T-cell lymphoma with leukemic/disseminated phase (clinical overlap discussed in reviews). (hussein2020aggressivenkcell pages 1-3)
+
+### 10.4 Suggested tests / biomarkers
+- EBER ISH in marrow/tissue
+- Flow cytometry with NK markers (CD56, CD94, CD16, CD2; absence of surface CD3/TCR)
+- Plasma EBV DNA (used in related NK/T malignancies; specific ANKL thresholds not established in retrieved evidence)
+
+---
+
+## 11. Outcome / prognosis
+
+### 11.1 Key statistics
+- **Median overall survival:** 55 days in a multicenter cohort (n=113). (tang2017aggressivenkcellleukemia pages 1-2)
+- **1-year survival:** 4.42% (5/113) in that cohort. (tang2017aggressivenkcellleukemia pages 1-2)
+- **Median survival ~2 months:** reported in a Western clinicopathologic series and cited broadly in reviews. (hussein2020genomicandimmunophenotypic pages 1-2, hussein2020aggressivenkcell pages 1-3)
+
+### 11.2 Prognostic factors (reported)
+Univariate/multivariate analyses in the large cohort identified clinical subtype, LDH, and treatment modality as prognostic; administration of L-asparaginase-based chemotherapy and allo-HSCT were associated with improved survival. (tang2017aggressivenkcellleukemia pages 2-4)
+
+---
+
+## 12. Treatment
+
+### 12.1 Standard practice (current real-world implementation)
+Evidence across cohorts/reviews supports:
+1) **L-asparaginase (or pegylated asparaginase)–containing induction chemotherapy** (e.g., SMILE, AspaMetDex, related regimens)
+2) **Allogeneic hematopoietic stem cell transplantation (allo-HSCT)** in eligible responders
+Despite these strategies, outcomes remain poor for many patients due to rapid progression and treatment-related toxicity in critically ill presentations. (ni2024clinicopathologicalfeaturesand pages 1-2, tang2017aggressivenkcellleukemia pages 1-2, tang2017aggressivenkcellleukemia pages 2-4)
+
+### 12.2 Chemotherapy outcomes (quantitative)
+In Tang et al. (n=113 cohort), among 13 newly diagnosed patients treated with **AspaMetDex** chemotherapy alone:
+- **CR:** 30.77% (4/13)
+- **ORR:** 76.92% (10/13)
+- **Median OS:** 115 days (range 37–450)
+- **Grade 3–4 hematologic AEs:** 53.84% (7/13)
+These data highlight that responses are achievable, but durability is limited without consolidation. (tang2017aggressivenkcellleukemia pages 2-4)
+
+A 2024 pediatric case review notes chemotherapy CR rates overall as **<36%** and summarizes that allo-HSCT still has high relapse/progression within 1 year (~55.5%). (ni2024clinicopathologicalfeaturesand pages 1-2)
+
+### 12.3 Allo-HSCT outcomes (quantitative)
+In Tang et al., 7 patients underwent allo-HSCT after CR:
+- **Median OS:** 300 days (range 174–1480)
+- **2-year OS:** 42.86% (3/7)
+This supports allo-HSCT as a key consolidation strategy when remission is achieved and a donor is available. (tang2017aggressivenkcellleukemia pages 2-4)
+
+### 12.4 Emerging/targeted therapies (expert analysis)
+Genomic and drug profiling evidence indicates potential vulnerabilities:
+- **JAK inhibition** (for JAK/STAT-activated disease)
+- **BCL2 inhibition** (drug sensitivity profiling highlighted NK cells’ sensitivity)
+- **Immune checkpoint blockade** in selected contexts (PD-L1 expression reported in a subset)
+These approaches are not yet established as standard-of-care in the retrieved evidence but are rationally motivated by the genomic landscape. (hussein2020genomicandimmunophenotypic pages 1-2, dufva2018aggressivenaturalkillercell pages 3-4)
+
+### 12.5 Clinical trials (NCT identifiers)
+- **NCT03719105** (start 2019-03-01; Early Phase 1; Recruiting): Modified SMILE (mSMILE) including calaspargase pegol; pembrolizumab added for <CR after 2 cycles; followed by allo-HSCT when possible; explicitly includes ANKL in cohort 1. (NCT03719105 chunk 1)
+  - URL: https://clinicaltrials.gov/study/NCT03719105
+- **NCT03623087** (start 2017-07-01; Phase 3; status uncertain in record): “SIMPLE” chemotherapy regimen (cisplatin, gemcitabine, ifosfamide, etoposide, L-asparaginase, dexamethasone) designed as non-inferiority vs SMILE and includes aggressive NK leukaemia among target conditions. (NCT03623087 chunk 1)
+  - URL: https://clinicaltrials.gov/study/NCT03623087
+- **NCT05863234** (2023; Phase I/II; Recruiting; n=7): PPMX-T003 continuous IV administration safety/PK study in ANKL; excludes patients eligible for chemotherapy. (NCT05863234 chunk 1)
+  - URL: https://clinicaltrials.gov/study/NCT05863234
+
+### 12.6 Suggested MAXO terms (examples)
+- Chemotherapy **MAXO:0000647**
+- L-asparaginase therapy (map as chemotherapy + specific drug exposure; MAXO may not have a dedicated asparaginase term)
+- Allogeneic hematopoietic stem cell transplantation **MAXO:0000747** (or closest HSCT term depending on MAXO release)
+- Immune checkpoint inhibitor therapy (immunotherapy; PD-1 inhibitor)
+
+---
+
+## 13. Prevention
+No primary prevention strategies are established for ANKL in retrieved evidence. Prevention is largely not applicable beyond general EBV disease management and immunosuppression/immune dysregulation surveillance in high-risk contexts (not quantified here).
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring veterinary analogs were identified in retrieved evidence.
+
+---
+
+## 15. Model organisms
+No dedicated animal models were identified in the retrieved evidence. The strongest mechanistic evidence here is from human tumor genomics and ex vivo drug sensitivity profiling. (dufva2018aggressivenaturalkillercell pages 3-4)
+
+---
+
+## Recent developments & 2023–2024 highlights (prioritized)
+1) **2024 case-based literature** emphasizes that ANKL may present as refractory EBV-HLH and that lack of a “distinct immunologic and morphologic signature” delays diagnosis; early, repeated marrow/peripheral blood flow cytometry is highlighted as critical. (spaner2024casereportaggressive pages 1-2)
+2) **2024 pediatric case series** supports the operational treatment strategy of intensive pegaspargase/anthracycline-containing chemotherapy with consideration of HSCT, while underscoring high early mortality (e.g., tumor lysis) and the need for rapid supportive care. (ni2024clinicopathologicalfeaturesand pages 1-2)
+3) **WHO/ICC-era classification synthesis (2024)** provides clinicians/pathologists a consolidated view of how modern frameworks align, improving standardization of terminology and diagnostic categorization for mature T/NK neoplasms. (ferry2024maturebt pages 8-10)
+
+---
+
+## Key statistics (for knowledge base)
+- **Median OS:** 55 days (Tang et al., 2017; n=113). (tang2017aggressivenkcellleukemia pages 1-2)
+- **1-year survival:** 4.42% (5/113). (tang2017aggressivenkcellleukemia pages 1-2)
+- **AspaMetDex induction (subset):** CR 30.77%; ORR 76.92%; median OS 115 days; grade 3–4 hematologic AEs 53.84%. (tang2017aggressivenkcellleukemia pages 2-4)
+- **Allo-HSCT (subset):** 2-year OS 42.86% (3/7). (tang2017aggressivenkcellleukemia pages 2-4)
+
+---
+
+## Visual evidence (genomic landscape)
+Dufva et al. provide figure panels and a table summarizing JAK-STAT pathway alterations (mutations and copy-number gains) across ANKL cohorts and related NK/T malignancies; these visuals support the centrality of JAK/STAT dysregulation in ANKL and the rationale for pathway-directed therapy hypotheses. (dufva2018aggressivenaturalkillercell media 01c6d37e, dufva2018aggressivenaturalkillercell media 2b03bded)
+
+---
+
+## Limitations of this evidence set
+- Several requested identifiers (MONDO, OMIM, Orphanet, MeSH, ICD-10/ICD-11) were not available from the retrieved texts in this run.
+- Many articles in this run do not provide PMIDs in the extracted text, so **PMID-preferring citations cannot always be satisfied** without additional PubMed-specific retrieval.
+- Incidence/prevalence rates and validated QoL measures were not found in the retrieved evidence.
+
+
+
+References
+
+1. (hussein2020aggressivenkcell pages 1-3): Siba El Hussein, L. Medeiros, and Joseph Khoury. Aggressive nk cell leukemia: current state of the art. Cancers, 12:2900, Oct 2020. URL: https://doi.org/10.3390/cancers12102900, doi:10.3390/cancers12102900. This article has 67 citations.
+
+2. (spaner2024casereportaggressive pages 1-2): Caroline Spaner, Jessica Durkee-Shock, Andrew Weng, Ryan Stubbins, Alina S. Gerrie, Stefania Pittaluga, Jeffrey I. Cohen, and Luke Y. C. Chen. Case report: aggressive natural killer cell leukemia and refractory hemophagocytic lymphohistiocytosis in an adolescent. Frontiers in Hematology, Jul 2024. URL: https://doi.org/10.3389/frhem.2024.1413794, doi:10.3389/frhem.2024.1413794. This article has 0 citations.
+
+3. (ferry2024maturebt pages 8-10): Judith A. Ferry, Brian Hill, and Eric D. Hsi. Mature b, t and nk-cell, plasma cell and histiocytic/dendritic cell neoplasms: classification according to the world health organization and international consensus classification. Journal of Hematology & Oncology, Jul 2024. URL: https://doi.org/10.1186/s13045-024-01570-5, doi:10.1186/s13045-024-01570-5. This article has 19 citations and is from a domain leading peer-reviewed journal.
+
+4. (hussein2020genomicandimmunophenotypic pages 1-2): Siba El Hussein, Keyur P. Patel, Hong Fang, Beenu Thakral, Sanam Loghavi, Rashmi Kanagal-Shamanna, Sergej Konoplev, Elias J. Jabbour, L. Jeffrey Medeiros, and Joseph D. Khoury. Genomic and immunophenotypic landscape of aggressive nk-cell leukemia. The American Journal of Surgical Pathology, 44:1235-1243, Jun 2020. URL: https://doi.org/10.1097/pas.0000000000001518, doi:10.1097/pas.0000000000001518. This article has 46 citations.
+
+5. (ishida2018aggressivenkcellleukemia pages 1-2): Fumihiro Ishida. Aggressive nk-cell leukemia. Frontiers in Pediatrics, Oct 2018. URL: https://doi.org/10.3389/fped.2018.00292, doi:10.3389/fped.2018.00292. This article has 66 citations.
+
+6. (tang2017aggressivenkcellleukemia pages 1-2): Yuan Tang, D. Wang, H. Luo, M. Xiao, H-S Zhou, D. Liu, Shaoping Ling, N. Wang, X-L Hu, Y. Luo, X. Mao, Q. Ao, J. Huang, W. Zhang, L. Sheng, L. Zhu, Z. Shang, L. Gao, P-L Zhang, M. Zhou, K. Zhou, L. Qiu, Q.‐F. Liu, H.-Y. Zhang, J. Li, J. Jin, L. Fu, W-L Zhao, J-P Chen, X. Du, G. Huang, Q-f Wang, J. Zhou, and L. Huang. Aggressive nk-cell leukemia: clinical subtypes, molecular features, and treatment outcomes. Blood Cancer Journal, Dec 2017. URL: https://doi.org/10.1038/s41408-017-0021-z, doi:10.1038/s41408-017-0021-z. This article has 72 citations and is from a domain leading peer-reviewed journal.
+
+7. (hussein2020aggressivenkcell pages 3-5): Siba El Hussein, L. Medeiros, and Joseph Khoury. Aggressive nk cell leukemia: current state of the art. Cancers, 12:2900, Oct 2020. URL: https://doi.org/10.3390/cancers12102900, doi:10.3390/cancers12102900. This article has 67 citations.
+
+8. (ni2024clinicopathologicalfeaturesand pages 1-2): Yongan Ni, Lei Li, Yuping Wang, and Lirong Sun. Clinicopathological features and treatment of aggressive natural killer cell leukemia: case series and literature review. The Turkish journal of pediatrics, 66 4:481-489, Oct 2024. URL: https://doi.org/10.24953/turkjpediatr.2024.5072, doi:10.24953/turkjpediatr.2024.5072. This article has 1 citations.
+
+9. (hussein2020genomicandimmunophenotypic pages 2-3): Siba El Hussein, Keyur P. Patel, Hong Fang, Beenu Thakral, Sanam Loghavi, Rashmi Kanagal-Shamanna, Sergej Konoplev, Elias J. Jabbour, L. Jeffrey Medeiros, and Joseph D. Khoury. Genomic and immunophenotypic landscape of aggressive nk-cell leukemia. The American Journal of Surgical Pathology, 44:1235-1243, Jun 2020. URL: https://doi.org/10.1097/pas.0000000000001518, doi:10.1097/pas.0000000000001518. This article has 46 citations.
+
+10. (dufva2018aggressivenaturalkillercell pages 3-4): Olli Dufva, Matti Kankainen, Tiina Kelkka, Nodoka Sekiguchi, Shady Adnan Awad, Samuli Eldfors, Bhagwan Yadav, Heikki Kuusanmäki, Disha Malani, Emma I Andersson, Paavo Pietarinen, Leena Saikko, Panu E. Kovanen, Teija Ojala, Dean A. Lee, Thomas P. Loughran, Hideyuki Nakazawa, Junji Suzumiya, Ritsuro Suzuki, Young Hyeh Ko, Won Seog Kim, Shih-Sung Chuang, Tero Aittokallio, Wing C. Chan, Koichi Ohshima, Fumihiro Ishida, and Satu Mustjoki. Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight jak-stat signaling as therapeutic target. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03987-2, doi:10.1038/s41467-018-03987-2. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+11. (sumbly2022aggressivenaturalkiller pages 2-3): Vikram Sumbly, Mallorie Vest, and Ian Landry. Aggressive natural killer cell leukemia: a brief overview of its genomic landscape, histological features, and current management. Cureus, Feb 2022. URL: https://doi.org/10.7759/cureus.22537, doi:10.7759/cureus.22537. This article has 17 citations.
+
+12. (NCT03623087 chunk 1): Professor Yok-lam Kwong. SIMPLE Chemotherapy for NK Lymphoma/Leukaemia. The University of Hong Kong. 2017. ClinicalTrials.gov Identifier: NCT03623087
+
+13. (dufva2018aggressivenaturalkillercell media 01c6d37e): Olli Dufva, Matti Kankainen, Tiina Kelkka, Nodoka Sekiguchi, Shady Adnan Awad, Samuli Eldfors, Bhagwan Yadav, Heikki Kuusanmäki, Disha Malani, Emma I Andersson, Paavo Pietarinen, Leena Saikko, Panu E. Kovanen, Teija Ojala, Dean A. Lee, Thomas P. Loughran, Hideyuki Nakazawa, Junji Suzumiya, Ritsuro Suzuki, Young Hyeh Ko, Won Seog Kim, Shih-Sung Chuang, Tero Aittokallio, Wing C. Chan, Koichi Ohshima, Fumihiro Ishida, and Satu Mustjoki. Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight jak-stat signaling as therapeutic target. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03987-2, doi:10.1038/s41467-018-03987-2. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+14. (dufva2018aggressivenaturalkillercell media 2b03bded): Olli Dufva, Matti Kankainen, Tiina Kelkka, Nodoka Sekiguchi, Shady Adnan Awad, Samuli Eldfors, Bhagwan Yadav, Heikki Kuusanmäki, Disha Malani, Emma I Andersson, Paavo Pietarinen, Leena Saikko, Panu E. Kovanen, Teija Ojala, Dean A. Lee, Thomas P. Loughran, Hideyuki Nakazawa, Junji Suzumiya, Ritsuro Suzuki, Young Hyeh Ko, Won Seog Kim, Shih-Sung Chuang, Tero Aittokallio, Wing C. Chan, Koichi Ohshima, Fumihiro Ishida, and Satu Mustjoki. Aggressive natural killer-cell leukemia mutational landscape and drug profiling highlight jak-stat signaling as therapeutic target. Nature Communications, Apr 2018. URL: https://doi.org/10.1038/s41467-018-03987-2, doi:10.1038/s41467-018-03987-2. This article has 163 citations and is from a highest quality peer-reviewed journal.
+
+15. (tang2017aggressivenkcellleukemia pages 2-4): Yuan Tang, D. Wang, H. Luo, M. Xiao, H-S Zhou, D. Liu, Shaoping Ling, N. Wang, X-L Hu, Y. Luo, X. Mao, Q. Ao, J. Huang, W. Zhang, L. Sheng, L. Zhu, Z. Shang, L. Gao, P-L Zhang, M. Zhou, K. Zhou, L. Qiu, Q.‐F. Liu, H.-Y. Zhang, J. Li, J. Jin, L. Fu, W-L Zhao, J-P Chen, X. Du, G. Huang, Q-f Wang, J. Zhou, and L. Huang. Aggressive nk-cell leukemia: clinical subtypes, molecular features, and treatment outcomes. Blood Cancer Journal, Dec 2017. URL: https://doi.org/10.1038/s41408-017-0021-z, doi:10.1038/s41408-017-0021-z. This article has 72 citations and is from a domain leading peer-reviewed journal.
+
+16. (NCT03719105 chunk 1): Mitchell Cairo. Chemoimmunotherapy and Allogeneic Stem Cell Transplant for NK T-cell Leukemia/Lymphoma. New York Medical College. 2019. ClinicalTrials.gov Identifier: NCT03719105
+
+17. (NCT05863234 chunk 1):  Safety Evaluation Study for Patients With Aggressive NK-cell Leukemia. Hiroshima University Hospital. 2023. ClinicalTrials.gov Identifier: NCT05863234

--- a/research/Aggressive_NK-cell_Leukemia-deep-research-falcon.md.citations.md
+++ b/research/Aggressive_NK-cell_Leukemia-deep-research-falcon.md.citations.md
@@ -1,0 +1,480 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Aggressive NK-cell Leukemia
+- **MONDO ID:**  (if available)
+- **Category:**
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Aggressive NK-cell Leukemia** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T14:04:19.824446
+
+1. spaner2024casereportaggressive pages 1-2
+2. ferry2024maturebt pages 8-10
+3. tang2017aggressivenkcellleukemia pages 1-2
+4. hussein2020genomicandimmunophenotypic pages 1-2
+5. sumbly2022aggressivenaturalkiller pages 2-3
+6. ni2024clinicopathologicalfeaturesand pages 1-2
+7. tang2017aggressivenkcellleukemia pages 2-4
+8. dufva2018aggressivenaturalkillercell pages 3-4
+9. hussein2020genomicandimmunophenotypic pages 2-3
+10. hussein2020aggressivenkcell pages 1-3
+11. ishida2018aggressivenkcellleukemia pages 1-2
+12. hussein2020aggressivenkcell pages 3-5
+13. https://doi.org/10.3390/cancers12102900
+14. https://doi.org/10.1097/pas.0000000000001518
+15. https://doi.org/10.24953/turkjpediatr.2024.5072
+16. https://doi.org/10.1038/s41467-018-03987-2
+17. https://doi.org/10.1038/s41408-017-0021-z
+18. https://clinicaltrials.gov/study/NCT03719105
+19. https://clinicaltrials.gov/study/NCT03623087
+20. https://clinicaltrials.gov/study/NCT05863234
+21. https://doi.org/10.3390/cancers12102900,
+22. https://doi.org/10.3389/frhem.2024.1413794,
+23. https://doi.org/10.1186/s13045-024-01570-5,
+24. https://doi.org/10.1097/pas.0000000000001518,
+25. https://doi.org/10.3389/fped.2018.00292,
+26. https://doi.org/10.1038/s41408-017-0021-z,
+27. https://doi.org/10.24953/turkjpediatr.2024.5072,
+28. https://doi.org/10.1038/s41467-018-03987-2,
+29. https://doi.org/10.7759/cureus.22537,


### PR DESCRIPTION
## Summary
- Add Falcon-backed DISMECH curation for aggressive NK-cell leukemia (MONDO:0019470).
- Cover EBV association, NK-cell immunophenotype, HLH/DIC phenotypes, JAK-STAT/genetic mechanisms, diagnosis, treatment approaches, and ANKL-relevant clinical trials.
- Add generated Falcon report/citations and cited reference caches generated via `just fetch-reference`.

## Validation
- `just validate kb/disorders/Aggressive_NK-cell_Leukemia.yaml`
- `just validate-references kb/disorders/Aggressive_NK-cell_Leukemia.yaml` (passes; repo config reports 0 checks for DOI/clinical trial refs)
- `just validate-terms kb/disorders/Aggressive_NK-cell_Leukemia.yaml`
- `just compliance kb/disorders/Aggressive_NK-cell_Leukemia.yaml` (90.0% global, 90.6% weighted)
- `git diff --check`