### PR TITLE
Add craniopharyngioma curation

### DIFF
--- a/kb/disorders/Craniopharyngioma.yaml
+++ b/kb/disorders/Craniopharyngioma.yaml
@@ -1,6 +1,6 @@
 name: Craniopharyngioma
 creation_date: "2026-05-11T17:51:07Z"
-updated_date: "2026-05-11T18:28:01Z"
+updated_date: "2026-05-11T19:00:26Z"
 synonyms:
 - Rathke pouch tumor
 - Rathke pouch neoplasm
@@ -55,7 +55,8 @@ definitions:
       This clinical review directly defines the anatomic origin, benign WHO
       grade, and two major craniopharyngioma entities.
 has_subtypes:
-- name: Adamantinomatous Craniopharyngioma
+- name: ACP
+  display_name: Adamantinomatous Craniopharyngioma
   description: >-
     Adamantinomatous craniopharyngioma is the CTNNB1/Wnt-driven subtype that
     occurs in children and adults, often with cystic/solid components,
@@ -85,7 +86,8 @@ has_subtypes:
     explanation: >-
       This molecular review supports CTNNB1 mutation as the characteristic
       marker for ACP.
-- name: Papillary Craniopharyngioma
+- name: PCP
+  display_name: Papillary Craniopharyngioma
   description: >-
     Papillary craniopharyngioma is the BRAF V600E/MAPK-driven subtype, mainly
     seen in adults, with a strong precision-oncology treatment signal from
@@ -271,7 +273,7 @@ pathophysiology:
   - reference: PMID:37565822
     reference_title: Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
     supports: SUPPORT
-    evidence_source: COMPUTATIONAL
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       The WNT subgroup showed higher Wnt/β-catenin pathway activity, with a
       greater number of epithelial cells and more predominantly solid tumors.
@@ -344,7 +346,7 @@ pathophysiology:
   - reference: PMID:37565822
     reference_title: Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
     supports: SUPPORT
-    evidence_source: COMPUTATIONAL
+    evidence_source: HUMAN_CLINICAL
     snippet: >-
       The ImA and ImB subgroups had activated inflammatory and interferon
       response pathways, with enhanced immune cell infiltration and more
@@ -465,6 +467,26 @@ phenotypes:
       This supports pituitary endocrine deficiency as a frequent disease
       manifestation.
 - category: Endocrine
+  name: Growth Hormone Deficiency
+  description: >-
+    Growth hormone deficiency is a specific and predominant endocrinological
+    disturbance in craniopharyngioma, reflecting pituitary and
+    hypothalamic-pituitary axis involvement.
+  phenotype_term:
+    preferred_term: Growth hormone deficiency
+    term:
+      id: HP:0000824
+      label: Decreased response to growth hormone stimulation test
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Growth hormone deficiency is the most predominant endocrinological disturbance associated with craniopharyngioma."
+    explanation: >-
+      The review specifically identifies growth hormone deficiency as the
+      predominant endocrine disturbance in craniopharyngioma.
+- category: Endocrine
   name: Diabetes Insipidus
   description: >-
     Posterior pituitary and hypothalamic injury can produce central diabetes
@@ -515,6 +537,29 @@ phenotypes:
       manifestations; hydrocephalus is retained as the mechanistic HPO mapping
       for obstructive raised-pressure presentations but is not directly named in
       this abstract snippet.
+- category: Neurological
+  name: Memory Impairment
+  description: >-
+    Memory impairment can occur as part of craniopharyngioma morbidity,
+    especially when disease or local treatment affects hypothalamic and adjacent
+    brain structures.
+  phenotype_term:
+    preferred_term: Memory impairment
+    term:
+      id: HP:0002354
+      label: Memory impairment
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with the use of surgery, radiation, or both is often associated
+      with substantial morbidity related to vision loss, neuroendocrine
+      dysfunction, and memory loss.
+    explanation: >-
+      The phase 2 trial background explicitly names memory loss among major
+      morbidity domains associated with craniopharyngioma treatment.
 genetic:
 - name: CTNNB1
   association: Somatic activating mutation in adamantinomatous craniopharyngioma
@@ -604,20 +649,19 @@ histopathology:
     explanation: >-
       This review supports PCP as a distinct histologic and molecular entity.
 diagnosis:
-- name: MRI and CT Sellar Region Imaging
+- name: MRI Sellar Region Imaging
   description: >-
     MRI characterizes the cystic and solid sellar/suprasellar mass and its
     relationship to the optic chiasm, pituitary gland, hypothalamus, and third
-    ventricle; CT helps detect calcified ACP components.
+    ventricle.
   diagnosis_term:
-    preferred_term: clinical assessment
+    preferred_term: magnetic resonance imaging procedure
     term:
-      id: MAXO:0000487
-      label: clinical assessment
+      id: MAXO:0000424
+      label: magnetic resonance imaging procedure
   results: >-
-    Sellar/parasellar or suprasellar cystic-solid mass, calcification on CT when
-    present, and anatomic relationship to optic and hypothalamic-pituitary
-    structures.
+    Sellar/parasellar or suprasellar cystic-solid mass and anatomic relationship
+    to optic and hypothalamic-pituitary structures.
   evidence:
   - reference: PMID:38961911
     reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
@@ -626,6 +670,25 @@ diagnosis:
     snippet: "Magnetic Resonance Imaging (MRI) further characterizes craniopharyngiomas and helps to narrow down the differential diagnoses."
     explanation: >-
       The review supports MRI as a key diagnostic characterization tool.
+- name: CT Calcification Assessment
+  description: >-
+    CT is used to detect calcification within craniopharyngioma tissue, a common
+    imaging feature particularly relevant to ACP.
+  diagnosis_term:
+    preferred_term: computed tomography procedure
+    term:
+      id: MAXO:0000571
+      label: computed tomography procedure
+  results: Calcification in craniopharyngioma tissue when present.
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Computed tomography (CT) is gold standard to detect calcifications in CP tissue"
+    explanation: >-
+      The review specifically supports CT for identifying calcified
+      craniopharyngioma tissue.
 - name: Integrated Histologic and Molecular Subtyping
   description: >-
     Diagnosis and treatment planning integrate clinical, endocrine, imaging,
@@ -696,6 +759,46 @@ treatments:
     explanation: >-
       The review directly states the diagnostic, decompressive, and cytoreductive
       rationale for surgery.
+- name: Radiation Therapy for Local Tumor Control
+  description: >-
+    Radiation therapy is used with or after surgery for local disease control,
+    but must be balanced against morbidity involving the optic,
+    hypothalamic-pituitary, and adjacent brain structures.
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
+  target_mechanisms:
+  - target: Sellar-Suprasellar Rathke Pouch Tumor Formation
+    treatment_effect: INHIBITS
+    description: >-
+      Radiation therapy aims to control residual or recurrent local tumor growth.
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with the use of surgery, radiation, or both is often associated
+      with substantial morbidity related to vision loss, neuroendocrine
+      dysfunction, and memory loss.
+    explanation: >-
+      The phase 2 trial background identifies radiation, alone or with surgery,
+      as part of traditional craniopharyngioma treatment and notes associated
+      morbidity.
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Recent neurosurgical technical advances, including innovative surgical
+      approaches, detailed radiotherapy protocols, targeted therapy, replacement
+      of lost hormonal functions and quality of life all have the potential to
+      improve the outcome of patients with craniopharyngioma.
+    explanation: >-
+      This review supports radiotherapy protocols as part of contemporary
+      craniopharyngioma management.
 - name: BRAF/MEK Inhibition for BRAF V600E Papillary Craniopharyngioma
   description: >-
     Combined BRAF and MEK inhibition, such as vemurafenib plus cobimetinib or

