### PR TITLE
Add dimethylglycine dehydrogenase deficiency curation

### DIFF
--- a/kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Dimethylglycine Dehydrogenase Deficiency
 creation_date: "2026-05-11T17:50:11Z"
-updated_date: "2026-05-11T18:32:22Z"
+updated_date: "2026-05-11T19:07:58Z"
 category: Mendelian
 synonyms:
 - DMG dehydrogenase deficiency
@@ -66,9 +66,10 @@ progression:
 pathophysiology:
 - name: DMGDH molecular function deficiency
   description: >-
-    DMGDH encodes a mitochondrial matrix flavoprotein that catalyses oxidative
-    demethylation of N,N-dimethylglycine to sarcosine. Deficient DMGDH activity
-    blocks this metabolic step and causes dimethylglycine accumulation.
+    DMGDH encodes a mitochondrial matrix enzyme that uses flavin adenine
+    dinucleotide and tetrahydrofolate to catalyse oxidative demethylation of
+    N,N-dimethylglycine to sarcosine. Deficient DMGDH activity blocks this
+    choline and one-carbon metabolic step and causes dimethylglycine accumulation.
   genes:
   - preferred_term: DMGDH
     term:
@@ -79,6 +80,17 @@ pathophysiology:
     term:
       id: GO:0047865
       label: dimethylglycine dehydrogenase activity
+    modifier: DECREASED
+  biological_processes:
+  - preferred_term: choline metabolic process
+    term:
+      id: GO:0019695
+      label: choline metabolic process
+    modifier: DECREASED
+  - preferred_term: one-carbon metabolic process
+    term:
+      id: GO:0006730
+      label: one-carbon metabolic process
     modifier: DECREASED
   locations:
   - preferred_term: mitochondrion
@@ -96,7 +108,17 @@ pathophysiology:
       id: CHEBI:57433
       label: sarcosine zwitterion
     modifier: DECREASED
+  - preferred_term: tetrahydrofolate
+    term:
+      id: CHEBI:67016
+      label: tetrahydrofolate
   evidence:
+  - reference: DOI:10.1111/febs.13828
+    reference_title: "Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease-related H109R variant"
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The human dimethylglycine dehydrogenase (hDMGDH) is a flavin adenine dinucleotide (FAD)‐ and tetrahydrofolate (THF)‐dependent, mitochondrial matrix enzyme taking part in choline degradation, one‐carbon metabolism and electron transfer to the respiratory chain."
+    explanation: Recombinant structural and biochemical work places DMGDH in mitochondrial choline and one-carbon metabolism and identifies tetrahydrofolate as a cofactor.
   - reference: DOI:10.1007/s10545-008-0999-2
     reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
     supports: SUPPORT
@@ -207,6 +229,32 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
       explanation: The discovery case links the biochemical disorder to a fish-odor presentation.
+  - target: Muscle fatigue
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: >-
+      The index patient had marked dimethylglycine accumulation together with
+      unusual muscle fatigue, but the causal intermediate connecting the
+      metabolite abnormality to muscle symptoms is not defined.
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+      explanation: The same patient had the defining DMG accumulation and unusual muscle fatigue, supporting an indirect clinical association but not a proven causal intermediate.
+  - target: Elevated serum creatine kinase
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: >-
+      Increased serum creatine kinase co-occurred with dimethylglycine
+      accumulation in the index patient, but the mechanism linking the
+      metabolite abnormality to muscle injury is unknown.
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "unusual muscle fatigue with increased serum creatine kinase."
+      explanation: The case report supports co-occurrence of muscle fatigue and serum CK elevation, while the causal mechanism remains unresolved.
 phenotypes:
 - category: Clinical
   name: Fish-like body odor
@@ -414,9 +462,10 @@ treatments:
     explanation: Identification of a homozygous disease-associated gene finding supports genetic counseling for affected families.
 - name: Supportive clinical monitoring
   description: >-
-    No cache-backed evidence identified an established disease-modifying
-    therapy. Current curation therefore limits management to supportive
-    monitoring of reported manifestations and diagnostic clarification.
+    Supportive care should focus on monitoring the reported manifestations,
+    including fish-like body odor, muscle fatigue, and serum creatine kinase
+    elevation, while confirming the biochemical and genetic diagnosis. No
+    disease-modifying therapy has been established for this ultra-rare disorder.
   treatment_term:
     preferred_term: supportive care
     term:

