### PR TITLE
[codex] Link prostate testosterone surrogate endpoint

### DIFF
--- a/kb/disorders/Metastatic_Prostate_Cancer.yaml
+++ b/kb/disorders/Metastatic_Prostate_Cancer.yaml
@@ -185,6 +185,39 @@ phenotypes:
     term:
       id: HP:0012378
       label: Fatigue
+biochemical:
+- name: Plasma testosterone
+  context: >-
+    Pharmacodynamic marker of androgen deprivation in advanced prostate cancer;
+    suppression toward castrate levels indicates reduced androgen ligand drive.
+  readouts:
+  - target: Persistent Androgen Receptor Signaling
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-cancer-015
+    interpretation: >-
+      Higher plasma testosterone indicates greater androgen ligand availability
+      for AR signaling, whereas effective GnRH-antagonist therapy suppresses
+      testosterone as the pharmacodynamic endpoint.
+    evidence:
+    - reference: PMID:40063046
+      reference_title: "Prostate Cancer: A Review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Treatment of metastatic prostate cancer primarily relies on androgen deprivation therapy, most commonly through medical castration with gonadotropin-releasing hormone agonists.
+      explanation: >-
+        This review supports testosterone suppression through medical castration
+        as a central pharmacodynamic mechanism in metastatic prostate cancer.
+    - reference: PMID:34771580
+      reference_title: "Androgen Receptor Signaling in Prostate Cancer and Therapeutic Strategies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Understanding of the molecular mechanisms of prostate cancer has led to development of therapeutic strategies targeting androgen receptor (AR).
+      explanation: >-
+        This review supports the linked AR-signaling pathograph node that plasma
+        testosterone pharmacodynamically reports on.
 treatments:
 - name: Androgen Deprivation plus AR Pathway Inhibition
   description: >-

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -3415,8 +3415,19 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: solid tumors; population: Patients with advanced prostate cancer;
     endpoint: Plasma testosterone levels; approval context: traditional; drug mechanism: Gonadotropin-releasing
     hormone antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Prostate Adenocarcinoma
+  - Metastatic Prostate Cancer
+  mapped_disease_files:
+  - kb/disorders/Prostate_Adenocarcinoma.yaml
+  - kb/disorders/Metastatic_Prostate_Cancer.yaml
+  mapping_notes: >-
+    Candidate mapped to prostate cancer pages because the FDA row uses the
+    broader advanced prostate cancer context. The Metastatic Prostate Cancer page
+    now links plasma testosterone as a pharmacodynamic androgen-deprivation
+    readout of persistent androgen receptor signaling; Prostate Adenocarcinoma
+    remains a broader related disease mapping.
 - row_id: FDA-SE-adult-cancer-016
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related


### PR DESCRIPTION
## Summary

Links the FDA advanced-prostate-cancer plasma testosterone surrogate endpoint into the metastatic prostate cancer disease YAML as a pharmacodynamic biomarker readout of persistent androgen receptor signaling.

Updates the FDA surrogate endpoint source row `FDA-SE-adult-cancer-015` to a candidate dismech mapping because the FDA context is broader "advanced prostate cancer" while the disease page captures a curated advanced/metastatic prostate cancer biology context.

## Validation

- `just validate kb/disorders/Metastatic_Prostate_Cancer.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`