--- a/kb/disorders/Craniopharyngioma.yaml
+++ b/kb/disorders/Craniopharyngioma.yaml
@@ -1,0 +1,892 @@
+name: Craniopharyngioma
+creation_date: "2026-05-11T17:51:07Z"
+updated_date: "2026-05-11T18:28:01Z"
+synonyms:
+- Rathke pouch tumor
+- Rathke pouch neoplasm
+- craniopharyngeal duct tumor
+- adamantinomatous craniopharyngioma
+- papillary craniopharyngioma
+description: >-
+  Craniopharyngioma is a rare, WHO grade 1 epithelial neoplasm of the
+  sellar/parasellar and suprasellar region, usually arising from Rathke pouch
+  epithelial remnants. The two main entities, adamantinomatous
+  craniopharyngioma and papillary craniopharyngioma, differ in age distribution,
+  histology, imaging pattern, and molecular drivers. Morbidity is dominated by
+  local mass effect and treatment injury involving the optic apparatus,
+  hypothalamus, and pituitary gland, causing visual impairment, headache,
+  hypopituitarism, diabetes insipidus, hypothalamic dysfunction, and long-term
+  quality-of-life burden.
+categories:
+- Central Nervous System Neoplasm
+- Pediatric Brain Tumor
+- Sellar Region Tumor
+- Endocrine Neoplasia
+- Benign Epithelial Neoplasm
+parents:
+- central nervous system organ benign neoplasm
+- sella turcica neoplasm
+- benign epithelial neoplasm
+disease_term:
+  preferred_term: craniopharyngioma
+  term:
+    id: MONDO:0018907
+    label: craniopharyngioma
+definitions:
+- name: Craniopharyngioma literature definition
+  definition_type: CASE_DEFINITION
+  description: >-
+    A rare intracranial epithelial tumor arising from Rathke pouch remnants in
+    the sellar/parasellar region, histologically low-grade but clinically
+    morbid because of its position near the optic, hypothalamic, and pituitary
+    structures.
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Craniopharyngioma (CP) is a rare intracranial tumor arising from the
+      epithelial remnants of Rathke's pouch, most frequently originating in the
+      sellar/parasellar region. Histologically, CP is a benign low-grade tumor
+      (WHO grade 1) with two distinct phenotypes: adamantinomatous CP (ACP) and
+      papillary CP (PCP).
+    explanation: >-
+      This clinical review directly defines the anatomic origin, benign WHO
+      grade, and two major craniopharyngioma entities.
+has_subtypes:
+- name: Adamantinomatous Craniopharyngioma
+  description: >-
+    Adamantinomatous craniopharyngioma is the CTNNB1/Wnt-driven subtype that
+    occurs in children and adults, often with cystic/solid components,
+    calcification, wet keratin, palisading epithelium, and a reactive
+    inflammatory/glial microenvironment.
+  evidence:
+  - reference: PMID:36979325
+    reference_title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Craniopharyngiomas are classically distinguished into two histological
+      types (adamantinomatous and papillary), which have been recently considered
+      by the WHO classification of CNS tumors as two independent entities, due to
+      different epidemiological, radiological, histopathological, and genetic
+      patterns.
+    explanation: >-
+      This review supports adamantinomatous craniopharyngioma as one of the two
+      WHO-recognized clinicopathologic entities.
+  - reference: PMID:36748936
+    reference_title: The molecular pathogenesis of craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ACP and PCP subtypes can be identified by the presence of mutations in
+      CTNNB1 and BRAF genes, with prevalence around 60% and 90%, respectively.
+    explanation: >-
+      This molecular review supports CTNNB1 mutation as the characteristic
+      marker for ACP.
+- name: Papillary Craniopharyngioma
+  description: >-
+    Papillary craniopharyngioma is the BRAF V600E/MAPK-driven subtype, mainly
+    seen in adults, with a strong precision-oncology treatment signal from
+    BRAF/MEK inhibition.
+  evidence:
+  - reference: PMID:36979325
+    reference_title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "With regard to papillary craniopharyngioma, a BRAF V600 mutation is detected in 95% of cases."
+    explanation: >-
+      This review supports papillary craniopharyngioma as a BRAF V600-mutant
+      entity.
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Genotyping has shown that more than 90% of papillary craniopharyngiomas carry BRAF V600E mutations"
+    explanation: >-
+      This phase 2 trial abstract supports the high prevalence of BRAF V600E in
+      papillary craniopharyngioma.
+prevalence:
+- population: General population
+  notes: >-
+    Craniopharyngioma is rare, with published incidence estimates in recent
+    reviews spanning roughly 0.13 to 2 per 100,000 population per year.
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The annual incidence ranges from 0.13 to 2 per 100,000 population per year with no gender predilection."
+    explanation: >-
+      The review provides the incidence range and notes absence of a strong
+      overall sex predilection.
+progression:
+- phase: Indolent local growth with high morbidity
+  notes: >-
+    Despite benign histology, recurrence and long-term morbidity are common
+    clinical problems because of the tumor's proximity to the
+    hypothalamic-pituitary and optic structures.
+  evidence:
+  - reference: PMID:36979325
+    reference_title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Craniopharyngiomas are commonly classified as low-grade tumors, although
+      they may harbor a malignant behavior due to their high rate of recurrence
+      and long-term morbidity.
+    explanation: >-
+      This review supports modeling the disease course as locally recurrent and
+      morbidity-heavy despite low-grade classification.
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with the use of surgery, radiation, or both is often associated
+      with substantial morbidity related to vision loss, neuroendocrine
+      dysfunction, and memory loss.
+    explanation: >-
+      The trial background summarizes the major long-term morbidity domains
+      associated with traditional local treatment.
+pathophysiology:
+- name: Sellar-Suprasellar Rathke Pouch Tumor Formation
+  description: >-
+    Craniopharyngioma arises from epithelial remnants of Rathke pouch in the
+    sellar/parasellar and suprasellar region, producing a slow-growing but
+    space-occupying epithelial mass near the pituitary gland and hypothalamus.
+  cell_types:
+  - preferred_term: Rathke pouch-derived epithelial cell
+    term:
+      id: CL:0000066
+      label: epithelial cell
+  locations:
+  - preferred_term: sella turcica
+    term:
+      id: UBERON:0003689
+      label: sella turcica
+  - preferred_term: Rathke pouch epithelium
+    term:
+      id: UBERON:0012287
+      label: Rathkes pouch epithelium
+  - preferred_term: pituitary gland
+    term:
+      id: UBERON:0000007
+      label: pituitary gland
+  biological_processes:
+  - preferred_term: tumor cell proliferation
+    modifier: INCREASED
+    term:
+      id: GO:0008283
+      label: cell population proliferation
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Craniopharyngioma (CP) is a rare intracranial tumor arising from the
+      epithelial remnants of Rathke's pouch, most frequently originating in the
+      sellar/parasellar region.
+    explanation: >-
+      The review directly anchors the tumor's origin and sellar/parasellar
+      localization.
+  downstream:
+  - target: Optic-Hypothalamic-Pituitary Mass Effect
+    causal_link_type: DIRECT
+    description: >-
+      Expansion in the sellar/suprasellar region compresses or injures nearby
+      optic, hypothalamic, pituitary, and third-ventricle structures.
+- name: Optic-Hypothalamic-Pituitary Mass Effect
+  description: >-
+    Local tumor extension and treatment effects injure the optic chiasma,
+    pituitary gland, hypothalamus, and adjacent ventricular pathways, explaining
+    visual impairment, headache, hypopituitarism, diabetes insipidus, and
+    hydrocephalus or raised intracranial pressure.
+  locations:
+  - preferred_term: optic chiasm
+    term:
+      id: UBERON:0000959
+      label: optic chiasma
+  - preferred_term: hypothalamus
+    term:
+      id: UBERON:0001898
+      label: hypothalamus
+  - preferred_term: pituitary gland
+    term:
+      id: UBERON:0000007
+      label: pituitary gland
+  - preferred_term: third ventricle
+    term:
+      id: UBERON:0002286
+      label: third ventricle
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its unique anatomical locations, the most frequently reported
+      clinical manifestations are headache, visual impairment, nausea/vomiting,
+      and endocrine deficiencies resulting in sexual dysfunction in adults and
+      growth failure in children.
+    explanation: >-
+      The clinical manifestations are directly attributable to mass effect and
+      hypothalamic-pituitary involvement at the tumor site.
+- name: CTNNB1-Wnt ACP Tumor Signaling
+  description: >-
+    In adamantinomatous craniopharyngioma, somatic CTNNB1 alterations stabilize
+    beta-catenin and activate Wnt signaling in tumor clusters. These clusters
+    act as signaling centers that support epithelial proliferation, cystic/solid
+    architecture, and paracrine interaction with surrounding glial and immune
+    tissue.
+  genes:
+  - preferred_term: CTNNB1
+    term:
+      id: hgnc:2514
+      label: CTNNB1
+  cell_types:
+  - preferred_term: tumor epithelial cell
+    term:
+      id: CL:0000066
+      label: epithelial cell
+  biological_processes:
+  - preferred_term: Wnt signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0016055
+      label: Wnt signaling pathway
+  evidence:
+  - reference: PMID:29541918
+    reference_title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Adamantinomatous craniopharyngiomas (ACPs) are clinically challenging
+      tumours, the majority of which have activating mutations in CTNNB1.
+    explanation: >-
+      This human tumor molecular study supports CTNNB1 activation as the main
+      upstream ACP driver.
+  - reference: PMID:37565822
+    reference_title: Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: >-
+      The WNT subgroup showed higher Wnt/β-catenin pathway activity, with a
+      greater number of epithelial cells and more predominantly solid tumors.
+    explanation: >-
+      Multi-omics subgrouping links Wnt/beta-catenin activity to epithelial-rich
+      ACP tumor architecture.
+  downstream:
+  - target: ACP Inflammatory and MAPK Microenvironment
+    causal_link_type: DIRECT
+    description: >-
+      CTNNB1-mutant ACP cluster cells signal to adjacent tumor, glial, and
+      immune compartments through paracrine pathways.
+- name: ACP Inflammatory and MAPK Microenvironment
+  description: >-
+    ACP contains a reactive glial and immune microenvironment with inflammatory,
+    interferon, cytokine, and MAPK/ERK signaling programs. These pathways shape
+    invasive front behavior, cystic tumor biology, and potential sensitivity to
+    MEK inhibition or other anti-inflammatory strategies.
+  cell_types:
+  - preferred_term: astrocyte
+    term:
+      id: CL:0000127
+      label: astrocyte
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  - preferred_term: T cell
+    term:
+      id: CL:0000084
+      label: T cell
+  biological_processes:
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  - preferred_term: cytokine-mediated signaling pathway
+    modifier: INCREASED
+    term:
+      id: GO:0019221
+      label: cytokine-mediated signaling pathway
+  - preferred_term: MAPK cascade
+    modifier: INCREASED
+    term:
+      id: GO:0000165
+      label: MAPK cascade
+  evidence:
+  - reference: PMID:29541918
+    reference_title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We validate these results by immunostaining against immune cell markers,
+      cytokine ELISA and proteome analysis in both solid tumour and cystic fluid
+      from ACP patients.
+    explanation: >-
+      Human ACP tissue and cyst-fluid measurements support immune and cytokine
+      microenvironment involvement.
+  - reference: PMID:29541918
+    reference_title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: >-
+      We reveal that inhibiting the MAPK/ERK pathway with trametinib, a
+      clinically approved MEK inhibitor, results in reduced proliferation and
+      increased apoptosis in explant cultures of human and mouse ACP.
+    explanation: >-
+      Ex vivo explant evidence supports MAPK/ERK as a tractable ACP pathway.
+  - reference: PMID:37565822
+    reference_title: Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
+    supports: SUPPORT
+    evidence_source: COMPUTATIONAL
+    snippet: >-
+      The ImA and ImB subgroups had activated inflammatory and interferon
+      response pathways, with enhanced immune cell infiltration and more
+      predominantly cystic tumors.
+    explanation: >-
+      Multi-omics clustering supports inflammatory/immune ACP subgroups linked
+      to cystic tumor architecture.
+  downstream:
+  - target: Optic-Hypothalamic-Pituitary Mass Effect
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: >-
+      Inflammatory and invasive-front biology can intensify local tissue
+      reaction around critical hypothalamic and optic structures.
+- name: BRAF V600E MAPK PCP Tumor Signaling
+  description: >-
+    Papillary craniopharyngioma is driven in most cases by BRAF V600E, which
+    activates MAPK/ERK signaling and creates a genotype-matched therapeutic
+    vulnerability to combined BRAF and MEK inhibition.
+  genes:
+  - preferred_term: BRAF
+    term:
+      id: hgnc:1097
+      label: BRAF
+  biological_processes:
+  - preferred_term: MAPK cascade
+    modifier: INCREASED
+    term:
+      id: GO:0000165
+      label: MAPK cascade
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Genotyping has shown that more than 90% of papillary craniopharyngiomas carry BRAF V600E mutations"
+    explanation: >-
+      This phase 2 trial background supports BRAF V600E as the defining PCP
+      driver lesion.
+  - reference: PMID:39634188
+    reference_title: Practical application of precision oncology in adult onset craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Identification of specific molecular driver mutations in each type- BRAF
+      V600E in papillary craniopharyngiomas (PCP) and CTNNB1 in
+      adamantinomatous craniopharyngiomas (ACP) has resulted in a paradigm
+      shift in the management of adult CPs.
+    explanation: >-
+      This adult precision-oncology review links BRAF V600E and CTNNB1 to the
+      subtype-specific treatment paradigm.
+phenotypes:
+- category: Neurological
+  name: Headache
+  description: >-
+    Headache is a common presenting manifestation from sellar/suprasellar mass
+    effect and raised intracranial pressure.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its unique anatomical locations, the most frequently reported
+      clinical manifestations are headache, visual impairment, nausea/vomiting,
+      and endocrine deficiencies resulting in sexual dysfunction in adults and
+      growth failure in children.
+    explanation: >-
+      The review names headache among the most frequently reported clinical
+      manifestations.
+- category: Ophthalmologic
+  name: Visual Impairment
+  description: >-
+    Visual impairment and visual-field deficits reflect compression or injury of
+    the optic chiasma and nearby optic pathways.
+  phenotype_term:
+    preferred_term: Visual impairment
+    term:
+      id: HP:0000505
+      label: Visual impairment
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its unique anatomical locations, the most frequently reported
+      clinical manifestations are headache, visual impairment, nausea/vomiting,
+      and endocrine deficiencies resulting in sexual dysfunction in adults and
+      growth failure in children.
+    explanation: >-
+      The review names visual impairment as a frequent manifestation.
+- category: Endocrine
+  name: Hypopituitarism
+  description: >-
+    Anterior pituitary hormone deficiencies can cause growth failure in
+    children and sexual dysfunction or other endocrine-axis failure in adults.
+  phenotype_term:
+    preferred_term: Hypopituitarism
+    term:
+      id: HP:0040075
+      label: Hypopituitarism
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its unique anatomical locations, the most frequently reported
+      clinical manifestations are headache, visual impairment, nausea/vomiting,
+      and endocrine deficiencies resulting in sexual dysfunction in adults and
+      growth failure in children.
+    explanation: >-
+      This supports pituitary endocrine deficiency as a frequent disease
+      manifestation.
+- category: Endocrine
+  name: Diabetes Insipidus
+  description: >-
+    Posterior pituitary and hypothalamic injury can produce central diabetes
+    insipidus, especially after tumor growth or local therapy affects the
+    hypothalamic-pituitary axis.
+  phenotype_term:
+    preferred_term: Diabetes insipidus
+    term:
+      id: HP:0000873
+      label: Diabetes insipidus
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment with the use of surgery, radiation, or both is often associated
+      with substantial morbidity related to vision loss, neuroendocrine
+      dysfunction, and memory loss.
+    explanation: >-
+      The abstract supports neuroendocrine dysfunction as a major morbidity
+      domain; the specific diabetes-insipidus mapping is a common
+      hypothalamic-pituitary manifestation rather than directly named in this
+      abstract.
+- category: Neurological
+  name: Hydrocephalus or Raised Intracranial Pressure
+  description: >-
+    Large suprasellar tumors may obstruct ventricular pathways, producing
+    hydrocephalus or raised intracranial pressure with nausea, vomiting, and
+    headache.
+  phenotype_term:
+    preferred_term: Hydrocephalus
+    term:
+      id: HP:0000238
+      label: Hydrocephalus
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Due to its unique anatomical locations, the most frequently reported
+      clinical manifestations are headache, visual impairment, nausea/vomiting,
+      and endocrine deficiencies resulting in sexual dysfunction in adults and
+      growth failure in children.
+    explanation: >-
+      The review supports nausea/vomiting and headache among common
+      manifestations; hydrocephalus is retained as the mechanistic HPO mapping
+      for obstructive raised-pressure presentations but is not directly named in
+      this abstract snippet.
+genetic:
+- name: CTNNB1
+  association: Somatic activating mutation in adamantinomatous craniopharyngioma
+  gene_term:
+    preferred_term: CTNNB1
+    term:
+      id: hgnc:2514
+      label: CTNNB1
+  notes: >-
+    Somatic CTNNB1 mutations are the core ACP driver and activate Wnt/beta-catenin
+    signaling.
+  evidence:
+  - reference: PMID:36748936
+    reference_title: The molecular pathogenesis of craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      ACP and PCP subtypes can be identified by the presence of mutations in
+      CTNNB1 and BRAF genes, with prevalence around 60% and 90%, respectively.
+    explanation: >-
+      This molecular review identifies CTNNB1 mutations as the ACP-defining
+      alteration.
+- name: BRAF
+  association: Somatic BRAF V600E mutation in papillary craniopharyngioma
+  gene_term:
+    preferred_term: BRAF
+    term:
+      id: hgnc:1097
+      label: BRAF
+  notes: >-
+    BRAF V600E is present in most papillary craniopharyngiomas and predicts
+    sensitivity to BRAF/MEK inhibitor combinations.
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Genotyping has shown that more than 90% of papillary craniopharyngiomas carry BRAF V600E mutations"
+    explanation: >-
+      This trial background supports BRAF V600E as the dominant PCP alteration.
+histopathology:
+- name: Adamantinomatous Craniopharyngioma
+  finding_term:
+    preferred_term: Adamantinomatous Craniopharyngioma
+    term:
+      id: NCIT:C4726
+      label: Adamantinomatous Craniopharyngioma
+  diagnostic: true
+  description: >-
+    ACP is the adamantinomatous histologic entity, with CTNNB1-driven epithelial
+    clusters, cystic and solid components, palisading epithelium, and an
+    inflammatory/glial reaction.
+  evidence:
+  - reference: PMID:29541918
+    reference_title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      They are histologically complex, showing cystic and solid components, the
+      latter comprised of different morphological cell types (e.g.
+      β-catenin-accumulating cluster cells and palisading epithelium),
+      surrounded by a florid glial reaction with immune cells.
+    explanation: >-
+      This human ACP molecular-pathology study describes the diagnostic
+      histologic architecture and microenvironment.
+- name: Papillary Craniopharyngioma
+  finding_term:
+    preferred_term: Papillary Craniopharyngioma
+    term:
+      id: NCIT:C4725
+      label: Papillary Craniopharyngioma
+  diagnostic: true
+  description: >-
+    PCP is the papillary histologic entity, distinguished from ACP by BRAF V600E
+    mutation status and integrated histologic, radiologic, and genetic features.
+  evidence:
+  - reference: PMID:36979325
+    reference_title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Craniopharyngiomas are classically distinguished into two histological
+      types (adamantinomatous and papillary), which have been recently considered
+      by the WHO classification of CNS tumors as two independent entities, due to
+      different epidemiological, radiological, histopathological, and genetic
+      patterns.
+    explanation: >-
+      This review supports PCP as a distinct histologic and molecular entity.
+diagnosis:
+- name: MRI and CT Sellar Region Imaging
+  description: >-
+    MRI characterizes the cystic and solid sellar/suprasellar mass and its
+    relationship to the optic chiasm, pituitary gland, hypothalamus, and third
+    ventricle; CT helps detect calcified ACP components.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  results: >-
+    Sellar/parasellar or suprasellar cystic-solid mass, calcification on CT when
+    present, and anatomic relationship to optic and hypothalamic-pituitary
+    structures.
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Magnetic Resonance Imaging (MRI) further characterizes craniopharyngiomas and helps to narrow down the differential diagnoses."
+    explanation: >-
+      The review supports MRI as a key diagnostic characterization tool.
+- name: Integrated Histologic and Molecular Subtyping
+  description: >-
+    Diagnosis and treatment planning integrate clinical, endocrine, imaging,
+    histologic, and molecular evidence, including BRAF V600E testing in PCP and
+    CTNNB1/Wnt evidence in ACP.
+  diagnosis_term:
+    preferred_term: clinical assessment
+    term:
+      id: MAXO:0000487
+      label: clinical assessment
+  markers: CTNNB1 mutation, BRAF V600E mutation, beta-catenin localization
+  evidence:
+  - reference: PMID:36979325
+    reference_title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Based on our research and experience, we strongly suggest a multimodal
+      approach combining clinical, endocrinological, radiological, histological,
+      and oncological findings in both preoperative workup and postoperative
+      follow up to define a roadmap integrating every aspect of this challenging
+      condition.
+    explanation: >-
+      The review supports an integrated diagnostic and management approach that
+      combines clinical, endocrine, radiologic, histologic, and oncologic data.
+  - reference: PMID:39634188
+    reference_title: Practical application of precision oncology in adult onset craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Identification of specific molecular driver mutations in each type- BRAF
+      V600E in papillary craniopharyngiomas (PCP) and CTNNB1 in
+      adamantinomatous craniopharyngiomas (ACP) has resulted in a paradigm
+      shift in the management of adult CPs.
+    explanation: >-
+      This supports molecular subtype testing as clinically actionable.
+treatments:
+- name: Maximal Safe Surgical Resection
+  description: >-
+    Surgery is used to establish diagnosis, decompress symptomatic mass effect,
+    and remove as much tumor as safely possible while limiting hypothalamic,
+    optic, and pituitary injury.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  target_mechanisms:
+  - target: Sellar-Suprasellar Rathke Pouch Tumor Formation
+    treatment_effect: INHIBITS
+    description: >-
+      Surgical cytoreduction removes tumor tissue and reduces the local
+      space-occupying lesion.
+  - target: Optic-Hypothalamic-Pituitary Mass Effect
+    treatment_effect: INHIBITS
+    description: >-
+      Decompression aims to relieve mass-related symptoms affecting optic,
+      pituitary, hypothalamic, and ventricular structures.
+  evidence:
+  - reference: PMID:38961911
+    reference_title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In almost all craniopharyngioma cases, surgery is indicated to: establish
+      the diagnosis, relieve mass-related symptoms, and remove as much tumor as
+      is safely possible.
+    explanation: >-
+      The review directly states the diagnostic, decompressive, and cytoreductive
+      rationale for surgery.
+- name: BRAF/MEK Inhibition for BRAF V600E Papillary Craniopharyngioma
+  description: >-
+    Combined BRAF and MEK inhibition, such as vemurafenib plus cobimetinib or
+    dabrafenib plus trametinib, is a genotype-matched treatment strategy for
+    BRAF V600E papillary craniopharyngioma and may reduce the need for morbid
+    local therapy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: vemurafenib
+      term:
+        id: CHEBI:63637
+        label: vemurafenib
+    - preferred_term: cobimetinib
+      term:
+        id: CHEBI:90851
+        label: cobimetinib
+    - preferred_term: dabrafenib
+      term:
+        id: CHEBI:75045
+        label: dabrafenib
+    - preferred_term: trametinib
+      term:
+        id: CHEBI:75998
+        label: trametinib
+  target_mechanisms:
+  - target: BRAF V600E MAPK PCP Tumor Signaling
+    treatment_effect: INHIBITS
+    description: >-
+      Combined BRAF and MEK inhibition targets the genotype-matched MAPK driver
+      pathway in papillary craniopharyngioma.
+  evidence:
+  - reference: PMID:37437144
+    reference_title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The median reduction in the volume of the tumor was 91% (range, 68 to 99).
+    explanation: >-
+      This phase 2 trial supports high objective response to
+      vemurafenib-cobimetinib in BRAF-mutant PCP.
+  - reference: PMID:39456573
+    reference_title: "Update on Neoadjuvant and Adjuvant BRAF Inhibitors in Papillary Craniopharyngioma: A Systematic Review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment is shifting to a wider multidisciplinary management, where a key
+      role is played by targeted therapies, to improve outcomes and quality of
+      life for patients with BRAF-mutated craniopharyngiomas.
+    explanation: >-
+      The systematic review supports targeted therapy as an increasingly central
+      component of BRAF-mutated PCP management.
+- name: Binimetinib for Recurrent Adamantinomatous Craniopharyngioma
+  description: >-
+    Binimetinib MEK inhibition is under phase 2 clinical investigation for
+    pediatric and young-adult recurrent ACP, supported by ACP MAPK pathway
+    biology but not yet established as standard care.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: binimetinib
+      term:
+        id: CHEBI:145371
+        label: binimetinib
+  target_mechanisms:
+  - target: ACP Inflammatory and MAPK Microenvironment
+    treatment_effect: INHIBITS
+    description: >-
+      MEK inhibition is intended to inhibit MAPK signaling active in ACP
+      microenvironmental compartments.
+  evidence:
+  - reference: clinicaltrials:NCT05286788
+    reference_title: Phase 2 Study of the MEK Inhibitor MEKTOVI® (Binimetinib) for the Treatment of Pediatric Adamantinomatous Craniopharyngioma
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this Phase II, the drug will be used to treat pediatric patients
+      diagnosed with recurrent Adamantinomatous Craniopharyngioma including
+      patients who have undergone surgery and/or radiation therapy.
+    explanation: >-
+      The ClinicalTrials.gov summary supports binimetinib as an investigational
+      treatment for recurrent pediatric ACP.
+  - reference: PMID:29541918
+    reference_title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+    supports: PARTIAL
+    evidence_source: IN_VITRO
+    snippet: >-
+      We reveal that inhibiting the MAPK/ERK pathway with trametinib, a
+      clinically approved MEK inhibitor, results in reduced proliferation and
+      increased apoptosis in explant cultures of human and mouse ACP.
+    explanation: >-
+      Ex vivo ACP explant data support MEK inhibition as a mechanistic rationale,
+      but not yet as proven clinical efficacy.
+- name: Brachytherapy for Cystic Craniopharyngioma
+  description: >-
+    Intracystic or local brachytherapy is an alternative radiation-based
+    strategy for selected cystic craniopharyngiomas, with long-term
+    progression-free-survival evidence from pooled clinical trials.
+  treatment_term:
+    preferred_term: radiation therapy
+    term:
+      id: MAXO:0000014
+      label: radiation therapy
+  target_mechanisms:
+  - target: Sellar-Suprasellar Rathke Pouch Tumor Formation
+    treatment_effect: INHIBITS
+    description: >-
+      Local radiation delivered to the cystic tumor compartment aims to control
+      tumor progression while limiting broader exposure.
+  evidence:
+  - reference: PMID:38790011
+    reference_title: "Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of long-term follow-up."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Brachytherapy has been indicated as an alternative option for treating
+      cystic craniopharyngiomas (CPs).
+    explanation: >-
+      This systematic review and meta-analysis supports brachytherapy as an
+      option for cystic craniopharyngioma.
+  - reference: PMID:38790011
+    reference_title: "Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of long-term follow-up."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The results of the meta-analysis showed that 1-year, 2-3 years and 5 years
+      progression free survival rates (PFS) are 75% (95%CI: 66-84%), 62%
+      (95%CI: 52-72%) and 57% (95%CI: 22-92%), respectively.
+    explanation: >-
+      The pooled clinical-trial analysis provides long-term PFS estimates for
+      brachytherapy.
+clinical_trials:
+- name: NCT03224767
+  phase: PHASE_II
+  description: >-
+    Phase 2 Alliance study of vemurafenib plus cobimetinib for BRAF V600E
+    mutation-positive papillary craniopharyngioma.
+  evidence:
+  - reference: clinicaltrials:NCT03224767
+    reference_title: Phase II Trial of BRAF/MEK Inhibitors in Papillary Craniopharyngiomas
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This phase II trial studies how well vemurafenib and cobimetinib work in
+      treating patients with BRAF V600E mutation positive craniopharyngioma.
+    explanation: >-
+      The trial summary directly describes the BRAF/MEK inhibitor intervention
+      and disease genotype.
+- name: NCT05525273
+  phase: PHASE_II
+  description: >-
+    Phase 2 study of neoadjuvant and postoperative dabrafenib plus trametinib
+    for BRAF-mutated papillary craniopharyngioma.
+  evidence:
+  - reference: clinicaltrials:NCT05525273
+    reference_title: Neoadjuvant and Postoperative Treatment With Dabrafenib and Trametinib in BRAF Mutated Papillary Craniopharyngioma
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Subjects with papillary craniopharyngioma harboring a BRAF mutation will
+      be treated with a BRAF + MEK inhibitor (dabrafenib + trametinib) after
+      informed consent.
+    explanation: >-
+      The trial summary supports ongoing genotype-matched dabrafenib/trametinib
+      evaluation in papillary craniopharyngioma.
+- name: NCT05286788
+  phase: PHASE_II
+  description: >-
+    Phase 2 study of the MEK inhibitor binimetinib in recurrent pediatric
+    adamantinomatous craniopharyngioma after surgery and/or radiation therapy.
+  evidence:
+  - reference: clinicaltrials:NCT05286788
+    reference_title: Phase 2 Study of the MEK Inhibitor MEKTOVI® (Binimetinib) for the Treatment of Pediatric Adamantinomatous Craniopharyngioma
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In this Phase II, the drug will be used to treat pediatric patients
+      diagnosed with recurrent Adamantinomatous Craniopharyngioma including
+      patients who have undergone surgery and/or radiation therapy.
+    explanation: >-
+      The trial summary supports binimetinib as an active investigational ACP
+      treatment strategy.
+notes: >-
+  Falcon research and the fetched abstracts did not identify established
+  environmental, infectious, lifestyle, or inherited familial risk factors for
+  craniopharyngioma. Differential diagnosis of sellar/suprasellar masses was
+  not curated here because the Falcon report explicitly marked that evidence as
+  incomplete for this run.