--- a/kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml
@@ -1,0 +1,431 @@
+name: Dimethylglycine Dehydrogenase Deficiency
+creation_date: "2026-05-11T17:50:11Z"
+updated_date: "2026-05-11T18:32:22Z"
+category: Mendelian
+synonyms:
+- DMG dehydrogenase deficiency
+- DMGDH deficiency
+- DMGDHD
+- hyperdimethylglycinemia
+- defect in dimethylglycine dehydrogenase
+description: >-
+  Dimethylglycine dehydrogenase deficiency is an extremely rare autosomal
+  recessive inborn error of choline, methylamine, and one-carbon metabolism
+  caused by deficient mitochondrial DMGDH activity. The original patient
+  presented with childhood-onset fish odor, unusual muscle fatigue, increased
+  serum creatine kinase, and marked accumulation of N,N-dimethylglycine in
+  serum and urine. Functional studies of the disease-associated H109R DMGDH
+  variant show impaired flavin binding and reduced catalytic activity,
+  supporting a hypomorphic loss-of-function mechanism.
+disease_term:
+  preferred_term: dimethylglycine dehydrogenase deficiency
+  term:
+    id: MONDO:0011610
+    label: dimethylglycine dehydrogenase deficiency
+parents:
+- disorder of methylamine metabolism
+- Inborn error of metabolism
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0011610
+      label: dimethylglycine dehydrogenase deficiency
+    mapping_predicate: skos:exactMatch
+    mapping_source: MONDO
+    mapping_justification: MONDO exact match for Orphanet ORPHA:243343 and OMIM:605850.
+inheritance:
+- name: Autosomal recessive
+  inheritance_term:
+    preferred_term: Autosomal recessive inheritance
+    term:
+      id: HP:0000007
+      label: Autosomal recessive inheritance
+  description: >-
+    The disorder is represented by a homozygous disease-associated DMGDH
+    variant in the reported patient, consistent with recessive inheritance.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A homozygous missense mutation was found in the DMGDH gene of the patient."
+    explanation: The original patient carried a homozygous DMGDH missense variant, supporting recessive inheritance for this single-family disorder.
+progression:
+- phase: Childhood-onset odor with adult biochemical diagnosis
+  age_range: Childhood to adulthood
+  notes: >-
+    The reported individual had fish odor from about age 5 and was evaluated
+    as an adult with unusual muscle fatigue and increased serum creatine kinase.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+    explanation: The discovery report gives the childhood onset of odor and adult clinical findings.
+pathophysiology:
+- name: DMGDH molecular function deficiency
+  description: >-
+    DMGDH encodes a mitochondrial matrix flavoprotein that catalyses oxidative
+    demethylation of N,N-dimethylglycine to sarcosine. Deficient DMGDH activity
+    blocks this metabolic step and causes dimethylglycine accumulation.
+  genes:
+  - preferred_term: DMGDH
+    term:
+      id: hgnc:24475
+      label: DMGDH
+  molecular_functions:
+  - preferred_term: dimethylglycine dehydrogenase activity
+    term:
+      id: GO:0047865
+      label: dimethylglycine dehydrogenase activity
+    modifier: DECREASED
+  locations:
+  - preferred_term: mitochondrion
+    term:
+      id: GO:0005739
+      label: mitochondrion
+  chemical_entities:
+  - preferred_term: N,N-dimethylglycine
+    term:
+      id: CHEBI:58251
+      label: N,N-dimethylglycine zwitterion
+    modifier: INCREASED
+  - preferred_term: sarcosine
+    term:
+      id: CHEBI:57433
+      label: sarcosine zwitterion
+    modifier: DECREASED
+  evidence:
+  - reference: DOI:10.1007/s10545-008-0999-2
+    reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Dimethylglycine dehydrogenase (DMGDH) is a mitochondrial matrix flavoprotein that catalyses the demethylation of dimethylglycine to form sarcosine"
+    explanation: Recombinant enzyme work establishes the DMGDH-catalyzed metabolic reaction and mitochondrial context.
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The high concentration of DMG was caused by a deficiency of the enzyme dimethylglycine dehydrogenase (DMGDH)."
+    explanation: The discovery study directly links high DMG in the patient to DMGDH deficiency.
+  downstream:
+  - target: Dimethylglycine accumulation
+    causal_link_type: DIRECT
+    description: >-
+      Reduced DMGDH activity blocks oxidative demethylation of dimethylglycine,
+      allowing N,N-dimethylglycine to accumulate in serum and urine.
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The concentration of N,N-dimethylglycine (DMG) was increased ∼100-fold in the serum and ∼20-fold in the urine."
+      explanation: Patient metabolite measurements show the downstream accumulation expected from DMGDH deficiency.
+- name: H109R DMGDH variant functional impairment
+  description: >-
+    The disease-associated H109R DMGDH variant has reduced bound flavin and
+    markedly impaired catalytic performance in recombinant biochemical assays,
+    providing a mechanistic basis for its pathogenicity.
+  genes:
+  - preferred_term: DMGDH
+    term:
+      id: hgnc:24475
+      label: DMGDH
+  molecular_functions:
+  - preferred_term: dimethylglycine dehydrogenase activity
+    term:
+      id: GO:0047865
+      label: dimethylglycine dehydrogenase activity
+    modifier: DECREASED
+  chemical_entities:
+  - preferred_term: FAD
+    term:
+      id: CHEBI:57692
+      label: FAD(3-)
+    modifier: DECREASED
+  evidence:
+  - reference: DOI:10.1007/s10545-008-0999-2
+    reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The H109R variant, however, had only 47% of the wild‐type level of bound flavin as expressed in E. coli, indicating its reduced affinity for FAD"
+    explanation: The H109R recombinant protein had reduced flavin binding, supporting a cofactor-affinity defect.
+  - reference: DOI:10.1007/s10545-008-0999-2
+    reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "The flavinated H109R variant protein exhibited a 27‐fold decrease in specific activity and a 65‐fold increase in Km, explaining its pathogenicity."
+    explanation: Functional enzyme kinetics directly support reduced activity and pathogenicity of H109R.
+  - reference: DOI:10.1111/febs.13828
+    reference_title: "Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease-related H109R variant"
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "A comparative study with the H109R variant demonstrated that the variant suffers from decreased protein stability, cofactor saturation, and substrate affinity."
+    explanation: Later recombinant structural/biochemical work independently supports H109R functional impairment.
+  downstream:
+  - target: DMGDH molecular function deficiency
+    causal_link_type: DIRECT
+    description: >-
+      H109R-related cofactor and substrate-affinity defects reduce DMGDH
+      molecular function.
+    evidence:
+    - reference: DOI:10.1007/s10545-008-0999-2
+      reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "The flavinated H109R variant protein exhibited a 27‐fold decrease in specific activity and a 65‐fold increase in Km, explaining its pathogenicity."
+      explanation: The variant-level biochemical impairment explains the upstream molecular deficiency.
+- name: Dimethylglycine accumulation
+  description: >-
+    Impaired DMGDH activity produces a biochemical phenotype dominated by
+    accumulation of N,N-dimethylglycine in body fluids.
+  chemical_entities:
+  - preferred_term: N,N-dimethylglycine
+    term:
+      id: CHEBI:58251
+      label: N,N-dimethylglycine zwitterion
+    modifier: INCREASED
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The concentration of N,N-dimethylglycine (DMG) was increased ∼100-fold in the serum and ∼20-fold in the urine."
+    explanation: NMR-based patient biochemistry identifies serum and urinary DMG accumulation as the defining biomarker.
+  downstream:
+  - target: Fish-like body odor
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: >-
+      The relationship between dimethylglycine accumulation and fish-like odor
+      is clinically associated in the index patient, but the odor-generating
+      intermediate is not established.
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+      explanation: The discovery case links the biochemical disorder to a fish-odor presentation.
+phenotypes:
+- category: Clinical
+  name: Fish-like body odor
+  description: >-
+    The reported patient had fish odor beginning in childhood; this presentation
+    overlaps clinically with trimethylaminuria and related fish-odor syndromes.
+  phenotype_term:
+    preferred_term: fish-like body odor
+    term:
+      id: HP:0500001
+      label: Body odor
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A38-year-old man presented with a history of fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+    explanation: The original case report states the fish-odor phenotype and age of onset.
+- category: Clinical
+  name: Muscle fatigue
+  description: >-
+    Unusual muscle fatigue was part of the reported presentation.
+  phenotype_term:
+    preferred_term: increased muscle fatiguability
+    term:
+      id: HP:0003750
+      label: Increased muscle fatiguability
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+    explanation: The discovery case directly reports unusual muscle fatigue.
+- category: Biochemical
+  name: Elevated serum creatine kinase
+  description: >-
+    Increased serum creatine kinase was reported alongside muscle fatigue in
+    the index patient, suggesting biochemical evidence of muscle involvement.
+  phenotype_term:
+    preferred_term: elevated serum creatine kinase
+    term:
+      id: HP:0003236
+      label: Elevated circulating creatine kinase concentration
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "unusual muscle fatigue with increased serum creatine kinase."
+    explanation: The original patient had increased serum creatine kinase as part of the presentation.
+biochemical:
+- name: N,N-dimethylglycine
+  biomarker_term:
+    preferred_term: N,N-dimethylglycine
+    term:
+      id: CHEBI:58251
+      label: N,N-dimethylglycine zwitterion
+  presence: INCREASED
+  context: >-
+    Marked elevation of N,N-dimethylglycine in serum and urine is the defining
+    diagnostic biochemical abnormality.
+  readouts:
+  - target: Dimethylglycine accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >-
+      Increased serum or urinary N,N-dimethylglycine reports the primary
+      metabolic block in DMGDH deficiency.
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The concentration of N,N-dimethylglycine (DMG) was increased ∼100-fold in the serum and ∼20-fold in the urine."
+      explanation: The biomarker quantitatively reports the dimethylglycine-accumulation node.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The concentration of N,N-dimethylglycine (DMG) was increased ∼100-fold in the serum and ∼20-fold in the urine."
+    explanation: The discovery study defines the diagnostic serum and urinary DMG elevation.
+genetic:
+- name: DMGDH pathogenic variants
+  gene_term:
+    preferred_term: DMGDH
+    term:
+      id: hgnc:24475
+      label: DMGDH
+  presence: PRESENT
+  inheritance:
+  - name: Autosomal recessive
+    evidence:
+    - reference: DOI:10.1093/clinchem/45.4.459
+      reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A homozygous missense mutation was found in the DMGDH gene of the patient."
+      explanation: The homozygous DMGDH missense variant supports recessive inheritance within the genetic section.
+  variants:
+  - name: H109R
+    description: >-
+      Homozygous missense variant p.His109Arg (H109R), also described as
+      A326G in the Falcon report, identified in the reported patient and shown
+      to impair DMGDH flavin binding and catalytic activity in vitro.
+    evidence:
+    - reference: DOI:10.1007/s10545-008-0999-2
+      reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "the H109R variant identified in a DMGDH‐deficient patient"
+      explanation: The recombinant biochemical study identifies H109R as the patient variant studied.
+    - reference: DOI:10.1007/s10545-008-0999-2
+      reference_title: "Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R"
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "The flavinated H109R variant protein exhibited a 27‐fold decrease in specific activity and a 65‐fold increase in Km, explaining its pathogenicity."
+      explanation: The same study provides variant-level functional evidence.
+  features: >-
+    Dimethylglycine dehydrogenase deficiency is associated with homozygous
+    pathogenic variation affecting DMGDH.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A homozygous missense mutation was found in the DMGDH gene of the patient."
+    explanation: The discovery report identifies the gene and zygosity in the reported patient.
+diagnosis:
+- name: Serum and urine NMR metabolite analysis
+  diagnosis_term:
+    preferred_term: biomarker analysis
+    term:
+      id: MAXO:0000018
+      label: biomarker analysis
+  description: >-
+    Proton NMR spectroscopy of serum and urine can detect the characteristic
+    DMG elevation; the original study also used carbon-13 NMR and GC-MS to
+    confirm DMG as the storage product.
+  markers: N,N-dimethylglycine
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We used 1H NMR spectroscopy to study serum and urine from the patient."
+    explanation: The original diagnosis used serum and urine proton NMR spectroscopy.
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The presence of DMG as a storage product was confirmed by use of 13C NMR spectroscopy and gas chromatography–mass spectrometry."
+    explanation: The same report used orthogonal chemical methods to confirm the DMG biomarker.
+- name: Molecular genetic testing of DMGDH
+  diagnosis_term:
+    preferred_term: molecular genetic testing
+    term:
+      id: MAXO:0000533
+      label: molecular genetic testing
+  description: >-
+    DMGDH sequencing confirms the diagnosis by identifying biallelic pathogenic
+    variants in a compatible biochemical phenotype.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A homozygous missense mutation was found in the DMGDH gene of the patient."
+    explanation: The discovery study used DMGDH molecular findings to establish the genetic cause.
+differential_diagnoses:
+- name: Fish-odor syndromes including trimethylaminuria
+  description: >-
+    Fish-like odor is an overlapping presentation, so DMGDH deficiency should
+    be considered when fish odor is accompanied by marked DMG elevation rather
+    than a primary trimethylamine-oxidation defect.
+  distinguishing_features:
+  - Increased serum and urinary N,N-dimethylglycine.
+  - Homozygous disease-associated DMGDH variant.
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "DMGDH deficiency must be added to the differential diagnosis of patients complaining of a fish odor."
+    explanation: The original authors explicitly frame DMGDH deficiency as a differential diagnosis for fish-odor complaints.
+treatments:
+- name: Genetic counseling
+  description: >-
+    Genetic counseling is appropriate for families once biallelic DMGDH
+    pathogenic variation is identified, with discussion of recessive recurrence
+    risk and the very limited human natural-history evidence.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A homozygous missense mutation was found in the DMGDH gene of the patient."
+    explanation: Identification of a homozygous disease-associated gene finding supports genetic counseling for affected families.
+- name: Supportive clinical monitoring
+  description: >-
+    No cache-backed evidence identified an established disease-modifying
+    therapy. Current curation therefore limits management to supportive
+    monitoring of reported manifestations and diagnostic clarification.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: DOI:10.1093/clinchem/45.4.459
+    reference_title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: "A38-year-old man presented with a history of fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase."
+    explanation: The case report supports the manifestations that would be followed clinically; it does not establish a disease-modifying treatment.