--- a/kb/disorders/Craniopharyngioma.yaml
+++ b/kb/disorders/Craniopharyngioma.yaml
@@ -1,6 +1,6 @@
 name: Craniopharyngioma
 creation_date: "2026-05-11T17:51:07Z"
-updated_date: "2026-05-11T19:00:26Z"
+updated_date: "2026-05-11T19:12:44Z"
 synonyms:
 - Rathke pouch tumor
 - Rathke pouch neoplasm
@@ -397,6 +397,13 @@ pathophysiology:
     explanation: >-
       This adult precision-oncology review links BRAF V600E and CTNNB1 to the
       subtype-specific treatment paradigm.
+  downstream:
+  - target: Optic-Hypothalamic-Pituitary Mass Effect
+    causal_link_type: DIRECT
+    description: >-
+      BRAF V600E-driven MAPK activation leads to papillary craniopharyngioma
+      tumor growth in the sellar/suprasellar region, producing optic,
+      hypothalamic, and pituitary mass effect.
 phenotypes:
 - category: Neurological
   name: Headache

--- a/references_cache/PMID_29541918.md
+++ b/references_cache/PMID_29541918.md
@@ -1,0 +1,184 @@
+---
+reference_id: "PMID:29541918"
+title: Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+authors:
+- Apps JR
+- Carreno G
+- Gonzalez-Meljem JM
+- Haston S
+- Guiho R
+- Cooper JE
+- Manshaei S
+- Jani N
+- Hölsken A
+- Pettorini B
+- Beynon RJ
+- Simpson DM
+- Fraser HC
+- Hong Y
+- Hallang S
+- Stone TJ
+- Virasami A
+- Donson AM
+- Jones D
+- Aquilina K
+- Spoudeas H
+- Joshi AR
+- Grundy R
+- Storer LCD
+- Korbonits M
+- Hilton DA
+- Tossell K
+- Thavaraj S
+- Ungless MA
+- Gil J
+- Buslei R
+- Hankinson T
+- Hargrave D
+- Goding C
+- Andoniadou CL
+- Brogan P
+- Jacques TS
+- Williams HJ
+- Martinez-Barbera JP
+journal: Acta Neuropathol
+year: '2018'
+doi: 10.1007/s00401-018-1830-2
+keywords:
+- Animals
+- Computational Biology
+- "Craniopharyngioma/metabolism, pathology, therapy"
+- Cytokines/metabolism
+- "Disease Models, Animal"
+- Humans
+- "Inflammation/metabolism, therapy"
+- Laser Capture Microdissection
+- MAP Kinase Signaling System
+- Mice
+- Neuroglia/metabolism
+- Odontogenesis/physiology
+- "Pituitary Gland/embryology, pathology"
+- "Pituitary Neoplasms/metabolism, pathology, therapy"
+- "Sequence Analysis, RNA"
+- Tissue Culture Techniques
+- Transcriptome
+- Tumor Microenvironment/physiology
+content_type: abstract_only
+---
+
+# Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the MAPK/ERK pathway as a novel therapeutic target.
+**Authors:** Apps JR, Carreno G, Gonzalez-Meljem JM, Haston S, Guiho R, Cooper JE, Manshaei S, Jani N, Hölsken A, Pettorini B, Beynon RJ, Simpson DM, Fraser HC, Hong Y, Hallang S, Stone TJ, Virasami A, Donson AM, Jones D, Aquilina K, Spoudeas H, Joshi AR, Grundy R, Storer LCD, Korbonits M, Hilton DA, Tossell K, Thavaraj S, Ungless MA, Gil J, Buslei R, Hankinson T, Hargrave D, Goding C, Andoniadou CL, Brogan P, Jacques TS, Williams HJ, Martinez-Barbera JP
+**Journal:** Acta Neuropathol (2018)
+**DOI:** [10.1007/s00401-018-1830-2](https://doi.org/10.1007/s00401-018-1830-2)
+
+## Content
+
+1. Acta Neuropathol. 2018 May;135(5):757-777. doi: 10.1007/s00401-018-1830-2.
+Epub  2018 Mar 14.
+
+Tumour compartment transcriptomics demonstrates the activation of inflammatory 
+and odontogenic programmes in human adamantinomatous craniopharyngioma and 
+identifies the MAPK/ERK pathway as a novel therapeutic target.
+
+Apps JR(1)(2), Carreno G(3), Gonzalez-Meljem JM(3)(4), Haston S(3), Guiho R(3), 
+Cooper JE(3), Manshaei S(3), Jani N(5), Hölsken A(6), Pettorini B(7), Beynon 
+RJ(8), Simpson DM(8), Fraser HC(3), Hong Y(9), Hallang S(10), Stone TJ(3)(11), 
+Virasami A(11), Donson AM(12), Jones D(13), Aquilina K(14), Spoudeas H(15), 
+Joshi AR(16), Grundy R(17), Storer LCD(17), Korbonits M(18), Hilton DA(19), 
+Tossell K(20), Thavaraj S(21), Ungless MA(20), Gil J(20), Buslei R(6)(22), 
+Hankinson T(12), Hargrave D(23), Goding C(24), Andoniadou CL(25)(26), Brogan 
+P(9)(27), Jacques TS(3)(11), Williams HJ(5), Martinez-Barbera JP(28).
+
+Author information:
+(1)Developmental Biology and Cancer Programme, Birth Defects Research Centre, 
+UCL Great Ormond Street Institute of Child Health, University College London, 
+London, UK. j.apps@ucl.ac.uk.
+(2)Histopathology Department, Great Ormond Street Hospital NHS Trust, London, 
+UK. j.apps@ucl.ac.uk.
+(3)Developmental Biology and Cancer Programme, Birth Defects Research Centre, 
+UCL Great Ormond Street Institute of Child Health, University College London, 
+London, UK.
+(4)Basic Research Department, National Institute of Geriatrics, Mexico City, 
+Mexico.
+(5)Centre for Translational Omics-GOSgene, Genetics and Genomic Medicine 
+Programme, UCL Institute of Child Health, University College London, London, UK.
+(6)Department of Neuropathology, Friedrich-Alexander University 
+Erlangen-Nürnberg (FAU), Erlangen, Germany.
+(7)Alder Hey Children's Hospital NHS Foundation Trust, Liverpool, UK.
+(8)Centre for Proteome Research, Institute of Integrative Biology, University of 
+Liverpool, Liverpool, UK.
+(9)Infection, Immunity and Inflammation Programme, UCL Great Ormond Street 
+Institute of Child Health, University College London, London, UK.
+(10)Centre for Craniofacial and Regenerative Biology, King's College London, 
+London, UK.
+(11)Histopathology Department, Great Ormond Street Hospital NHS Trust, London, 
+UK.
+(12)Department of Pediatrics, University of Colorado Anschutz Medical Campus, 
+Aurora, CO, USA.
+(13)German Cancer Research Center (DKFZ), Heidelberg, Germany.
+(14)Neurosurgery Department, Great Ormond Street Hospital NHS Trust, London, UK.
+(15)Endocrinology Department, Great Ormond Street Hospital NHS Trust, London, 
+UK.
+(16)Laboratory Medicine, Royal Victoria Infirmary, Newcastle, UK.
+(17)Children's Brain Tumour Research Centre, University of Nottingham, 
+Nottingham, UK.
+(18)William Harvey Research Institute, Barts and the London School of Medicine 
+and Dentistry, Queen Mary University, London, UK.
+(19)Pathology Department, Plymouth Hospitals NHS Trust, Plymouth, UK.
+(20)MRC London Institute of Medical Sciences, Imperial College London, London, 
+UK.
+(21)Head and Neck Pathology, Dental Institute, King's College London, London, 
+UK.
+(22)Institute of Pathology, Klinikum Sozialstiftung Bamberg, Bamberg, Germany.
+(23)Haematology and Oncology Department, Great Ormond Street Hospital NHS Trust, 
+London, UK.
+(24)Ludwig Institute for Cancer Research, Oxford University, Old Road Campus, 
+Headington, Oxford, UK.
+(25)Centre for Craniofacial and Regenerative Biology, King's College London, 
+Guy's Hospital, Floor 27 Tower Wing, London, UK.
+(26)Department of Internal Medicine III, Technische Universität Dresden, 
+Fetscherstaße 74, 01307, Dresden, Germany.
+(27)Rheumatology Department, Great Ormond Street Hospital NHS Trust, London, UK.
+(28)Developmental Biology and Cancer Programme, Birth Defects Research Centre, 
+UCL Great Ormond Street Institute of Child Health, University College London, 
+London, UK. j.martinez-barbera@ucl.ac.uk.
+
+Adamantinomatous craniopharyngiomas (ACPs) are clinically challenging tumours, 
+the majority of which have activating mutations in CTNNB1. They are 
+histologically complex, showing cystic and solid components, the latter 
+comprised of different morphological cell types (e.g. β-catenin-accumulating 
+cluster cells and palisading epithelium), surrounded by a florid glial reaction 
+with immune cells. Here, we have carried out RNA sequencing on 18 ACP samples 
+and integrated these data with an existing ACP transcriptomic dataset. No 
+studies so far have examined the patterns of gene expression within the 
+different cellular compartments of the tumour. To achieve this goal, we have 
+combined laser capture microdissection with computational analyses to reveal 
+groups of genes that are associated with either epithelial tumour cells 
+(clusters and palisading epithelium), glial tissue or immune infiltrate. We use 
+these human ACP molecular signatures and RNA-Seq data from two ACP mouse models 
+to reveal that cell clusters are molecularly analogous to the enamel knot, a 
+critical signalling centre controlling normal tooth morphogenesis. Supporting 
+this finding, we show that human cluster cells express high levels of several 
+members of the FGF, TGFB and BMP families of secreted factors, which signal to 
+neighbouring cells as evidenced by immunostaining against the phosphorylated 
+proteins pERK1/2, pSMAD3 and pSMAD1/5/9 in both human and mouse ACP. We reveal 
+that inhibiting the MAPK/ERK pathway with trametinib, a clinically approved MEK 
+inhibitor, results in reduced proliferation and increased apoptosis in explant 
+cultures of human and mouse ACP. Finally, we analyse a prominent molecular 
+signature in the glial reactive tissue to characterise the inflammatory 
+microenvironment and uncover the activation of inflammasomes in human ACP. We 
+validate these results by immunostaining against immune cell markers, cytokine 
+ELISA and proteome analysis in both solid tumour and cystic fluid from ACP 
+patients. Our data support a new molecular paradigm for understanding ACP 
+tumorigenesis as an aberrant mimic of natural tooth development and opens new 
+therapeutic opportunities by revealing the activation of the MAPK/ERK and 
+inflammasome pathways in human ACP.
+
+DOI: 10.1007/s00401-018-1830-2
+PMCID: PMC5904225
+PMID: 29541918 [Indexed for MEDLINE]
+
+Conflict of interest statement: P.B. has received institutional grants from 
+SOBI, Roche and Novartis; consultancy fees from Roche; and lecturing fees from 
+SOBI and Novartis. The other authors declare that they have no conflict of 
+interest.

--- a/references_cache/PMID_31796950.md
+++ b/references_cache/PMID_31796950.md
@@ -1,0 +1,118 @@
+---
+reference_id: "PMID:31796950"
+title: "An epidemiology report for primary central nervous system tumors in adolescents and young adults: a nationwide population-based study in France, 2008-2013."
+authors:
+- Ng S
+- Zouaoui S
+- Bessaoud F
+- Rigau V
+- Roux A
+- Darlix A
+- Bauchet F
+- Mathieu-Daudé H
+- Trétarre B
+- Figarella-Branger D
+- Pallud J
+- Frappaz D
+- Roujeau T
+- Bauchet L
+journal: Neuro Oncol
+year: '2020'
+doi: 10.1093/neuonc/noz227
+keywords:
+- Adolescent
+- Adult
+- Age Distribution
+- Brain Neoplasms/epidemiology
+- Central Nervous System Neoplasms/epidemiology
+- Europe
+- Female
+- France/epidemiology
+- Humans
+- Incidence
+- Male
+- Young Adult
+content_type: abstract_only
+---
+
+# An epidemiology report for primary central nervous system tumors in adolescents and young adults: a nationwide population-based study in France, 2008-2013.
+**Authors:** Ng S, Zouaoui S, Bessaoud F, Rigau V, Roux A, Darlix A, Bauchet F, Mathieu-Daudé H, Trétarre B, Figarella-Branger D, Pallud J, Frappaz D, Roujeau T, Bauchet L
+**Journal:** Neuro Oncol (2020)
+**DOI:** [10.1093/neuonc/noz227](https://doi.org/10.1093/neuonc/noz227)
+
+## Content
+
+1. Neuro Oncol. 2020 Jun 9;22(6):851-863. doi: 10.1093/neuonc/noz227.
+
+An epidemiology report for primary central nervous system tumors in adolescents 
+and young adults: a nationwide population-based study in France, 2008-2013.
+
+Ng S(1), Zouaoui S(1), Bessaoud F(2), Rigau V(3), Roux A(4)(5), Darlix 
+A(6)(7)(8), Bauchet F(8), Mathieu-Daudé H(8)(9), Trétarre B(2), 
+Figarella-Branger D(10)(11), Pallud J(4)(5), Frappaz D(12), Roujeau T(1), 
+Bauchet L(1)(8)(13).
+
+Author information:
+(1)Department of Neurosurgery, Gui de Chauliac Hospital, University Hospital 
+Center (CHU) Montpellier, Montpellier University Medical Center, Montpellier, 
+France.
+(2)Tumor Registry of the Hérault, Institut du Cancer de Montpellier, 
+Montpellier, France.
+(3)Department of Neuropathology, Gui de Chauliac Hospital, CHU Montpellier, 
+Montpellier University Medical Center, Montpellier, France.
+(4)Department of Neurosurgery, University Hospital Group Paris, Sainte-Anne 
+Hospital, Paris, France.
+(5)Paris Descartes University, Imaging Biomarkers of Brain Disorders, Institute 
+of Psychiatry and Neurosciences of Paris, Paris, France.
+(6)Department of Medical Oncology, Institut du Cancer de Montpellier, 
+Montpellier, France.
+(7)University of Montpellier, Montpellier, France.
+(8)Neuro-Oncology Group of Languedoc Roussillon, Institut du Cancer de 
+Montpellier, Montpellier, France.
+(9)Department of Medical Informatics, Institut du Cancer de Montpellier, 
+Montpellier, France.
+(10)Aix-Marseille University, National Center for Scientific Research, Institute 
+of Neuro-Physiopathology, Marseille, France.
+(11)Department of Pathology and Neuropathology, Timone Hospital, Marseille, 
+France.
+(12)Institute of Pediatric Onco-Hematology, Lyon, France.
+(13)National Institute of Health and Medical Research unit 1051, Montpellier, 
+France.
+
+Comment in
+    Neuro Oncol. 2020 Jun 9;22(6):752-753. doi: 10.1093/neuonc/noaa079.
+
+BACKGROUND: Primary central nervous system tumors (PCNST) among adolescents and 
+young adults (AYA, 15-39 y) have rarely been reported. We present a nationwide 
+report of PCNST histologically confirmed in the French AYA population between 
+2008 and 2013.
+METHODS: Patients were identified through the French Brain Tumor Database 
+(FBTDB), a national dataset that includes prospectively all histologically 
+confirmed cases of PCNST in France. Patients aged 15 to 39 years with 
+histologically confirmed PCNST diagnosed between 2008 and 2013 were included. 
+For each of the 143 histological subtypes of PCNST, crude rates, sex, surgery, 
+and age distribution were provided. To enable international comparisons, 
+age-standardized incidence rates were adjusted to the world-standard, European, 
+and USA populations.
+RESULTS: For 6 years, 9661 PCNST (males/females: 4701/4960) were histologically 
+confirmed in the French AYA population. The overall crude rate was 8.15 per 
+100 000 person-years. Overall, age-standardized incidence rates were (per 
+100 000 person-years, population of reference: world/Europe/USA): 
+7.64/8.07/8.21, respectively. Among patients aged 15-24 years, the crude rate 
+was 5.13 per 100 000. Among patients aged 25-39 years, the crude rate was 10.10 
+per 100 000. Age-standardized incidence rates were reported for each of the 143 
+histological subtypes. Moreover, for each histological subtype, data were 
+detailed by sex, age, type of surgery (surgical resection or biopsy), and 
+cryopreserved samples.
+CONCLUSION: These data represent an exhaustive report of all histologically 
+confirmed cases of PCNST with their frequency and distribution in the French AYA 
+population in 2008-2013. For the first time in this age group, complete 
+histological subtypes and rare tumor identification are detailed.
+
+© The Author(s) 2019. Published by Oxford University Press on behalf of the 
+Society for Neuro-Oncology. All rights reserved. For permissions, please e-mail: 
+journals.permissions@oup.com.
+
+DOI: 10.1093/neuonc/noz227
+PMCID: PMC7283028
+PMID: 31796950 [Indexed for MEDLINE]

--- a/references_cache/PMID_36748936.md
+++ b/references_cache/PMID_36748936.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:36748936"
+title: The molecular pathogenesis of craniopharyngiomas.
+authors:
+- Campanini ML
+- Almeida JP
+- Martins CS
+- de Castro M
+journal: Arch Endocrinol Metab
+year: '2023'
+doi: 10.20945/2359-3997000000600
+keywords:
+- Adult
+- Child
+- Humans
+- "Craniopharyngioma/genetics, metabolism, pathology"
+- Pituitary Neoplasms/genetics
+- Mutation/genetics
+- Tumor Microenvironment
+content_type: abstract_only
+---
+
+# The molecular pathogenesis of craniopharyngiomas.
+**Authors:** Campanini ML, Almeida JP, Martins CS, de Castro M
+**Journal:** Arch Endocrinol Metab (2023)
+**DOI:** [10.20945/2359-3997000000600](https://doi.org/10.20945/2359-3997000000600)
+
+## Content
+
+1. Arch Endocrinol Metab. 2023 Mar 10;67(2):266-275. doi: 
+10.20945/2359-3997000000600. Epub 2023 Feb 7.
+
+The molecular pathogenesis of craniopharyngiomas.
+
+Campanini ML(1), Almeida JP(2), Martins CS(3)(4), de Castro M(3).
+
+Author information:
+(1)Departamento de Clínica Médica, Faculdade de Medicina de Ribeirão Preto, 
+Universidade de São Paulo, Ribeirão Preto, SP, Brasil, mlanciotti@gmail.com.
+(2)Department of Neurosurgery, Mayo Clinic, Jacksonville, FL, United States.
+(3)Departamento de Clínica Médica, Faculdade de Medicina de Ribeirão Preto, 
+Universidade de São Paulo, Ribeirão Preto, SP, Brasil.
+(4)Faculdade de Medicina, Universidade Federal do Mato Grosso do Sul, Campo 
+Grande, RS, Brasil.
+
+Research from the last 20 years has provided important insights into the 
+molecular pathogenesis of craniopharyngiomas (CPs). Besides the well-known 
+clinical and histological differences between the subtypes of CPs, 
+adamantinomatous (ACP) and papillary (PCP) craniopharyngiomas, other molecular 
+differences have been identified, further elucidating pathways related to the 
+origin and development of such tumors. The present minireview assesses current 
+knowledge on embryogenesis and the genetic, epigenetic, transcriptomic, and 
+signaling pathways involved in the ACP and PCP subtypes, revealing the 
+similarities and differences in their profiles. ACP and PCP subtypes can be 
+identified by the presence of mutations in CTNNB1 and BRAF genes, with 
+prevalence around 60% and 90%, respectively. Therefore, β-catenin accumulates in 
+the nucleus-cytoplasm of cell clusters in ACPs and, in PCPs, cell immunostaining 
+with specific antibody against the V600E-mutated protein can be seen. Distinct 
+patterns of DNA methylation further differentiate ACPs and PCPs. In addition, 
+research on genetic and epigenetic changes and tumor microenvironment 
+specificities have further clarified the development and progression of the 
+disease. No relevant transcriptional differences in ACPs have emerged between 
+children and adults. In conclusion, ACPs and PCPs present diverse genetic 
+signatures and each subtype is associated with specific signaling pathways. A 
+better understanding of the pathways related to the growth of such tumors is 
+paramount for the development of novel targeted therapeutic agents.
+
+DOI: 10.20945/2359-3997000000600
+PMCID: PMC10689043
+PMID: 36748936 [Indexed for MEDLINE]
+
+Conflict of interest statement: Disclosure: no potential conflict of interest 
+relevant to this article was reported.

--- a/references_cache/PMID_36979325.md
+++ b/references_cache/PMID_36979325.md
@@ -1,0 +1,68 @@
+---
+reference_id: "PMID:36979325"
+title: "Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature."
+authors:
+- Jannelli G
+- Calvanese F
+- Paun L
+- Raverot G
+- Jouanneau E
+journal: Brain Sci
+year: '2023'
+doi: 10.3390/brainsci13030515
+content_type: abstract_only
+---
+
+# Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and Overview of the Literature.
+**Authors:** Jannelli G, Calvanese F, Paun L, Raverot G, Jouanneau E
+**Journal:** Brain Sci (2023)
+**DOI:** [10.3390/brainsci13030515](https://doi.org/10.3390/brainsci13030515)
+
+## Content
+
+1. Brain Sci. 2023 Mar 20;13(3):515. doi: 10.3390/brainsci13030515.
+
+Current Advances in Papillary Craniopharyngioma: State-Of-The-Art Therapies and 
+Overview of the Literature.
+
+Jannelli G(#)(1)(2), Calvanese F(#)(1)(3), Paun L(2)(4), Raverot G(5)(6), 
+Jouanneau E(1)(6).
+
+Author information:
+(1)Skull Base and Pituitary Unit, Department of Neurosurgery B, Neurological 
+Hospital Pierre Wertheimer, Bron, 69677 Lyon, France.
+(2)Neurosurgical Unit, Faculty of Medicine, Geneva University Hospitals, 
+University of Geneva, 1205 Geneva, Switzerland.
+(3)Department of Neurosurgery, Helsinki University Central Hospital, Helsinki 
+University, Meilahden tornisairaala, Haartmaninkatu 4 Rakennus 1, 00290 
+Helsinki, Finland.
+(4)Department of Neurosurgery, GHU-Paris Psychiatrie et Neurosciences, Hôpital 
+Sainte Anne, 1 Rue Cabanis, CEDEX 14, 75014 Paris, France.
+(5)Department of Endocrinology, Neurological Hospital Pierre Wertheimer, 
+University Hospital of Lyon, 69500 Lyon, France.
+(6)Inserm U1052, CNRS UMR5286, Cancer Research Center of Lyon, University Claude 
+Bernard Lyon 1, 69000 Lyon, France.
+(#)Contributed equally
+
+Craniopharyngiomas are commonly classified as low-grade tumors, although they 
+may harbor a malignant behavior due to their high rate of recurrence and 
+long-term morbidity. Craniopharyngiomas are classically distinguished into two 
+histological types (adamantinomatous and papillary), which have been recently 
+considered by the WHO classification of CNS tumors as two independent entities, 
+due to different epidemiological, radiological, histopathological, and genetic 
+patterns. With regard to papillary craniopharyngioma, a BRAF V600 mutation is 
+detected in 95% of cases. This genetic feature is opening new frontiers in the 
+treatment of these tumors using an adjuvant or, in selected cases, a 
+neo-adjuvant approach. In this article, we present an overview of the more 
+recent literature, focusing on the specificities and the role of oncological 
+treatment in the management of papillary craniopharyngiomas. Based on our 
+research and experience, we strongly suggest a multimodal approach combining 
+clinical, endocrinological, radiological, histological, and oncological findings 
+in both preoperative workup and postoperative follow up to define a roadmap 
+integrating every aspect of this challenging condition.
+
+DOI: 10.3390/brainsci13030515
+PMCID: PMC10046497
+PMID: 36979325
+
+Conflict of interest statement: The authors declare no conflict of interest.

--- a/references_cache/PMID_37437144.md
+++ b/references_cache/PMID_37437144.md
@@ -1,0 +1,124 @@
+---
+reference_id: "PMID:37437144"
+title: BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+authors:
+- Brastianos PK
+- Twohy E
+- Geyer S
+- Gerstner ER
+- Kaufmann TJ
+- Tabrizi S
+- Kabat B
+- Thierauf J
+- Ruff MW
+- Bota DA
+- Reardon DA
+- Cohen AL
+- De La Fuente MI
+- Lesser GJ
+- Campian J
+- Agarwalla PK
+- Kumthekar P
+- Mann B
+- Vora S
+- Knopp M
+- Iafrate AJ
+- Curry WT Jr
+- Cahill DP
+- Shih HA
+- Brown PD
+- Santagata S
+- Barker FG 2nd
+- Galanis E
+journal: N Engl J Med
+year: '2023'
+doi: 10.1056/NEJMoa2213329
+keywords:
+- Humans
+- "Craniopharyngioma/drug therapy, genetics"
+- Disease Progression
+- "Mitogen-Activated Protein Kinase Kinases/antagonists & inhibitors, genetics"
+- "Pituitary Neoplasms/drug therapy, genetics"
+- "Proto-Oncogene Proteins B-raf/antagonists & inhibitors, genetics"
+- "Vemurafenib/adverse effects, therapeutic use"
+- "Antineoplastic Agents/adverse effects, therapeutic use"
+- Remission Induction
+- Azetidines
+- Piperidines
+content_type: abstract_only
+---
+
+# BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+**Authors:** Brastianos PK, Twohy E, Geyer S, Gerstner ER, Kaufmann TJ, Tabrizi S, Kabat B, Thierauf J, Ruff MW, Bota DA, Reardon DA, Cohen AL, De La Fuente MI, Lesser GJ, Campian J, Agarwalla PK, Kumthekar P, Mann B, Vora S, Knopp M, Iafrate AJ, Curry WT Jr, Cahill DP, Shih HA, Brown PD, Santagata S, Barker FG 2nd, Galanis E
+**Journal:** N Engl J Med (2023)
+**DOI:** [10.1056/NEJMoa2213329](https://doi.org/10.1056/NEJMoa2213329)
+
+## Content
+
+1. N Engl J Med. 2023 Jul 13;389(2):118-126. doi: 10.1056/NEJMoa2213329.
+
+BRAF-MEK Inhibition in Newly Diagnosed Papillary Craniopharyngiomas.
+
+Brastianos PK(1), Twohy E(1), Geyer S(1), Gerstner ER(1), Kaufmann TJ(1), 
+Tabrizi S(1), Kabat B(1), Thierauf J(1), Ruff MW(1), Bota DA(1), Reardon DA(1), 
+Cohen AL(1), De La Fuente MI(1), Lesser GJ(1), Campian J(1), Agarwalla PK(1), 
+Kumthekar P(1), Mann B(1), Vora S(1), Knopp M(1), Iafrate AJ(1), Curry WT Jr(1), 
+Cahill DP(1), Shih HA(1), Brown PD(1), Santagata S(1), Barker FG 2nd(1), Galanis 
+E(1).
+
+Author information:
+(1)From Massachusetts General Hospital Cancer Center, Harvard Medical School 
+(P.K.B., E.R.G., S.T., J.T., A.J.I., W.T.C., D.P.C., H.A.S., F.G.B.), 
+Dana-Farber Cancer Institute (D.A.R.), and Brigham and Women's Hospital, Harvard 
+Program in Therapeutic Science, Dana-Farber Partners CancerCare (S.S.) - all in 
+Boston; Alliance Statistics and Data Management Center (E.T., S.G., B.K.), Mayo 
+Clinic (T.J.K., M.W.R., P.D.B., E.G.), Rochester, MN; UC Irvine-Chao Family 
+Comprehensive Cancer Center, Orange, CA (D.A.B.); Huntsman Cancer Institute, 
+University of Utah, Salt Lake City (A.L.C.); Sylvester Comprehensive Cancer 
+Center, University of Miami Miller School of Medicine, Miami (M.I.D.L.F.); Wake 
+Forest University School of Medicine, Winston-Salem, NC (G.J.L.); Washington 
+University School of Medicine, St. Louis (J.C.); Rutgers Cancer Institute, New 
+Brunswick, NJ (P.K.A.); Northwestern University, Chicago (P.K.); the Cancer 
+Therapy Evaluation Program, National Cancer Institute, Bethesda, MD (B.M.); and 
+Ohio State University Comprehensive Cancer Center, Columbus (S.V., M.K.).
+
+Comment in
+    Cancer Discov. 2023 Sep 6;13(9):1960. doi: 10.1158/2159-8290.CD-RW2023-116.
+
+BACKGROUND: Craniopharyngiomas, primary brain tumors of the 
+pituitary-hypothalamic axis, can cause clinically significant sequelae. 
+Treatment with the use of surgery, radiation, or both is often associated with 
+substantial morbidity related to vision loss, neuroendocrine dysfunction, and 
+memory loss. Genotyping has shown that more than 90% of papillary 
+craniopharyngiomas carry BRAF V600E mutations, but data are lacking with regard 
+to the safety and efficacy of BRAF-MEK inhibition in patients with papillary 
+craniopharyngiomas who have not undergone previous radiation therapy.
+METHODS: Eligible patients who had papillary craniopharyngiomas that tested 
+positive for BRAF mutations, had not undergone radiation therapy previously, and 
+had measurable disease received the BRAF-MEK inhibitor combination 
+vemurafenib-cobimetinib in 28-day cycles. The primary end point of this 
+single-group, phase 2 study was objective response at 4 months as determined 
+with the use of centrally determined volumetric data.
+RESULTS: Of the 16 patients in the study, 15 (94%; 95% confidence interval [CI], 
+70 to 100) had a durable objective partial response or better to therapy. The 
+median reduction in the volume of the tumor was 91% (range, 68 to 99). The 
+median follow-up was 22 months (95% CI, 19 to 30) and the median number of 
+treatment cycles was 8. Progression-free survival was 87% (95% CI, 57 to 98) at 
+12 months and 58% (95% CI, 10 to 89) at 24 months. Three patients had disease 
+progression during follow-up after therapy had been discontinued; none have 
+died. The sole patient who did not have a response stopped treatment after 8 
+days owing to toxic effects. Grade 3 adverse events that were at least possibly 
+related to treatment occurred in 12 patients, including rash in 6 patients. In 2 
+patients, grade 4 adverse events (hyperglycemia in 1 patient and increased 
+creatine kinase levels in 1 patient) were reported; 3 patients discontinued 
+treatment owing to adverse events.
+CONCLUSIONS: In this small, single-group study involving patients with papillary 
+craniopharyngiomas, 15 of 16 patients had a partial response or better to the 
+BRAF-MEK inhibitor combination vemurafenib-cobimetinib. (Funded by the National 
+Cancer Institute and others; ClinicalTrials.gov number, NCT03224767.).
+
+Copyright © 2023 Massachusetts Medical Society.
+
+DOI: 10.1056/NEJMoa2213329
+PMCID: PMC10464854
+PMID: 37437144 [Indexed for MEDLINE]

--- a/references_cache/PMID_37565822.md
+++ b/references_cache/PMID_37565822.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:37565822"
+title: Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
+authors:
+- Wang X
+- Zhao C
+- Lin J
+- Liu H
+- Zeng Q
+- Chen H
+- Wang Y
+- Xu D
+- Chen W
+- Xu M
+- Zhang E
+- Lin D
+- Lin Z
+journal: Chin Med J (Engl)
+year: '2024'
+doi: 10.1097/CM9.0000000000002774
+keywords:
+- Humans
+- Child
+- "Craniopharyngioma/genetics, metabolism, pathology"
+- Prognosis
+- Multiomics
+- "Pituitary Neoplasms/genetics, pathology"
+- Wnt Signaling Pathway
+content_type: abstract_only
+---
+
+# Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance.
+**Authors:** Wang X, Zhao C, Lin J, Liu H, Zeng Q, Chen H, Wang Y, Xu D, Chen W, Xu M, Zhang E, Lin D, Lin Z
+**Journal:** Chin Med J (Engl) (2024)
+**DOI:** [10.1097/CM9.0000000000002774](https://doi.org/10.1097/CM9.0000000000002774)
+
+## Content
+
+1. Chin Med J (Engl). 2024 Apr 5;137(7):859-870. doi:
+10.1097/CM9.0000000000002774.  Epub 2023 Aug 11.
+
+Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct 
+molecular subgroups with prognostic and treatment response significance.
+
+Wang X(1), Zhao C(2), Lin J(1), Liu H(2), Zeng Q(1), Chen H(1), Wang Y(2), Xu 
+D(1), Chen W(1), Xu M(1), Zhang E(1), Lin D(2), Lin Z(2).
+
+Author information:
+(1)Department of Bioinformatics, School of Medical Technology and Engineering, 
+Key Laboratory of Medical Bioinformatics, Key Laboratory of Ministry of 
+Education for Gastrointestinal Cancer, Fujian Medical University, Fuzhou, Fujian 
+350122, China.
+(2)Department of Neurosurgery, Sanbo Brain Hospital, Capital Medical University, 
+Beijing 100093, China.
+
+BACKGROUND: Adamantinomatous craniopharyngioma (ACP) is the commonest pediatric 
+sellar tumor. No effective drug is available and interpatient heterogeneity is 
+prominent. This study aimed to identify distinct molecular subgroups of ACP 
+based on the multi-omics profiles, imaging findings, and histological features, 
+in order to predict the response to anti-inflammatory treatment and 
+immunotherapies.
+METHODS: Totally 142 Chinese cases diagnosed with craniopharyngiomas were 
+profiled, including 119 ACPs and 23 papillary craniopharyngiomas. Whole-exome 
+sequencing (151 tumors, including recurrent ones), RNA sequencing (84 tumors), 
+and DNA methylome profiling (95 tumors) were performed. Consensus clustering and 
+non-negative matrix factorization were used for subgrouping, and Cox regression 
+were utilized for prognostic evaluation, respectively.
+RESULTS: Three distinct molecular subgroups were identified: WNT, ImA, and ImB. 
+The WNT subgroup showed higher Wnt/β-catenin pathway activity, with a greater 
+number of epithelial cells and more predominantly solid tumors. The ImA and ImB 
+subgroups had activated inflammatory and interferon response pathways, with 
+enhanced immune cell infiltration and more predominantly cystic tumors. 
+Mitogen-activated protein kinases (MEK/MAPK) signaling was activated only in ImA 
+samples, while IL-6 and epithelial-mesenchymal transition biomarkers were highly 
+expressed in the ImB group, mostly consisting of children. The degree of 
+astrogliosis was significantly elevated in the ImA group, with severe 
+finger-like protrusions at the invasive front of the tumor. The molecular 
+subgrouping was an independent prognostic factor, with the WNT group having 
+longer event-free survival than ImB (Cox, P = 0.04). ImA/ImB cases were more 
+likely to respond to immune checkpoint blockade (ICB) therapy than the WNT group 
+( P <0.01). In the preliminary screening of subtyping markers, CD38 was 
+significantly downregulated in WNT compared with ImA and ImB ( P = 0.01).
+CONCLUSIONS: ACP comprises three molecular subtypes with distinct imaging and 
+histological features. The prognosis of the WNT type is better than that of the 
+ImB group, which is more likely to benefit from the ICB treatment.
+
+Copyright © 2024 The Chinese Medical Association, produced by Wolters Kluwer, 
+Inc. under the CC-BY-NC-ND license.
+
+DOI: 10.1097/CM9.0000000000002774
+PMCID: PMC10997223
+PMID: 37565822 [Indexed for MEDLINE]
+
+Conflict of interest statement: None.

--- a/references_cache/PMID_38790011.md
+++ b/references_cache/PMID_38790011.md
@@ -1,0 +1,90 @@
+---
+reference_id: "PMID:38790011"
+title: "Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of long-term follow-up."
+authors:
+- Zhang LY
+- Guo W
+- Du HZ
+- Pan H
+- Sun YC
+- Zhu HJ
+- Song SH
+- Guo XY
+- Jiang Y
+- Sun QQ
+journal: BMC Cancer
+year: '2024'
+doi: 10.1186/s12885-024-12397-1
+keywords:
+- Humans
+- "Brachytherapy/methods, adverse effects"
+- Craniopharyngioma/radiotherapy
+- Follow-Up Studies
+- Pituitary Neoplasms/radiotherapy
+- Progression-Free Survival
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of long-term follow-up.
+**Authors:** Zhang LY, Guo W, Du HZ, Pan H, Sun YC, Zhu HJ, Song SH, Guo XY, Jiang Y, Sun QQ
+**Journal:** BMC Cancer (2024)
+**DOI:** [10.1186/s12885-024-12397-1](https://doi.org/10.1186/s12885-024-12397-1)
+
+## Content
+
+1. BMC Cancer. 2024 May 24;24(1):637. doi: 10.1186/s12885-024-12397-1.
+
+Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of 
+long-term follow-up.
+
+Zhang LY(#)(1), Guo W(#)(2), Du HZ(#)(1), Pan H(3), Sun YC(4), Zhu HJ(1), Song 
+SH(1), Guo XY(1), Jiang Y(1), Sun QQ(5).
+
+Author information:
+(1)Department of Endocrinology, Key Laboratory of Endocrinology of National 
+Health Commission, State Key Laboratory of Complex Severe and Rare Diseases, 
+Peking Union Medical College Hospital, Chinese Academy of Medical Science and 
+Peking Union Medical College, Beijing, 100730, China.
+(2)Department of Radiation Oncology, Hebei Province Cangzhou Hospital of 
+Integrated Traditional and Western Medicine, Cangzhou Hebei, Hebei, 061000, 
+China.
+(3)Department of Endocrinology, Key Laboratory of Endocrinology of National 
+Health Commission, State Key Laboratory of Complex Severe and Rare Diseases, 
+Peking Union Medical College Hospital, Chinese Academy of Medical Science and 
+Peking Union Medical College, Beijing, 100730, China. panhui20111111@163.com.
+(4)Department of Radiation Oncology, Hebei Province Cangzhou Hospital of 
+Integrated Traditional and Western Medicine, Cangzhou Hebei, Hebei, 061000, 
+China. doctorsunyc@126.com.
+(5)Department of Endocrinology, The ninth Hospital of Xingtai, Xingtai, Hebei, 
+055250, China.
+(#)Contributed equally
+
+OBJECTIVE: Brachytherapy has been indicated as an alternative option for 
+treating cystic craniopharyngiomas (CPs). The potential benefits of 
+brachytherapy for CPs have not yet been clarified. The purpose of this work was 
+to conduct a meta-analysis to analyze the long-term efficacy and adverse 
+reactions profile of brachytherapy for CPs.
+MATERIALS AND METHODS: The relevant databases were searched to collect the 
+clinical trials on brachytherapy in patients with CPs. Included studies were 
+limited to publications in full manuscript form with at least 5-year median 
+follow-up, and adequate reporting of treatment outcomes and adverse reactions 
+data. Stata 12.0 was used for data analysis.
+RESULTS: According to the inclusion and exclusion criteria, a total of 6 
+clinical trials involving 266 patients with CPs were included in this 
+meta-analysis. The minimum average follow-up was 5 years. The results of the 
+meta-analysis showed that 1-year, 2-3 years and 5 years progression free 
+survival rates (PFS) are 75% (95%CI: 66-84%), 62% (95%CI: 52-72%) and 57% 
+(95%CI: 22-92%), respectively. At the last follow-up, less than 16% of patients 
+with visual outcomes worser than baseline in all included studies. While, for 
+endocrine outcomes, less than 32% of patients worser than baseline level.
+CONCLUSION: In general, based on the above results, brachytherapy should be 
+considered as a good choice for the treatment of CP.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s12885-024-12397-1
+PMCID: PMC11127349
+PMID: 38790011 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no competing interests.

--- a/references_cache/PMID_38961911.md
+++ b/references_cache/PMID_38961911.md
@@ -1,0 +1,80 @@
+---
+reference_id: "PMID:38961911"
+title: "Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective."
+authors:
+- Alboqami MN
+- Khalid S Albaiahy A
+- Bukhari BH
+- Alkhaibary A
+- Alharbi A
+- Khairy S
+- Alassiri AH
+- AlSufiani F
+- Alkhani A
+- Aloraidi A
+journal: Heliyon
+year: '2024'
+doi: 10.1016/j.heliyon.2024.e32112
+content_type: abstract_only
+---
+
+# Craniopharyngioma: A comprehensive review of the clinical presentation, radiological findings, management, and future Perspective.
+**Authors:** Alboqami MN, Khalid S Albaiahy A, Bukhari BH, Alkhaibary A, Alharbi A, Khairy S, Alassiri AH, AlSufiani F, Alkhani A, Aloraidi A
+**Journal:** Heliyon (2024)
+**DOI:** [10.1016/j.heliyon.2024.e32112](https://doi.org/10.1016/j.heliyon.2024.e32112)
+
+## Content
+
+1. Heliyon. 2024 May 31;10(11):e32112. doi: 10.1016/j.heliyon.2024.e32112. 
+eCollection 2024 Jun 15.
+
+Craniopharyngioma: A comprehensive review of the clinical presentation, 
+radiological findings, management, and future Perspective.
+
+Alboqami MN(1)(2), Khalid S Albaiahy A(1)(2), Bukhari BH(1)(2), Alkhaibary 
+A(1)(2)(3), Alharbi A(1)(2)(3), Khairy S(1)(2)(3), Alassiri AH(1)(2)(4), 
+AlSufiani F(2)(4), Alkhani A(2)(3), Aloraidi A(1)(2)(3).
+
+Author information:
+(1)College of Medicine, King Saud bin Abdulaziz University for Health Sciences, 
+Riyadh, Saudi Arabia.
+(2)King Abdullah International Medical Research Center, Riyadh, Saudi Arabia.
+(3)Division of Neurosurgery, Department of Surgery, King Abdulaziz Medical City, 
+Ministry of National Guard - Health Affairs, Riyadh, Saudi Arabia.
+(4)Department of Pathology and Laboratory Medicine, King Abdulaziz Medical City, 
+Ministry of National Guard - Health Affairs, Riyadh, Saudi Arabia.
+
+Craniopharyngioma (CP) is a rare intracranial tumor arising from the epithelial 
+remnants of Rathke's pouch, most frequently originating in the sellar/parasellar 
+region. Histologically, CP is a benign low-grade tumor (WHO grade 1) with two 
+distinct phenotypes: adamantinomatous CP (ACP) and papillary CP (PCP). 
+Craniopharyngioma constitutes 1-3% of all primary intracranial tumors in adults 
+and 5-10 % of intracranial tumors in children. The annual incidence ranges from 
+0.13 to 2 per 100,000 population per year with no gender predilection. Due to 
+its unique anatomical locations, the most frequently reported clinical 
+manifestations are headache, visual impairment, nausea/vomiting, and endocrine 
+deficiencies resulting in sexual dysfunction in adults and growth failure in 
+children. Growth hormone deficiency is the most predominant endocrinological 
+disturbance associated with craniopharyngioma. Computed tomography (CT) is gold 
+standard to detect calcifications in CP tissue (found in 90 % of these tumors). 
+Magnetic Resonance Imaging (MRI) further characterizes craniopharyngiomas and 
+helps to narrow down the differential diagnoses. In almost all craniopharyngioma 
+cases, surgery is indicated to: establish the diagnosis, relieve mass-related 
+symptoms, and remove as much tumor as is safely possible. Recent neurosurgical 
+technical advances, including innovative surgical approaches, detailed 
+radiotherapy protocols, targeted therapy, replacement of lost hormonal functions 
+and quality of life all have the potential to improve the outcome of patients 
+with craniopharyngioma. In this article, we present extensive literature on 
+craniopharyngioma clinical presentation, radiological findings, management, and 
+future prospective. The present article helps to identify further research areas 
+that set the basis for the management of such a complex tumor.
+
+© 2024 The Authors.
+
+DOI: 10.1016/j.heliyon.2024.e32112
+PMCID: PMC11219339
+PMID: 38961911
+
+Conflict of interest statement: The authors declare that they have no known 
+competing financial interests or personal relationships that could have appeared 
+to influence the work reported in this paper.

--- a/references_cache/PMID_39456573.md
+++ b/references_cache/PMID_39456573.md
@@ -1,0 +1,100 @@
+---
+reference_id: "PMID:39456573"
+title: "Update on Neoadjuvant and Adjuvant BRAF Inhibitors in Papillary Craniopharyngioma: A Systematic Review."
+authors:
+- Cossu G
+- Ramsay DSC
+- Daniel RT
+- El Cadhi A
+- Kerherve L
+- Morlaix E
+- Houidi SA
+- Millot-Piccoli C
+- Chapon R
+- Le Van T
+- Cao C
+- Farah W
+- Lleu M
+- Baland O
+- Beaurain J
+- Petit JM
+- Lemogne B
+- Messerer M
+- Berhouma M
+journal: Cancers (Basel)
+year: '2024'
+doi: 10.3390/cancers16203479
+content_type: abstract_only
+---
+
+# Update on Neoadjuvant and Adjuvant BRAF Inhibitors in Papillary Craniopharyngioma: A Systematic Review.
+**Authors:** Cossu G, Ramsay DSC, Daniel RT, El Cadhi A, Kerherve L, Morlaix E, Houidi SA, Millot-Piccoli C, Chapon R, Le Van T, Cao C, Farah W, Lleu M, Baland O, Beaurain J, Petit JM, Lemogne B, Messerer M, Berhouma M
+**Journal:** Cancers (Basel) (2024)
+**DOI:** [10.3390/cancers16203479](https://doi.org/10.3390/cancers16203479)
+
+## Content
+
+1. Cancers (Basel). 2024 Oct 14;16(20):3479. doi: 10.3390/cancers16203479.
+
+Update on Neoadjuvant and Adjuvant BRAF Inhibitors in Papillary 
+Craniopharyngioma: A Systematic Review.
+
+Cossu G(1)(2), Ramsay DSC(3)(4), Daniel RT(1), El Cadhi A(2), Kerherve L(2), 
+Morlaix E(2), Houidi SA(2), Millot-Piccoli C(2), Chapon R(2), Le Van T(2), Cao 
+C(2), Farah W(2), Lleu M(2), Baland O(2), Beaurain J(2), Petit JM(5), Lemogne 
+B(6), Messerer M(1), Berhouma M(2)(7).
+
+Author information:
+(1)Department of Neurosurgery, University Hospital of Lausanne and University of 
+Lausanne, 1011 Lausanne, Switzerland.
+(2)Department of Neurosurgery, University Hospital of Dijon Bourgogne, 21000 
+Dijon, France.
+(3)Imperial Brain and Spine Initiative, London W2 1NY, UK.
+(4)Imperial College School of Medicine, London W2 1PG, UK.
+(5)Department of Endocrinology, University Hospital of Dijon Bourgogne, 21000 
+Dijon, France.
+(6)Department of Neuroradiology, University Hospital of Dijon Bourgogne, 21000 
+Dijon, France.
+(7)Functional and Molecular Imaging Team (CNRS 6302), Molecular Chemistry 
+Institute (ICMUB), University of Burgundy, 21078 Dijon, France.
+
+Background/Objectives: The recent discovery of BRAF mutation in papillary 
+craniopharyngiomas opened new avenues for targeted therapies to control tumour 
+growth, decreasing the need for invasive treatments and relative complications. 
+The aim of this systematic review was to summarize the recent scientific data 
+dealing with the use of targeted therapies in papillary craniopharyngiomas, as 
+adjuvant and neoadjuvant treatments. Methods: The PRISMA guidelines were 
+followed with searches performed in Scopus, MEDLINE, and Embase, following a 
+dedicated PICO approach. Results: We included 21 pertinent studies encompassing 
+53 patients: 26 patients received BRAF inhibitors (BRAFi) as adjuvant treatment, 
+while 25 received them as neoadjuvant treatment. In the adjuvant setting, BRAFi 
+were used to treat recurrent tumours after surgery or adjuvant radiation 
+therapy. The most common regimen combined dabrafenib (BRAFi) with trametinib 
+(MEK1 and 2 inhibitor) in 81% of cases. The mean treatment length was 8.8 months 
+(range 1.6 to 28 months) and 32% were continuing BRAFi. A reduction of tumour 
+volume variable from 24% to 100% was observed at cerebral MRI during treatment 
+and volumetric reduction ≥80% was described in 64% of cases. Once the treatment 
+was stopped, adjuvant treatments were performed to stabilize patients in 
+remission in 11 cases (65%) or when a progression was detected in three cases 
+(12%). In four cases no further therapies were administered (16%). Mean 
+follow-up after the end of targeted therapy was 17.1 months. As neoadjuvant 
+regimen, 36% of patients were treated with dabrafenib and trametinib with a near 
+complete radiological response in all the cases with a mean treatment of 5.7 
+months. The neoadjuvant use of verumafenib (BRAFi) and cometinib (MEK1 
+inhibitor) induced a near complete response in 15 patients (94%), with a median 
+volumetric reduction between 85% and 91%. Ten patients did not receive further 
+treatments. Side effects varied among studies. The optimal timing, sequencing, 
+and duration of treatment of these new therapies should be established. 
+Moreover, questions remain about the choice of specific BRAF/MEK inhibitors, the 
+optimal protocol of treatment, and the strategies for managing adverse events. 
+Conclusions: Treatment is shifting to a wider multidisciplinary management, 
+where a key role is played by targeted therapies, to improve outcomes and 
+quality of life for patients with BRAF-mutated craniopharyngiomas. Future, 
+larger comparative trials will optimize their protocol of use and integration 
+into multimodal strategies of treatment.
+
+DOI: 10.3390/cancers16203479
+PMCID: PMC11506763
+PMID: 39456573
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_39634188.md
+++ b/references_cache/PMID_39634188.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:39634188"
+title: Practical application of precision oncology in adult onset craniopharyngiomas.
+authors:
+- Biswas C
+- Mansur G
+- Wu KC
+- Prevedello DM
+- Ghalib L
+journal: Front Endocrinol (Lausanne)
+year: '2024'
+doi: 10.3389/fendo.2024.1488958
+keywords:
+- Adult
+- Humans
+- Age of Onset
+- "Craniopharyngioma/diagnosis, genetics, pathology, therapy"
+- Medical Oncology/methods
+- Molecular Targeted Therapy/methods
+- Mutation
+- "Pituitary Neoplasms/therapy, genetics, pathology, diagnosis"
+- Precision Medicine/methods
+- Proto-Oncogene Proteins B-raf/genetics
+content_type: abstract_only
+---
+
+# Practical application of precision oncology in adult onset craniopharyngiomas.
+**Authors:** Biswas C, Mansur G, Wu KC, Prevedello DM, Ghalib L
+**Journal:** Front Endocrinol (Lausanne) (2024)
+**DOI:** [10.3389/fendo.2024.1488958](https://doi.org/10.3389/fendo.2024.1488958)
+
+## Content
+
+1. Front Endocrinol (Lausanne). 2024 Nov 20;15:1488958. doi: 
+10.3389/fendo.2024.1488958. eCollection 2024.
+
+Practical application of precision oncology in adult onset craniopharyngiomas.
+
+Biswas C(1), Mansur G(1), Wu KC(1), Prevedello DM(1), Ghalib L(2).
+
+Author information:
+(1)Department of Neurologic Surgery, The Ohio State University Wexner Medical 
+Centre, Columbus, OH, United States.
+(2)Division of Endocrinology, Diabetes and Metabolism, Department of Internal 
+Medicine, The Ohio State University Wexner Medical Centre, Columbus, OH, United 
+States.
+
+INTRODUCTION: Craniopharyngiomas (CPs) are benign and rare tumors found in 
+adults. Their location close to vital neurovascular structures makes traditional 
+treatment modalities (surgery and radiation) challenging and potentially fraught 
+with morbidity. The 2021 WHO classification has divided what was previously 
+considered two subtypes of craniopharyngioma into separate entities. 
+Identification of specific molecular driver mutations in each type- BRAF V600E 
+in papillary craniopharyngiomas (PCP) and CTNNB1 in adamantinomatous 
+craniopharyngiomas (ACP) has resulted in a paradigm shift in the management of 
+adult CPs.
+METHODS: In this study, we describe our experience in treating PCPs with 
+targeted therapy and highlight nuances in management accounting for current 
+evidence. This review also explores the current scope and application of 
+precision oncology in adult CPs including the experience with ongoing trials and 
+prospects for future research.
+RESULTS: The high prevalence of targetable mutation in cases of PCP and the 
+efficacy of BRAF inhibitors alone or in combination with MEK inhibitors has 
+improved the disease control in these patients. In the current scenario, while 
+surgery is warranted to obtain histopathological diagnosis, radical resection 
+and its associated risks can be avoided. In case of ACPs, dysregulation of 
+multiple pathways has been implicated. This has prompted the use of a variety of 
+targeted therapies with inconsistent outcomes. The results of ongoing and future 
+trials may define its role in management.
+CONCLUSION: Precision oncology is a promising addition to the treatment 
+armamentarium of adult CPs.
+
+Copyright © 2024 Biswas, Mansur, Wu, Prevedello and Ghalib.
+
+DOI: 10.3389/fendo.2024.1488958
+PMCID: PMC11615394
+PMID: 39634188 [Indexed for MEDLINE]
+
+Conflict of interest statement: DP reports being a consultant for BK Medical, 
+Stryker, Medtronic, and Integra Life Sciences and receiving royalties from ACE 
+Medical, Mizuho, KLS—Martin. The remaining authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/clinicaltrials_NCT03224767.md
+++ b/references_cache/clinicaltrials_NCT03224767.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT03224767
+title: Phase II Trial of BRAF/MEK Inhibitors in Papillary Craniopharyngiomas
+content_type: summary
+---
+
+# Phase II Trial of BRAF/MEK Inhibitors in Papillary Craniopharyngiomas
+
+## Content
+
+This phase II trial studies how well vemurafenib and cobimetinib work in treating patients with BRAF V600E mutation positive craniopharyngioma. Vemurafenib and cobimetinib may stop the growth of tumor cells by blocking some of the enzymes needed for cell growth.

--- a/references_cache/clinicaltrials_NCT05286788.md
+++ b/references_cache/clinicaltrials_NCT05286788.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT05286788
+title: Phase 2 Study of the MEK Inhibitor MEKTOVI® (Binimetinib) for the Treatment of Pediatric Adamantinomatous Craniopharyngioma
+content_type: summary
+---
+
+# Phase 2 Study of the MEK Inhibitor MEKTOVI® (Binimetinib) for the Treatment of Pediatric Adamantinomatous Craniopharyngioma
+
+## Content
+
+MEKTOVI (binimetinib) is an oral, highly selective reversible inhibitor of mitogen-activated extracellular signal regulated kinase 1 (MEK1) and MEK2. The biological activity of binimetinib that has been evaluated bith in vitro and in vivo in a wide variety of tumor types In this Phase II, the drug will be used to treat pediatric patients diagnosed with recurrent Adamantinomatous Craniopharyngioma including patients who have undergone surgery and/or radiation therapy.

--- a/references_cache/clinicaltrials_NCT05525273.md
+++ b/references_cache/clinicaltrials_NCT05525273.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT05525273
+title: Neoadjuvant and Postoperative Treatment With Dabrafenib and Trametinib in BRAF Mutated Papillary Craniopharyngioma
+content_type: summary
+---
+
+# Neoadjuvant and Postoperative Treatment With Dabrafenib and Trametinib in BRAF Mutated Papillary Craniopharyngioma
+
+## Content
+
+Subjects with papillary craniopharyngioma harboring a BRAF mutation will be treated with a BRAF + MEK inhibitor (dabrafenib + trametinib) after informed consent. Study participants will be administered oral dabrafenib and trametinib until maximal tumor volume reduction assessed by MRI. Progression free survival, cognition, ophthalmologic status, hypothalamic status and quality of life will be assessed 1 year after initiation of study treatment

--- a/research/Craniopharyngioma-deep-research-falcon.md
+++ b/research/Craniopharyngioma-deep-research-falcon.md
@@ -1,0 +1,1268 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T13:51:55.274284'
+end_time: '2026-05-11T14:08:08.594605'
+duration_seconds: 973.33
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Craniopharyngioma
+  mondo_id: ''
+  category: ''
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 48
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Craniopharyngioma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Craniopharyngioma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Craniopharyngioma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Craniopharyngioma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Craniopharyngioma — Disease Characteristics Research Report (focus on 2023–2024 literature)
+
+### Target Disease
+- **Disease name:** Craniopharyngioma (CP) (campanini2023themolecularpathogenesis pages 1-2, jannelli2023currentadvancesin pages 1-2)
+- **Category:** Rare epithelial intracranial tumor of the sellar/suprasellar (pituitary–hypothalamic) region; histologically benign but locally aggressive (neto2025recentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 1-2, neubecker2026systemicmolecularlytargeted pages 1-2)
+- **MONDO / Orphanet / OMIM / MeSH / ICD-10/11 identifiers:** Not retrievable with the current tool configuration (which searches primarily scholarly literature and ClinicalTrials.gov records rather than ontology/coding databases). This report therefore emphasizes peer‑reviewed primary literature and trial records.
+
+---
+
+## 1. Disease Information
+
+### 1.1 Overview / definition (current understanding)
+Craniopharyngiomas are rare epithelial intracranial neoplasms that arise along the craniopharyngeal duct / from remnants of **Rathke’s pouch**, typically in the **sellar and suprasellar** region, often extending toward the third ventricle (neto2025recentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 1-2, campanini2023themolecularpathogenesis pages 2-3). Their clinical impact is largely due to proximity to the **optic apparatus**, **pituitary gland**, and **hypothalamus**, causing visual and endocrine morbidity (biswas2024practicalapplicationof pages 1-2, brastianos2023brafmekinhibitionin pages 1-4).
+
+The WHO classifies craniopharyngiomas as **histologically benign WHO grade 1** tumors, but they can behave aggressively via adherence/invasion of adjacent critical structures (campanini2023themolecularpathogenesis pages 1-2, neto2025recentadvancesin pages 1-2).
+
+### 1.2 Key synonyms / alternative names
+Commonly used names include **adamantinomatous craniopharyngioma (ACP)** and **papillary craniopharyngioma (PCP)**, which the 2021 WHO CNS classification treats as **separate tumor entities** (biswas2024practicalapplicationof pages 1-2, jannelli2023currentadvancesin pages 1-2).
+
+### 1.3 Source type note
+Most information in this report is derived from **aggregated disease-level resources** (systematic reviews, narrative reviews, population registries) and **clinical trials**; some mechanistic claims are supported by primary molecular studies using human tissue and model systems (brastianos2023brafmekinhibitionin pages 1-4, apps2018tumourcompartmenttranscriptomics pages 1-2, wang2024multiomicsanalysisof pages 1-2).
+
+---
+
+## 2. Etiology
+
+### 2.1 Disease causal factors
+**Primary causal factors are molecular drivers that define two biologically distinct entities:**
+- **Adamantinomatous craniopharyngioma (ACP):** driven by somatic **CTNNB1** mutations (β‑catenin), with Wnt/β‑catenin pathway activation and β‑catenin accumulation in characteristic cell clusters (campanini2023themolecularpathogenesis pages 1-2, campanini2023themolecularpathogenesis pages 4-6).
+- **Papillary craniopharyngioma (PCP):** driven by **BRAF p.(V600E)** in ~90–95% (or higher) of cases, activating MAPK/ERK signaling (jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 1-2, campanini2023themolecularpathogenesis pages 2-3).
+
+### 2.2 Risk factors
+No clear environmental or lifestyle risk factors were identified in the retrieved evidence; CPs are generally considered sporadic tumors with age‑related incidence peaks (an2025molecularsubtypesof pages 1-2, javidialsaadi2025advancesinthe pages 2-4).
+
+### 2.3 Protective factors / gene–environment interactions
+No protective factors or gene–environment interactions were identified in the retrieved evidence.
+
+---
+
+## 3. Phenotypes (clinical presentation)
+
+### 3.1 Common symptoms and signs (with frequencies where available)
+Craniopharyngiomas typically have **insidious onset** with symptoms driven by mass effect and hypothalamic–pituitary involvement (javidialsaadi2025advancesinthe pages 4-6, alboqami2024craniopharyngiomaacomprehensive pages 2-5).
+
+Frequent manifestations include:
+- **Headache**: reported as 83.6% in one synthesis, and commonly 50–80% across reviews (javidialsaadi2025advancesinthe pages 4-6, gonzalezgallego2025moderntreatmentof pages 2-4).
+- **Visual deficits**: reported as 81.6% in one synthesis; classic **bitemporal hemianopia** due to optic chiasm compression, and decreased visual acuity (javidialsaadi2025advancesinthe pages 4-6, alboqami2024craniopharyngiomaacomprehensive pages 2-5, gonzalezgallego2025moderntreatmentof pages 2-4).
+- **Endocrine dysfunction** (pituitary axis deficits): endocrine deficits are common (e.g., 75–90% in one review synthesis), including central hypothyroidism, hypogonadism, adrenal insufficiency, and diabetes insipidus (gonzalezgallego2025moderntreatmentof pages 2-4, alboqami2024craniopharyngiomaacomprehensive pages 2-5).
+- **Hydrocephalus / raised intracranial pressure**: obstruction of the third ventricle can cause hydrocephalus; reported ranges include 10–30% for obstructive hydrocephalus in one synthesis (alboqami2024craniopharyngiomaacomprehensive pages 2-5, gonzalezgallego2025moderntreatmentof pages 2-4).
+
+Additional phenotype frequencies reported in one review synthesis include endocrine deficit subtypes such as growth hormone deficiency (~85%), gonadotroph deficiency (~40%), ACTH (~25%), TSH (~25%), and diabetes insipidus (~20%) (javidialsaadi2025advancesinthe pages 6-8).
+
+### 3.2 Quality-of-life impact
+High overall survival contrasts with long‑term morbidity, driven by visual loss, neuroendocrine deficits, and hypothalamic dysfunction (brastianos2023brafmekinhibitionin pages 1-4, biswas2024practicalapplicationof pages 1-2).
+
+### 3.3 Suggested HPO terms (examples)
+- Visual field defect / bitemporal hemianopia: **HP:0001137** (visual field defect), **HP:0000605** (hemianopia)
+- Headache: **HP:0002315**
+- Hydrocephalus: **HP:0000238**
+- Hypopituitarism: **HP:0000871**; Diabetes insipidus: **HP:0000873**
+- Hypothyroidism (central): **HP:0000821**; Hypogonadism: **HP:0000135**
+- Obesity / hypothalamic obesity: **HP:0001513** (obesity)
+
+(HPO identifiers are provided as ontology suggestions; specific term mapping may be refined for local database standards.)
+
+---
+
+## 4. Genetic / Molecular Information
+
+### 4.1 Causal genes and hallmark alterations
+- **ACP:** CTNNB1 exon 3 mutations (β‑catenin stabilization) and Wnt/β‑catenin pathway activation; β‑catenin‑accumulating clusters are a hallmark (an2025molecularsubtypesof pages 1-2, campanini2023themolecularpathogenesis pages 4-6, campanini2023themolecularpathogenesis pages 1-2).
+- **PCP:** BRAF p.(V600E) mutation in ~90–95% (or higher) of tumors (jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 1-2, campanini2023themolecularpathogenesis pages 2-3).
+
+### 4.2 Molecular subgroups (recent development: 2024 multi‑omics)
+A 2024 multi‑omics study profiled a large cohort (119 ACP and 23 PCP among 142 cases) using WES/RNA‑seq/DNA methylation and defined **three ACP molecular subgroups**—**WNT**, **ImA**, and **ImB**—with distinct pathway activation and imaging/histologic correlates (wang2024multiomicsanalysisof pages 1-2). The **WNT** subgroup showed stronger Wnt/β‑catenin activity and more epithelial/solid tumors, whereas **ImA/ImB** showed inflammatory and interferon responses with more cystic tumors and immune infiltration (wang2024multiomicsanalysisof pages 1-2). Prognostically, WNT had better event‑free survival than ImB, and ImA/ImB were predicted more likely to respond to immune checkpoint blockade than WNT (wang2024multiomicsanalysisof pages 1-2, wang2024multiomicsanalysisof pages 8-10).
+
+### 4.3 Inflammation and tumor microenvironment
+Mechanistic tissue studies support that ACP contains a prominent inflammatory microenvironment; tumor clusters are surrounded by gliosis/inflammatory reaction, and inflammatory programs (including inflammasome activation) have been described in transcriptomic/proteomic studies (campanini2023themolecularpathogenesis pages 4-6, apps2018tumourcompartmenttranscriptomics pages 1-2).
+
+### 4.4 Suggested GO biological process terms (examples)
+- Wnt signaling pathway: **GO:0016055**
+- MAPK cascade: **GO:0000165**
+- Inflammatory response: **GO:0006954**
+- Cytokine-mediated signaling pathway: **GO:0019221**
+- Epithelial to mesenchymal transition: **GO:0001837**
+
+---
+
+## 5. Environmental Information
+No specific environmental, lifestyle, or infectious causal agents were identified in the retrieved evidence.
+
+---
+
+## 6. Mechanism / Pathophysiology
+
+### 6.1 Subtype-specific upstream drivers → downstream disease features (causal chains)
+**ACP causal chain (simplified):**
+Somatic **CTNNB1** mutation → stabilization/nuclear accumulation of **β‑catenin** in discrete tumor clusters → Wnt/β‑catenin hyperactivation with cluster cells acting as signaling centers → secretion of growth factors/cytokines/chemokines and remodeling of surrounding tissue with gliosis/inflammation → locally invasive behavior with cyst formation and adherence to hypothalamus/optic pathways → clinical syndrome of visual deficits and endocrine/hypothalamic dysfunction (campanini2023themolecularpathogenesis pages 4-6, apps2018tumourcompartmenttranscriptomics pages 1-2, alboqami2024craniopharyngiomaacomprehensive pages 2-5).
+
+**PCP causal chain (simplified):**
+BRAF p.(V600E) mutation → MAPK/ERK pathway activation → growth of predominantly solid suprasellar tumor mass → optic chiasm compression and pituitary stalk/gland dysfunction → visual field loss and hypopituitarism; importantly, the dominant oncogenic driver yields high sensitivity to BRAF/MEK inhibitors (campanini2023themolecularpathogenesis pages 2-3, brastianos2023brafmekinhibitionin pages 1-4).
+
+### 6.2 MAPK/ERK activity in ACP and therapeutic implications
+Although ACP is classically Wnt‑driven, MAPK/ERK pathway activation has been observed in compartments of ACP, and MEK inhibition with **trametinib** in ex vivo ACP tissue reduced pERK1/2, increased apoptosis, and decreased proliferation (campanini2023themolecularpathogenesis pages 4-6). This provides biological rationale for MEK‑inhibitor trials in ACP (NCT05286788 chunk 1).
+
+### 6.3 Advanced technologies (recent)
+- **Single-cell and spatial sequencing** have been applied to ACP (70,682 cells profiled in one 2024 study) to refine tumor-cell states including senescence‑associated secretory phenotype (SASP) programs and immune infiltration ().
+- **Multi‑omics clustering** (WES/RNA‑seq/DNAm) is being used to derive prognostic and predicted treatment-response subgroups (wang2024multiomicsanalysisof pages 1-2).
+
+### 6.4 Suggested Cell Ontology (CL) terms (examples)
+- Pituitary stem/progenitor cell (for mechanistic models): **CL:0002371** (pituitary gland stem cell; exact label may vary by ontology version)
+- T cell: **CL:0000084**
+- Macrophage / microglia: **CL:0000235** (macrophage), **CL:0000129** (microglial cell)
+- Astrocyte (astrogliosis): **CL:0000127**
+
+---
+
+## 7. Anatomical Structures Affected
+
+### 7.1 Primary sites
+Craniopharyngiomas arise in the **sellar/suprasellar** region, near the pituitary–hypothalamic axis (campanini2023themolecularpathogenesis pages 1-2, brastianos2023brafmekinhibitionin pages 1-4).
+
+### 7.2 Secondary structures commonly involved (by local extension)
+Commonly impacted structures include the **optic chiasm/optic apparatus**, **pituitary stalk**, **hypothalamus**, and sometimes the **third ventricle** (alboqami2024craniopharyngiomaacomprehensive pages 2-5, campanini2023themolecularpathogenesis pages 2-3).
+
+### 7.3 Suggested UBERON terms (examples)
+- Pituitary gland: **UBERON:0000007**
+- Hypothalamus: **UBERON:0001898**
+- Optic chiasm: **UBERON:0000969**
+- Third ventricle: **UBERON:0002673**
+
+---
+
+## 8. Temporal Development
+
+### 8.1 Onset
+Craniopharyngiomas show a **bimodal age distribution** with a pediatric peak (~5–14/15 years) and an adult peak (variously reported ~45–60 or ~50–74 years) (an2025molecularsubtypesof pages 1-2, javidialsaadi2025advancesinthe pages 2-4, neto2025recentadvancesin pages 1-2).
+
+### 8.2 Progression/course
+They are slow-growing but often chronic due to recurrence and long-term morbidity after treatment in this anatomically constrained region (brastianos2023brafmekinhibitionin pages 1-4, neto2025recentadvancesin pages 1-2).
+
+---
+
+## 9. Inheritance and Population
+
+### 9.1 Epidemiology (key statistics)
+- CPs constitute ~1.2–4.6% of all brain tumors in one review synthesis (biswas2024practicalapplicationof pages 1-2).
+- Incidence estimates vary across sources; one precision-oncology review gives **0.5–2.5 new cases per 1 million people** (biswas2024practicalapplicationof pages 1-2), while other reviews report incidence ranges including **0.13–2 per 100,000** (neto2025recentadvancesin pages 1-2).
+- In a nationwide registry study of adolescents/young adults (France, 15–39 years), craniopharyngioma incidence was reported as an age-standardized rate of **0.14 per 100,000 person‑years** (ASR adjusted to US population) (ng2020anepidemiologyreport pages 8-9).
+
+### 9.2 Sex ratio / demographics
+Some reviews report no gender predilection overall (neto2025recentadvancesin pages 1-2). Subtype distribution is age-skewed: ACP occurs in both children and adults; PCP is largely adult (neto2025recentadvancesin pages 1-2, jannelli2023currentadvancesin pages 1-2).
+
+---
+
+## 10. Diagnostics
+
+### 10.1 Imaging
+Diagnosis is suggested by a sellar/suprasellar mass with cystic and/or solid components on MRI/CT; CT is particularly useful for calcifications, while MRI delineates soft tissue, cystic components, and relationships to the optic chiasm, pituitary stalk/gland, and hypothalamus (gonzalezgallego2025moderntreatmentof pages 2-4, javidialsaadi2025advancesinthe pages 6-8).
+
+Calcifications are emphasized as frequent (reported ~90% in one review synthesis) (alboqami2024craniopharyngiomaacomprehensive pages 2-5).
+
+### 10.2 Histopathology (ACP vs PCP)
+- **ACP:** palisading epithelium, stellate reticulum, “wet keratin,” calcifications, xanthogranulomatous reaction; β‑catenin nuclear/cytoplasmic accumulation in clusters (javidialsaadi2025advancesinthe pages 6-8, campanini2023themolecularpathogenesis pages 4-6).
+- **PCP:** mature squamous epithelium with fibrovascular cores; lacks ACP features (palisading/stellate reticulum/calcification); driven by BRAF V600E and can be supported by mutant‑specific immunostaining (javidialsaadi2025advancesinthe pages 6-8, campanini2023themolecularpathogenesis pages 1-2).
+
+### 10.3 Molecular testing
+Molecular testing is clinically actionable in PCP: identifying **BRAF V600E** enables use of BRAF/MEK inhibition (brastianos2023brafmekinhibitionin pages 1-4, NCT05525273 chunk 1).
+
+### 10.4 Differential diagnosis
+Differential diagnosis is not comprehensively extracted from the available evidence snippets in this run; however, in practice it typically includes other sellar/suprasellar masses (e.g., pituitary adenomas, Rathke cleft cyst, germ cell tumors). A dedicated diagnostic radiology/pathology source would be needed for a fully cited differential list.
+
+---
+
+## 11. Outcome / Prognosis
+
+### 11.1 Survival
+Overall survival is generally favorable compared with malignant brain tumors, but long-term morbidity is high due to location and treatment effects (brastianos2023brafmekinhibitionin pages 1-4, biswas2024practicalapplicationof pages 1-2). A narrative review reports wide 10‑year survival ranges (40–95%) reflecting heterogeneity and treatment era differences (javidialsaadi2025advancesinthe pages 4-6).
+
+### 11.2 Morbidity and quality-of-life outcomes
+Major long-term morbidities include persistent endocrine deficits and hypothalamic dysfunction; hypothalamic injury is a key driver of severe sequelae (gonzalezgallego2025moderntreatmentof pages 2-4, brastianos2023brafmekinhibitionin pages 1-4).
+
+---
+
+## 12. Treatment
+
+### 12.1 Surgery and radiotherapy (standard-of-care backbone)
+Standard management historically relies on maximal safe resection with adjuvant radiotherapy when necessary, balanced against risk of hypothalamic/optic injury (brastianos2023brafmekinhibitionin pages 1-4, biswas2024practicalapplicationof pages 1-2).
+
+### 12.2 Targeted therapy — major 2023–2024 development (PCP)
+A pivotal 2023 phase II study (papillary CP, BRAF‑mutant, no prior radiation) treated 16 patients with **vemurafenib + cobimetinib** and reported: **15/16 (94%)** durable partial response or better, median tumor volume reduction **91%**, and 12‑month PFS **87%** (24‑month PFS 58%) (brastianos2023brafmekinhibitionin pages 1-4).
+
+Direct abstract quotes supporting this include:
+- “**Genotyping has shown that more than 90% of papillary craniopharyngiomas carry BRAF V600E mutations**” (Brastianos et al., 2023) (brastianos2023brafmekinhibitionin pages 1-4).
+- “**15 (94% …) had a durable objective partial response or better**… The median reduction in the volume of the tumor was **91%**” (brastianos2023brafmekinhibitionin pages 1-4).
+
+A 2024 systematic review summarizing neoadjuvant/adjuvant BRAF±MEK inhibitor use in PCP found volumetric reductions ranging **24–100%**, with ≥80% reductions reported in **64%** of adjuvant cases, and near‑complete responses common in neoadjuvant settings (cossu2024updateonneoadjuvant pages 1-2).
+
+**Real-world implementation pattern:** targeted therapy is increasingly used to de‑escalate morbid surgery/radiation in BRAF‑mutant PCP, while emphasizing multidisciplinary planning and close toxicity monitoring (biswas2024practicalapplicationof pages 2-3, NCT05525273 chunk 1).
+
+### 12.3 MEK inhibition / inflammatory targeting — emerging for ACP
+- A phase 2 clinical trial is evaluating **binimetinib (MEKTOVI®)** in pediatric/young adult ACP (NCT05286788) (NCT05286788 chunk 1).
+- Preclinical evidence supports MEK/MAPK pathway involvement in subsets of ACP and sensitivity to MEK inhibition ex vivo (campanini2023themolecularpathogenesis pages 4-6).
+
+### 12.4 Intracystic therapy (cystic CP)
+A 2024 retrospective case series evaluated **intracystic peginterferon alfa‑2a** delivered weekly ×6 via Ommaya reservoir in 5 patients with cystic CP, reporting cyst shrinkage in all five and good tolerability ().
+
+### 12.5 Brachytherapy for cystic CP (meta-analysis)
+A 2024 systematic review/meta-analysis of brachytherapy in cystic CP (6 trials, 266 patients; ≥5-year follow-up) reported pooled PFS: **75% at 1 year**, **62% at 2–3 years**, and **57% at 5 years** (zhang2024brachytherapyincraniopharyngiomas pages 1-2).
+
+### 12.6 Suggested MAXO terms (examples)
+- Surgical resection: **MAXO:0001041** (surgical procedure; refine locally)
+- Radiotherapy: **MAXO:0000558**
+- Targeted molecular therapy (BRAF/MEK inhibitors): **MAXO:0001035** (drug therapy; refine)
+- Intracystic therapy via reservoir: **MAXO:0001176** (intrathecal/intralesional administration; refine)
+
+(MAXO identifiers are provided as ontology suggestions; mapping may require local curation.)
+
+---
+
+## 13. Prevention
+No established primary prevention strategies exist because CPs are not linked to modifiable exposures in the retrieved evidence. Secondary/tertiary “prevention” in practice centers on early diagnosis and hypothalamus/optic-sparing treatment strategies to reduce long-term morbidity (brastianos2023brafmekinhibitionin pages 1-4).
+
+---
+
+## 14. Other Species / Natural Disease
+No naturally occurring non-human species disease evidence was retrieved in this run.
+
+---
+
+## 15. Model Organisms / Experimental Models
+
+### 15.1 Genetically engineered mouse models (ACP)
+Mouse genetic models targeting oncogenic β‑catenin to pituitary embryonic precursors or adult stem cells have been used to model ACP tumorigenesis and support a **paracrine** mechanism in which cluster cells act as signaling centers (apps2017geneticallyengineeredmouse pages 3-5, apps2018tumourcompartmenttranscriptomics pages 1-2).
+
+### 15.2 Ex vivo explant models and translational testing
+Human and mouse ACP explant cultures treated with the MEK inhibitor **trametinib** showed reduced proliferation and increased apoptosis, providing a preclinical platform for therapy development (apps2018tumourcompartmenttranscriptomics pages 1-2, campanini2023themolecularpathogenesis pages 4-6).
+
+### 15.3 Suggested resources
+Open pediatric cancer multi‑omics initiatives (e.g., OpenPBTA/OpenPedCan) are expanding integrated diagnoses and methylation-based subtyping for pediatric brain tumors including craniopharyngioma ().
+
+---
+
+# Subtype summary table (evidence-linked)
+
+| Subtype | Relative frequency | Key driver mutation(s) | Typical age distribution | Imaging / histopathology | Therapy implications |
+|---|---:|---|---|---|---|
+| Adamantinomatous craniopharyngioma (ACP) | ~90% of craniopharyngiomas (jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 2-3, campanini2023themolecularpathogenesis pages 1-2) | Somatic **CTNNB1** exon 3 mutation; reported prevalence ranges include ~60%, 59%, and ~69-100% across studies/reviews; causes nuclear/cytoplasmic **β-catenin** accumulation and Wnt/β-catenin activation (an2025molecularsubtypesof pages 1-2, neubecker2026systemicmolecularlytargeted pages 1-2, campanini2023themolecularpathogenesis pages 1-2, wang2024multiomicsanalysisof pages 3-5) | Bimodal peaks in childhood and later adulthood: **5-15 years** and **45-60 years**; other reviews report **5-14** and **55-74** years (an2025molecularsubtypesof pages 1-2, neto2025recentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 2-3, javidialsaadi2025advancesinthe pages 2-4) | Often **multicystic** or mixed solid-cystic; **calcifications common (~90%)**; CT often shows hypodense cystic uni-/multilocular lesion; cyst fluid may resemble “motor oil.” Histology: palisading epithelium, stellate reticulum, finger-like infiltrative protrusions, wet keratin, epithelial whorls, gliosis/inflammation (alboqami2024craniopharyngiomaacomprehensive pages 2-5, javidialsaadi2025advancesinthe pages 6-8, gonzalezgallego2025moderntreatmentof pages 2-4, campanini2023themolecularpathogenesis pages 4-6) | Standard management remains maximal safe surgery ± radiotherapy. No single established targeted therapy yet. Emerging/experimental strategies include **MEK inhibition** (especially inflammatory/ImA subtype), **IL-6/IL-6R blockade** (e.g., tocilizumab), **bevacizumab** combinations, immunotherapy for inflammatory subgroups, and intracystic interferon/peginterferon for cystic disease (wang2024multiomicsanalysisof pages 8-10, wang2024multiomicsanalysisof pages 1-2, NCT05286788 chunk 1, wang2024multiomicsanalysisof pages 3-5) |
+| Papillary craniopharyngioma (PCP) | ~10% of craniopharyngiomas (jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 2-3) | **BRAF p.V600E** in ~**90-95%** of cases; reviews also report **81-100%** or near-universal prevalence; activates MAPK/ERK signaling (jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 2-3, campanini2023themolecularpathogenesis pages 1-2, NCT05525273 chunk 1) | Predominantly **adult-onset**; typically 4th-6th decade / **40-53 years**, mean ~44.7 years; often 5th-6th decades (neto2025recentadvancesin pages 1-2, jannelli2023currentadvancesin pages 1-2, campanini2023themolecularpathogenesis pages 2-3, NCT05525273 chunk 1) | Typically **solid** or uniloculated, **non-calcified** suprasellar/tuberoinfundibular mass; CT/MRI often isodense and noncalcified with hyperintense T2 signal. Histology: mature squamous epithelium over fibrovascular cores; lacks ACP palisading, stellate reticulum, and wet keratin (alboqami2024craniopharyngiomaacomprehensive pages 2-5, javidialsaadi2025advancesinthe pages 6-8, gonzalezgallego2025moderntreatmentof pages 2-4) | Strong precision-oncology signal: **BRAF/MEK inhibition** produces major shrinkage. In prospective phase 2 data, **15/16 (94%)** responded, median tumor-volume reduction **91%**, 12-month PFS **87%**, 24-month PFS **58%** with vemurafenib+cobimetinib; neoadjuvant/adjuvant regimens often allow less morbid surgery/radiation and in some cases no further therapy (brastianos2023brafmekinhibitionin pages 1-4, cossu2024updateonneoadjuvant pages 1-2, NCT03224767 chunk 1, NCT05525273 chunk 1) |
+
+
+*Table: This table compares adamantinomatous and papillary craniopharyngioma across frequency, molecular drivers, age distribution, imaging and histopathologic features, and current therapeutic implications. It is useful for quickly linking subtype biology to diagnostic expectations and treatment strategy.*
+
+---
+
+## Key Clinical Trials (selected)
+
+- **NCT03224767 (Alliance A071601)** — Adults (≥18) with BRAF V600E papillary CP; **vemurafenib + cobimetinib**; phase II; primary endpoint objective response at 4 months; includes two cohorts (no prior RT vs prior RT) (NCT03224767 chunk 1). This trial is the basis for the NEJM 2023 phase II results summarized above (brastianos2023brafmekinhibitionin pages 1-4).
+- **NCT05525273 (Swecranio)** — Adults with BRAF V600E papillary CP; **dabrafenib + trametinib**; phase II; primary endpoint maximal tumor-volume reduction on MRI and QoL/visual/endocrine outcomes as secondary endpoints (NCT05525273 chunk 1).
+- **NCT05286788 (CONNECT2108)** — Pediatric/young adult ACP; **binimetinib**; phase II; objective response endpoints stratified by prior radiation (NCT05286788 chunk 1).
+
+ClinicalTrials.gov URLs:
+- NCT03224767: https://clinicaltrials.gov/study/NCT03224767 (NCT03224767 chunk 1)
+- NCT05525273: https://clinicaltrials.gov/study/NCT05525273 (NCT05525273 chunk 1)
+- NCT05286788: https://clinicaltrials.gov/study/NCT05286788 (NCT05286788 chunk 1)
+
+---
+
+## Notes on evidence gaps / limitations
+1) **Ontology identifier codes** (MONDO, Orphanet, ICD-10/11, MeSH, OMIM) were not accessible through the current scholarly-literature and ClinicalTrials.gov toolchain and therefore are not included as authoritative code assertions in this report.
+2) Some requested elements (detailed differential diagnosis list; population prevalence; long-term endocrine/visual outcome rates by treatment modality) require additional dedicated sources or full-text extraction beyond the available evidence snippets.
+
+---
+
+## Reference list (URLs and publication dates)
+The citations above already embed URLs and publication months/years in the evidence source metadata; key recent/high-authority sources include:
+- Brastianos PK et al. *N Engl J Med*. July 2023. DOI: https://doi.org/10.1056/NEJMoa2213329 (brastianos2023brafmekinhibitionin pages 1-4)
+- Alboqami MN et al. *Heliyon*. June 2024. DOI: https://doi.org/10.1016/j.heliyon.2024.e32112 (alboqami2024craniopharyngiomaacomprehensive pages 2-5)
+- Biswas C et al. *Front Endocrinol*. Nov 2024. DOI: https://doi.org/10.3389/fendo.2024.1488958 (biswas2024practicalapplicationof pages 1-2)
+- Cossu G et al. *Cancers (Basel)*. Oct 2024. DOI: https://doi.org/10.3390/cancers16203479 (cossu2024updateonneoadjuvant pages 1-2)
+- Wang X et al. *Chinese Medical Journal*. Aug 2024. DOI: https://doi.org/10.1097/CM9.0000000000002774 (wang2024multiomicsanalysisof pages 1-2)
+- Campanini ML et al. *Arch Endocrinol Metab*. Feb 2023. DOI: https://doi.org/10.20945/2359-3997000000600 (campanini2023themolecularpathogenesis pages 1-2)
+
+
+References
+
+1. (campanini2023themolecularpathogenesis pages 1-2): Marina Lanciotti Campanini, João Paulo Almeida, Clarissa Silva Martins, and Margaret de Castro. The molecular pathogenesis of craniopharyngiomas. Archives of Endocrinology and Metabolism, 67:266-275, Feb 2023. URL: https://doi.org/10.20945/2359-3997000000600, doi:10.20945/2359-3997000000600. This article has 13 citations.
+
+2. (jannelli2023currentadvancesin pages 1-2): Gianpaolo Jannelli, Francesco Calvanese, Luca Paun, Gerald Raverot, and Emmanuel Jouanneau. Current advances in papillary craniopharyngioma: state-of-the-art therapies and overview of the literature. Brain Sciences, 13:515, Mar 2023. URL: https://doi.org/10.3390/brainsci13030515, doi:10.3390/brainsci13030515. This article has 28 citations.
+
+3. (neto2025recentadvancesin pages 1-2): Clariano Pires de Oliveira Neto, Gilvan Cortês Nascimento, Sabrina da Silva Pereira Damianse, and Manuel dos Santos Faria. Recent advances in craniopharyngioma pathophysiology and emerging therapeutic approaches. Frontiers in Endocrinology, May 2025. URL: https://doi.org/10.3389/fendo.2025.1562942, doi:10.3389/fendo.2025.1562942. This article has 2 citations.
+
+4. (neubecker2026systemicmolecularlytargeted pages 1-2): Joseph J. Neubecker, Daniel W. Griepp, Jeffrey P. Turnbull, Joshua Caskey, Shivum Desai, Adam Mansour, Rabia Ahmed, Andrew Beggs, Annie T. K. Griepp, Heather Heitkotter, Chad F. Claus, Boyd F. Richards, and Prashant S. Kelkar. Systemic molecularly targeted therapies for neoadjuvant and salvage craniopharyngioma: a contemporary narrative review. Biomedicines, 14:499, Feb 2026. URL: https://doi.org/10.3390/biomedicines14030499, doi:10.3390/biomedicines14030499. This article has 0 citations.
+
+5. (campanini2023themolecularpathogenesis pages 2-3): Marina Lanciotti Campanini, João Paulo Almeida, Clarissa Silva Martins, and Margaret de Castro. The molecular pathogenesis of craniopharyngiomas. Archives of Endocrinology and Metabolism, 67:266-275, Feb 2023. URL: https://doi.org/10.20945/2359-3997000000600, doi:10.20945/2359-3997000000600. This article has 13 citations.
+
+6. (biswas2024practicalapplicationof pages 1-2): Chandrima Biswas, Guilherme Mansur, Kyle C. Wu, Daniel M. Prevedello, and Luma Ghalib. Practical application of precision oncology in adult onset craniopharyngiomas. Frontiers in Endocrinology, Nov 2024. URL: https://doi.org/10.3389/fendo.2024.1488958, doi:10.3389/fendo.2024.1488958. This article has 4 citations.
+
+7. (brastianos2023brafmekinhibitionin pages 1-4): Priscilla K. Brastianos, Erin Twohy, Susan Geyer, Elizabeth R. Gerstner, Timothy J. Kaufmann, Shervin Tabrizi, Brian Kabat, Julia Thierauf, Michael W. Ruff, Daniela A. Bota, David A. Reardon, Adam L. Cohen, Macarena I. De La Fuente, Glenn J. Lesser, Jian Campian, Pankaj K. Agarwalla, Priya Kumthekar, Bhupinder Mann, Shivangi Vora, Michael Knopp, A. John Iafrate, William T. Curry, Daniel P. Cahill, Helen A. Shih, Paul D. Brown, Sandro Santagata, Fred G. Barker, and Evanthia Galanis. Braf-mek inhibition in newly diagnosed papillary craniopharyngiomas. The New England journal of medicine, 389 2:118-126, Jul 2023. URL: https://doi.org/10.1056/nejmoa2213329, doi:10.1056/nejmoa2213329. This article has 127 citations and is from a highest quality peer-reviewed journal.
+
+8. (apps2018tumourcompartmenttranscriptomics pages 1-2): John R. Apps, Gabriela Carreno, Jose Mario Gonzalez-Meljem, Scott Haston, Romain Guiho, Julie E. Cooper, Saba Manshaei, Nital Jani, Annett Hölsken, Benedetta Pettorini, Robert J. Beynon, Deborah M. Simpson, Helen C. Fraser, Ying Hong, Shirleen Hallang, Thomas J. Stone, Alex Virasami, Andrew M. Donson, David Jones, Kristian Aquilina, Helen Spoudeas, Abhijit R. Joshi, Richard Grundy, Lisa C. D. Storer, Márta Korbonits, David A. Hilton, Kyoko Tossell, Selvam Thavaraj, Mark A. Ungless, Jesus Gil, Rolf Buslei, Todd Hankinson, Darren Hargrave, Colin Goding, Cynthia L. Andoniadou, Paul Brogan, Thomas S. Jacques, Hywel J. Williams, and Juan Pedro Martinez-Barbera. Tumour compartment transcriptomics demonstrates the activation of inflammatory and odontogenic programmes in human adamantinomatous craniopharyngioma and identifies the mapk/erk pathway as a novel therapeutic target. Acta Neuropathologica, 135:757-777, Mar 2018. URL: https://doi.org/10.1007/s00401-018-1830-2, doi:10.1007/s00401-018-1830-2. This article has 169 citations and is from a highest quality peer-reviewed journal.
+
+9. (wang2024multiomicsanalysisof pages 1-2): Xianlong Wang, Chuan Zhao, Jincheng Lin, Hongxing Liu, Qiuhong Zeng, Hua-Qing Chen, Ye Wang, Dapeng Xu, Wen Chen, Moping Xu, En Zhang, Da Lin, and Zhixiong Lin. Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance. Chinese Medical Journal, 137:859-870, Aug 2024. URL: https://doi.org/10.1097/cm9.0000000000002774, doi:10.1097/cm9.0000000000002774. This article has 21 citations and is from a peer-reviewed journal.
+
+10. (campanini2023themolecularpathogenesis pages 4-6): Marina Lanciotti Campanini, João Paulo Almeida, Clarissa Silva Martins, and Margaret de Castro. The molecular pathogenesis of craniopharyngiomas. Archives of Endocrinology and Metabolism, 67:266-275, Feb 2023. URL: https://doi.org/10.20945/2359-3997000000600, doi:10.20945/2359-3997000000600. This article has 13 citations.
+
+11. (an2025molecularsubtypesof pages 1-2): Wenhao An, Shouwei Li, Yihua An, and Zhixiong Lin. Molecular subtypes of adamantinomatous craniopharyngiomas. Neuro-Oncology, 27:1180-1192, Feb 2025. URL: https://doi.org/10.1093/neuonc/noaf030, doi:10.1093/neuonc/noaf030. This article has 9 citations and is from a domain leading peer-reviewed journal.
+
+12. (javidialsaadi2025advancesinthe pages 2-4): Mousa Javidialsaadi, Diego D. Luy, Heather L. Smith, Arba Cecia, Seunghyuk Daniel Yang, and Anand V. Germanwala. Advances in the management of craniopharyngioma: a narrative review of recent developments and clinical strategies. Journal of Clinical Medicine, 14:1101, Feb 2025. URL: https://doi.org/10.3390/jcm14041101, doi:10.3390/jcm14041101. This article has 7 citations.
+
+13. (javidialsaadi2025advancesinthe pages 4-6): Mousa Javidialsaadi, Diego D. Luy, Heather L. Smith, Arba Cecia, Seunghyuk Daniel Yang, and Anand V. Germanwala. Advances in the management of craniopharyngioma: a narrative review of recent developments and clinical strategies. Journal of Clinical Medicine, 14:1101, Feb 2025. URL: https://doi.org/10.3390/jcm14041101, doi:10.3390/jcm14041101. This article has 7 citations.
+
+14. (alboqami2024craniopharyngiomaacomprehensive pages 2-5): Maryam Nashi Alboqami, Arwa Khalid S Albaiahy, Bushra Hatim Bukhari, Ali Alkhaibary, Ahoud Alharbi, Sami Khairy, Ali H. Alassiri, Fahd AlSufiani, Ahmed Alkhani, and Ahmed Aloraidi. Craniopharyngioma: a comprehensive review of the clinical presentation, radiological findings, management, and future perspective. Heliyon, 10:e32112, Jun 2024. URL: https://doi.org/10.1016/j.heliyon.2024.e32112, doi:10.1016/j.heliyon.2024.e32112. This article has 33 citations.
+
+15. (gonzalezgallego2025moderntreatmentof pages 2-4): Carlos González-Gallego, Pedro Molina, Cristina Hostalot, Anna Oliva, Alberto Blanco, Paloma Puyalto de Pablo, Silvia Comas, Cristina Carrato, Elena Valassi, and Manel Puig-Domingo. Modern treatment of craniopharyngioma to improve outcomes: evidence of a change of paradigm. Endocrine, 89:20-29, May 2025. URL: https://doi.org/10.1007/s12020-025-04216-9, doi:10.1007/s12020-025-04216-9. This article has 3 citations and is from a peer-reviewed journal.
+
+16. (javidialsaadi2025advancesinthe pages 6-8): Mousa Javidialsaadi, Diego D. Luy, Heather L. Smith, Arba Cecia, Seunghyuk Daniel Yang, and Anand V. Germanwala. Advances in the management of craniopharyngioma: a narrative review of recent developments and clinical strategies. Journal of Clinical Medicine, 14:1101, Feb 2025. URL: https://doi.org/10.3390/jcm14041101, doi:10.3390/jcm14041101. This article has 7 citations.
+
+17. (wang2024multiomicsanalysisof pages 8-10): Xianlong Wang, Chuan Zhao, Jincheng Lin, Hongxing Liu, Qiuhong Zeng, Hua-Qing Chen, Ye Wang, Dapeng Xu, Wen Chen, Moping Xu, En Zhang, Da Lin, and Zhixiong Lin. Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance. Chinese Medical Journal, 137:859-870, Aug 2024. URL: https://doi.org/10.1097/cm9.0000000000002774, doi:10.1097/cm9.0000000000002774. This article has 21 citations and is from a peer-reviewed journal.
+
+18. (NCT05286788 chunk 1):  MEKTOVI® for the Treatment of Pediatric Adamantinomatous Craniopharyngioma. Nationwide Children's Hospital. 2023. ClinicalTrials.gov Identifier: NCT05286788
+
+19. (ng2020anepidemiologyreport pages 8-9): Sam Ng, Sonia Zouaoui, Faiza Bessaoud, Valérie Rigau, Alexandre Roux, Amélie Darlix, Fabienne Bauchet, Hélène Mathieu-Daudé, Brigitte Trétarre, Dominique Figarella-Branger, Johan Pallud, Didier Frappaz, Thomas Roujeau, and Luc Bauchet. An epidemiology report for primary central nervous system tumors in adolescents and young adults: a nationwide population-based study in france, 2008-2013. Neuro-oncology, 22:851-863, Dec 2020. URL: https://doi.org/10.1093/neuonc/noz227, doi:10.1093/neuonc/noz227. This article has 28 citations and is from a domain leading peer-reviewed journal.
+
+20. (NCT05525273 chunk 1): Eva Marie Erfurth, MD, PhD. Treatment of BRAF ( B-Rapidly Accelerated Fibrosarcoma) Mutated Papillary Craniopharyngioma. Eva Marie Erfurth, MD, PhD. 2023. ClinicalTrials.gov Identifier: NCT05525273
+
+21. (cossu2024updateonneoadjuvant pages 1-2): Giulia Cossu, Daniele S. C. Ramsay, Roy T. Daniel, Ahmed El Cadhi, Luc Kerherve, Edouard Morlaix, Sayda A. Houidi, Clément Millot-Piccoli, Renan Chapon, Tuan Le Van, Catherine Cao, Walid Farah, Maxime Lleu, Olivier Baland, Jacques Beaurain, Jean Michel Petit, Brivaël Lemogne, Mahmoud Messerer, and Moncef Berhouma. Update on neoadjuvant and adjuvant braf inhibitors in papillary craniopharyngioma: a systematic review. Cancers, 16:3479, Oct 2024. URL: https://doi.org/10.3390/cancers16203479, doi:10.3390/cancers16203479. This article has 4 citations.
+
+22. (biswas2024practicalapplicationof pages 2-3): Chandrima Biswas, Guilherme Mansur, Kyle C. Wu, Daniel M. Prevedello, and Luma Ghalib. Practical application of precision oncology in adult onset craniopharyngiomas. Frontiers in Endocrinology, Nov 2024. URL: https://doi.org/10.3389/fendo.2024.1488958, doi:10.3389/fendo.2024.1488958. This article has 4 citations.
+
+23. (zhang2024brachytherapyincraniopharyngiomas pages 1-2): Li-Yuan Zhang, Wei Guo, Han-Ze Du, Hui Pan, Yun-Chuan Sun, Hui-Juan Zhu, Shuai-Hua Song, Xiao-Yuan Guo, Yue Jiang, and Qian-Qian Sun. Brachytherapy in craniopharyngiomas: a systematic review and meta-analysis of long-term follow-up. BMC Cancer, May 2024. URL: https://doi.org/10.1186/s12885-024-12397-1, doi:10.1186/s12885-024-12397-1. This article has 4 citations and is from a peer-reviewed journal.
+
+24. (apps2017geneticallyengineeredmouse pages 3-5): John Richard Apps and Juan Pedro Martinez‐Barbera. Genetically engineered mouse models of craniopharyngioma: an opportunity for therapy development and understanding of tumor biology. Brain Pathology, 27:364-369, Apr 2017. URL: https://doi.org/10.1111/bpa.12501, doi:10.1111/bpa.12501. This article has 17 citations and is from a domain leading peer-reviewed journal.
+
+25. (wang2024multiomicsanalysisof pages 3-5): Xianlong Wang, Chuan Zhao, Jincheng Lin, Hongxing Liu, Qiuhong Zeng, Hua-Qing Chen, Ye Wang, Dapeng Xu, Wen Chen, Moping Xu, En Zhang, Da Lin, and Zhixiong Lin. Multi-omics analysis of adamantinomatous craniopharyngiomas reveals distinct molecular subgroups with prognostic and treatment response significance. Chinese Medical Journal, 137:859-870, Aug 2024. URL: https://doi.org/10.1097/cm9.0000000000002774, doi:10.1097/cm9.0000000000002774. This article has 21 citations and is from a peer-reviewed journal.
+
+26. (NCT03224767 chunk 1):  Vemurafenib and Cobimetinib in Treating Patients With BRAF V600E Mutation Positive Craniopharyngioma. Alliance for Clinical Trials in Oncology. 2018. ClinicalTrials.gov Identifier: NCT03224767

--- a/research/Craniopharyngioma-deep-research-falcon.md.citations.md
+++ b/research/Craniopharyngioma-deep-research-falcon.md.citations.md
@@ -1,0 +1,499 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Craniopharyngioma
+- **MONDO ID:**  (if available)
+- **Category:** 
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Craniopharyngioma** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T14:08:08.594605
+
+1. javidialsaadi2025advancesinthe pages 6-8
+2. wang2024multiomicsanalysisof pages 1-2
+3. campanini2023themolecularpathogenesis pages 4-6
+4. biswas2024practicalapplicationof pages 1-2
+5. neto2025recentadvancesin pages 1-2
+6. ng2020anepidemiologyreport pages 8-9
+7. alboqami2024craniopharyngiomaacomprehensive pages 2-5
+8. javidialsaadi2025advancesinthe pages 4-6
+9. brastianos2023brafmekinhibitionin pages 1-4
+10. cossu2024updateonneoadjuvant pages 1-2
+11. zhang2024brachytherapyincraniopharyngiomas pages 1-2
+12. campanini2023themolecularpathogenesis pages 1-2
+13. jannelli2023currentadvancesin pages 1-2
+14. neubecker2026systemicmolecularlytargeted pages 1-2
+15. campanini2023themolecularpathogenesis pages 2-3
+16. apps2018tumourcompartmenttranscriptomics pages 1-2
+17. an2025molecularsubtypesof pages 1-2
+18. javidialsaadi2025advancesinthe pages 2-4
+19. gonzalezgallego2025moderntreatmentof pages 2-4
+20. wang2024multiomicsanalysisof pages 8-10
+21. biswas2024practicalapplicationof pages 2-3
+22. apps2017geneticallyengineeredmouse pages 3-5
+23. wang2024multiomicsanalysisof pages 3-5
+24. https://clinicaltrials.gov/study/NCT03224767
+25. https://clinicaltrials.gov/study/NCT05525273
+26. https://clinicaltrials.gov/study/NCT05286788
+27. https://doi.org/10.1056/NEJMoa2213329
+28. https://doi.org/10.1016/j.heliyon.2024.e32112
+29. https://doi.org/10.3389/fendo.2024.1488958
+30. https://doi.org/10.3390/cancers16203479
+31. https://doi.org/10.1097/CM9.0000000000002774
+32. https://doi.org/10.20945/2359-3997000000600
+33. https://doi.org/10.20945/2359-3997000000600,
+34. https://doi.org/10.3390/brainsci13030515,
+35. https://doi.org/10.3389/fendo.2025.1562942,
+36. https://doi.org/10.3390/biomedicines14030499,
+37. https://doi.org/10.3389/fendo.2024.1488958,
+38. https://doi.org/10.1056/nejmoa2213329,
+39. https://doi.org/10.1007/s00401-018-1830-2,
+40. https://doi.org/10.1097/cm9.0000000000002774,
+41. https://doi.org/10.1093/neuonc/noaf030,
+42. https://doi.org/10.3390/jcm14041101,
+43. https://doi.org/10.1016/j.heliyon.2024.e32112,
+44. https://doi.org/10.1007/s12020-025-04216-9,
+45. https://doi.org/10.1093/neuonc/noz227,
+46. https://doi.org/10.3390/cancers16203479,
+47. https://doi.org/10.1186/s12885-024-12397-1,
+48. https://doi.org/10.1111/bpa.12501,


### PR DESCRIPTION
## Summary
- Add a Craniopharyngioma disorder page with ACP/PCP subtypes, CTNNB1-Wnt and BRAF-MAPK mechanisms, major visual/endocrine/hypothalamic phenotypes, diagnostics, treatments, and trials.
- Add the Falcon deep-research report and citation artifact.
- Add cited PMID and ClinicalTrials.gov reference caches generated via `just fetch-reference`.

## Validation
- `just validate kb/disorders/Craniopharyngioma.yaml`
- `just validate-references kb/disorders/Craniopharyngioma.yaml`
- `just validate-terms kb/disorders/Craniopharyngioma.yaml`
- `git diff --check`
- `just compliance kb/disorders/Craniopharyngioma.yaml` (Global 92.4%, weighted 93.0%)