--- a/references_cache/DOI_10.1007_s10545-008-0999-2.md
+++ b/references_cache/DOI_10.1007_s10545-008-0999-2.md
@@ -1,0 +1,21 @@
+---
+reference_id: "DOI:10.1007/s10545-008-0999-2"
+title: Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R
+authors:
+- R. P. McAndrew
+- J. Vockley
+- J.‐J. P. Kim
+journal: Journal of Inherited Metabolic Disease
+year: '2008'
+doi: 10.1007/s10545-008-0999-2
+content_type: abstract_only
+---
+
+# Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R
+**Authors:** R. P. McAndrew, J. Vockley, J.‐J. P. Kim
+**Journal:** Journal of Inherited Metabolic Disease (2008)
+**DOI:** [10.1007/s10545-008-0999-2](https://doi.org/10.1007/s10545-008-0999-2)
+
+## Content
+
+SummaryDimethylglycine dehydrogenase (DMGDH) is a mitochondrial matrix flavoprotein that catalyses the demethylation of dimethylglycine to form sarcosine, accompanied by the reduction of the covalently bound FAD cofactor. Electron‐transfer flavoprotein reoxidizes the reduced flavin and transfers reducing equivalents to the main mitochondrial respiratory chain through the enzyme ETF‐ubiquinone oxidoreductase. DMGDH plays a prominent role in choline and 1‐carbon metabolism. We have expressed the mature form of human DMGDH and the H109R variant identified in a DMGDH‐deficient patient as N‐terminally His6‐tagged proteins in E. coli. The enzymes were purified to homogeneity by nickel affinity and anion exchange chromatography. The presence of FAD in the wild‐type enzyme was confirmed by spectrophotometric analysis. The H109R variant, however, had only 47% of the wild‐type level of bound flavin as expressed in E. coli, indicating its reduced affinity for FAD As previously described for rat enzyme studies, the wild‐type human enzyme exhibited two Km values for N,N‐dimethylglycine (Km1 = 0.039 ± 0.010 mmol/L and Km2 = 15.4 ± 1.2 mmol/L). The addition of 4 μmol/L tetrahydrofolate resulted in a slight decrease in specific activity and a substantial decrease in Km2 (1.10 ± 0.55 mmol/L). The flavinated H109R variant protein exhibited a 27‐fold decrease in specific activity and a 65‐fold increase in Km, explaining its pathogenicity. Additionally, the current expression system represents a significant improvement over a previously described rat DMGDH expression system and will enhance our ability to further study this important metabolic enzyme.

--- a/references_cache/DOI_10.1093_clinchem_45.4.459.md
+++ b/references_cache/DOI_10.1093_clinchem_45.4.459.md
@@ -1,0 +1,27 @@
+---
+reference_id: "DOI:10.1093/clinchem/45.4.459"
+title: "Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study"
+authors:
+- Sytske H Moolenaar
+- Jo Poggi-Bach
+- Udo FH Engelke
+- Jacqueline MB Corstiaensen
+- Arend Heerschap
+- Jan GN de Jong
+- Barbara A Binzak
+- Jerry Vockley
+- Ron A Wevers
+journal: Clinical Chemistry
+year: '1999'
+doi: 10.1093/clinchem/45.4.459
+content_type: abstract_only
+---
+
+# Defect in Dimethylglycine Dehydrogenase, a New Inborn Error of Metabolism: NMR Spectroscopy Study
+**Authors:** Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, Ron A Wevers
+**Journal:** Clinical Chemistry (1999)
+**DOI:** [10.1093/clinchem/45.4.459](https://doi.org/10.1093/clinchem/45.4.459)
+
+## Content
+
+AbstractBackground: A38-year-old man presented with a history of fish odor (since age 5) and unusual muscle fatigue with increased serum creatine kinase. Our aim was to identify the metabolic error in this new condition.Methods: We used 1H NMR spectroscopy to study serum and urine from the patient.Results: The concentration of N,N-dimethylglycine (DMG) was increased ∼100-fold in the serum and ∼20-fold in the urine. The presence of DMG as a storage product was confirmed by use of 13C NMR spectroscopy and gas chromatography–mass spectrometry. The high concentration of DMG was caused by a deficiency of the enzyme dimethylglycine dehydrogenase (DMGDH). A homozygous missense mutation was found in the DMGDH gene of the patient.Conclusions: DMGDH deficiency must be added to the differential diagnosis of patients complaining of a fish odor. This deficiency is the first inborn error of metabolism discovered by use of in vitro 1H NMR spectroscopy of body fluids.

--- a/references_cache/DOI_10.1111_febs.13828.md
+++ b/references_cache/DOI_10.1111_febs.13828.md
@@ -1,0 +1,23 @@
+---
+reference_id: "DOI:10.1111/febs.13828"
+title: Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease‐related H109R variant
+authors:
+- Peter Augustin
+- Altijana Hromic
+- Tea Pavkov‐Keller
+- Karl Gruber
+- Peter Macheroux
+journal: The FEBS Journal
+year: '2016'
+doi: 10.1111/febs.13828
+content_type: abstract_only
+---
+
+# Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease‐related H109R variant
+**Authors:** Peter Augustin, Altijana Hromic, Tea Pavkov‐Keller, Karl Gruber, Peter Macheroux
+**Journal:** The FEBS Journal (2016)
+**DOI:** [10.1111/febs.13828](https://doi.org/10.1111/febs.13828)
+
+## Content
+
+The human dimethylglycine dehydrogenase (hDMGDH) is a flavin adenine dinucleotide (FAD)‐ and tetrahydrofolate (THF)‐dependent, mitochondrial matrix enzyme taking part in choline degradation, one‐carbon metabolism and electron transfer to the respiratory chain. The rare natural variant H109R causes dimethylglycine dehydrogenase deficiency leading to increased blood and urinary dimethylglycine concentrations. A detailed biochemical and structural characterization of hDMGDH was thus far hampered by insufficient heterologous expression of the protein. In the present study, we report the development of an intracellular, heterologous expression system in Komagataella phaffii (formerly known as Pichia pastoris) providing the opportunity to determine kinetic parameters, spectroscopic properties, thermostability, and the redox potential of hDMGDH. Moreover, we have successfully crystallized the wild‐type enzyme and determined the structure to 3.1‐Å resolution. The structure‐based analysis of our biochemical data provided new insights into the kinetic properties of the enzyme in particular with respect to oxygen reactivity. A comparative study with the H109R variant demonstrated that the variant suffers from decreased protein stability, cofactor saturation, and substrate affinity.DatabaseStructural data are available in the PDB database under the accession number 5L46.

--- a/research/Dimethylglycine_Dehydrogenase_Deficiency-deep-research-falcon.md
+++ b/research/Dimethylglycine_Dehydrogenase_Deficiency-deep-research-falcon.md
@@ -1,0 +1,1237 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T13:58:46.995300'
+end_time: '2026-05-11T14:13:30.425167'
+duration_seconds: 883.43
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Dimethylglycine Dehydrogenase Deficiency
+  mondo_id: ''
+  category: Mendelian
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 25
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dimethylglycine Dehydrogenase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dimethylglycine Dehydrogenase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dimethylglycine Dehydrogenase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dimethylglycine Dehydrogenase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Dimethylglycine Dehydrogenase Deficiency (DMGDH deficiency; hyperdimethylglycinemia): Comprehensive Disease Characteristics Report
+
+## Target disease
+- **Disease name:** Dimethylglycine dehydrogenase deficiency
+- **Category:** Mendelian / inborn error of metabolism (one‑carbon/choline degradation pathway)
+- **Key identifier available from retrieved sources:** **OMIM 605850** (reported in mechanistic/structural papers) (augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3)
+- **MONDO / Orphanet / MeSH / ICD-10/ICD-11:** Not identified in the retrieved corpus for this run; these identifiers should be added from external ontology resources during curation (limitation of this tool-run).
+
+## Executive summary
+Dimethylglycine dehydrogenase deficiency is an ultra‑rare inborn error of choline catabolism/one‑carbon metabolism caused by loss of function in **DMGDH**, a mitochondrial **FAD- and tetrahydrofolate (THF)**‑dependent enzyme that oxidatively demethylates **N,N‑dimethylglycine (DMG)** to **sarcosine**. The canonical human phenotype is mild and has been described primarily in a **single adult patient**, featuring a **lifelong fish‑like odor**, **muscle fatigue/weakness**, and **persistent creatine kinase (CK) elevation**, with massively increased **DMG** in serum and urine. Diagnosis relies on **targeted metabolite measurement** (historically by **^1H NMR spectroscopy** of urine/serum) and confirmatory **molecular genetic testing** identifying **biallelic DMGDH variants** (e.g., **A326G; p.His109Arg**). Evidence for disease mechanism and variant pathogenicity is strengthened by biochemical/structural characterization of the H109R variant showing marked impairment in substrate affinity/cofactor incorporation and catalytic efficiency. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, mcandrew2008molecularbasisof pages 1-3, moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 1-1)
+
+| Disease name / synonym used | Causal gene | Key reported patient findings (clinical, biochemical, diagnostics) | Key quantitative lab values | Pathogenic variant / frequency | Evidence type |
+|---|---|---|---|---|---|
+| Dimethylglycine dehydrogenase deficiency; hyperdimethylglycinemia; “defect in dimethylglycine dehydrogenase”; sometimes discussed with fish-odor syndromes because odor was a presenting complaint (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-1, moolenaar2001invivoand pages 89-94) | **DMGDH** (mitochondrial dimethylglycine dehydrogenase) (mcandrew2008molecularbasisof pages 1-3, augustin2016structureandbiochemical pages 1-3) | Single reported index patient: 38-year-old man of African ancestry; fish-like body odor since age 5, worse with stress/exertion; unusual muscle fatigue/weakness; normal intelligence/overall good health; persistent CK elevation. Biochemical hallmark was marked accumulation of dimethylglycine with absent detectable sarcosine. Diagnosis used **1H NMR** of urine/serum, confirmed by **13C NMR**, **GC-MS**, and later **molecular testing**; trimethylaminuria was excluded by fish challenge and low urinary trimethylamine (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 1-1, moolenaar2001invivoand pages 94-98, moolenaar1999defectindimethylglycine pages 1-2, moolenaar1999defectindimethylglycine pages 3-4, moolenaar1999defectindimethylglycine pages 5-5, moolenaar2001invivoand pages 98-101) | Serum DMG **221** vs ref **1–5**; urine DMG **457** and **441 mmol/mol creatinine** vs ref **1–26** (age >2 months); CK **1066 U/L** vs ref **30–270 U/L** (~4× ULN). Urine trimethylamine **<2 mmol/mol creatinine**; trimethylamine N-oxide **55 mmol/mol creatinine** (ref **20–125**) (moolenaar1999defectindimethylglycine pages 4-5, moolenaar2001invivoand pages 94-98, moolenaar1999defectindimethylglycine pages 1-2, moolenaar1999defectindimethylglycine pages 3-4, moolenaar2001invivoand pages 98-101, moolenaar1999defectindimethylglycine media 773767bc) | Homozygous **A326G** causing **H109R (His109Arg)** near flavin attachment site; reported as disease-causing in the index patient (walker2012trimethylaminuriaanddimethylglycine pages 3-5, mcandrew2008molecularbasisof pages 1-3, moolenaar1999defectindimethylglycine pages 1-1) | Human case report / diagnostic discovery study (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 1-1) |
+| Dimethylglycine dehydrogenase deficiency (OMIM 605850); mild/non-fatal disorder with DMG accumulation and fish-like odor (augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3) | **DMGDH** (augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3) | Recombinant/structural studies linked H109R to decreased expression, reduced FAD saturation, lower thermal stability, impaired substrate affinity, and lower catalytic efficiency, providing mechanistic support for the patient phenotype of DMG accumulation, muscle fatigue, and odor (mcandrew2008molecularbasisof pages 4-6, mcandrew2008molecularbasisof pages 6-8, augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3) | WT kinetics: Km1 **0.039 ± 0.010 mmol/L**, Km2 **15.4 ± 1.2 mmol/L**; with 4 mmol/L THF, Km2 **1.10 ± 0.55 mmol/L**. H109R: ~**47%** WT bound flavin in one expression system; **27-fold** lower specific activity, **65-fold** higher Km, ~**1800-fold** lower catalytic efficiency in one study; other study reported ~**10-fold** lower catalytic efficiency and **15–25-fold** higher Km (mcandrew2008molecularbasisof pages 4-6, augustin2016structureandbiochemical pages 7-9, mcandrew2008molecularbasisof pages 1-3, augustin2016structureandbiochemical pages 1-3, mcandrew2008molecularbasisof pages 6-8) | **H109R** present in ExAC **58/118,656 alleles (0.049%)**, noted as predominantly in individuals of African descent (augustin2016structureandbiochemical pages 1-3) | Biochemical / structural study (mcandrew2008molecularbasisof pages 4-6, augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3) |
+| Dimethylglycine dehydrogenase deficiency in choline-related inherited metabolic disease reviews; very rare / likely autosomal recessive disorder (walker2012trimethylaminuriaanddimethylglycine pages 3-5) | **DMGDH** (walker2012trimethylaminuriaanddimethylglycine pages 3-5) | Chapter/review sources summarize that only one case had been reported at that time; disease blocks choline catabolism, causing major DMG accumulation in plasma/urine; suggested practical diagnosis is raised plasma/urine DMG, ideally sampled when odor present. Proton NMR is emphasized as useful; routine liver biopsy would be needed for enzyme confirmation because activity is not normally detectable in blood cells/fibroblasts. Management suggestions included counseling, dietary choline restriction, avoiding excessive sweating; antibiotics to alter gut flora not indicated; riboflavin alone did not help, and folate plus riboflavin was suggested as a trial (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 5-5) | Plasma DMG increase described as ~**100-fold** and urine increase ~**20-fold**; healthy adult plasma reference **1–5 µmol/L**; urine reference **<26 mmol/mol creatinine** after age 2 months, with higher neonatal values up to ~**550 mmol/mol creatinine** in first 2 months (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 4-5) | Homozygous **A326G / H109R** summarized as causative in the known patient (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-1) | Review / book chapter (walker2012trimethylaminuriaanddimethylglycine pages 3-5) |
+
+
+*Table: This table condenses the core literature on dimethylglycine dehydrogenase deficiency, including the nomenclature used, the causal gene, the single well-described human case, key quantitative laboratory abnormalities, and the main pathogenic variant with biochemical evidence. It is useful as a quick reference for disease curation and knowledge base population.*
+
+---
+
+## 1. Disease information
+### 1.1 What is the disease?
+Dimethylglycine dehydrogenase deficiency (also called hyperdimethylglycinemia) is a genetic metabolic disorder in which impaired DMGDH activity blocks the mitochondrial step converting DMG to sarcosine, leading to **marked accumulation of DMG in body fluids** and a **mild clinical phenotype** in the best‑described patient. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-1, moolenaar1999defectindimethylglycine pages 1-2)
+
+### 1.2 Common synonyms / alternative names (from primary literature)
+- “Dimethylglycine dehydrogenase deficiency” (walker2012trimethylaminuriaanddimethylglycine pages 3-5, augustin2016structureandbiochemical pages 7-9)
+- “Hyperdimethylglycinemia” (used as a descriptor for DMG elevation in the discovery paper) (moolenaar1999defectindimethylglycine pages 1-1)
+- “Defect in dimethylglycine dehydrogenase” (title/terminology of original case report) (moolenaar1999defectindimethylglycine pages 1-1)
+
+### 1.3 Evidence source type
+The disease description is derived primarily from:
+- **Individual human case report/discovery study** using metabolomics/NMR and molecular genetics (moolenaar1999defectindimethylglycine pages 1-1, moolenaar1999defectindimethylglycine pages 1-2)
+- **Authoritative chapter-level synthesis** describing rarity, diagnostic approach, and management suggestions (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Biochemical/structural functional studies** of the disease-associated variant (mcandrew2008molecularbasisof pages 1-3, augustin2016structureandbiochemical pages 1-3)
+
+---
+
+## 2. Etiology
+### 2.1 Disease causal factors
+- **Genetic cause:** Biallelic pathogenic variants in **DMGDH**. The index patient was **homozygous for A326G**, encoding **p.His109Arg (H109R)**. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, mcandrew2008molecularbasisof pages 1-3)
+- **Mechanistic cause:** Loss of DMGDH enzymatic function causing failure of DMG demethylation and consequent accumulation of DMG in blood/urine. (augustin2016structureandbiochemical pages 1-3, moolenaar1999defectindimethylglycine pages 1-1)
+
+### 2.2 Risk factors
+- **Genetic:** Having biallelic loss‑of‑function or severely hypomorphic variants in DMGDH (autosomal recessive inferred). A chapter review states the disorder is “likely autosomal recessive” and notes “only one case” had been reported at that time. (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Environmental:** No validated environmental risk factors were identified; symptoms (odor) were reported to worsen with **stress/exertion** in the index patient (not a cause, but a trigger/modifier of symptom expression). (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+
+### 2.3 Protective factors / gene–environment interactions
+No protective genetic variants or gene–environment interactions specific to disease penetrance were reported in the retrieved literature. Given the extremely limited case count, these remain unknown.
+
+---
+
+## 3. Phenotypes
+### 3.1 Reported human phenotypes (best-described index case)
+**Clinical signs/symptoms**
+- Fish‑like body odor beginning in childhood (age 5) and persisting into adulthood. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+- Unusual muscle fatigue and/or mild muscle weakness. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, mcandrew2008molecularbasisof pages 1-3, moolenaar1999defectindimethylglycine pages 1-2)
+- Normal intelligence and generally good health otherwise reported in the original case. (moolenaar1999defectindimethylglycine pages 1-2)
+
+**Laboratory abnormalities**
+- Markedly increased DMG in serum and urine (quantified in Table 1 of discovery report). (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine media 773767bc)
+- Persistently increased serum/plasma creatine kinase (~4× upper limit of normal). (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+
+**Phenotype timing and severity**
+- **Age of onset:** childhood for odor complaint (age ~5). (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+- **Course:** chronic/lifelong in the index patient. (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Severity:** described as mild/non‑fatal in later mechanistic literature. (augustin2016structureandbiochemical pages 7-9)
+
+### 3.2 Suggested HPO terms (mapping based on described features)
+(These are ontology suggestions for curation; HPO IDs not retrieved in this run.)
+- Fishy body odor / abnormal body odor: **Abnormal body odor**
+- Fatigue: **Fatigue**
+- Muscle weakness: **Muscle weakness**
+- Elevated creatine kinase: **Elevated circulating creatine kinase concentration**
+- Increased dimethylglycine: **Abnormal circulating metabolite concentration** (specific metabolite annotation may require custom term)
+
+### 3.3 Quantitative phenotype-associated data
+Table 1 in the original Clinical Chemistry report provides the key quantitative biochemical phenotype:
+- **Serum DMG:** **221** (reported as mmol/L in excerpt) vs reference **1–5** (moolenaar1999defectindimethylglycine pages 4-5)
+- **Urine DMG:** **457** and **441 mmol/mol creatinine** vs reference **1–26** (for age >2 months) (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine media 773767bc)
+- **Creatine kinase:** **1066 U/L** (ref 30–270 U/L) (moolenaar1999defectindimethylglycine pages 1-2)
+
+**Visual evidence:** Table 1/Figure 5 showing these abnormalities and age-related urine DMG reference distribution are captured as cropped images. (moolenaar1999defectindimethylglycine media 773767bc, moolenaar1999defectindimethylglycine media 214a655b)
+
+### 3.4 Quality of life impact
+The index case reported severe psychosocial impact from persistent odor (qualitative description in follow-on NMR paper). (moolenaar2001invivoand pages 94-98)
+
+---
+
+## 4. Genetic / molecular information
+### 4.1 Causal gene
+- **DMGDH** encodes mitochondrial dimethylglycine dehydrogenase, a covalently flavinylated enzyme requiring THF. (augustin2016structureandbiochemical pages 1-3, moolenaar1999defectindimethylglycine pages 1-2)
+
+### 4.2 Pathogenic variant(s)
+- **Index disease variant:** **c.326A>G; p.His109Arg (H109R)**, homozygous in the reported patient. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, mcandrew2008molecularbasisof pages 1-3)
+
+### 4.3 Functional consequences (variant-level)
+Two independent functional analyses support pathogenicity:
+- H109R shows reduced flavin incorporation/cofactor saturation, markedly impaired substrate affinity and/or catalytic efficiency, and reduced stability—mechanistic routes to decreased enzymatic flux and DMG accumulation. (mcandrew2008molecularbasisof pages 4-6, augustin2016structureandbiochemical pages 7-9, augustin2016structureandbiochemical pages 1-3)
+- Quantitatively, one study reports the H109R mutant as having a **~65‑fold increase in Km** and **~27‑fold decrease in activity**, with overall **~1800‑fold loss in catalytic efficiency** (after accounting for flavination), consistent with a severe hypomorphic/LOF allele. (mcandrew2008molecularbasisof pages 4-6)
+
+### 4.4 Population frequency context
+The H109R allele was observed in ExAC at **58/118,656 alleles (0.049%)**, predominantly in individuals of African descent, highlighting that population presence does not exclude pathogenicity for autosomal recessive disease when homozygosity is rare. (augustin2016structureandbiochemical pages 1-3)
+
+### 4.5 Modifier genes / epigenetics / chromosomal abnormalities
+No modifier genes, epigenetic findings, or chromosomal abnormalities were reported for DMGDH deficiency in the retrieved sources.
+
+---
+
+## 5. Environmental information
+No established environmental toxins, lifestyle factors, or infectious triggers are reported as causal. Symptom fluctuation with stress/exertion (odor worsening) is noted in the index case. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+
+---
+
+## 6. Mechanism / pathophysiology
+### 6.1 Molecular pathway and causal chain
+**Upstream:** Dietary choline → betaine → DMG (as part of choline catabolism / methyl group metabolism).
+
+**Core defect:** DMGDH is a mitochondrial **FAD- and THF-dependent** enzyme that demethylates DMG to sarcosine; THF accepts the methyl group (preventing release of formaldehyde). (augustin2016structureandbiochemical pages 1-3)
+
+**Downstream biochemical consequence:** DMGDH deficiency results in **marked accumulation of DMG** in serum and urine, and **absent/undetectable sarcosine** in the original biochemical profile. (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 1-2)
+
+**Clinical consequence (known):** fish‑like odor (likely from volatile DMG), fatigue/weakness, and elevated CK. However, because the phenotype is based on very few individuals, links beyond metabolite accumulation remain uncertain. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 5-5)
+
+### 6.2 Suggested GO biological process / cellular component terms
+(ontology suggestions)
+- **GO: one‑carbon metabolic process**
+- **GO: choline metabolic process / betaine metabolic process**
+- **GO: glycine metabolic process**
+- **GO cellular component:** mitochondrial matrix (DMGDH is mitochondrial) (augustin2016structureandbiochemical pages 1-3)
+
+### 6.3 Suggested cell types (Cell Ontology)
+No specific cell type pathology is described; enzyme is liver‑relevant in catabolism. For curation, consider:
+- Hepatocyte (primary site of choline metabolism; inferred, not directly evidenced here)
+- Skeletal muscle cell (given CK and fatigue; speculative)
+
+---
+
+## 7. Anatomical structures affected
+### 7.1 Organ/system level (evidence-based)
+- **Muscle involvement:** suggested by fatigue/weakness and persistently elevated CK. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-2)
+
+### 7.2 Suggested UBERON terms
+- Skeletal muscle tissue (UBERON suggestion)
+- Liver (UBERON suggestion; diagnostic enzyme assay discussion implies liver relevance) (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+### 7.3 Subcellular localization
+- **Mitochondrial enzyme** (matrix-associated) consistent with biochemical characterization. (augustin2016structureandbiochemical pages 1-3)
+
+---
+
+## 8. Temporal development
+- **Onset:** childhood for odor (age ~5). (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Course:** chronic/lifelong; no defined staging described. (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+---
+
+## 9. Inheritance and population
+### 9.1 Inheritance
+- Inferred **autosomal recessive** (chapter source: “likely autosomal recessive”; index patient homozygous). (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+### 9.2 Epidemiology
+- Extremely rare; as of the chapter publication, “only one case has been reported.” (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- No robust incidence/prevalence estimates were identified in the retrieved sources.
+
+### 9.3 Population/ancestry
+- Index case: described as a man of **African ancestry**. (moolenaar1999defectindimethylglycine pages 1-2)
+- H109R allele: enriched in ExAC African ancestry subset. (augustin2016structureandbiochemical pages 1-3)
+
+---
+
+## 10. Diagnostics
+### 10.1 Core diagnostic biomarker
+- **Elevated DMG in plasma/serum and urine** is the defining biochemical abnormality. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 4-5)
+
+### 10.2 Laboratory methods (real-world implementations)
+- **^1H NMR spectroscopy** of urine and serum was a key diagnostic approach in the discovery study; DMG displayed characteristic singlets (2.93 and 3.80 ppm) and was confirmed by spiking experiments. (moolenaar1999defectindimethylglycine pages 4-5)
+- **GC‑MS** confirmation can be performed, but the discovery paper notes DMG can be missed by routine organic-acid workflows using solvent extraction (lost during ethyl acetate extraction). (moolenaar1999defectindimethylglycine pages 3-4, walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Fish‑challenge testing** and urinary trimethylamine measures were used to exclude trimethylaminuria in the presenting “fish odor” complaint. (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 3-4)
+
+### 10.3 Enzyme assay
+A chapter notes DMGDH activity is not normally detectable in blood cells/fibroblasts, so confirmatory enzyme testing would require **liver tissue (biopsy)**—a major practical limitation. (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+### 10.4 Genetic testing
+Confirmatory diagnosis is via **DMGDH sequencing** to identify biallelic pathogenic variants (e.g., A326G/H109R). (moolenaar1999defectindimethylglycine pages 1-1, walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+### 10.5 Differential diagnosis
+Given the presenting symptom of fish-like odor, differential considerations include trimethylaminuria; DMGDH deficiency can be distinguished by **massively elevated DMG** and low trimethylamine after fish challenge. (moolenaar1999defectindimethylglycine pages 4-5, moolenaar1999defectindimethylglycine pages 3-4)
+
+---
+
+## 11. Outcome / prognosis
+- Later biochemical/structural literature describes the disorder as **non‑fatal** and typically **mild**. (augustin2016structureandbiochemical pages 7-9)
+- No survival statistics, long-term organ outcomes, or standardized quality-of-life metrics were identified, due to limited case ascertainment.
+
+---
+
+## 12. Treatment
+### 12.1 Evidence-based interventions (limited)
+No established disease-modifying therapy exists.
+
+**Riboflavin trial (index case):** The original report states the patient received **riboflavin 10 mg/day for 3 months without clinical improvement**. (moolenaar1999defectindimethylglycine pages 3-4)
+
+**Supportive/empiric measures (expert opinion from authoritative chapter):**
+- Counseling
+- Dietary **choline restriction** and avoidance of excessive sweating (odor management)
+- Antibiotics to alter intestinal microflora “not indicated”
+- Suggested trial of folate with riboflavin (hypothesis-driven, not proven)
+(walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+### 12.2 Suggested MAXO terms
+(ontology suggestions)
+- Dietary modification / dietary choline restriction
+- Vitamin supplementation (riboflavin; folate)
+- Genetic counseling
+
+### 12.3 Clinical trials
+No DMGDH deficiency–specific trials were retrieved.
+
+---
+
+## 13. Prevention
+- **Primary prevention:** not applicable in the usual sense for an autosomal recessive condition.
+- **Secondary prevention:** early biochemical/genetic diagnosis may reduce psychosocial morbidity by explaining odor and guiding supportive measures. (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- **Genetic counseling:** indicated for families once a causative DMGDH genotype is identified (inferred from AR inheritance and chapter guidance). (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+
+---
+
+## 14. Other species / natural disease
+No naturally occurring veterinary disease analogs were identified in the retrieved sources.
+
+---
+
+## 15. Model organisms / experimental systems
+### 15.1 Human protein functional models
+Functional evidence is largely derived from recombinant enzyme studies and structural biology (including a reported PDB structure for human DMGDH in one study). (augustin2016structureandbiochemical pages 1-3)
+
+### 15.2 Need for in vivo models
+The molecular basis paper notes that additional DMGDH‑deficient humans or an appropriate mouse model would be needed to resolve genotype–phenotype questions. (mcandrew2008molecularbasisof pages 8-8)
+
+---
+
+## Recent developments (prioritizing 2023–2024)
+Direct 2023–2024 primary case expansions were not available in the retrievable corpus for this run. As a proxy for “latest research” relevant to real‑world implementation, the most concrete near‑term development is the continued mainstreaming of **broad metabolomics and sequencing** for rare disease diagnosis (with older but still relevant metabolomics evidence in this run). For example, DI‑HRMS metabolomics has been evaluated for inborn errors using dried blood spots and plasma; one limitation noted is that some workflows may fail to recognize DMGDH deficiency depending on feature detection/annotation. (moolenaar2001invivoand pages 98-101)
+
+---
+
+## Key primary sources (URLs and publication dates)
+- Moolenaar SH et al. **“Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: NMR spectroscopy study.”** *Clinical Chemistry* (Apr **1999**). https://doi.org/10.1093/clinchem/45.4.459 (moolenaar1999defectindimethylglycine pages 1-1)
+- McAndrew R et al. **“Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant H109R.”** *Journal of Inherited Metabolic Disease* (Oct **2008**). https://doi.org/10.1007/s10545-008-0999-2 (mcandrew2008molecularbasisof pages 1-3)
+- Walker V, Wevers RA. **“Trimethylaminuria and Dimethylglycine Dehydrogenase Deficiency.”** In *Inborn Metabolic Diseases* (Jan **2012**). https://doi.org/10.1007/978-3-540-28785-8_31 (walker2012trimethylaminuriaanddimethylglycine pages 3-5)
+- Augustin P et al. **“Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease-related H109R variant.”** *FEBS Journal* (Oct **2016**). https://doi.org/10.1111/febs.13828 (augustin2016structureandbiochemical pages 1-3)
+
+---
+
+## Clinical trials / registries relevant to real-world implementation
+- **CoRDS (Coordination of Rare Diseases at Sanford)** observational registry / natural history infrastructure: **NCT01793168** (first posted Feb **2013**, recruiting; last update posted May **2025**). https://clinicaltrials.gov/study/NCT01793168 (NCT01793168 chunk 2, NCT01793168 chunk 1)
+
+---
+
+## Limitations of the current evidence base
+1. The human phenotype and natural history remain weakly defined because the core evidence is dominated by a single well-described individual and secondary summaries. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 1-1)
+2. Standard disease identifiers beyond OMIM (e.g., MONDO, Orphanet, ICD, MeSH) were not found in the retrieved set and must be added via direct ontology database queries.
+3. Therapeutic guidance is largely expert opinion and hypothesis-driven supplementation trials rather than controlled clinical evidence. (walker2012trimethylaminuriaanddimethylglycine pages 3-5, moolenaar1999defectindimethylglycine pages 3-4)
+
+
+References
+
+1. (augustin2016structureandbiochemical pages 7-9): Peter Augustin, Altijana Hromic, Tea Pavkov‐Keller, Karl Gruber, and Peter Macheroux. Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease‐related h109r variant. The Febs Journal, 283:3587-3603, Oct 2016. URL: https://doi.org/10.1111/febs.13828, doi:10.1111/febs.13828. This article has 27 citations.
+
+2. (augustin2016structureandbiochemical pages 1-3): Peter Augustin, Altijana Hromic, Tea Pavkov‐Keller, Karl Gruber, and Peter Macheroux. Structure and biochemical properties of recombinant human dimethylglycine dehydrogenase and comparison to the disease‐related h109r variant. The Febs Journal, 283:3587-3603, Oct 2016. URL: https://doi.org/10.1111/febs.13828, doi:10.1111/febs.13828. This article has 27 citations.
+
+3. (walker2012trimethylaminuriaanddimethylglycine pages 3-5): Valerie Walker and Ron A. Wevers. Trimethylaminuria and dimethylglycine dehydrogenase deficiency. Inborn Metabolic Diseases, pages 381-385, Jan 2012. URL: https://doi.org/10.1007/978-3-540-28785-8\_31, doi:10.1007/978-3-540-28785-8\_31. This article has 3 citations.
+
+4. (mcandrew2008molecularbasisof pages 1-3): Ryan McAndrew, Jerry Vockley, and Jung-Ja P. Kim. Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant h109r. Journal of Inherited Metabolic Disease, 31:761-768, Oct 2008. URL: https://doi.org/10.1007/s10545-008-0999-2, doi:10.1007/s10545-008-0999-2. This article has 14 citations and is from a peer-reviewed journal.
+
+5. (moolenaar1999defectindimethylglycine pages 4-5): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+6. (moolenaar1999defectindimethylglycine pages 1-1): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+7. (moolenaar2001invivoand pages 89-94): Sytske H. Moolenaar, Marjo S. van der Knaap, Udo F. H. Engelke, Petra J. W. Pouwels, Fokje S. M. Janssen‐Zijlstra, Nanda M. Verhoeven, Cornelis Jakobs, and Ron A. Wevers. In vivo and in vitro nmr spectroscopy reveal a putative novel inborn error involving polyol metabolism. NMR in Biomedicine, 14:167-176, May 2001. URL: https://doi.org/10.1002/nbm.690, doi:10.1002/nbm.690. This article has 58 citations and is from a peer-reviewed journal.
+
+8. (moolenaar2001invivoand pages 94-98): Sytske H. Moolenaar, Marjo S. van der Knaap, Udo F. H. Engelke, Petra J. W. Pouwels, Fokje S. M. Janssen‐Zijlstra, Nanda M. Verhoeven, Cornelis Jakobs, and Ron A. Wevers. In vivo and in vitro nmr spectroscopy reveal a putative novel inborn error involving polyol metabolism. NMR in Biomedicine, 14:167-176, May 2001. URL: https://doi.org/10.1002/nbm.690, doi:10.1002/nbm.690. This article has 58 citations and is from a peer-reviewed journal.
+
+9. (moolenaar1999defectindimethylglycine pages 1-2): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+10. (moolenaar1999defectindimethylglycine pages 3-4): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+11. (moolenaar1999defectindimethylglycine pages 5-5): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+12. (moolenaar2001invivoand pages 98-101): Sytske H. Moolenaar, Marjo S. van der Knaap, Udo F. H. Engelke, Petra J. W. Pouwels, Fokje S. M. Janssen‐Zijlstra, Nanda M. Verhoeven, Cornelis Jakobs, and Ron A. Wevers. In vivo and in vitro nmr spectroscopy reveal a putative novel inborn error involving polyol metabolism. NMR in Biomedicine, 14:167-176, May 2001. URL: https://doi.org/10.1002/nbm.690, doi:10.1002/nbm.690. This article has 58 citations and is from a peer-reviewed journal.
+
+13. (moolenaar1999defectindimethylglycine media 773767bc): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+14. (mcandrew2008molecularbasisof pages 4-6): Ryan McAndrew, Jerry Vockley, and Jung-Ja P. Kim. Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant h109r. Journal of Inherited Metabolic Disease, 31:761-768, Oct 2008. URL: https://doi.org/10.1007/s10545-008-0999-2, doi:10.1007/s10545-008-0999-2. This article has 14 citations and is from a peer-reviewed journal.
+
+15. (mcandrew2008molecularbasisof pages 6-8): Ryan McAndrew, Jerry Vockley, and Jung-Ja P. Kim. Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant h109r. Journal of Inherited Metabolic Disease, 31:761-768, Oct 2008. URL: https://doi.org/10.1007/s10545-008-0999-2, doi:10.1007/s10545-008-0999-2. This article has 14 citations and is from a peer-reviewed journal.
+
+16. (moolenaar1999defectindimethylglycine media 214a655b): Sytske H Moolenaar, Jo Poggi-Bach, Udo FH Engelke, Jacqueline MB Corstiaensen, Arend Heerschap, Jan GN de Jong, Barbara A Binzak, Jerry Vockley, and Ron A Wevers. Defect in dimethylglycine dehydrogenase, a new inborn error of metabolism: nmr spectroscopy study. Clinical chemistry, 45 4:459-64, Apr 1999. URL: https://doi.org/10.1093/clinchem/45.4.459, doi:10.1093/clinchem/45.4.459. This article has 100 citations and is from a highest quality peer-reviewed journal.
+
+17. (mcandrew2008molecularbasisof pages 8-8): Ryan McAndrew, Jerry Vockley, and Jung-Ja P. Kim. Molecular basis of dimethylglycine dehydrogenase deficiency associated with pathogenic variant h109r. Journal of Inherited Metabolic Disease, 31:761-768, Oct 2008. URL: https://doi.org/10.1007/s10545-008-0999-2, doi:10.1007/s10545-008-0999-2. This article has 14 citations and is from a peer-reviewed journal.
+
+18. (NCT01793168 chunk 2):  Rare Disease Patient Registry & Natural History Study - Coordination of Rare Diseases at Sanford. Sanford Health. 2010. ClinicalTrials.gov Identifier: NCT01793168
+
+19. (NCT01793168 chunk 1):  Rare Disease Patient Registry & Natural History Study - Coordination of Rare Diseases at Sanford. Sanford Health. 2010. ClinicalTrials.gov Identifier: NCT01793168

--- a/research/Dimethylglycine_Dehydrogenase_Deficiency-deep-research-falcon.md.citations.md
+++ b/research/Dimethylglycine_Dehydrogenase_Deficiency-deep-research-falcon.md.citations.md
@@ -1,0 +1,476 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Dimethylglycine Dehydrogenase Deficiency
+- **MONDO ID:**  (if available)
+- **Category:** Mendelian
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Dimethylglycine Dehydrogenase Deficiency** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T14:13:30.425167
+
+1. augustin2016structureandbiochemical pages 1-3
+2. walker2012trimethylaminuriaanddimethylglycine pages 3-5
+3. moolenaar1999defectindimethylglycine pages 1-1
+4. moolenaar1999defectindimethylglycine pages 1-2
+5. augustin2016structureandbiochemical pages 7-9
+6. moolenaar1999defectindimethylglycine pages 4-5
+7. moolenaar2001invivoand pages 94-98
+8. mcandrew2008molecularbasisof pages 4-6
+9. moolenaar1999defectindimethylglycine pages 3-4
+10. mcandrew2008molecularbasisof pages 8-8
+11. moolenaar2001invivoand pages 98-101
+12. mcandrew2008molecularbasisof pages 1-3
+13. moolenaar2001invivoand pages 89-94
+14. moolenaar1999defectindimethylglycine pages 5-5
+15. mcandrew2008molecularbasisof pages 6-8
+16. https://doi.org/10.1093/clinchem/45.4.459
+17. https://doi.org/10.1007/s10545-008-0999-2
+18. https://doi.org/10.1007/978-3-540-28785-8_31
+19. https://doi.org/10.1111/febs.13828
+20. https://clinicaltrials.gov/study/NCT01793168
+21. https://doi.org/10.1111/febs.13828,
+22. https://doi.org/10.1007/978-3-540-28785-8\_31,
+23. https://doi.org/10.1007/s10545-008-0999-2,
+24. https://doi.org/10.1093/clinchem/45.4.459,
+25. https://doi.org/10.1002/nbm.690,


### PR DESCRIPTION
## Summary
- Adds `Dimethylglycine_Dehydrogenase_Deficiency.yaml` for MONDO:0011610.
- Integrates the Falcon report into pathophysiology, phenotypes, biochemical biomarkers, genetics, diagnosis, differential diagnosis, and limited management.
- Adds fetched reference caches for the cited 1999 discovery study, 2008 H109R biochemical study, and 2016 recombinant DMGDH study.

## Validation
- `just validate kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml`
- `just validate-references kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml` (repo validator reported 0 checks for this DOI-based file)
- `just validate-terms kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml`
- `just compliance kb/disorders/Dimethylglycine_Dehydrogenase_Deficiency.yaml` -> 98.6% global / 100.0% weighted
- local read-only snippet check: 26/26 evidence snippets found in fetched caches
- `git diff --check` / `git diff --cached --check`
