### PR TITLE
Add acquired partial lipodystrophy curation

### DIFF
--- a/kb/disorders/Acquired_Partial_Lipodystrophy.yaml
+++ b/kb/disorders/Acquired_Partial_Lipodystrophy.yaml
@@ -1,0 +1,1203 @@
+name: Acquired Partial Lipodystrophy
+category: Complex
+creation_date: "2026-05-11T00:00:00Z"
+updated_date: "2026-05-11T00:00:00Z"
+description: >-
+  Acquired partial lipodystrophy, also called Barraquer-Simons syndrome, is a
+  rare acquired partial lipodystrophy with progressive cephalocaudal loss of
+  subcutaneous adipose tissue from the face, neck, upper limbs, and trunk while
+  lower-extremity adipose tissue is relatively spared. Human cohort and tissue
+  evidence supports an immune-mediated complement phenotype, with low serum C3,
+  C3 nephritic factor and other complement autoantibodies, elevated factor
+  D/adipsin in some patients, and local complement-directed adipose-tissue
+  injury. Important complications include autoimmune disease association,
+  complement-mediated renal disease such as membranoproliferative
+  glomerulonephritis/C3 glomerulopathy, variable metabolic complications, and
+  quality-of-life impact from lipoatrophy.
+disease_term:
+  preferred_term: acquired partial lipodystrophy
+  term:
+    id: MONDO:0012104
+    label: acquired partial lipodystrophy
+parents:
+- acquired lipodystrophy
+- partial lipodystrophy
+synonyms:
+- APLD
+- Barraquer-Simons syndrome
+- partial acquired lipodystrophy
+- progressive cephalothoracic lipodystrophy
+definitions:
+- name: Clinical fat-loss pattern
+  definition_type: CASE_DEFINITION
+  description: >-
+    Acquired partial lipodystrophy is recognized by gradual loss of upper-body
+    subcutaneous adipose tissue, especially face, neck, upper limbs, thorax, and
+    trunk, with sparing of the lower extremities.
+  scope: Clinical recognition of classic Barraquer-Simons syndrome
+  evidence:
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Barraquer-Simons syndrome (BSS), a form of acquired partial lipodystrophy,
+      is a rare condition characterized by gradual loss of adipose tissue from
+      the upper body, keeping intact the white adipose tissue of the lower
+      extremities.
+    explanation: >-
+      This human tissue case report gives a compact clinical definition of the
+      acquired partial lipodystrophy fat-loss pattern.
+  - reference: PMID:32404319
+    reference_title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It is a rare disease characterised by a gradual and progressive onset of
+      lipoatrophy limited to the face, neck, upper limbs, thorax and abdomen
+      and sparing the lower extremities.
+    explanation: >-
+      This case report independently supports the characteristic regional
+      distribution and progression of lipoatrophy.
+epidemiology:
+- name: Rare acquired lipodystrophy in referral cohorts
+  description: >-
+    Acquired partial lipodystrophy is one of the rare acquired lipodystrophy
+    syndromes encountered in specialist lipodystrophy and insulin-resistance
+    pathways. Published pathway data show long diagnostic delays across these
+    rare syndromes.
+  evidence:
+  - reference: PMID:38678257
+    reference_title: "Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A cohort of 292 patients was analyzed, including 208 women, with the
+      following diagnosis: Familial Partial LipoDystrophy (FPLD, n = 124,
+      including n = 67 FPLD2/Dunnigan Syndrome); Acquired lipodystrophy
+      syndromes (n = 98, with n = 13 Acquired Generalized Lipodystrophy, AGL);
+    explanation: >-
+      The national reference-center cohort documents acquired lipodystrophy
+      syndromes among rare lipodystrophy and insulin-resistance referrals.
+progression:
+- phase: Childhood or adult onset with progressive cephalocaudal spread
+  age_range: Childhood to adulthood
+  notes: >-
+    The fat-loss pattern may begin in childhood and progress gradually from the
+    face and neck to upper extremities and trunk. Delayed recognition is common
+    in rare lipodystrophy pathways.
+  evidence:
+  - reference: PMID:27402657
+    reference_title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This case report describes a female patient diagnosed with
+      Barraquer-Simons syndrome, a rare form of acquired partial lipodystrophy
+      characterised by symmetrical loss of adipose tissue from face, neck,
+      upper extremities and the trunk with onset in early childhood.
+    explanation: >-
+      The patient-perspective case report documents early-childhood onset and
+      the symmetrical upper-body distribution.
+  - reference: PMID:38678257
+    reference_title: "Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Improving knowledge to reduce diagnostic delay is an important objective
+      of the PRISIS reference center.
+    explanation: >-
+      Rare lipodystrophy pathway data support delayed diagnosis after first
+      symptoms, relevant to APL recognition and specialist referral.
+pathophysiology:
+- name: Alternative Complement Pathway Dysregulation
+  description: >-
+    Acquired partial lipodystrophy is strongly associated with alternative
+    complement pathway dysregulation. C3 nephritic factor and other
+    complement-directed autoantibodies can stabilize complement activation,
+    leading to C3 consumption, low serum C3, and persistent complement
+    activation.
+  biological_processes:
+  - preferred_term: complement activation, alternative pathway
+    modifier: INCREASED
+    term:
+      id: GO:0006957
+      label: complement activation, alternative pathway
+  - preferred_term: complement activation
+    modifier: DYSREGULATED
+    term:
+      id: GO:0006956
+      label: complement activation
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      BACKGROUND: C3 hypocomplementemia and the presence of C3 nephritic factor
+      (C3NeF), an autoantibody causing complement system over-activation, are
+      common features among most patients affected by Barraquer-Simons syndrome
+      (BSS), an acquired form of partial lipodystrophy.
+    explanation: >-
+      The 13-patient immunology cohort identifies low C3 and C3NeF-mediated
+      complement over-activation as common features of BSS/APL.
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Moreover, the finding of autoantibodies targeting complement system
+      proteins points to complement dysregulation as a central pathological
+      event in the development of BSS.
+    explanation: >-
+      The cohort authors explicitly interpret complement autoantibodies as a
+      central pathological event.
+  downstream:
+  - target: Adipose Complement-Directed Injury
+    description: >-
+      Persistent complement dysregulation can produce local complement
+      activation and complement-directed injury in affected adipose tissue.
+    evidence:
+    - reference: PMID:32890433
+      reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Simultaneous detection of IgG, C3, C5a and C5b-9 proved the ongoing
+        complement activity and complement-directed injury within the adipose
+        tissue.
+      explanation: >-
+        Local IgG, C3, C5a, and C5b-9 detection supports the edge from
+        complement dysregulation to adipose complement-directed injury.
+  - target: Complement-Mediated Glomerular Disease Risk
+    description: >-
+      Alternative pathway dysregulation also links APL/BSS to C3
+      glomerulopathy and membranoproliferative glomerulonephritis.
+    evidence:
+    - reference: PMID:34205507
+      reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The mechanistic connection with complement activation is further
+        reinforced by the fact that 20% of BSS patients eventually develop C3G
+        [1].
+      explanation: >-
+        The BSS full-text evidence supports the edge from complement activation
+        to later C3 glomerulopathy risk.
+- name: Factor D/Adipsin Amplification in Adipose Tissue
+  description: >-
+    Complement factor D, also called adipsin, is a key alternative-pathway
+    protease largely produced by adipocytes and macrophages in adipose tissue.
+    Elevated factor D in BSS may amplify local complement activation in the
+    adipose-tissue environment and has been proposed as a diagnostic biomarker.
+  biological_processes:
+  - preferred_term: complement activation, alternative pathway
+    modifier: INCREASED
+    term:
+      id: GO:0006957
+      label: complement activation, alternative pathway
+  cell_types:
+  - preferred_term: adipocyte
+    term:
+      id: CL:0000136
+      label: adipocyte
+  - preferred_term: macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  locations:
+  - preferred_term: subcutaneous adipose tissue
+    term:
+      id: UBERON:0002190
+      label: subcutaneous adipose tissue
+  evidence:
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Complement Factor D (FD) is a serine protease with a crucial role in the
+      activation of the alternative pathway of the complement system, which is
+      mainly synthesized by adipose tissue.
+    explanation: >-
+      The factor D cohort paper links FD/adipsin to alternative pathway
+      activation and adipose-tissue production.
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We found significantly elevated FD levels in BSS cases compared with the
+      remaining cohorts (p < 0.001).
+    explanation: >-
+      The case-control cohort supports elevated circulating factor D in BSS.
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our results suggest that FD could be a reliable diagnostic biomarker
+      involved in the pathophysiology of BSS by promoting unrestrained local
+      complement system activation in the adipose tissue environment.
+    explanation: >-
+      The authors explicitly propose FD as both a biomarker and a contributor
+      to local adipose complement activation.
+  downstream:
+  - target: Adipose Complement-Directed Injury
+    description: >-
+      Elevated FD/adipsin can accelerate local alternative pathway activation
+      in adipose tissue already exposed to C3NeF-associated dysregulation.
+    evidence:
+    - reference: PMID:34205507
+      reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our results suggest that FD could be a reliable diagnostic biomarker
+        involved in the pathophysiology of BSS by promoting unrestrained local
+        complement system activation in the adipose tissue environment.
+      explanation: >-
+        This supports the edge from elevated FD/adipsin to local adipose
+        complement activation and injury.
+- name: Adipose Complement-Directed Injury
+  description: >-
+    Active affected adipose tissue shows atrophied and dead adipocytes,
+    abnormal extracellular matrix production, macrophage infiltration, and
+    local IgG/C3/C5a/C5b-9 deposition, supporting direct complement-mediated
+    tissue injury as a mechanism for progressive lipoatrophy.
+  biological_processes:
+  - preferred_term: complement activation
+    modifier: INCREASED
+    term:
+      id: GO:0006956
+      label: complement activation
+  - preferred_term: inflammatory response
+    modifier: INCREASED
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  - preferred_term: extracellular matrix organization
+    modifier: INCREASED
+    term:
+      id: GO:0030198
+      label: extracellular matrix organization
+  - preferred_term: apoptotic process
+    modifier: INCREASED
+    term:
+      id: GO:0006915
+      label: apoptotic process
+  cell_types:
+  - preferred_term: adipocyte
+    modifier: DECREASED
+    term:
+      id: CL:0000136
+      label: adipocyte
+  - preferred_term: macrophage
+    modifier: INCREASED
+    term:
+      id: CL:0000235
+      label: macrophage
+  locations:
+  - preferred_term: subcutaneous adipose tissue
+    modifier: DECREASED
+    term:
+      id: UBERON:0002190
+      label: subcutaneous adipose tissue
+  evidence:
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Adipose tissue from the patient showed atrophied and dead adipocytes, an
+      abnormal production of extracellular matrix, and a remarkable accumulation
+      of infiltrating CD68 macrophages and adipocyte precursors (marked by
+      c-Kit positiveness).
+    explanation: >-
+      Human affected adipose tissue demonstrates adipocyte loss, extracellular
+      matrix remodeling, and macrophage-rich inflammation.
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Simultaneous detection of IgG, C3, C5a and C5b-9 proved the ongoing
+      complement activity and complement-directed injury within the adipose
+      tissue.
+    explanation: >-
+      Local immunostaining provides direct evidence for complement activity and
+      complement-directed injury in adipose tissue.
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our results showed the first evidence that the complement system
+      hyperactivation occurs within the adipose tissue and is linked with fat
+      loss in patients with BSS.
+    explanation: >-
+      The study directly links adipose complement hyperactivation with fat loss
+      in BSS.
+  downstream:
+  - target: Progressive Upper-Body Lipoatrophy
+    description: >-
+      Complement-directed injury to adipocytes in affected subcutaneous adipose
+      depots produces the clinical upper-body lipoatrophy phenotype.
+    evidence:
+    - reference: PMID:32890433
+      reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our results showed the first evidence that the complement system
+        hyperactivation occurs within the adipose tissue and is linked with fat
+        loss in patients with BSS.
+      explanation: >-
+        The affected adipose-tissue study directly supports complement
+        hyperactivation as linked with fat loss.
+- name: Impaired Adipogenesis and Mitochondrial Gene Expression
+  description: >-
+    A human adipose biopsy case report found reduced expression of adipogenesis
+    and mitochondrial-function genes in affected subcutaneous adipose tissue,
+    suggesting impaired adipocyte maintenance may accompany complement-driven
+    tissue loss.
+  biological_processes:
+  - preferred_term: adipose tissue development
+    modifier: DECREASED
+    term:
+      id: GO:0060612
+      label: adipose tissue development
+  cell_types:
+  - preferred_term: adipocyte
+    modifier: DECREASED
+    term:
+      id: CL:0000136
+      label: adipocyte
+  locations:
+  - preferred_term: subcutaneous adipose tissue
+    modifier: DECREASED
+    term:
+      id: UBERON:0002190
+      label: subcutaneous adipose tissue
+  evidence:
+  - reference: PMID:18752661
+    reference_title: "Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The expression of marker genes of adipogenesis and adipocyte metabolism,
+      including the master regulator PPARgamma, was down-regulated in
+      subcutaneous adipose tissue from this patient.
+    explanation: >-
+      The case report supports impaired adipogenic gene expression in affected
+      APL subcutaneous adipose tissue.
+  - reference: PMID:18752661
+    reference_title: "Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Expression of genes related to mitochondrial function was reduced despite
+      unaltered levels of mitochondrial DNA.
+    explanation: >-
+      The same adipose biopsy supports reduced mitochondrial gene expression in
+      affected tissue.
+  downstream:
+  - target: Progressive Upper-Body Lipoatrophy
+    description: >-
+      Impaired adipogenesis and adipocyte metabolic gene expression may weaken
+      adipocyte maintenance in affected depots.
+    evidence:
+    - reference: PMID:18752661
+      reference_title: "Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is concluded that adipogenic and mitochondrial gene expression is
+        impaired in adipose tissue in this patient with acquired partial
+        lipodystrophy.
+      explanation: >-
+        The biopsy case report supports impaired adipogenic and mitochondrial
+        gene expression in adipose tissue as a contributor to lipoatrophy.
+- name: Complement-Mediated Glomerular Disease Risk
+  description: >-
+    The same alternative pathway abnormalities implicated in APL/BSS overlap
+    mechanistically with C3 glomerulopathy and membranoproliferative
+    glomerulonephritis, where C3NeF stabilizes C3 convertase and can produce
+    proteinuria, hematuria, hypertension, or kidney failure.
+  biological_processes:
+  - preferred_term: complement activation, alternative pathway
+    modifier: INCREASED
+    term:
+      id: GO:0006957
+      label: complement activation, alternative pathway
+  locations:
+  - preferred_term: renal glomerulus
+    term:
+      id: UBERON:0000074
+      label: renal glomerulus
+  evidence:
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The mechanistic connection with complement activation is further
+      reinforced by the fact that 20% of BSS patients eventually develop C3G
+      [1].
+    explanation: >-
+      The factor D full-text review context states the reported C3
+      glomerulopathy risk in BSS.
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The underlying cause of both DDD and C3Gn is an abnormal activation of
+      the alternative complement pathway, which can result from acquired or
+      genetic alteration.
+    explanation: >-
+      This C3 glomerulopathy review identifies abnormal alternative pathway
+      activation as the cause of DDD and C3GN.
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      In acquired forms of DDD and C3GN, the dysregulation of the alternative
+      pathway is commonly induced by the presence of C3 nephritic factors
+      (C3NeFs), which are autoantibodies that stabilize C3 convertase.
+    explanation: >-
+      The review links acquired C3 glomerulopathy to the same C3NeF biology
+      implicated in APL/BSS.
+phenotypes:
+- category: Adipose tissue
+  name: Progressive Upper-Body Lipoatrophy
+  frequency: OBLIGATE
+  diagnostic: true
+  description: >-
+    The defining phenotype is progressive lipoatrophy of upper-body
+    subcutaneous adipose depots with sparing of lower extremities.
+  phenotype_term:
+    preferred_term: Lipoatrophy
+    term:
+      id: HP:0100578
+      label: Lipoatrophy
+  evidence:
+  - reference: PMID:32404319
+    reference_title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It is a rare disease characterised by a gradual and progressive onset of
+      lipoatrophy limited to the face, neck, upper limbs, thorax and abdomen
+      and sparing the lower extremities.
+    explanation: >-
+      The case report supports progressive upper-body lipoatrophy as the
+      defining clinical phenotype.
+- category: Adipose tissue
+  name: Loss of facial adipose tissue
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Facial fat loss is typically part of the cephalocaudal fat-loss pattern and
+    often drives cosmetic and psychosocial morbidity.
+  phenotype_term:
+    preferred_term: Loss of facial adipose tissue
+    term:
+      id: HP:0000292
+      label: Loss of facial adipose tissue
+  evidence:
+  - reference: PMID:27402657
+    reference_title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This case report describes a female patient diagnosed with
+      Barraquer-Simons syndrome, a rare form of acquired partial lipodystrophy
+      characterised by symmetrical loss of adipose tissue from face, neck,
+      upper extremities and the trunk with onset in early childhood.
+    explanation: >-
+      The case report directly includes facial adipose-tissue loss in the
+      characteristic distribution.
+- category: Adipose tissue
+  name: Decreased adipose tissue around neck
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Neck adipose-tissue loss is part of the classic upper-body distribution.
+  phenotype_term:
+    preferred_term: Decreased adipose tissue around neck
+    term:
+      id: HP:0005995
+      label: Decreased adipose tissue around neck
+  evidence:
+  - reference: PMID:27402657
+    reference_title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This case report describes a female patient diagnosed with
+      Barraquer-Simons syndrome, a rare form of acquired partial lipodystrophy
+      characterised by symmetrical loss of adipose tissue from face, neck,
+      upper extremities and the trunk with onset in early childhood.
+    explanation: >-
+      The case report directly lists neck adipose-tissue loss in the BSS/APL
+      distribution.
+- category: Adipose tissue
+  name: Loss of subcutaneous adipose tissue from upper limbs
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Upper-limb lipoatrophy follows the face and neck in the cephalocaudal
+    pattern.
+  phenotype_term:
+    preferred_term: Loss of subcutaneous adipose tissue from upper limbs
+    term:
+      id: HP:0009056
+      label: Loss of subcutaneous adipose tissue from upper limbs
+  evidence:
+  - reference: PMID:30604443
+    reference_title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The authors report a case of a young woman, who presented with gradual
+      loss of subcutaneous fat from the face, upper limbs, and trunk.
+    explanation: >-
+      The filler case report documents upper-limb subcutaneous fat loss.
+- category: Adipose tissue
+  name: Loss of truncal subcutaneous adipose tissue
+  frequency: VERY_FREQUENT
+  diagnostic: true
+  description: >-
+    Truncal and thoracoabdominal subcutaneous fat loss are part of the
+    progressive upper-body phenotype.
+  phenotype_term:
+    preferred_term: Loss of truncal subcutaneous adipose tissue
+    term:
+      id: HP:0009002
+      label: Loss of truncal subcutaneous adipose tissue
+  evidence:
+  - reference: PMID:30604443
+    reference_title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The authors report a case of a young woman, who presented with gradual
+      loss of subcutaneous fat from the face, upper limbs, and trunk.
+    explanation: >-
+      The filler case report documents truncal subcutaneous fat loss.
+- category: Immunologic
+  name: Decreased circulating complement C3 concentration
+  frequency: FREQUENT
+  diagnostic: true
+  description: >-
+    Low circulating C3 is a frequent biochemical and immunologic hallmark,
+    often occurring with C3 nephritic factor.
+  phenotype_term:
+    preferred_term: Decreased circulating complement C3 concentration
+    term:
+      id: HP:0005421
+      label: Decreased circulating complement C3 concentration
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      C3, C4 and FB levels were significantly reduced in patients with BSS as
+      compared with healthy subjects.
+    explanation: >-
+      Human cohort data support reduced circulating C3 and other complement
+      proteins in BSS.
+- category: Immunologic
+  name: C3 nephritic factor positivity
+  frequency: FREQUENT
+  diagnostic: true
+  description: >-
+    C3 nephritic factor is the most frequently detected complement
+    autoantibody in the studied BSS cohort.
+  phenotype_term:
+    preferred_term: C3 nephritic factor positivity
+    term:
+      id: HP:0030888
+      label: C3 nephritic factor positivity
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      C3NeF was the most frequently found autoantibody (69.2% of cases),
+      followed by anti-C3 (38.5%), and anti-P and anti-FB (30.8% each).
+    explanation: >-
+      The immunology cohort provides a percentage for C3NeF positivity in
+      BSS/APL.
+- category: Immune system
+  name: Autoimmunity
+  frequency: FREQUENT
+  description: >-
+    Autoimmune diseases and complement-directed autoantibodies are common in
+    studied BSS cohorts.
+  phenotype_term:
+    preferred_term: Autoimmunity
+    term:
+      id: HP:0002960
+      label: Autoimmunity
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Clinical data showed high prevalence of autoimmune diseases (38.5%), the
+      majority of patients (61.5%) being positive for at least one of the
+      autoantibodies tested.
+    explanation: >-
+      The cohort supports autoimmune disease association and broader
+      autoantibody positivity.
+- category: Renal
+  name: Membranoproliferative glomerulonephritis
+  frequency: OCCASIONAL
+  description: >-
+    Complement-mediated glomerular disease is a clinically important
+    complication of BSS/APL and may present as C3 glomerulopathy or
+    membranoproliferative glomerulonephritis.
+  phenotype_term:
+    preferred_term: Membranoproliferative glomerulonephritis
+    term:
+      id: HP:0000793
+      label: Membranoproliferative glomerulonephritis
+  evidence:
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Dense deposit disease (DDD) and C3 glomerulonephritis (C3GN) are types of
+      membranoproliferative glomerulonephritis classified as C3
+      glomerulopathies.
+    explanation: >-
+      The C3 glomerulopathy review maps DDD and C3GN to the
+      membranoproliferative glomerulonephritis pattern.
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The mechanistic connection with complement activation is further
+      reinforced by the fact that 20% of BSS patients eventually develop C3G
+      [1].
+    explanation: >-
+      APL/BSS full-text evidence supports C3 glomerulopathy as a later
+      complication in a subset of patients.
+- category: Renal
+  name: Proteinuria
+  frequency: OCCASIONAL
+  description: >-
+    Proteinuria is a presenting feature of complement-mediated glomerular
+    disease that should be monitored when BSS/APL patients develop renal
+    involvement.
+  phenotype_term:
+    preferred_term: Proteinuria
+    term:
+      id: HP:0000093
+      label: Proteinuria
+  evidence:
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The presenting features of these diseases are variable and may include
+      proteinuria, hematuria, hypertension, or kidney failure.
+    explanation: >-
+      The C3 glomerulopathy review supports proteinuria as a renal surveillance
+      endpoint in complement-mediated glomerular disease.
+- category: Ophthalmologic
+  name: Drusen
+  frequency: OCCASIONAL
+  description: >-
+    Drusen may occur in complement-mediated dense deposit disease contexts and
+    are relevant to ocular surveillance when APL overlaps with C3
+    glomerulopathy.
+  phenotype_term:
+    preferred_term: Drusen
+    term:
+      id: HP:0011510
+      label: Drusen
+  evidence:
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      A common finding in these diseases is low serum C3 levels with normal
+      serum C4 levels.
+    explanation: >-
+      The same complement-mediated renal disease context motivates ocular
+      monitoring in APL/C3G overlap, although the abstracted evidence does not
+      quantify drusen frequency in APL.
+- category: Metabolic
+  name: Hypertriglyceridemia
+  frequency: OCCASIONAL
+  description: >-
+    Metabolic complications are variable in acquired partial lipodystrophy but
+    include hypertriglyceridemia and other insulin-resistance complications
+    when adipose storage capacity is reduced.
+  phenotype_term:
+    preferred_term: Hypertriglyceridemia
+    term:
+      id: HP:0002155
+      label: Hypertriglyceridemia
+  evidence:
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The metabolic abnormalities associated with lipodystrophy include insulin
+      resistance, hypertriglyceridemia, and hepatic steatosis.
+    explanation: >-
+      Lipodystrophy review evidence supports hypertriglyceridemia as a
+      lipodystrophy-associated metabolic complication.
+- category: Metabolic
+  name: Hepatic steatosis
+  frequency: OCCASIONAL
+  description: >-
+    Hepatic steatosis can occur as part of the metabolic complication spectrum
+    of lipodystrophy.
+  phenotype_term:
+    preferred_term: Hepatic steatosis
+    term:
+      id: HP:0001397
+      label: Hepatic steatosis
+  evidence:
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The metabolic abnormalities associated with lipodystrophy include insulin
+      resistance, hypertriglyceridemia, and hepatic steatosis.
+    explanation: >-
+      Lipodystrophy review evidence supports hepatic steatosis as a metabolic
+      complication in lipodystrophy syndromes.
+biochemical:
+- name: Low serum complement C3
+  presence: DECREASED
+  notes: >-
+    Low C3 is a central complement abnormality in BSS/APL and often occurs with
+    C3NeF-mediated alternative pathway activation.
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSIONS: Our results confirmed the association between BSS,
+      autoimmunity and C3 hypocomplementemia.
+    explanation: >-
+      The immunology cohort directly supports low C3 as a BSS-associated
+      biochemical abnormality.
+- name: C3 nephritic factor
+  presence: PRESENT
+  notes: >-
+    C3NeF positivity supports the diagnosis and provides a mechanistic clue for
+    chronic alternative pathway activation.
+  evidence:
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Laboratory findings such as low complement C3 and the presence of C3NeF
+      were used during the diagnosis of BSS.
+    explanation: >-
+      The factor D study describes low C3 and C3NeF as laboratory findings used
+      during BSS diagnosis.
+- name: Complement factor D/adipsin
+  presence: INCREASED
+  notes: >-
+    Plasma factor D is elevated in BSS compared with comparator cohorts and may
+    function as a diagnostic biomarker.
+  evidence:
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      We found significantly elevated FD levels in BSS cases compared with the
+      remaining cohorts (p < 0.001).
+    explanation: >-
+      Case-control data support elevated FD/adipsin in BSS.
+histopathology:
+- name: Atrophied adipocytes with macrophage-rich complement injury
+  diagnostic: false
+  description: >-
+    Affected adipose tissue can show adipocyte atrophy/death, abnormal
+    extracellular matrix, macrophage accumulation, and local complement
+    deposition.
+  evidence:
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Adipose tissue from the patient showed atrophied and dead adipocytes, an
+      abnormal production of extracellular matrix, and a remarkable accumulation
+      of infiltrating CD68 macrophages and adipocyte precursors (marked by
+      c-Kit positiveness).
+    explanation: >-
+      Affected human adipose tissue showed adipocyte loss, matrix remodeling,
+      and macrophage-rich infiltration.
+  - reference: PMID:32890433
+    reference_title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Simultaneous detection of IgG, C3, C5a and C5b-9 proved the ongoing
+      complement activity and complement-directed injury within the adipose
+      tissue.
+    explanation: >-
+      Immunostaining supported local complement-directed injury in affected
+      adipose tissue.
+genetic:
+- name: HLA-DRB1
+  gene_term:
+    preferred_term: HLA-DRB1
+    term:
+      id: hgnc:4948
+      label: HLA-DRB1
+  association: Risk-associated HLA allele enrichment, not a monogenic cause
+  notes: >-
+    Classic acquired partial lipodystrophy is not defined by causal monogenic
+    variants in the cited evidence. One immunology cohort found enrichment of
+    HLA-DRB1*11, especially DRB1*11:03, supporting immune-genetic
+    susceptibility rather than Mendelian inheritance.
+  evidence:
+  - reference: PMID:31924231
+    reference_title: Immunological features of patients affected by Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The HLA allele DRB1*11 was present in 54% of BSS patients, and the
+      majority of them (31%) were positive for *11:03 (vs 1.3% in the general
+      population).
+    explanation: >-
+      The cohort supports an HLA-DRB1 association signal but does not establish
+      a causal monogenic gene-disease relationship.
+diagnosis:
+- name: Clinical fat-distribution assessment
+  description: >-
+    Diagnosis begins with recognition of the characteristic acquired and
+    progressive upper-body fat-loss pattern with lower-extremity sparing.
+  diagnosis_term:
+    preferred_term: disease screening
+    term:
+      id: MAXO:0000124
+      label: disease screening
+  results: >-
+    Progressive loss of face, neck, upper-limb, thoracic, and abdominal
+    subcutaneous fat with lower-extremity sparing supports APL/BSS.
+  evidence:
+  - reference: PMID:32404319
+    reference_title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      It is a rare disease characterised by a gradual and progressive onset of
+      lipoatrophy limited to the face, neck, upper limbs, thorax and abdomen
+      and sparing the lower extremities.
+    explanation: >-
+      This case report supports the clinical fat-distribution pattern used for
+      recognition.
+- name: Complement biomarker analysis
+  description: >-
+    Complement testing for C3, C4, C3NeF, factor B, and related complement
+    autoantibodies supports diagnosis and risk assessment.
+  diagnosis_term:
+    preferred_term: biomarker analysis
+    term:
+      id: MAXO:0000018
+      label: biomarker analysis
+  results: >-
+    Low complement C3 and C3NeF positivity support BSS/APL; elevated factor
+    D/adipsin may further support diagnosis in specialized settings.
+  evidence:
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Laboratory findings such as low complement C3 and the presence of C3NeF
+      were used during the diagnosis of BSS.
+    explanation: >-
+      The cohort methods describe low C3 and C3NeF as diagnostic laboratory
+      findings.
+  - reference: PMID:34205507
+    reference_title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Our results suggest that FD could be a reliable diagnostic biomarker
+      involved in the pathophysiology of BSS by promoting unrestrained local
+      complement system activation in the adipose tissue environment.
+    explanation: >-
+      The factor D study supports FD/adipsin as a candidate diagnostic
+      biomarker.
+- name: Renal surveillance for complement-mediated glomerular disease
+  description: >-
+    Surveillance for renal involvement is important because C3 glomerulopathy
+    and membranoproliferative glomerulonephritis are mechanistically linked to
+    complement dysregulation and may present with proteinuria or kidney
+    dysfunction.
+  diagnosis_term:
+    preferred_term: disease screening
+    term:
+      id: MAXO:0000124
+      label: disease screening
+  results: >-
+    Proteinuria, hematuria, hypertension, kidney failure, or persistent low C3
+    should prompt evaluation for complement-mediated renal disease.
+  evidence:
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The presenting features of these diseases are variable and may include
+      proteinuria, hematuria, hypertension, or kidney failure.
+    explanation: >-
+      C3 glomerulopathy review evidence supports renal surveillance endpoints.
+  - reference: PMID:38076230
+    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      A common finding in these diseases is low serum C3 levels with normal
+      serum C4 levels.
+    explanation: >-
+      The review supports complement testing as part of renal evaluation.
+- name: Metabolic complication surveillance
+  description: >-
+    Patients should be monitored for insulin resistance, hypertriglyceridemia,
+    and hepatic steatosis because acquired partial lipodystrophy is a
+    lipodystrophy syndrome with variable metabolic risk.
+  diagnosis_term:
+    preferred_term: disease screening
+    term:
+      id: MAXO:0000124
+      label: disease screening
+  results: >-
+    Abnormal fasting glucose/HbA1c, triglycerides, liver enzymes, or hepatic
+    imaging can identify metabolic complications requiring treatment.
+  evidence:
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Lipodystrophies are heterogeneous disorders characterized by varying
+      degrees of body fat loss and predisposition to insulin resistance and its
+      metabolic complications.
+    explanation: >-
+      Review evidence supports monitoring for insulin-resistance complications
+      across lipodystrophy syndromes.
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The metabolic abnormalities associated with lipodystrophy include insulin
+      resistance, hypertriglyceridemia, and hepatic steatosis.
+    explanation: >-
+      The review specifies the metabolic complications to screen for.
+treatments:
+- name: Metabolic complication management
+  description: >-
+    Treatment of APL includes prevention and management of metabolic
+    complications such as insulin resistance, hypertriglyceridemia, and hepatic
+    steatosis when present.
+  treatment_term:
+    preferred_term: therapeutic procedure
+    term:
+      id: MAXO:0000002
+      label: therapeutic procedure
+  target_phenotypes:
+  - preferred_term: Hypertriglyceridemia
+    term:
+      id: HP:0002155
+      label: Hypertriglyceridemia
+  - preferred_term: Hepatic steatosis
+    term:
+      id: HP:0001397
+      label: Hepatic steatosis
+  evidence:
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Management focuses on preventing and treating metabolic complications.
+    explanation: >-
+      Review evidence supports metabolic prevention and treatment as the core
+      management principle for lipodystrophy syndromes.
+- name: Autologous fat grafting or lipotransfer
+  description: >-
+    Autologous fat grafting/lipotransfer can be used for soft-tissue
+    restoration in disfiguring facial or upper-body lipoatrophy and has
+    published case-report support for quality-of-life benefit.
+  treatment_term:
+    preferred_term: surgical procedure
+    term:
+      id: MAXO:0000004
+      label: surgical procedure
+  target_phenotypes:
+  - preferred_term: Loss of facial adipose tissue
+    term:
+      id: HP:0000292
+      label: Loss of facial adipose tissue
+  - preferred_term: Lipoatrophy
+    term:
+      id: HP:0100578
+      label: Lipoatrophy
+  evidence:
+  - reference: PMID:27402657
+    reference_title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment of lipoatrophy in these patients is limited to cosmetic
+      restoration, and autologous fat grafting has shown sustained positive
+      effects with no or very little loss of volume at follow-ups.
+    explanation: >-
+      The patient-perspective case report supports autologous fat grafting for
+      lipoatrophy recontouring.
+  - reference: PMID:27402657
+    reference_title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Furthermore, the treatment has resulted in considerable improvements in
+      her quality of life and daily functioning.
+    explanation: >-
+      The same report supports quality-of-life benefit after recontouring.
+  - reference: PMID:32404319
+    reference_title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Autologous fat transfer is an established plastic and reconstructive
+      procedure that is safe and minimally invasive and can be used to
+      reconstruct a variety of soft tissue defects and has shown to be an
+      effective treatment modality in patients with APL.
+    explanation: >-
+      A second case report supports lipotransfer as an effective reconstructive
+      treatment for APL soft-tissue defects.
+- name: Hyaluronic acid filler for facial volume loss
+  description: >-
+    Hyaluronic acid filler can be used for midface volume restoration in
+    selected patients with BSS/APL.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Loss of facial adipose tissue
+    term:
+      id: HP:0000292
+      label: Loss of facial adipose tissue
+  evidence:
+  - reference: PMID:30604443
+    reference_title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Fillers, autologous fat transplant or cosmetic surgeries can be used to
+      correct the volume deficit.
+    explanation: >-
+      The cosmetic dermatology case report identifies filler therapy as a
+      management option for volume deficit.
+  - reference: PMID:30604443
+    reference_title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSION: Hyaluronic acid filler is safe and effective for the
+      management of volume loss in BSS.
+    explanation: >-
+      The report supports hyaluronic acid filler for facial volume loss in BSS.
+- name: Plastic surgeon evaluation
+  description: >-
+    Evaluation by plastic and reconstructive surgery is appropriate when
+    progressive lipoatrophy produces soft-tissue defects or psychosocial
+    burden requiring reconstructive planning.
+  treatment_term:
+    preferred_term: plastic surgeon evaluation
+    term:
+      id: MAXO:0000713
+      label: plastic surgeon evaluation
+  target_phenotypes:
+  - preferred_term: Lipoatrophy
+    term:
+      id: HP:0100578
+      label: Lipoatrophy
+  evidence:
+  - reference: PMID:32404319
+    reference_title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Treatment is aimed at surgical correction of soft tissue destruction.
+    explanation: >-
+      The case report supports surgical evaluation and reconstruction for
+      soft-tissue destruction.
+references:
+- reference: PMID:31924231
+  title: Immunological features of patients affected by Barraquer-Simons syndrome.
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:32890433
+  title: "Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:34205507
+  title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:38678257
+  title: "Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:38076230
+  title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:27823605
+  title: Lipodystrophy Syndromes.
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:18752661
+  title: "Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:27402657
+  title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:30604443
+  title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:32404319
+  title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+notes: >-
+  Curation is based on the Falcon report and exact snippets from generated
+  reference caches. The cited evidence supports complement dysregulation and
+  immune-genetic susceptibility, but does not establish a monogenic cause for
+  classic acquired partial lipodystrophy.

--- a/kb/disorders/Acquired_Partial_Lipodystrophy.yaml
+++ b/kb/disorders/Acquired_Partial_Lipodystrophy.yaml
@@ -363,11 +363,11 @@ pathophysiology:
     suggesting impaired adipocyte maintenance may accompany complement-driven
     tissue loss.
   biological_processes:
-  - preferred_term: adipose tissue development
+  - preferred_term: fat cell differentiation
     modifier: DECREASED
     term:
-      id: GO:0060612
-      label: adipose tissue development
+      id: GO:0045444
+      label: fat cell differentiation
   cell_types:
   - preferred_term: adipocyte
     modifier: DECREASED
@@ -715,30 +715,30 @@ phenotypes:
     explanation: >-
       The C3 glomerulopathy review supports proteinuria as a renal surveillance
       endpoint in complement-mediated glomerular disease.
-- category: Ophthalmologic
-  name: Drusen
+- category: Metabolic
+  name: Insulin resistance
   frequency: OCCASIONAL
   description: >-
-    Drusen may occur in complement-mediated dense deposit disease contexts and
-    are relevant to ocular surveillance when APL overlaps with C3
-    glomerulopathy.
+    Insulin resistance is part of the variable metabolic complication spectrum
+    of lipodystrophy, including acquired partial lipodystrophy when adipose
+    storage capacity is reduced.
   phenotype_term:
-    preferred_term: Drusen
+    preferred_term: Insulin resistance
     term:
-      id: HP:0011510
-      label: Drusen
+      id: HP:0000855
+      label: Insulin resistance
   evidence:
-  - reference: PMID:38076230
-    reference_title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+  - reference: PMID:27823605
+    reference_title: Lipodystrophy Syndromes.
     supports: SUPPORT
     evidence_source: OTHER
     snippet: >-
-      A common finding in these diseases is low serum C3 levels with normal
-      serum C4 levels.
+      Lipodystrophies are heterogeneous disorders characterized by varying
+      degrees of body fat loss and predisposition to insulin resistance and its
+      metabolic complications.
     explanation: >-
-      The same complement-mediated renal disease context motivates ocular
-      monitoring in APL/C3G overlap, although the abstracted evidence does not
-      quantify drusen frequency in APL.
+      Lipodystrophy review evidence supports insulin resistance as a metabolic
+      complication of lipodystrophy syndromes.
 - category: Metabolic
   name: Hypertriglyceridemia
   frequency: OCCASIONAL
@@ -1026,6 +1026,10 @@ treatments:
       id: MAXO:0000002
       label: therapeutic procedure
   target_phenotypes:
+  - preferred_term: Insulin resistance
+    term:
+      id: HP:0000855
+      label: Insulin resistance
   - preferred_term: Hypertriglyceridemia
     term:
       id: HP:0002155
@@ -1044,6 +1048,69 @@ treatments:
     explanation: >-
       Review evidence supports metabolic prevention and treatment as the core
       management principle for lipodystrophy syndromes.
+- name: Metreleptin pharmacotherapy for severe metabolic complications
+  description: >-
+    Metreleptin is a recombinant leptin analogue with expanded-access evidence
+    in partial lipodystrophy patients with diabetes and/or hypertriglyceridemia.
+    Applicability to classic APL/BSS is limited because the Ajluni cohort was a
+    mixed partial-lipodystrophy cohort rather than APL-specific, and the
+    abstract states FDA approval for generalized forms of lipodystrophy.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: metreleptin
+      term:
+        id: NCIT:C170171
+        label: Metreleptin
+  target_phenotypes:
+  - preferred_term: Insulin resistance
+    term:
+      id: HP:0000855
+      label: Insulin resistance
+  - preferred_term: Hypertriglyceridemia
+    term:
+      id: HP:0002155
+      label: Hypertriglyceridemia
+  evidence:
+  - reference: PMID:27642538
+    reference_title: "Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Metreleptin is approved by the United States Food and Drug Administration
+      for treatment of generalized forms of lipodystrophy.
+    explanation: >-
+      This establishes metreleptin's approved context and supports caution
+      when applying partial-lipodystrophy evidence to classic APL/BSS.
+  - reference: PMID:27642538
+    reference_title: "Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Study FHA101 (ClinicalTrials.gov identifier: NCT00677313) was an
+      open-label, expanded-access, long-term clinical effectiveness and safety
+      study in 23 patients with partial lipodystrophy and diabetes and/or
+      hypertriglyceridemia with no prespecified leptin level.
+    explanation: >-
+      The expanded-access cohort directly studied metreleptin in partial
+      lipodystrophy with metabolic complications, but was not specific to
+      classic APL/BSS.
+  - reference: PMID:27642538
+    reference_title: "Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      CONCLUSIONS: Our clinical observations document the large heterogeneity
+      and disease burden of partial lipodystrophy syndromes and suggest that
+      metreleptin treatment benefits may extend to patients with partial
+      lipodystrophy.
+    explanation: >-
+      The authors frame the benefit as potentially extending to partial
+      lipodystrophy, supporting limited rather than definitive applicability to
+      acquired partial lipodystrophy.
 - name: Autologous fat grafting or lipotransfer
   description: >-
     Autologous fat grafting/lipotransfer can be used for soft-tissue
@@ -1105,6 +1172,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: hyaluronic acid
+      term:
+        id: CHEBI:16336
+        label: hyaluronic acid
   target_phenotypes:
   - preferred_term: Loss of facial adipose tissue
     term:
@@ -1155,6 +1227,35 @@ treatments:
     explanation: >-
       The case report supports surgical evaluation and reconstruction for
       soft-tissue destruction.
+clinical_trials:
+- name: NCT06484868
+  phase: PHASE_IV
+  status: RECRUITING
+  description: >-
+    Open-label Phase IV post-authorisation trial evaluating daily subcutaneous
+    metreleptin treatment in people with partial lipodystrophy, including
+    acquired partial lipodystrophy in the Falcon report.
+  target_phenotypes:
+  - preferred_term: Insulin resistance
+    term:
+      id: HP:0000855
+      label: Insulin resistance
+  - preferred_term: Hypertriglyceridemia
+    term:
+      id: HP:0002155
+      label: Hypertriglyceridemia
+  evidence:
+  - reference: clinicaltrials:NCT06484868
+    reference_title: "A 24-Month, Multi-Centre, Open Label Phase IV Post Authorisation Efficacy Study to Evaluate the Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin Treatment in Patients With Partial Lipodystrophy"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      This is an Open Label, Phase IV, Post Authorisation Study to Evaluate the
+      Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin
+      Treatment in people with Partial Lipodystrophy
+    explanation: >-
+      The ClinicalTrials.gov summary supports the Phase IV metreleptin study in
+      partial lipodystrophy. The structured status is recorded as recruiting.
 references:
 - reference: PMID:31924231
   title: Immunological features of patients affected by Barraquer-Simons syndrome.
@@ -1194,6 +1295,14 @@ references:
   - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
 - reference: PMID:32404319
   title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: PMID:27642538
+  title: "Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program."
+  found_in:
+  - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+- reference: clinicaltrials:NCT06484868
+  title: "A 24-Month, Multi-Centre, Open Label Phase IV Post Authorisation Efficacy Study to Evaluate the Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin Treatment in Patients With Partial Lipodystrophy"
   found_in:
   - Acquired_Partial_Lipodystrophy-deep-research-falcon.md
 notes: >-

--- a/references_cache/PMID_18752661.md
+++ b/references_cache/PMID_18752661.md
@@ -1,0 +1,64 @@
+---
+reference_id: "PMID:18752661"
+title: "Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report."
+authors:
+- Guallar JP
+- Rojas-Garcia R
+- Garcia-Arumi E
+- Domingo JC
+- Gallardo E
+- Andreu AL
+- Domingo P
+- Illa I
+- Giralt M
+- Villarroya F
+journal: J Med Case Rep
+year: '2008'
+doi: 10.1186/1752-1947-2-284
+content_type: abstract_only
+---
+
+# Impaired expression of mitochondrial and adipogenic genes in adipose tissue from a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a case report.
+**Authors:** Guallar JP, Rojas-Garcia R, Garcia-Arumi E, Domingo JC, Gallardo E, Andreu AL, Domingo P, Illa I, Giralt M, Villarroya F
+**Journal:** J Med Case Rep (2008)
+**DOI:** [10.1186/1752-1947-2-284](https://doi.org/10.1186/1752-1947-2-284)
+
+## Content
+
+1. J Med Case Rep. 2008 Aug 27;2:284. doi: 10.1186/1752-1947-2-284.
+
+Impaired expression of mitochondrial and adipogenic genes in adipose tissue from 
+a patient with acquired partial lipodystrophy (Barraquer-Simons syndrome): a 
+case report.
+
+Guallar JP(1), Rojas-Garcia R, Garcia-Arumi E, Domingo JC, Gallardo E, Andreu 
+AL, Domingo P, Illa I, Giralt M, Villarroya F.
+
+Author information:
+(1)Departament de Bioquímica i Biologia Molecular and Institut de Biomedicina 
+(IBUB), Universitat de Barcelona, and CIBER Fisiopatologia Obesidad y Nutrición, 
+Instituto de Salud Carlos III, Avda Diagonal 645, 08028, Barcelona, Spain. 
+jordi.gualler@gmail.com
+
+INTRODUCTION: Acquired partial lipodystrophy or Barraquer-Simons syndrome is a 
+rare form of progressive lipodystrophy. The etiopathogenesis of adipose tissue 
+atrophy in these patients is unknown.
+CASE PRESENTATION: This is a case report of a 44-year-old woman with acquired 
+partial lipodystrophy. To obtain insight into the molecular basis of lipoatrophy 
+in acquired partial lipodystrophy, we examined gene expression in adipose tissue 
+from this patient newly diagnosed with acquired partial lipodystrophy. A biopsy 
+of subcutaneous adipose tissue was obtained from the patient, and DNA and RNA 
+were extracted in order to evaluate mitochondrial DNA abundance and mRNA 
+expression levels.
+CONCLUSION: The expression of marker genes of adipogenesis and adipocyte 
+metabolism, including the master regulator PPARgamma, was down-regulated in 
+subcutaneous adipose tissue from this patient. Adiponectin mRNA expression was 
+also reduced but leptin mRNA levels were unaltered. Markers of local 
+inflammatory status were unaltered. Expression of genes related to mitochondrial 
+function was reduced despite unaltered levels of mitochondrial DNA. It is 
+concluded that adipogenic and mitochondrial gene expression is impaired in 
+adipose tissue in this patient with acquired partial lipodystrophy.
+
+DOI: 10.1186/1752-1947-2-284
+PMCID: PMC2533346
+PMID: 18752661

--- a/references_cache/PMID_27402657.md
+++ b/references_cache/PMID_27402657.md
@@ -1,0 +1,66 @@
+---
+reference_id: "PMID:27402657"
+title: "Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment."
+authors:
+- Heidemann LN
+- Thomsen JB
+- Sørensen JA
+journal: BMJ Case Rep
+year: '2016'
+doi: 10.1136/bcr-2016-216134
+keywords:
+- Activities of Daily Living
+- Adipose Tissue/surgery
+- Adult
+- Disease Progression
+- Female
+- Humans
+- Lipodystrophy/surgery
+- Quality of Life
+- Syndrome
+- Tissue Transplantation/methods
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease progression and recontouring treatment.
+**Authors:** Heidemann LN, Thomsen JB, Sørensen JA
+**Journal:** BMJ Case Rep (2016)
+**DOI:** [10.1136/bcr-2016-216134](https://doi.org/10.1136/bcr-2016-216134)
+
+## Content
+
+1. BMJ Case Rep. 2016 Jul 11;2016:bcr2016216134. doi: 10.1136/bcr-2016-216134.
+
+Barraquer-Simons syndrome: a unique patient's perspective on diagnosis, disease 
+progression and recontouring treatment.
+
+Heidemann LN(1), Thomsen JB(1), Sørensen JA(1).
+
+Author information:
+(1)Department of Plastic and Reconstructive Surgery, Odense University Hospital, 
+Odense, Denmark.
+
+Erratum in
+    BMJ Case Rep. 2021 Jul 6;14(7):e216134corr1. doi: 
+10.1136/bcr-2016-216134corr1.
+
+This case report describes a female patient diagnosed with Barraquer-Simons 
+syndrome, a rare form of acquired partial lipodystrophy characterised by 
+symmetrical loss of adipose tissue from face, neck, upper extremities and the 
+trunk with onset in early childhood. Initial symptoms were seen at the age of 
+8 years. Our patient did not show signs of renal impairment and this may be 
+associated with the syndrome. Treatment of lipoatrophy in these patients is 
+limited to cosmetic restoration, and autologous fat grafting has shown sustained 
+positive effects with no or very little loss of volume at follow-ups. 
+Furthermore, the treatment has resulted in considerable improvements in her 
+quality of life and daily functioning. She has not experienced any adverse 
+effects. Accurate and early diagnosis is important, and clinicians should 
+consider early intervention for these patients. Autologous fat grafting is 
+recommended as a safe procedure.
+
+2016 BMJ Publishing Group Ltd.
+
+DOI: 10.1136/bcr-2016-216134
+PMCID: PMC4956967
+PMID: 27402657 [Indexed for MEDLINE]

--- a/references_cache/PMID_27642538.md
+++ b/references_cache/PMID_27642538.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:27642538"
+title: "Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program."
+authors:
+- Ajluni N
+- Dar M
+- Xu J
+- Neidert AH
+- Oral EA
+journal: J Diabetes Metab
+year: '2016'
+doi: 10.4172/2155-6156.1000659
+content_type: abstract_only
+---
+
+# Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: Lessons from an Expanded Access Program.
+**Authors:** Ajluni N, Dar M, Xu J, Neidert AH, Oral EA
+**Journal:** J Diabetes Metab (2016)
+**DOI:** [10.4172/2155-6156.1000659](https://doi.org/10.4172/2155-6156.1000659)
+
+## Content
+
+1. J Diabetes Metab. 2016 Mar;7(3):659. doi: 10.4172/2155-6156.1000659. Epub 2016
+ Mar 23.
+
+Efficacy and Safety of Metreleptin in Patients with Partial Lipodystrophy: 
+Lessons from an Expanded Access Program.
+
+Ajluni N(1), Dar M(2), Xu J(3), Neidert AH(1), Oral EA(1).
+
+Author information:
+(1)Brehm Center for Diabetes Research and Division of Metabolism, Endocrinology 
+and Diabetes, University of Michigan, Ann Arbor, MI, USA.
+(2)Greenville Veterans Affairs Health Care Center, Division of Endocrinology and 
+Metabolism, Brody School of Medicine, East Carolina University, Greenville, NC, 
+USA.
+(3)AstraZeneca, Gaithersburg, MD, USA.
+
+OBJECTIVE: Patients with lipodystrophy have severe metabolic abnormalities 
+(insulin resistance, diabetes, and hypertriglyceridemia) that may increase 
+morbidity and mortality. Metreleptin is approved by the United States Food and 
+Drug Administration for treatment of generalized forms of lipodystrophy. We 
+aimed to determine the efficacy and safety of metreleptin among patients with 
+partial lipodystrophy using an expanded-access model.
+METHODS: Study FHA101 (ClinicalTrials.gov identifier: NCT00677313) was an 
+open-label, expanded-access, long-term clinical effectiveness and safety study 
+in 23 patients with partial lipodystrophy and diabetes and/or 
+hypertriglyceridemia with no prespecified leptin level. Metreleptin was 
+administered subcutaneously at 0.02 mg/kg twice daily (BID) at Week 1, followed 
+by 0.04 mg/kg BID at Week 2. Dose adjustments thereafter were based on patient 
+response (maximum dose of 0.08 mg/kg BID). One-year changes in glycated 
+hemoglobin (HbA1c), fasting plasma glucose, triglycerides, alanine and aspartate 
+aminotransferases, and treatment-emergent adverse events (TEAEs) were evaluated.
+RESULTS: HbA1c, fasting plasma glucose, and triglycerides were numerically 
+decreased throughout 1 year, with mean (standard error) changes from baseline of 
+-0.88 (0.62)%, -42.0 (22.4) mg/dL, and -119.8 (84.1) mg/dL, respectively, which 
+were greater among patients with higher baseline abnormalities. Liver enzymes 
+did not worsen, and the most frequently observed TEAEs (≥ 10% incidence) were 
+mild to moderate and included nausea (39.1%), hypoglycemia (26.1%), and urinary 
+tract infections (26.1%)-all reported previously. There were no reports of 
+clinically significant immune-related adverse events or new safety signals.
+CONCLUSIONS: Our clinical observations document the large heterogeneity and 
+disease burden of partial lipodystrophy syndromes and suggest that metreleptin 
+treatment benefits may extend to patients with partial lipodystrophy. Additional 
+studies are needed to confirm these preliminary findings.
+
+DOI: 10.4172/2155-6156.1000659
+PMCID: PMC5026130
+PMID: 27642538

--- a/references_cache/PMID_27823605.md
+++ b/references_cache/PMID_27823605.md
@@ -1,0 +1,60 @@
+---
+reference_id: "PMID:27823605"
+title: Lipodystrophy Syndromes.
+authors:
+- Hussain I
+- Garg A
+journal: Endocrinol Metab Clin North Am
+year: '2016'
+doi: 10.1016/j.ecl.2016.06.012
+keywords:
+- Fatty Liver/complications
+- HIV Infections/complications
+- Humans
+- Hypertriglyceridemia/complications
+- Insulin Resistance
+- "Lipodystrophy/classification, physiopathology"
+- Syndrome
+content_type: abstract_only
+---
+
+# Lipodystrophy Syndromes.
+**Authors:** Hussain I, Garg A
+**Journal:** Endocrinol Metab Clin North Am (2016)
+**DOI:** [10.1016/j.ecl.2016.06.012](https://doi.org/10.1016/j.ecl.2016.06.012)
+
+## Content
+
+1. Endocrinol Metab Clin North Am. 2016 Dec;45(4):783-797. doi: 
+10.1016/j.ecl.2016.06.012. Epub 2016 Oct 6.
+
+Lipodystrophy Syndromes.
+
+Hussain I(1), Garg A(2).
+
+Author information:
+(1)Division of Endocrinology, Department of Internal Medicine, UT Southwestern 
+Medical Center, 5323 Harry Hines Boulevard, Dallas, TX 75390-8537, USA.
+(2)Division of Nutrition and Metabolic Diseases, Department of Internal 
+Medicine, Center for Human Nutrition, UT Southwestern Medical Center, 5323 Harry 
+Hines Boulevard, Dallas, TX 75390-8537, USA. Electronic address: 
+abhimanyu.garg@utsouthwestern.edu.
+
+Lipodystrophies are heterogeneous disorders characterized by varying degrees of 
+body fat loss and predisposition to insulin resistance and its metabolic 
+complications. They are subclassified depending on degree of fat loss and 
+whether the disorder is genetic or acquired. The two most common genetic 
+varieties include congenital generalized lipodystrophy and familial partial 
+lipodystrophy; the two most common acquired varieties include acquired 
+generalized lipodystrophy and acquired partial lipodystrophy. Highly active 
+antiretroviral therapy-induced lipodystrophy in patients infected with human 
+immunodeficiency virus and drug-induced localized lipodystrophy are common 
+subtypes. The metabolic abnormalities associated with lipodystrophy include 
+insulin resistance, hypertriglyceridemia, and hepatic steatosis. Management 
+focuses on preventing and treating metabolic complications.
+
+Published by Elsevier Inc.
+
+DOI: 10.1016/j.ecl.2016.06.012
+PMCID: PMC7590232
+PMID: 27823605 [Indexed for MEDLINE]

--- a/references_cache/PMID_30604443.md
+++ b/references_cache/PMID_30604443.md
@@ -1,0 +1,55 @@
+---
+reference_id: "PMID:30604443"
+title: Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+authors:
+- Afra TP
+- Vinay K
+- Razmi T M
+- Narang T
+- Dogra S
+journal: J Cosmet Dermatol
+year: '2019'
+doi: 10.1111/jocd.12847
+content_type: abstract_only
+---
+
+# Hyaluronic acid fillers for correcting midface volume deficit in Barraquer-Simons syndrome.
+**Authors:** Afra TP, Vinay K, Razmi T M, Narang T, Dogra S
+**Journal:** J Cosmet Dermatol (2019)
+**DOI:** [10.1111/jocd.12847](https://doi.org/10.1111/jocd.12847)
+
+## Content
+
+1. J Cosmet Dermatol. 2019 Oct;18(5):1264-1266. doi: 10.1111/jocd.12847. Epub
+2019  Jan 3.
+
+Hyaluronic acid fillers for correcting midface volume deficit in 
+Barraquer-Simons syndrome.
+
+Afra TP(1), Vinay K(1), Razmi T M(1), Narang T(1), Dogra S(1).
+
+Author information:
+(1)Dermatology, Venereology and Leprology, Postgraduate Institute of Medical 
+Education and Research, Chandigarh, India.
+
+BACKGROUND: Barraquer-Simons syndrome (BSS) or acquired partial lipodystrophy is 
+a disorder of loss of subcutaneous fat from the upper part of the body. The 
+resulting cosmetic disfigurement causes significant psychological distress in 
+the affected individuals. Fillers, autologous fat transplant or cosmetic 
+surgeries can be used to correct the volume deficit.
+METHODS: The authors report a case of a young woman, who presented with gradual 
+loss of subcutaneous fat from the face, upper limbs, and trunk. On evaluation, 
+she had low complement C3 levels, but there were no features to suggest any 
+metabolic complication. She was diagnosed with BSS. Her volume deficit in the 
+midface area was managed with hyaluronic acid (HA) filler.
+RESULTS: The treatment has resulted in the correction of her facial volume loss 
+immediately following the procedure with a maintained effect at follow-up 
+visits. She experienced no major adverse events.
+CONCLUSION: Hyaluronic acid filler is safe and effective for the management of 
+volume loss in BSS. It gives a long lasting result and an added self-confidence 
+to the patient.
+
+© 2019 Wiley Periodicals, Inc.
+
+DOI: 10.1111/jocd.12847
+PMID: 30604443

--- a/references_cache/PMID_31924231.md
+++ b/references_cache/PMID_31924231.md
@@ -1,0 +1,115 @@
+---
+reference_id: "PMID:31924231"
+title: Immunological features of patients affected by Barraquer-Simons syndrome.
+authors:
+- Corvillo F
+- Ceccarini G
+- Nozal P
+- Magno S
+- Pelosini C
+- Garrido S
+- López-Lera A
+- Moraru M
+- Vilches C
+- Fornaciari S
+- Gabbriellini S
+- Santini F
+- Araújo-Vilar D
+- López-Trascasa M
+journal: Orphanet J Rare Dis
+year: '2020'
+doi: 10.1186/s13023-019-1292-1
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Autoimmunity/physiology
+- Child
+- Complement C3/metabolism
+- Complement C3 Nephritic Factor/metabolism
+- Complement C4/metabolism
+- Complement Factor B/metabolism
+- Female
+- Humans
+- "Lipodystrophy/immunology, metabolism"
+- Male
+- Middle Aged
+- Properdin/metabolism
+- Young Adult
+content_type: abstract_only
+---
+
+# Immunological features of patients affected by Barraquer-Simons syndrome.
+**Authors:** Corvillo F, Ceccarini G, Nozal P, Magno S, Pelosini C, Garrido S, López-Lera A, Moraru M, Vilches C, Fornaciari S, Gabbriellini S, Santini F, Araújo-Vilar D, López-Trascasa M
+**Journal:** Orphanet J Rare Dis (2020)
+**DOI:** [10.1186/s13023-019-1292-1](https://doi.org/10.1186/s13023-019-1292-1)
+
+## Content
+
+1. Orphanet J Rare Dis. 2020 Jan 10;15(1):9. doi: 10.1186/s13023-019-1292-1.
+
+Immunological features of patients affected by Barraquer-Simons syndrome.
+
+Corvillo F(1)(2), Ceccarini G(3), Nozal P(4)(5)(6), Magno S(3), Pelosini C(3), 
+Garrido S(4)(5)(6), López-Lera A(4)(5), Moraru M(7), Vilches C(7), Fornaciari 
+S(8), Gabbriellini S(8), Santini F(3), Araújo-Vilar D(9), López-Trascasa 
+M(4)(10).
+
+Author information:
+(1)Complement Research Group, Hospital La Paz Institute for Health Research 
+(IdiPAZ), La Paz University Hospital, Paseo de la Castellana, 261, 28046, 
+Madrid, Spain. fcorvillo@yahoo.es.
+(2)Center for Biomedical Network Research on Rare Diseases (CIBERER U754), 
+Madrid, Spain. fcorvillo@yahoo.es.
+(3)Obesity and Lipodystrophy Centre at the Endocrinology Unit, University 
+Hospital of Pisa, Pisa, Italy.
+(4)Complement Research Group, Hospital La Paz Institute for Health Research 
+(IdiPAZ), La Paz University Hospital, Paseo de la Castellana, 261, 28046, 
+Madrid, Spain.
+(5)Center for Biomedical Network Research on Rare Diseases (CIBERER U754), 
+Madrid, Spain.
+(6)Unit of Immunology, La Paz University Hospital, Madrid, Spain.
+(7)Immunogenetics and Histocompatibility, Instituto de Investigación Sanitaria 
+Puerta de Hierro, Madrid, Spain.
+(8)Immunogenetics laboratory, University Hospital of Pisa, Pisa, Italy.
+(9)Thyroid and Metabolic Diseases Unit (U.E.T.eM.), Centro Singular de 
+Investigación en Medicina Molecular e Enfermidades Crónicas (CIMUS-IDIS), School 
+of Medicine, Universidad de Santiago de Compostela, Santiago de Compostela, 
+Spain.
+(10)Universidad Autónoma de Madrid, Madrid, Spain.
+
+Erratum in
+    Orphanet J Rare Dis. 2020 Mar 30;15(1):79. doi: 10.1186/s13023-020-1350-8.
+
+BACKGROUND: C3 hypocomplementemia and the presence of C3 nephritic factor 
+(C3NeF), an autoantibody causing complement system over-activation, are common 
+features among most patients affected by Barraquer-Simons syndrome (BSS), an 
+acquired form of partial lipodystrophy. Moreover, BSS is frequently associated 
+with autoimmune diseases. However, the relationship between complement system 
+dysregulation and BSS remains to be fully elucidated. The aim of this study was 
+to provide a comprehensive immunological analysis of the complement system 
+status, autoantibody signatures and HLA profile in BSS. Thirteen subjects with 
+BSS were recruited for the study. The circulating levels of complement 
+components, C3, C4, Factor B (FB) and Properdin (P), as well as an extended 
+autoantibody profile including autoantibodies targeting complement components 
+and regulators were assessed in serum. Additionally, HLA genotyping was carried 
+out using DNA extracted from peripheral blood mononuclear cells.
+RESULTS: C3, C4 and FB levels were significantly reduced in patients with BSS as 
+compared with healthy subjects. C3NeF was the most frequently found autoantibody 
+(69.2% of cases), followed by anti-C3 (38.5%), and anti-P and anti-FB (30.8% 
+each). Clinical data showed high prevalence of autoimmune diseases (38.5%), the 
+majority of patients (61.5%) being positive for at least one of the 
+autoantibodies tested. The HLA allele DRB1*11 was present in 54% of BSS 
+patients, and the majority of them (31%) were positive for *11:03 (vs 1.3% in 
+the general population).
+CONCLUSIONS: Our results confirmed the association between BSS, autoimmunity and 
+C3 hypocomplementemia. Moreover, the finding of autoantibodies targeting 
+complement system proteins points to complement dysregulation as a central 
+pathological event in the development of BSS.
+
+DOI: 10.1186/s13023-019-1292-1
+PMCID: PMC6954565
+PMID: 31924231 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_32404319.md
+++ b/references_cache/PMID_32404319.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:32404319"
+title: Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+authors:
+- Jeon FHK
+- Griffin M
+- Frosdick C
+- Butler PEM
+journal: BMJ Case Rep
+year: '2020'
+doi: 10.1136/bcr-2019-232601
+keywords:
+- Adipose Tissue/transplantation
+- Autografts
+- Face/surgery
+- Female
+- Humans
+- Lipodystrophy/surgery
+- Middle Aged
+- Plastic Surgery Procedures
+content_type: abstract_only
+---
+
+# Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy.
+**Authors:** Jeon FHK, Griffin M, Frosdick C, Butler PEM
+**Journal:** BMJ Case Rep (2020)
+**DOI:** [10.1136/bcr-2019-232601](https://doi.org/10.1136/bcr-2019-232601)
+
+## Content
+
+1. BMJ Case Rep. 2020 May 12;13(5):e232601. doi: 10.1136/bcr-2019-232601.
+
+Lipotransfer provides effective soft tissue replacement for acquired partial 
+lipodystrophy.
+
+Jeon FHK(1), Griffin M(2)(3), Frosdick C(3), Butler PEM(2)(3).
+
+Author information:
+(1)Division of Surgery & Interventional Science, University College London, 
+London, UK h.jeon@outlook.com.
+(2)Division of Surgery & Interventional Science, University College London, 
+London, UK.
+(3)Department of Plastic and Reconstructive Surgery, Royal Free London NHS 
+Foundation Trust, London, UK.
+
+We present a 48-year-old female patient who presented with features consistent 
+with acquired partial lipodystrophy (APL) also known as 'Barraquer-Simons 
+syndrome'. It is a rare disease characterised by a gradual and progressive onset 
+of lipoatrophy limited to the face, neck, upper limbs, thorax and abdomen and 
+sparing the lower extremities. The resultant physical appearance can have 
+significant psychosocial sequelae, further compounded by misdiagnosis and delay 
+in recognition and management. Treatment is aimed at surgical correction of soft 
+tissue destruction. Autologous fat transfer is an established plastic and 
+reconstructive procedure that is safe and minimally invasive and can be used to 
+reconstruct a variety of soft tissue defects and has shown to be an effective 
+treatment modality in patients with APL.
+
+© BMJ Publishing Group Limited 2020. No commercial re-use. See rights and 
+permissions. Published by BMJ.
+
+DOI: 10.1136/bcr-2019-232601
+PMCID: PMC7228454
+PMID: 32404319 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/references_cache/PMID_32890433.md
+++ b/references_cache/PMID_32890433.md
@@ -1,0 +1,93 @@
+---
+reference_id: "PMID:32890433"
+title: Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome.
+authors:
+- Corvillo F
+- Nozal P
+- López-Lera A
+- De Miguel MP
+- Piñero-Fernández JA
+- De Lucas R
+- García-Concepción MD
+- Beato MJ
+- Araújo-Vilar D
+- López-Trascasa M
+journal: J Dermatol
+year: '2020'
+doi: 10.1111/1346-8138.15570
+keywords:
+- Adipose Tissue
+- Child
+- Complement Activation
+- Complement C3 Nephritic Factor
+- Female
+- Humans
+- Lipodystrophy
+content_type: abstract_only
+---
+
+# Evidence of ongoing complement activation on adipose tissue from an 11-year-old girl with Barraquer-Simons syndrome.
+**Authors:** Corvillo F, Nozal P, López-Lera A, De Miguel MP, Piñero-Fernández JA, De Lucas R, García-Concepción MD, Beato MJ, Araújo-Vilar D, López-Trascasa M
+**Journal:** J Dermatol (2020)
+**DOI:** [10.1111/1346-8138.15570](https://doi.org/10.1111/1346-8138.15570)
+
+## Content
+
+1. J Dermatol. 2020 Dec;47(12):1439-1444. doi: 10.1111/1346-8138.15570. Epub 2020
+ Sep 5.
+
+Evidence of ongoing complement activation on adipose tissue from an 11-year-old 
+girl with Barraquer-Simons syndrome.
+
+Corvillo F(1)(2), Nozal P(1)(2)(3), López-Lera A(1)(2), De Miguel MP(4), 
+Piñero-Fernández JA(5), De Lucas R(6), García-Concepción MD(7), Beato MJ(7), 
+Araújo-Vilar D(8), López-Trascasa M(1)(9).
+
+Author information:
+(1)Complement Research Group, Hospital La Paz Institute for Health Research 
+(IdiPAZ), La Paz University Hospital, Madrid, Spain.
+(2)Center for Biomedical Network Research on Rare Diseases (CIBERER U754), 
+Madrid, Spain.
+(3)Unit of Immunology, La Paz University Hospital, Madrid, Spain.
+(4)Cell Engineering Laboratory, La Paz University Hospital Research Institute, 
+IdiPAZ, Madrid, Spain.
+(5)Department of Nephrology, Hospital Universitario Virgen de la Arrixaca, 
+Murcia, Spain.
+(6)Departments of, Department of, Dermatology, La Paz University Hospital 
+Madrid, Madrid, Spain.
+(7)Department of, Pathology, La Paz University Hospital Madrid, Madrid, Spain.
+(8)Thyroid and Metabolic Diseases Unit (U.E.T.eM.), Centre for Research in 
+Molecular Medicine and Chronic Diseases (CIMUS)-IDIS, University of Santiago de 
+Compostela School of Medicine, Universidad de Santiago de Compostela, Santiago 
+de Compostela, Spain.
+(9)Universidad Autónoma de Madrid, Madrid, Spain.
+
+Barraquer-Simons syndrome (BSS), a form of acquired partial lipodystrophy, is a 
+rare condition characterized by gradual loss of adipose tissue from the upper 
+body, keeping intact the white adipose tissue of the lower extremities. The 
+etiology of BSS is not well understood, and clinical follow-up studies have not 
+been assessed in these patients. Moreover, no histological studies have been 
+conducted during the active phase of the disease, and complement system 
+activation products have not been sought in the affected areas. The objective of 
+this work was to analyze the clinical, immunological and histological events in 
+an 11-year-old girl with BSS over a 5-year follow-up period. Clinical data were 
+collected during six regular visits for a time period of 5 years. The 
+circulating levels of C3, C3adesArg (a product released upon C3 activation), C4 
+and immunoglobulins (Ig) were quantified in serum while fat tissue from 
+lipoatrophic areas was examined by immunohistochemical and immunofluorescence 
+approaches. In her regular visits, no clinical or laboratory abnormalities had 
+been observed in the patient, except for the progression of lipoatrophy linked 
+to the C3 hypocomplementemia and the occurrence of C3 nephritic factor. Adipose 
+tissue from the patient showed atrophied and dead adipocytes, an abnormal 
+production of extracellular matrix, and a remarkable accumulation of 
+infiltrating CD68 macrophages and adipocyte precursors (marked by c-Kit 
+positiveness). Simultaneous detection of IgG, C3, C5a and C5b-9 proved the 
+ongoing complement activity and complement-directed injury within the adipose 
+tissue. Our results showed the first evidence that the complement system 
+hyperactivation occurs within the adipose tissue and is linked with fat loss in 
+patients with BSS.
+
+© 2020 Japanese Dermatological Association.
+
+DOI: 10.1111/1346-8138.15570
+PMID: 32890433 [Indexed for MEDLINE]

--- a/references_cache/PMID_34205507.md
+++ b/references_cache/PMID_34205507.md
@@ -1,0 +1,165 @@
+---
+reference_id: "PMID:34205507"
+title: Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+authors:
+- Corvillo F
+- González-Sánchez L
+- López-Lera A
+- Arjona E
+- Ceccarini G
+- Santini F
+- Araújo-Vilar D
+- Brown RJ
+- Villarroya J
+- Villarroya F
+- Rodríguez de Córdoba S
+- Caballero T
+- Nozal P
+- López-Trascasa M
+journal: Int J Mol Sci
+year: '2021'
+doi: 10.3390/ijms22126608
+keywords:
+- Adolescent
+- Adult
+- Aged
+- Biomarkers/blood
+- Case-Control Studies
+- Child
+- Cohort Studies
+- Complement Factor D/metabolism
+- Female
+- Humans
+- Lipodystrophy/blood
+- Male
+- Middle Aged
+- Young Adult
+content_type: full_text_xml
+---
+
+# Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial Lipodystrophy (Barraquer-Simons syndrome).
+**Authors:** Corvillo F, González-Sánchez L, López-Lera A, Arjona E, Ceccarini G, Santini F, Araújo-Vilar D, Brown RJ, Villarroya J, Villarroya F, Rodríguez de Córdoba S, Caballero T, Nozal P, López-Trascasa M
+**Journal:** Int J Mol Sci (2021)
+**DOI:** [10.3390/ijms22126608](https://doi.org/10.3390/ijms22126608)
+
+## Content
+
+1. Int J Mol Sci. 2021 Jun 21;22(12):6608. doi: 10.3390/ijms22126608.
+
+Complement Factor D (adipsin) Levels Are Elevated in Acquired Partial 
+Lipodystrophy (Barraquer-Simons syndrome).
+
+Corvillo F(1)(2), González-Sánchez L(1)(2), López-Lera A(1)(2), Arjona E(2)(3), 
+Ceccarini G(4), Santini F(4), Araújo-Vilar D(5), Brown RJ(6), Villarroya 
+J(7)(8), Villarroya F(7)(8), Rodríguez de Córdoba S(2)(3), Caballero 
+T(2)(9)(10), Nozal P(1)(2)(11), López-Trascasa M(1)(12).
+
+Author information:
+(1)Complement Research Group, Hospital La Paz Institute for Health Research 
+(IdiPAZ), La Paz University Hospital, 28046 Madrid, Spain.
+(2)Center for Biomedical Network Research on Rare Diseases, 28029 Madrid, Spain.
+(3)Department of Molecular Biomedicine, Margarita Salas Center for Biological 
+Research, 28040 Madrid, Spain.
+(4)Obesity and Lipodystrophy Center at the Endocrinology Unit, Department of 
+Clinical and Experimental Medicine, University Hospital of Pisa, 56126 Pisa, 
+Italy.
+(5)UETeM-Molecular Pathology Group, Department of Psychiatry, Radiology, Public 
+Health, Nursing and Medicine, IDIS-CIMUS, University of Santiago de Compostela, 
+15703 Santiago de Compostela, Spain.
+(6)National Institute of Diabetes and Digestive and Kidney Diseases, National 
+Institutes of Health, Bethesda, MD 20814, USA.
+(7)Departament de Bioquimica I Biomedicina Molecular, Institut de Biomedicina de 
+la Universitat de Barcelona, 08007 Barcelona, Catalonia, Spain.
+(8)CIBER Fisiopatología de La Obesidad Y Nutrición, 28029 Madrid, Spain.
+(9)Department of Allergy, La Paz University Hospital, 28046 Madrid, Spain.
+(10)Hospital La Paz Institute for Health Research (IdiPAZ), 28046 Madrid, Spain.
+(11)Immunology Unit, La Paz University Hospital, 28046 Madrid, Spain.
+(12)Department of Medicine, Universidad Autónoma de Madrid, 28049 Madrid, Spain.
+
+Complement overactivation has been reported in most patients with 
+Barraquer-Simons syndrome (BSS), a rare form of acquired partial lipodystrophy. 
+Complement Factor D (FD) is a serine protease with a crucial role in the 
+activation of the alternative pathway of the complement system, which is mainly 
+synthesized by adipose tissue. However, its role in the pathogenesis of BSS has 
+not been addressed. In this study, plasma FD concentration was measured in 13 
+patients with BSS, 20 patients with acquired generalized lipodystrophy, 22 
+patients with C3 glomerulopathy (C3G), and 50 healthy controls. Gene expression 
+and immunohistochemistry studies were assayed using atrophied adipose tissue 
+from a patient with BSS. We found significantly elevated FD levels in BSS cases 
+compared with the remaining cohorts (p < 0.001). There were no significant 
+differences in FD levels between sexes but FD was strongly and directly 
+associated with age in BSS (r = 0.7593, p = 0.0036). A positive correlation 
+between FD and C3 was seen in patients with C3G, characterized by decreased FD 
+levels due to chronic C3 consumption, but no correlation was detected for BSS. 
+Following mRNA quantification in the patient's adipose tissue, we observed 
+decreased CFD and C3 but elevated C5 transcript levels. In contrast, the 
+increased FD staining detected in the atrophied areas reflects the effects of 
+persistent tissue damage on the adipose tissue, thus providing information on 
+the ongoing pathogenic process. Our results suggest that FD could be a reliable 
+diagnostic biomarker involved in the pathophysiology of BSS by promoting 
+unrestrained local complement system activation in the adipose tissue 
+environment.
+
+DOI: 10.3390/ijms22126608
+PMCID: PMC8234012
+PMID: 34205507 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.
+
+Lipodystrophies are a heterogeneous group of rare disorders characterized by the loss of adipose tissue [1]. There are multiple subtypes of lipodystrophies, which can be congenital or acquired and which in turn vary in the distribution of adipose tissue loss, being partial, generalized, or localized. One of these diseases is Barraquer–Simons syndrome (BSS; ORPHA:79087), an acquired form of partial lipodystrophy characterized by bilateral symmetrical loss of adipose tissue at upper body locations [1]. Dysregulation of the alternative pathway (AP) of the complement system, denoted by C3 hypocomplementemia, is a frequent clinical feature among patients with BSS, commonly due to the presence of C3 nephritic factor (C3NeF) [2]. C3NeF is an autoantibody directed to the AP C3 convertase that acts by stabilizing and increasing the half-life of the complex, which leads to C3 consumption and chronic C3 hypocomplementemia [3]. In most of the published cohorts of patients with BSS, C3NeF is the most frequent antibody (70%) [2,4], although our group has described the existence of additional autoantibodies against AP proteins [2]. Moreover, Mathieson et al. evidenced that C3NeF could lyse adipocytes [5].
+
+C3NeF is not exclusive to patients with BSS, but is also involved in another pathological condition not related to lipodystrophy called C3 glomerulopathy (C3G) [6]. The mechanistic connection with complement activation is further reinforced by the fact that 20% of BSS patients eventually develop C3G [1]. Our group has recently published the first evidence of ongoing complement system activation in affected adipose tissue from an 11-year-old girl with BSS [7]. This finding, together with the abnormal levels of the AP proteins in patients with BSS, points to complement dysregulation as a central pathological event in the development of this rare disease; however, the exact mechanism by which complement causes fat loss remains unclear.
+
+Complement factor D (FD), also termed adipsin, is a serine protease with a crucial role in the activation of the AP of the complement system [8,9]. FD is secreted by several tissues and cell types, although the major source in humans is mature adipocytes and macrophages in adipose tissue [8,9,10]. Given the connection of FD with adipose tissue and complement system activation, it could be considered a central player in the pathogenesis of BSS, as previously suggested by other authors [4,5,11]. However, this assumption has not been demonstrated yet. In pathological situations where adipose tissue function is widely affected, such as lipodystrophy syndromes, the synthesis and secretion of the adipokines leptin and adiponectin are seriously impaired [1], but this is unknown for FD. Recently, Wu and collaborators showed that FD levels were reduced but still detected in patients with congenital and acquired generalized lipodystrophy (CGL and AGL, respectively), in contrast to patients with familial partial lipodystrophy (FPLD), in whom FD levels were similar to healthy subjects [12]. However, the authors did not quantify FD levels in patients with BSS nor did they analyze the existence of local differences in its expression levels and, therefore, the role of FD in the pathogenesis of the BSS remains unanswered.
+
+The present study aimed to quantify FD levels in a cohort of 13 patients with BSS and compare them with patients in other pathological situations, such as AGL and C3G, and with healthy donors. Another objective of this study was to explore the effect of age and sex on FD levels in the previously mentioned cohorts. Finally, gene expression studies and detection of FD were carried out on adipose tissue from a patient with BSS previously studied by our group.
+
+The plasma FD concentration was measured in 13 patients with BSS, 20 patients with AGL, 22 patients with C3G and 50 healthy donors. FD levels were significantly elevated in patients with BSS compared with individuals from the control, AGL and C3G cohorts (BSS: median 1.530 µg/mL (IQR—1.425–1.940); controls: 1.185 µg/mL (1.025–1.423); AGL: 0.905 µg/mL (0.753–1.125); C3G: 1.115 µg/mL (0.705–1.570); p < 0.05 for controls and C3G, and p < 0.001 for AGL) (Figure 1). In contrast, plasma FD levels in the AGL cohort were significantly lower than those of controls (p < 0.05) (Figure 1). We performed a Western blot on the plasma from controls, patients with BSS, C3G and AGL and observed that FD levels were reduced in patients with AGL and elevated in BSS compared to controls. Demographic details and basic clinical information are listed in Table 1.
+
+A ROC curve using FD levels was implemented to find a cut-off value for predicting the utility of this parameter as a diagnostic biomarker. ROC curve analysis indicated that plasma FD levels were a potential diagnostic biomarker for BSS and AGL, with Area Under the Curve (AUC) values of 0.83 (95% confidence interval (CI): 0.70–0.95, p < 0.001) (Figure 2A) and 0.75 (0.61–0.89, p < 0.001) (Figure 2B), respectively. In contrast, in patients with C3G, FD levels were not a reliable biomarker, with an AUC value of 0.54 (0.37–0.71, p = 0.54) (Figure 2C). The cut-off was chosen using the Youden index. An FD level value ≥1.47 µg/mL was associated with a higher probability to detect patients with BSS (sensitivity: 77%, specificity: 78%, negative predictive value: 77%, positive predictive value: 78%, likelihood ratio: 3.47). However, the validation of the cut-off value ≤0.92 µg/mL for patients with AGL did not show acceptable results (sensitivity: 15%, specificity: 33%, negative predictive value: 45%, positive predictive value: 10%, likelihood ratio: 0.23).
+
+We analyzed the effect of age on the concentration of FD in all cohorts. Linear regression analyses demonstrated a significant age-related effect for FD levels in controls, BSS and C3G cohorts, but not for patients with AGL. Age was significantly and positively correlated with FD levels in healthy controls (r = 0.2962, p = 0.0368, Figure 3A), patients with BSS (r = 0.7593, p = 0.0036, Figure 3B) and patients with C3G (r = 0.4782, p = 0.0244, Figure 3C), but not in patients with AGL (Figure 3D). No significant differences were observed in FD levels between males and females in all cohorts (Figure 4A–D).
+
+To better understand the differences seen in FD levels between patients with BSS and patients with C3G, we assessed the correlation between circulating C3 and FD levels. Our results showed that FD correlated significantly with C3 in patients with C3G (r = 0.5863, p = 0.0041), while no correlation was observed in patients with BSS and controls (Figure 5A–C). In addition, we studied the relationship between C3 levels and age, and no correlation was observed in any cohort (Figure 5D–F). We then compared FD levels between patients with positive/negative results for C3NeF autoantibodies in both the BSS and C3G cohorts. Patients with a positive result for C3NeF had significantly lower serum C3 levels in both cohorts (p < 0.001) (Figure 6A), although differences in FD concentration were found only in patients with C3G, being lower in those with C3NeF autoantibodies (C3NeF positive: 1.080 µg/mL (0.650–1.230), and C3NeF negative: 1.870 µg/mL (1.170–2.220); p < 0.001; Figure 6B).
+
+We performed an immunohistochemistry assay to analyze the presence and localization of FD in the adipose tissue from an 11-year-old girl with BSS and two healthy donors (a 69-year-old male and a 57-year-old female). We observed that FD was overrepresented and widely extended along affected areas of adipose tissue from the patient with BSS (Figure 7A) compared with adipose tissue from a healthy donor, in which FD was observed in small isolated spots (Figure 7B). Using a higher magnification image, we detected that, although most FD staining was present in the extracellular space and the stroma vascular cells, there were at least some adipocytes that show remarkable cytoplasmic staining (Figure 7C). To determine whether the results were due to nonspecific binding of the primary antibody, we performed isotype control staining (Figure 7D). This result prompted us to perform gene expression analyses in the same adipose tissue biopsies. Levels of transcripts corresponding to components of the complement system C3 and Complement Factor D (CFD) showed reduced expression in adipose tissue from the patient with respect to healthy controls; in contrast, C5 mRNA was marginally increased (Table 2). Furthermore, the examination of gene expression levels of master regulatory factors associated with the promotion of adipogenesis indicated that peroxisome proliferator-activated-γ (PPARG) and CCAAT/enhancer-binding protein α (CEBPA) mRNAs were down-regulated in the patient with BSS with respect to controls (Table 2).
+
+In this study, we found that plasma FD levels are significantly higher in a representative cohort of patients with BSS compared with controls and another two cohorts composed of patients with AGL and C3G. This study points to FD as a potential biomarker in BSS.
+
+At the end of the 1980s and the beginning of the 1990s, Dr. Spiegelman’s group showed that mouse adipocytes secreted a tissue-specific adipokine that they called adipsin, which has important functions for the development of adipose tissue [9]. This protein was found to be identical to human FD, which is considered to be a rate-limiting factor in the activation of the AP of the complement system [9]. In this pathway, FD cleaves complement factor B and catalyzes the formation of C3 convertase (C3bBb) [13], which leads to a proteolytic cascade that produces several complement fragments, including C3a, C3b, C5a, and C5b, and eventually leads to the formation of the membrane attack complex (C5b-9) [13].
+
+The role of the complement system in the biology of adipose tissue has been described in several papers [14,15,16]. The fact that FD is the only protein of the complement system that is mainly synthesized by adipocytes, in contrast to the other complement components, which are produced by the liver, places FD as an important player in adipose tissue function. Adipocytes are also capable of synthesizing other complement components, particularly those involved in the initial steps of complement activation (e.g., factors B, C2, C3, C4, C1Q, C1R, C1S) but they express almost none of the terminal complex components (C8A, C8B, C8G, C9), with the exception of C5, C6, and C7 [17,18,19,20]. Furthermore, local complement activation promotes lipid accumulation and adipocyte differentiation [21].
+
+Increased levels of serum FD are closely related to several pathological conditions. For example, plasma FD has been found to be elevated in patients with obesity [22,23,24], age-macular degeneration [25], coronary artery disease [26], osteoarthritis [27], non-alcoholic fatty liver disease [28], and polycystic ovary syndrome [29]. Conversely, according to different experimental and clinical studies, plasma FD concentrations are low in animals and patients with diabetes mellitus [30,31,32,33], and in those pathological conditions where adipose tissue is almost completely absent, such as CGL and AGL [12], in agreement with the results from our group (Figure 1). On the other hand, plasma FD concentrations were reported to be normal in patients with FPLD, in whom some adipose tissue is preserved [12]. Herein, we provide experimental evidence for altered FD plasma levels in patients with BSS and C3G, two conditions characterized by dysregulation of the AP of the complement system. Interestingly, while BSS patients exhibited significantly elevated FD concentrations, those with C3G showed a slight decrease in plasma FD (Figure 1). Additionally, our results suggest that FD levels may be a marker to identify patients with BSS (Figure 2A). Specifically, FD levels ≥1.47 µg/mL were associated with a higher probability of detecting patients with BSS. In contrast, FD levels were not a useful biomarker in patients with AGL (Figure 2B), which is consistent with the low FD levels typically found in all generalized lipodystrophies.
+
+Moreover, we observed a significant direct correlation of FD levels with age in healthy controls, BSS patients and C3G patients, with this correlation being stronger in the BSS cohort (Figure 3A–C). In striking contrast to this observation, the complete absence of adipose tissue that characterizes AGL could help explain the lack of age-dependence of FD levels in patients with this generalized form of lipodystrophy (Figure 3D). Additionally, no noticeable effect of sex on FD levels in the control, BSS and C3G cohorts was observed (Figure 4A–D).
+
+FD is constitutively secreted at high rates by adipose tissue but rapidly catabolized in the proximal renal tubules [9,34]. The fractional catabolic rate of plasma FD has been estimated to be 60% per hour, contributing to its low serum concentrations in non-pathological situations [35]. Serum FD levels were found to be elevated in patients with chronic renal failure due to a lower renal catabolic rate [35,36,37]. In this work, we did not observe differences in FD concentrations between patients with C3G and controls (Figure 1); however, a positive correlation between FD and C3 was seen in patients with C3G, a condition characterized by decreased FD levels due to chronic C3 consumption (Figure 5). Surprisingly, no such FD/C3 correlation was detected in BSS, a clinical condition also characterized by complement hyperactivation (Figure 5). When we analyzed FD in situations of complement dysregulation, such as in the presence of C3NeF, plasma FD was significantly lower in C3NeF-positive patients with C3G compared with the rest of the negative individuals (Figure 6B,C). In contrast, complement system activation did not affect FD levels in patients with BSS (Figure 6B,C). In a previous work, Gaya da Costa et al. showed that FD levels were not related to either the activity of the AP or C3 levels in a healthy population [38], in agreement with our results (Figure 5). In contrast to other AP proteins, FD does not undergo proteolytic activation to justify its consumption during AP activation. There are studies about FD levels in systemic lupus erythematosus (SLE), another condition characterized by pathological activation of the complement system, in which plasma levels of FD were not different from those of healthy controls [39,40]. Complement activation in SLE is mainly due to the classical pathway, with limited AP implication, is and normally not as pronounced as in C3G, which may explain why patients with SLE do not show a decrease in plasma FD levels. FD is almost completely reabsorbed in the renal tubule, but in situations where a selective defect of the tubular epithelium occurs, such as Fanconi’s syndrome, FD levels were elevated in urine and decreased in plasma [36]. C3G is a chronic disease that tends to progress to end-stage renal disease and tubular atrophy in advanced cases [41]. C3NeF induces a marked activation of the AP, which usually appears even before renal manifestations. This chronic activation of the complement system causes massive production of complement fragments which are deposited in the kidney, severely damaging the organ and leading to tubular dysfunction and renal failure [41]. Defective tubular reabsorption could therefore explain the lower levels of FD found in C3NeF-positive patients with C3G. However, further studies are needed to understand whether this is the case or whether the lower FD levels are mediated by different mechanisms secondary to complement activation.
+
+In our BSS cohort, three out of thirteen patients (23%) had kidney disease (Table 1), and all of them showed elevated levels of plasma FD in contrast to those observed in patients with C3G. Moreover, as we have previously clarified, in patients with BSS, FD levels do not correlate with the degree of activation of the complement system. Therefore, one possible explanation of our results is that adipose tissue of patients with BSS expresses more FD than unaffected adipose tissue, resulting in significantly elevated circulating levels. To further examine this hypothesis, we studied the presence of FD in the adipose tissue from the affected arm of an 11-year-old girl with BSS, observing that FD in the atrophied areas was significantly overrepresented compared to healthy donor tissue (Figure 7A,B). Although most FD staining was present in the extracellular space and the stroma vascular cells, some adipocytes showed remarkable cytoplasmic staining (Figure 7A,C). Considering these results, the stroma vascular fraction could have a determining role in the synthesis of complement components in the pathogenic context of BSS, but further experiments will be necessary to confirm this hypothesis. In a previous report from our group, we demonstrated ongoing complement activation by detecting local C3, C5a, and C5b-9 deposits in adipose tissue from this same patient [7]. In this context, if FD production is higher than usual, further activation of the AP could occur locally in the adipose tissue, and combined with the presence of C3NeF, damage of the tissue would occur. However, following mRNA quantification in the patient’s adipose tissue, we observed decreased CFD and C3 but elevated C5 transcript levels as compared to those from the adipose tissue of a control female obtained from the same anatomical location (Table 2). Although these results are somewhat conflicting with respect to those obtained by immunohistochemistry, they could be explained by the lower expression of PPARG and CEBPA regulatory genes observed in the patients’ samples, a scenario consistent with lipoatrophy (Table 2) [42]. In agreement with this, the down-regulation of PPARG may be the main causative event of the coordinate impairment in the expression of CFD and C3 genes, which are known targets of PPARG-dependent regulation [43,44]. Correspondingly, if the tissue sample was obtained at an advanced stage of lipodystrophy, the expression of complement genes may be significantly influenced by down-regulation of PPARG and CEBPA. However, the elevated expression of C5 (Table 2), a gene not controlled by PPARG, may suggest that upregulation of complement-related genes is a chronic phenomenon occurring before and during adipose tissue damage. Nevertheless, we cannot rule out that the differences we observed between the controls and the patient may be due to a lack of age matching. Previous data showed that C5, but not C3 levels, increase with age [38], and as we demonstrated in this work, FD concentration increased with age in controls. According to this higher CFD and C5 mRNA levels would be expected in controls as compared to the patient. Our finding of reduced expression of the CFD gene in the patient is in striking contrast to bibliography-based expectations, but conversely, we observed higher C5 expression in the patient´s tissue, which could partially support our hypothesis. However, we cannot rule out that the lower CFD expression in the BSS is a direct consequence of the down-regulation of the PPARG gene, or that it is due to the lack of appropriately age-matched controls. On the other hand, our immunohistochemistry results may instead reflect (i) a lack of correlation between FD and C3 mRNA/protein levels in this pathological context and (ii) the effects of persistent tissue damage on the adipose tissue, thus providing information on the ongoing pathogenic process. Moreover, in light of these observations, we cannot rule out the contribution of other non-adipose cell types to the adipocyte milieu of complement proteins. For these hypotheses to be tested, fat biopsies from affected and unaffected areas should be obtained during the progression of the disease, which is a major and evident limitation.
+
+In conclusion, the findings herein presented suggest that FD could be a reliable diagnostic biomarker involved in the pathophysiology of BSS by promoting unrestrained local complement system activation in the adipose tissue environment. Further studies are needed to validate its importance in the mechanism of the disease, as well as a possible treatment target.
+
+Thirteen patients with BSS and 20 patients with AGL were enrolled for this study. All of them were diagnosed based on standardized criteria [45]. Briefly, one criterion for both lipodystrophies was fat loss during childhood or adulthood. The patients with BSS were characterized by large areas of the body being affected, particularly the head, shoulders, upper extremities, and trunk, with preservation of adipose tissue in the lower extremities. In contrast, patients with AGL were characterized by loss of fat, affecting the entire body. The presence of autoimmune markers or autoimmune diseases can be supportive of the diagnosis of BSS and AGL. Laboratory findings such as low complement C3 and the presence of C3NeF were used during the diagnosis of BSS.
+
+Congenital forms of lipodystrophy were excluded based on the natural history of the disease, clinical features, age at onset, and/or pathogenic variants in CGL (AGPAT2, BSCL2, CAV1, PTRF, PPARG) and FPLD-related genes (LMNA, PPARG, PLIN1, CIDEC, LIPE, CAV1, AKT2). No consanguinity was reported in any case. The clinical, demographical, and immunological features for these 13 patients with BSS were previously described in [2].
+
+Twenty-two patients with biopsy-proven C3G were selected for inclusion in this study based on standardized criteria [6,46,47]. Additionally, 50 healthy subjects were recruited as controls.
+
+All cohorts were matched in terms of sex and age. For more details, see Table 1.
+
+Blood samples were drawn in plain tubes, allowed to clot at room temperature, and centrifuged for 10 min at 4 °C. EDTA-plasma was aliquoted and stored at –20 and –80 °C until use to avoid repeated freezing and thawing.
+
+Immunohistochemistry and gene expression studies were performed using subcutaneous adipose tissue biopsy from the arm of an 11-year-old girl with BSS (described in [7]). As controls, we collected subcutaneous adipose tissue from two healthy, lean, male and female (69- and 57-year-olds, respectively) obtained at similar anatomical sites (arm). Adipose samples from these healthy controls has been described elsewhere [48]. The tissues used for histological studies were stored in paraffin blocks. Fresh frozen tissues were preserved until their use to extract mRNA.
+
+Serum C3 levels were measured by nephelometry (Siemens Healthcare, Erlangen, Germany). C3NeF was detected by ELISA assay as previously described [49].
+
+Plasma FD was measured using an in-house ELISA assay, optimized for use in plasma. ELISA plates (MaxiSorp®, Nunc) were coated with 100 ng/well of mouse monoclonal anti-human FD (GAU 01-04-02, Invitrogen, Carlsbad, CA, USA) diluted in carbonate-bicarbonate buffer pH 9.3 (overnight, 4 °C). Plates were blocked with PBS-BSA 1% and washed with PBS-BSA 0.1% (both incubations 1 h at 37 °C). A standard curve ranging from 0 to 80 ng/mL of purified FD (Complement Technology, Tyler, TX, USA) was included on each plate, alongside one internal control plasma sample used to assess interassay variability. The interassay coefficient of variation was below 10%. Plasma samples were diluted in PBS-BSA 0.1% at 1/50, 1/100, and 1/200 dilutions for analysis. FD detection was made using a mouse monoclonal anti-human FD conjugated with biotin (GAU 008-01B-02, Invitrogen) (1/2500 dilution, 1 h at 37 °C) and then with streptavidin-peroxidase polymer (S2438, Sigma Aldrich, St Louis, MO, USA) (1/400, both incubations 45 min at 37 °C). The reactions were developed using ABTS as substrate and read at 405/620 nm using an Epoch™ Microplate Spectrophotometer (BioTek Instruments, Inc., Winooski, VT, USA). All samples were measured in duplicate.
+
+Plasma underwent electrophoresis in SDS-PAGE gels and was transferred to nitrocellulose membranes using iBlot 2 Dry Blotting System (Invitrogen). They were incubated with anti-FD antibody (PA5-79034, Invitrogen) (1/1000 dilution, overnight at 4 °C) and then with goat anti-rabbit IgG (#107-6515, Bio-Rad, Hercules, CA, USA) (1/40,000 dilution, 1 h at room temperature). Peroxidase activity was analyzed using ECL™ Select Western Blotting Detection Reagent (GE Healthcare Bio-Sciences, New Burnswick, NJ, USA). UVITEC Alliance 1D MAX (UVITEC Cambridge) was used for image acquisition.
+
+Adipose tissue samples were fragmented by mechanical disruption and then homogenized in RA-1 buffer (Macherey-Nagel, Düren, Germany) supplemented with 10% β-mercaptoethanol. RNA was immediately isolated from the homogenate using a column affinity-based methodology (NucleoSpin® RNA II; Macherey-Nagel). cDNA was synthesized from 0.5 µg of total RNA using MultiScribe reverse transcriptase and random hexamer primers (Applied Biosystems, Foster City, CA, USA). mRNA expression levels were determined by quantitative real-time reverse transcription-polymerase chain reaction (qRT-PCR) using TaqMan reagents and an Applied Biosystems 7500 Fast Real-Time PCR System (Applied Biosystems). Real-time PCR was performed in a final volume of 20 µL using TaqMan Universal PCR Master Mix, No AmpErase UNG reagent, and the following specific primer probes (TaqMan Gene Expression Assays; Applied Biosystems): C3 (Complement component 3), Hs00163811_m1; C5 (Complement component 5), Hs01004342_m1; CFD (Complement factor D, adipsin), Hs00157263_m1; PPARG (peroxisome proliferator-activated receptor-gamma, PPAR-γ), Hs00234592_m1; CEBPA (CCAAT enhancer-binding protein-alpha), Hs00269972_s1. Data for mRNA levels of the genes of interest were normalized to that of reference control (18S ribosomal RNA, Hs99999901_s1) and were calculated using the comparative 2-ΔCT method.
+
+The adipose tissue was sectioned (5 µm) using a rotary paraffin microtome (Leica, RM2255, Wetzlar, Germany). The sections were placed on IHC Microscope Slides (K8020, Dako, Santa Clara, CA, USA) and stored until their use. The sample was dewaxed with xylene and rehydrated with 100, 96, 80, 70% (5 min each) ethanol. After this step, the sample was washed in tris-buffered saline (TBS) (150 mM NaCl, 50 mM Tris-HCl, pH 7.6). The slides were placed into citrate-antigen repairing solution (0.01 M, pH 6.0) and the unmasking of the epitopes was performed using the PT LINK system (Dako) following the instructions of the manufacturer. The sample was blocked using TBS supplemented with 10% goat serum in a wet chamber for 1 h at room temperature. FD was detected using a polyclonal rabbit anti-human FD (PA5-79034, from Invitrogen) with a dilution of 1 µg/mL (overnight at 4 °C in a wet chamber). The color reaction was developed using the Mouse and Rabbit Specific HRP/DAB (ABC) Detection IHC kit (ab64264, from Abcam, Cambridge, UK). Staining was performed using a rabbit IgG (ab172730; Abcam) as an isotype control. Finally, the tissue was counterstained with hematoxylin and mounted with DPX mounting medium.
+
+Statistical analysis was performed using GraphPad Prism version 6.01 (San Diego, CA, USA). Concentrations of complement FD are represented as median with interquartile range (IQR). Mann–Whitney U and Kruskall–Wallis non-parametric tests were used for statistical analysis and Spearman Rank correlation coefficient (r) was used for correlation between variables. Receiver operating characteristic (ROC) curve analysis was used to analyze the diagnostic value of plasma FD levels as a potential biomarker. Additionally, other statistical parameters, such as sensitivity, specificity, cut-off value, positive predictive value, negative predictive value, and area under the ROC curve (AUC) with 95% confidence interval (CI), were also evaluated. p < 0.05 was considered statistically significant.

--- a/references_cache/PMID_38076230.md
+++ b/references_cache/PMID_38076230.md
@@ -1,0 +1,61 @@
+---
+reference_id: "PMID:38076230"
+title: "C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis."
+authors:
+- Ponticelli C
+- Calatroni M
+- Moroni G
+journal: Front Med (Lausanne)
+year: '2023'
+doi: 10.3389/fmed.2023.1289812
+content_type: abstract_only
+---
+
+# C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis.
+**Authors:** Ponticelli C, Calatroni M, Moroni G
+**Journal:** Front Med (Lausanne) (2023)
+**DOI:** [10.3389/fmed.2023.1289812](https://doi.org/10.3389/fmed.2023.1289812)
+
+## Content
+
+1. Front Med (Lausanne). 2023 Nov 24;10:1289812. doi: 10.3389/fmed.2023.1289812. 
+eCollection 2023.
+
+C3 glomerulopathies: dense deposit disease and C3 glomerulonephritis.
+
+Ponticelli C(1), Calatroni M(2)(3), Moroni G(2)(3).
+
+Author information:
+(1)Independent Researcher, Milan, Italy.
+(2)IRCCS Humanitas Research Hospital, Milan, Italy.
+(3)Department of Biomedical Sciences, Humanitas University, Milan, Italy.
+
+Dense deposit disease (DDD) and C3 glomerulonephritis (C3GN) are types of 
+membranoproliferative glomerulonephritis classified as C3 glomerulopathies. 
+These conditions are characterized by an increased number of intraglomerular 
+cells and diffuse thickening of the glomerular capillary walls, along with the 
+deposition of C3 and minimal or absent immunoglobulin deposits. The underlying 
+cause of both DDD and C3Gn is an abnormal activation of the alternative 
+complement pathway, which can result from acquired or genetic alteration. In 
+acquired forms of DDD and C3GN, the dysregulation of the alternative pathway is 
+commonly induced by the presence of C3 nephritic factors (C3NeFs), which are 
+autoantibodies that stabilize C3 convertase. Both DDD and C3GN can affect 
+individuals of any age, but DDD is primarily diagnosed in children, whereas C3GN 
+tends to be diagnosed at a significantly higher age. The presenting features of 
+these diseases are variable and may include proteinuria, hematuria, 
+hypertension, or kidney failure. A common finding in these diseases is low serum 
+C3 levels with normal serum C4 levels. Chronic deterioration of renal function 
+is commonly observed in DDD and C3GN, often leading to end-stage renal disease 
+(ESRD), especially in DDD. Kidney transplantation outcomes in patients with 
+these conditions are characterized by histological recurrence, which may 
+contribute to higher rates of allograft failure.
+
+Copyright © 2023 Ponticelli, Calatroni and Moroni.
+
+DOI: 10.3389/fmed.2023.1289812
+PMCID: PMC10704907
+PMID: 38076230
+
+Conflict of interest statement: The authors declare that the research was 
+conducted in the absence of any commercial or financial relationships that could 
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_38678257.md
+++ b/references_cache/PMID_38678257.md
@@ -1,0 +1,108 @@
+---
+reference_id: "PMID:38678257"
+title: "Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center."
+authors:
+- Donadille B
+- Janmaat S
+- Mosbah H
+- Belalem I
+- Lamothe S
+- Nedelcu M
+- Jannot AS
+- Christin-Maitre S
+- Fève B
+- Vatier C
+- Vigouroux C
+journal: Orphanet J Rare Dis
+year: '2024'
+doi: 10.1186/s13023-024-03173-2
+keywords:
+- Humans
+- Female
+- Male
+- Insulin Resistance/physiology
+- "Lipodystrophy/diagnosis, metabolism"
+- Adult
+- Middle Aged
+- Young Adult
+- France
+- Adolescent
+- Referral and Consultation
+content_type: abstract_only
+---
+
+# Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center.
+**Authors:** Donadille B, Janmaat S, Mosbah H, Belalem I, Lamothe S, Nedelcu M, Jannot AS, Christin-Maitre S, Fève B, Vatier C, Vigouroux C
+**Journal:** Orphanet J Rare Dis (2024)
+**DOI:** [10.1186/s13023-024-03173-2](https://doi.org/10.1186/s13023-024-03173-2)
+
+## Content
+
+1. Orphanet J Rare Dis. 2024 Apr 27;19(1):177. doi: 10.1186/s13023-024-03173-2.
+
+Diagnostic and referral pathways in patients with rare lipodystrophy and 
+insulin-resistance syndromes: key milestones assessed from a national reference 
+center.
+
+Donadille B(1), Janmaat S(2), Mosbah H(2)(3), Belalem I(2), Lamothe S(2), 
+Nedelcu M(2), Jannot AS(4), Christin-Maitre S(2)(5), Fève B(2)(3), Vatier 
+C(2)(3), Vigouroux C(6)(7).
+
+Author information:
+(1)Saint-Antoine Hospital, Reference Center for Rare Diseases of Insulin 
+Secretion and Insulin Sensitivity (PRISIS), Department of Endocrinology, 
+Assistance Publique-Hôpitaux de Paris (AP-HP), 184 rue du Faubourg 
+Saint-Antoine, 75012, Paris, France. bruno.donadille@aphp.fr.
+(2)Saint-Antoine Hospital, Reference Center for Rare Diseases of Insulin 
+Secretion and Insulin Sensitivity (PRISIS), Department of Endocrinology, 
+Assistance Publique-Hôpitaux de Paris (AP-HP), 184 rue du Faubourg 
+Saint-Antoine, 75012, Paris, France.
+(3)Saint-Antoine Research Center, Institute of CardioMetabolism and Nutrition 
+(ICAN), Sorbonne University, Inserm UMR_S 938, Paris, France.
+(4)Banque Nationale de Données Maladies Rares, DSN-I&D, APHP, Paris, France.
+(5)Sorbonne Université, Inserm UMR_S 933, Paris, France.
+(6)Saint-Antoine Hospital, Reference Center for Rare Diseases of Insulin 
+Secretion and Insulin Sensitivity (PRISIS), Department of Endocrinology, 
+Assistance Publique-Hôpitaux de Paris (AP-HP), 184 rue du Faubourg 
+Saint-Antoine, 75012, Paris, France. corinne.vigouroux@aphp.fr.
+(7)Saint-Antoine Research Center, Institute of CardioMetabolism and Nutrition 
+(ICAN), Sorbonne University, Inserm UMR_S 938, Paris, France. 
+corinne.vigouroux@aphp.fr.
+
+BACKGROUND: Rare syndromes of lipodystrophy and insulin-resistance display 
+heterogeneous clinical expressions. Their early recognition, diagnosis and 
+management are required to avoid long-term complications.
+OBJECTIVE: We aimed to evaluate the patients' age at referral to our dedicated 
+national reference center in France and their elapsed time from first symptoms 
+to diagnosis and access to specialized care.
+PATIENTS AND METHODS: We analyzed data from patients with rare lipodystrophy and 
+insulin-resistance syndromes referred to the coordinating PRISIS reference 
+center (Adult Endocrine Department, Saint-Antoine Hospital, AP-HP, Paris), 
+prospectively recorded between 2018 and 2023 in the French National Rare Disease 
+Database (BNDMR, Banque Nationale de Données Maladies Rares).
+RESULTS: A cohort of 292 patients was analyzed, including 208 women, with the 
+following diagnosis: Familial Partial LipoDystrophy (FPLD, n = 124, including 
+n = 67 FPLD2/Dunnigan Syndrome); Acquired lipodystrophy syndromes (n = 98, with 
+n = 13 Acquired Generalized Lipodystrophy, AGL); Symmetric cervical 
+adenolipomatosis (n = 27, Launois-Bensaude syndrome, LB), Congenital generalized 
+lipodystrophy (n = 18, CGL) and other rare severe insulin-resistance syndromes 
+(n = 25). The median age at referral was 47.6 years [IQR: 31-60], ranging from 
+25.2 (CGL) to 62.2 years old (LB). The median age at first symptoms of 27.6 
+years old [IQR: 16.8-42.0]) and the median diagnostic delay of 6.4 years [IQR: 
+1.3-19.5] varied among diagnostic groups. The gender-specific expression of 
+lipodystrophy is well-illustrated in the FPLD2 group (91% of women), presenting 
+with first signs at 19.3 years [IQR: 14.4-27.8] with a diagnostic delay of 10.5 
+years [IQR: 1.8-27.0].
+CONCLUSION: The national rare disease database provides an important tool for 
+assessment of care pathways in patients with lipodystrophy and rare 
+insulin-resistance syndromes in France. Improving knowledge to reduce diagnostic 
+delay is an important objective of the PRISIS reference center.
+
+© 2024. The Author(s).
+
+DOI: 10.1186/s13023-024-03173-2
+PMCID: PMC11056061
+PMID: 38678257 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/clinicaltrials_NCT06484868.md
+++ b/references_cache/clinicaltrials_NCT06484868.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT06484868
+title: "A 24-Month, Multi-Centre, Open Label Phase IV Post Authorisation Efficacy Study to Evaluate the Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin Treatment in Patients With Partial Lipodystrophy"
+content_type: summary
+---
+
+# A 24-Month, Multi-Centre, Open Label Phase IV Post Authorisation Efficacy Study to Evaluate the Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin Treatment in Patients With Partial Lipodystrophy
+
+## Content
+
+This is an Open Label, Phase IV, Post Authorisation Study to Evaluate the Efficacy, Safety and Immunogenicity of Daily Subcutaneous Metreleptin Treatment in people with Partial Lipodystrophy

--- a/research/Acquired_Partial_Lipodystrophy-deep-research-falcon.md
+++ b/research/Acquired_Partial_Lipodystrophy-deep-research-falcon.md
@@ -1,0 +1,1240 @@
+---
+provider: falcon
+model: Edison Scientific Literature
+cached: false
+start_time: '2026-05-11T13:57:57.868954'
+end_time: '2026-05-11T14:17:14.879336'
+duration_seconds: 1157.01
+template_file: templates/disease_pathophysiology_research.md
+template_variables:
+  disease_name: Acquired Partial Lipodystrophy
+  mondo_id: ''
+  category: Complex
+provider_config:
+  timeout: null
+  max_retries: 3
+  parameters:
+    allowed_domains: []
+    temperature: 0.1
+citation_count: 32
+---
+
+## Question
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acquired Partial Lipodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acquired Partial Lipodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+## Output
+
+Question: You are an expert researcher providing comprehensive, well-cited information.
+
+Provide detailed information focusing on:
+1. Key concepts and definitions with current understanding
+2. Recent developments and latest research (prioritize 2023-2024 sources)
+3. Current applications and real-world implementations
+4. Expert opinions and analysis from authoritative sources
+5. Relevant statistics and data from recent studies
+
+Format as a comprehensive research report with proper citations. Include URLs and publication dates where available.
+Always prioritize recent, authoritative sources and provide specific citations for all major claims.
+
+# Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acquired Partial Lipodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acquired Partial Lipodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+
+# Comprehensive Disease Characteristics Report: Acquired Partial Lipodystrophy (APL)
+
+## Executive summary
+Acquired partial lipodystrophy (APL), classically termed **Barraquer–Simons syndrome (BSS)**, is an ultra-rare acquired disorder characterized by **progressive, usually symmetric cephalocaudal loss of subcutaneous adipose tissue** (face → neck/shoulders/arms/trunk) with relative sparing of lower extremities (and sometimes relative lower-body fat hypertrophy) and a strong female predominance. (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3, donadille2024diagnosticandreferral pages 4-6)
+A central current concept is that **alternative complement pathway dysregulation**—often with **low serum C3** and **C3 nephritic factor (C3NeF)**—is mechanistically linked to adipocyte injury and to major complications such as **membranoproliferative glomerulonephritis/C3 glomerulopathy**. (corvillo2020immunologicalfeaturesof pages 1-2, corvillo2021complementfactord pages 1-2, corvillo2020evidenceofongoing pages 3-6)
+
+## 1. Disease information
+### 1.1 Overview / definition
+BSS is an acquired form of partial lipodystrophy characterized by “**bilateral symmetrical loss of adipose tissue that begins in the face and may variably spreads to neck, shoulders, arms and trunk, keeping intact the adipose tissue of the lower extremities**.” (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 1.2 Key identifiers (from retrieved sources)
+* **OMIM:** **608709** (reported in review literature). (pliszka2025severeinsulinresistance pages 17-18)
+* **Orphanet:** BSS noted as **ORPHA:79087** in complement-focused cohort work; French registry cohort lists APL/BSS as **ORPHA 98,307**. (corvillo2021complementfactord pages 1-2, donadille2024diagnosticandreferral pages 4-6, corvillo2020immunologicalfeaturesof pages 1-2)
+* **MONDO:** not identified in the retrieved full-text evidence in this run (cannot be asserted).
+* **ICD-10/ICD-11 / MeSH:** not extracted from the retrieved evidence in this run (cannot be asserted).
+
+### 1.3 Synonyms / alternative names
+* **Barraquer–Simons syndrome (BSS)**
+* **Acquired partial lipodystrophy (APL)**
+* **Progressive cephalothoracic / cephalocaudal lipodystrophy** (terminology used in reviews). (pliszka2025severeinsulinresistance pages 18-20, fossfreitas2025lipodystrophysyndromesone pages 10-11)
+
+### 1.4 Evidence source types
+The information in this report is derived from: (i) peer-reviewed cohort studies and case reports in humans, (ii) clinical registry/rare-disease referral pathway data, (iii) clinical trials registries for partial lipodystrophy/metreleptin, and (iv) mechanistic reviews integrating human and experimental data. (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6, corvillo2020evidenceofongoing pages 3-6, NCT06484868 chunk 1)
+
+| Disease / preferred name | Definition / fat-loss pattern | Common synonyms | Key identifiers | Key laboratory hallmarks | Key comorbidities / associated findings | Key citation |
+|---|---|---|---|---|---|---|
+| Acquired Partial Lipodystrophy | Rare acquired partial lipodystrophy with gradual, usually symmetrical cephalocaudal loss of subcutaneous fat beginning in the face and extending to neck, shoulders, arms, trunk/upper body, with relative sparing of lower extremities and often relative lower-body fat accumulation (corvillo2020immunologicalfeaturesof pages 1-2, ceccarini2021autoimmunityinlipodystrophy pages 3-4, fossfreitas2025lipodystrophysyndromesone pages 10-11, hussain2016lipodystrophysyndromes. pages 1-3) | Barraquer–Simons syndrome; BSS; APL; progressive cephalothoracic lipodystrophy; cephalocaudal lipodystrophy (pliszka2025severeinsulinresistance pages 18-20, fossfreitas2025lipodystrophysyndromesone pages 10-11) | OMIM 608709 (reported in reviews) (pliszka2025severeinsulinresistance pages 18-20, fossfreitas2025lipodystrophysyndromesone pages 10-11) | Low serum C3 common; C3 nephritic factor (C3NeF) frequent; reductions in C4 and factor B also reported; other complement autoantibodies include anti-C3, anti-properdin, anti-factor B (corvillo2020immunologicalfeaturesof pages 1-2, ceccarini2021autoimmunityinlipodystrophy pages 3-4) | C3 glomerulopathy / membranoproliferative glomerulonephritis; autoimmune diseases; metabolic abnormalities can occur; retinal drusen reported in recent cohort work (corvillo2020immunologicalfeaturesof pages 1-2, pliszka2025severeinsulinresistance pages 18-20) | Corvillo F et al. *Orphanet J Rare Dis* 2020. DOI: 10.1186/s13023-019-1292-1 (corvillo2020immunologicalfeaturesof pages 1-2) |
+| Complement-associated APL phenotype | Complement dysregulation–linked APL phenotype in which adipose tissue is a site of local alternative-pathway activation; adipocytes supply factor D/adipsin and may be selectively injured by complement activation products (corvillo2020evidenceofongoing pages 1-3, corvillo2021complementfactord pages 1-2) | Barraquer–Simons syndrome with complement dysregulation (corvillo2020evidenceofongoing pages 1-3, corvillo2021complementfactord pages 1-2) | No separate disease identifier established in gathered evidence | Persistent C3 hypocomplementemia; C3NeF-mediated stabilization of C3 convertase; elevated factor D/adipsin in plasma and atrophic adipose tissue; adipose deposition of IgG, C3, C5a, C5b-9/MAC in active lesions (corvillo2020evidenceofongoing pages 1-3, corvillo2020evidenceofongoing pages 3-6, corvillo2021complementfactord pages 1-2) | Progressive lipoatrophy; macrophage-rich inflammatory remodeling of adipose tissue; risk of later C3 glomerulopathy (corvillo2020evidenceofongoing pages 1-3, corvillo2021complementfactord pages 2-4) | Corvillo F et al. *J Dermatol* 2020. DOI: 10.1111/1346-8138.15570; Corvillo F et al. *Int J Mol Sci* 2021. DOI: 10.3390/ijms22126608 (corvillo2020evidenceofongoing pages 1-3, corvillo2021complementfactord pages 1-2) |
+| Clinical recognition summary | Predominantly affects females, often begins in childhood/adolescence, and is frequently underrecognized with long referral/diagnostic delays in rare-disease pathways (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6, donadille2024diagnosticandreferral pages 2-4) | APL; BSS (donadille2024diagnosticandreferral pages 4-6, donadille2024diagnosticandreferral pages 2-4) | French rare-disease cohort recognized 33 APL/BSS cases among 292 analyzed lipodystrophy/insulin-resistance patients; no separate Orphanet code captured in gathered evidence (donadille2024diagnosticandreferral pages 4-6, donadille2024diagnosticandreferral pages 2-4) | Complement testing recommended in practice context because low C3 and/or C3NeF support diagnosis (donadille2024diagnosticandreferral pages 4-6, donadille2024diagnosticandreferral pages 2-4) | Renal disease association (MPGN/C3G), autoimmune overlap, and ocular drusen are clinically important complications to screen for (corvillo2020immunologicalfeaturesof pages 1-2, pliszka2025severeinsulinresistance pages 18-20) | Donadille B et al. *Orphanet J Rare Dis* 2024. DOI: 10.1186/s13023-024-03173-2 (donadille2024diagnosticandreferral pages 4-6, donadille2024diagnosticandreferral pages 2-4) |
+
+
+*Table: This table summarizes the core nomenclature and identifying features of acquired partial lipodystrophy/Barraquer–Simons syndrome, including its characteristic fat-loss pattern, synonyms, OMIM identifier, hallmark complement abnormalities, and major associated complications. It is useful as a compact reference for disease recognition and knowledge-base curation.*
+
+## 2. Etiology
+### 2.1 Primary causal factors (current understanding)
+APL/BSS is generally considered **acquired** and frequently linked to **immune/complement dysregulation**, especially **overactivation of the alternative complement pathway** and autoantibodies that stabilize complement convertases. (corvillo2020immunologicalfeaturesof pages 1-2, corvillo2021complementfactord pages 1-2, corvillo2018acquiredpartiallipodystrophy pages 2-4)
+
+Direct abstract support (immunology cohort):
+* “**C3 hypocomplementemia and the presence of C3 nephritic factor (C3NeF), an autoantibody causing complement system over-activation, are common features**…” (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 2.2 Risk factors
+**Demographic risk**
+* **Sex:** females are more affected (reported ~4:1; cohort ratio 5.5:1 in one study; 90% female in a 2018–2023 French referral cohort’s APL group). (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6)
+* **Age of onset:** often **childhood/adolescence** (mean onset ~8 years in one cohort). (corvillo2020immunologicalfeaturesof pages 1-2)
+
+**Immune/complement risk and associated biology**
+* **C3NeF prevalence:** 69.2% (9/13) in Corvillo et al. cohort; additional complement autoantibodies were frequent (anti-C3 38.5%; anti-properdin and anti-factor B 30.8% each). (corvillo2020immunologicalfeaturesof pages 1-2)
+* **Complement factor D/adipsin** (primarily synthesized by adipose tissue) is implicated because it activates the alternative pathway and may amplify local complement injury within adipose tissue. (corvillo2021complementfactord pages 1-2, corvillo2020evidenceofongoing pages 3-6)
+
+**Potential triggers**
+* Viral infections are noted as preceding onset in some patients (reported in cohort background). (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 2.3 Protective factors
+No protective genetic or environmental factors were identified in the retrieved evidence.
+
+### 2.4 Gene–environment interactions
+Not directly established in the retrieved evidence; however, a plausible interaction is that environmental triggers (e.g., infections) may initiate or amplify autoimmune complement dysregulation in genetically susceptible backgrounds (e.g., HLA association signals). (corvillo2020immunologicalfeaturesof pages 1-2)
+
+## 3. Phenotypes
+### 3.1 Core phenotype: fat distribution
+* **Cephalocaudal lipoatrophy** of face/neck/upper trunk/upper limbs with sparing of lower body is the defining clinical pattern. (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3)
+
+### 3.2 Metabolic phenotypes
+Metabolic disease is **variable** and often **less frequent/severe** than in generalized lipodystrophy, but can still be clinically significant. (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2)
+* In a 13-patient immunologic cohort: diabetes in 1 patient; elevated triglycerides/cholesterol in 2; fatty liver in 3. (corvillo2020immunologicalfeaturesof pages 1-2)
+* Case-based epidemiologic estimates summarized in Oliveira et al. (2016): diabetes ~10%, hypertriglyceridemia ~30%. (oliveira2016barraquer–simonssyndromea pages 1-2)
+
+### 3.3 Renal phenotypes
+Renal disease is a major determinant of prognosis.
+* APL is described as associated with **membranoproliferative glomerulonephritis** in ~20% in one review/clinical classification source. (hussain2016lipodystrophysyndromes. pages 1-3)
+* Other summaries note **one third** with MPGN and that low C3/C3NeF may indicate renal involvement. (oliveira2016barraquer–simonssyndromea pages 1-2)
+* Complement cohort paper notes literature risk that **~20% of BSS patients eventually develop C3 glomerulopathy (C3G)**. (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 3.4 Ocular phenotypes
+**Drusen** may develop in complement-mediated renal disease contexts, and C3 glomerulopathy review notes that DDD patients may develop drusen and that DDD can be preceded/followed by APL. (ponticelli2023c3glomerulopathiesdense pages 1-2)
+
+### 3.5 Autoimmune phenotypes
+Autoimmune disease associations are common in some cohorts.
+* Corvillo et al.: autoimmune diseases in 38.5% (5/13). (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 3.6 Quality of life impact
+Facial/upper-body lipoatrophy can cause major psychosocial burden, and reconstructive procedures are implemented clinically to restore appearance. (jeon2020lipotransferprovideseffective pages 1-2)
+
+### 3.7 Suggested HPO terms
+A phenotype table with suggested HPO terms is provided below.
+
+| Domain | Phenotype/complication | Frequency/statistic (with numerator/denominator if available) | Typical onset/progression notes | Suggested HPO terms |
+|---|---|---|---|---|
+| Body fat distribution | Symmetric cephalocaudal loss of subcutaneous fat affecting face, neck, shoulders, arms, trunk/upper thorax with sparing of lower extremities | Core defining phenotype; no pooled percentage given because it is used diagnostically (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3, donadille2024diagnosticandreferral pages 4-6) | Usually begins in childhood or adolescence; gradual progressive spread from face downward over months to years; lower-body fat may become relatively increased after puberty, especially in females (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3, oliveira2016barraquer–simonssyndromea pages 1-2) | HP:0001596 Lipodystrophy; HP:0001018 Facial hemiatrophy/facial lipoatrophy-like term not exact; HP:0010623 Abnormality of the neck; HP:0009125 Abnormal subcutaneous adipose tissue |
+| Body fat distribution | Relative hypertrophy/increased fat in lower extremities or gluteofemoral region | Qualitative, reported in many women after puberty; no exact denominator in gathered cohort texts (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | Develops after upper-body fat loss; contributes to regional disproportion (corvillo2020immunologicalfeaturesof pages 1-2) | HP:0009125 Abnormal subcutaneous adipose tissue; HP:0012743 Abnormality of adipose tissue distribution |
+| Body fat distribution | Female predominance | 90% women in French APL cohort (33 cases) (donadille2024diagnosticandreferral pages 4-6); literature female:male ratio about 4:1 (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | Sex bias apparent across cohorts; often recognized late despite childhood onset (donadille2024diagnosticandreferral pages 4-6, corvillo2020immunologicalfeaturesof pages 1-2) | HP:0011458 Abnormal sex ratio (disease-level descriptor; no exact patient HPO) |
+| Metabolic | Diabetes mellitus / glucose intolerance | Diabetes about 10% in review/case-based overview (oliveira2016barraquer–simonssyndromea pages 1-2); one of 13 patients with diabetes in Corvillo cohort (1/13) (corvillo2020immunologicalfeaturesof pages 1-2) | Metabolic complications less common than in generalized or familial partial lipodystrophies, but can emerge with more extensive fat loss or longer disease duration (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | HP:0005978 Diabetes mellitus; HP:0003074 Hyperglycemia |
+| Metabolic | Hypertriglyceridemia / dyslipidemia | Hypertriglyceridemia about 30% in review/case-based overview (oliveira2016barraquer–simonssyndromea pages 1-2); elevated TG in 2/13 in Corvillo cohort (corvillo2020immunologicalfeaturesof pages 1-2) | Often mild or absent early; should be monitored longitudinally because severity is variable (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | HP:0002155 Hypertriglyceridemia; HP:0003124 Hypercholesterolemia |
+| Metabolic | Fatty liver / hepatic steatosis | 3/13 with fatty liver in immunologic cohort (corvillo2020immunologicalfeaturesof pages 1-2) | Can occur despite overall lower metabolic burden than other lipodystrophies; linked to ectopic fat and insulin resistance when present (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3) | HP:0001397 Hepatic steatosis |
+| Metabolic | Low/normal leptin, often less severe leptin deficiency than generalized lipodystrophy | Mild low leptin in 1/13 in Corvillo cohort (corvillo2020immunologicalfeaturesof pages 1-2) | Helps explain why metreleptin may be less effective in APL than in generalized lipodystrophy (oliveira2016barraquer–simonssyndromea pages 2-4) | HP:0012548 Abnormal circulating leptin level |
+| Renal | Membranoproliferative glomerulonephritis / C3 glomerulopathy / dense deposit disease | ~20% develop MPGN in review (hussain2016lipodystrophysyndromes. pages 1-3); one third with MPGN in Oliveira overview (oliveira2016barraquer–simonssyndromea pages 1-2); 20–40% MPGN in later review (fossfreitas2025lipodystrophysyndromesone pages 10-11); 20% eventually develop C3G in immunology review (corvillo2020immunologicalfeaturesof pages 1-2); 3/13 had renal diagnoses in Corvillo cohort (DDD, IgA nephropathy, C3-related disease) (corvillo2020immunologicalfeaturesof pages 1-2) | Often occurs years after onset of fat loss; renal disease is the major prognostic determinant and may progress to ESRD (oliveira2016barraquer–simonssyndromea pages 1-2, corvillo2020immunologicalfeaturesof pages 1-2) | HP:0000093 Proteinuria; HP:0000083 Renal insufficiency; HP:0012590 Membranoproliferative glomerulonephritis; HP:0012584 C3 glomerulopathy |
+| Renal | Low serum C3 associated with renal risk | Up to 80% with low serum C3 in review (fossfreitas2025lipodystrophysyndromesone pages 10-11); ~69% C3NeF positive and significant C3 reduction in 13-patient cohort (corvillo2020immunologicalfeaturesof pages 1-2) | Persistent hypocomplementemia may parallel disease activity and supports renal surveillance (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | HP:0012213 Decreased circulating complement C3 level |
+| Ocular | Drusen / retinal deposits | Reported as a complication in DDD/APL overlap; no numerator in the specified evidence set here (ponticelli2023c3glomerulopathiesdense pages 1-2) | May occur in patients with complement-mediated disease, analogous to renal dense deposits (ponticelli2023c3glomerulopathiesdense pages 1-2) | HP:0000608 Retinal drusen |
+| Autoimmune | Autoimmune disease association overall | 38.5% (5/13) in Corvillo cohort (corvillo2020immunologicalfeaturesof pages 1-2) | Autoimmune conditions may precede, accompany, or follow lipodystrophy; supports periodic autoimmune review of systems and serology as clinically indicated (corvillo2020immunologicalfeaturesof pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2) | HP:0002960 Autoimmunity |
+| Autoimmune | Specific associated autoimmune conditions | Qualitative spectrum includes SLE, dermatomyositis, autoimmune thyroiditis, localized scleroderma, idiopathic thrombocytopenic purpura, Sjögren syndrome (corvillo2020immunologicalfeaturesof pages 1-2) | Association reinforces acquired/immune-mediated etiology in at least a subset of patients (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6) | HP:0002725 Systemic lupus erythematosus; HP:0003541 Dermatomyositis; HP:0000821 Hypothyroidism; HP:0002960 Autoimmunity |
+| Diagnostic course / natural history | Childhood onset | Mean onset 8 years in Corvillo cohort (corvillo2020immunologicalfeaturesof pages 1-2); described as during childhood in review/classification texts (hussain2016lipodystrophysyndromes. pages 1-3, oliveira2016barraquer–simonssyndromea pages 1-2) | Insidious onset contributes to delayed diagnosis (donadille2024diagnosticandreferral pages 4-6) | HP:0011463 Childhood onset |
+| Diagnostic course / natural history | Delayed recognition/referral | In French rare-disease cohort, APL median age at referral 42.3 years [IQR 28.7–58.8]; overall cohort diagnostic delay 6.4 years and referral delay 15.1 years (donadille2024diagnosticandreferral pages 4-6) | Suggests substantial under-recognition and need for earlier specialist referral (donadille2024diagnosticandreferral pages 4-6) | HP:0034198 Progressive course (disease-level descriptor) |
+
+
+*Table: This table summarizes the main clinical domains, complication frequencies, and onset/progression patterns reported for acquired partial lipodystrophy/Barraquer–Simons syndrome from the gathered evidence. It is useful for rapid knowledge-base curation and phenotype mapping with suggested HPO terms.*
+
+## 4. Genetic / molecular information
+### 4.1 Causal genes
+APL/BSS is typically **acquired** and not defined by single-gene causation in the retrieved primary evidence; however, immune-genetic associations have been reported.
+* **HLA association signal:** HLA **DRB1*11** was present in 54% of BSS patients in one cohort (with enrichment of *11:03). (corvillo2020immunologicalfeaturesof pages 1-2)
+
+### 4.2 Pathogenic variants
+No specific pathogenic germline variants were established as causal for classic acquired APL/BSS in the retrieved evidence.
+
+### 4.3 Molecular pathways and mechanistic causal chain (current concept)
+**Alternative complement pathway dysregulation → terminal complement activation → adipocyte injury** is a leading mechanistic chain supported by human tissue evidence.
+
+Key steps supported by retrieved evidence:
+1. **C3NeF stabilizes the alternative-pathway C3 convertase (C3bBb)**, preventing normal regulator-mediated decay and increasing C3 consumption and activation. (corvillo2020immunologicalfeaturesof pages 1-2, corvillo2018acquiredpartiallipodystrophy pages 2-4)
+2. **Adipose tissue produces complement components**, especially **factor D/adipsin**, which is “a key activator of the AP,” making local adipose complement activation plausible. (corvillo2020evidenceofongoing pages 3-6, corvillo2021complementfactord pages 1-2)
+3. In an 11-year-old with active disease, adipose tissue showed: atrophied/dead adipocytes, high extracellular matrix/fibrosis, increased **CD68+ macrophages**, recruitment of **c-Kit+ adipocyte precursors**, plus **local complement deposition** (C3, C5a, C5b-9) in affected tissue but not control tissue—supporting ongoing local complement-mediated injury. (corvillo2020evidenceofongoing pages 3-6)
+4. The authors explicitly interpret colocalized **C5a** with macrophage crown-like structures as consistent with chemotaxis and inflammatory perpetuation. (corvillo2020evidenceofongoing pages 3-6)
+
+Direct excerpted statements supporting local complement injury:
+* “**C3 was detected…surrounding some adipocytes… C5a stained the CLS macrophages… C5b-9 was found ubiquitously**…” (corvillo2020evidenceofongoing pages 3-6)
+* “**This is the first report showing evidence of the activation of the complement system in affected subcutaneous WAT from a patient with BSS**.” (corvillo2020evidenceofongoing pages 3-6)
+
+**Complement factor D/adipsin as a biomarker and potential amplifier**
+* In Corvillo et al. 2021, FD was “**significantly elevated**” in BSS versus comparator cohorts and the authors conclude: “**FD could be a reliable diagnostic biomarker…by promoting unrestrained local complement system activation in the adipose tissue environment**.” (corvillo2021complementfactord pages 1-2)
+
+### 4.4 Suggested ontology terms (mechanism annotations)
+**GO biological processes (suggested)**
+* complement activation, alternative pathway
+* regulation of complement activation
+* membrane attack complex assembly
+* macrophage chemotaxis
+* extracellular matrix organization / fibrosis
+
+**Cell Ontology (CL) (suggested)**
+* **macrophage** (CD68+)
+* **adipocyte**
+* **adipose stromal/progenitor cell** (c-Kit+ precursors)
+
+**UBERON anatomical (suggested)**
+* subcutaneous adipose tissue of face/neck/upper limb/trunk
+* kidney glomerulus
+* retina/macula (for drusen)
+
+## 5. Environmental information
+No specific toxic, occupational, lifestyle, or infectious agent has been established as causal; however, viral infections are described as preceding onset in some patients. (corvillo2020immunologicalfeaturesof pages 1-2)
+Lifestyle factors are relevant for management of metabolic complications but are not established as protective/causal in APL onset. (oliveira2016barraquer–simonssyndromea pages 2-4)
+
+## 6. Mechanism / pathophysiology
+### 6.1 Complement-centric pathophysiology (upstream → downstream)
+**Upstream drivers:** C3NeF and other complement autoantibodies (anti-C3, anti-properdin, anti-factor B) and reduced complement components (C3/C4/factor B) indicate complement dysregulation. (corvillo2020immunologicalfeaturesof pages 1-2)
+
+**Tissue-level effect:** Local complement deposition and terminal pathway activation (C5b-9) are detected in affected subcutaneous adipose tissue during active disease, along with adipocyte death, macrophage infiltration, and fibrosis. (corvillo2020evidenceofongoing pages 3-6)
+
+**Downstream clinical manifestations:** progressive lipoatrophy; risk of renal complement-mediated glomerular disease (C3G/DDD/MPGN) and occasional ocular drusen in complement-mediated contexts. (corvillo2020immunologicalfeaturesof pages 1-2, ponticelli2023c3glomerulopathiesdense pages 1-2)
+
+## 7. Anatomical structures affected
+**Primary**: subcutaneous adipose tissue (face, neck, upper limbs, upper trunk/thorax). (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6)
+
+**Secondary/complications**
+* **Kidney:** glomerular disease including MPGN/C3G/DDD. (hussain2016lipodystrophysyndromes. pages 1-3, corvillo2020immunologicalfeaturesof pages 1-2)
+* **Liver:** fatty liver/steatosis in a subset. (corvillo2020immunologicalfeaturesof pages 1-2)
+* **Eye:** macular drusen in some complement-mediated cases. (ponticelli2023c3glomerulopathiesdense pages 1-2)
+
+## 8. Temporal development
+* **Onset:** typically childhood/adolescence (mean onset ~8 years in a cohort; example onset age 12 in review figure caption context). (corvillo2020immunologicalfeaturesof pages 1-2, hussain2016lipodystrophysyndromes. pages 1-3)
+* **Course:** gradual progressive fat loss over months/years. (pliszka2025severeinsulinresistance pages 17-18)
+* **Care pathway reality (2023–2024 development):** substantial delays—French reference center cohort reports a **median diagnostic delay 6.4 years** and **median referral delay 15.1 years** (whole cohort), while APL patients were referred at median age 42.3 years. (donadille2024diagnosticandreferral pages 4-6)
+
+## 9. Inheritance and population
+### 9.1 Epidemiology
+Prevalence/incidence estimates were not directly extractable from the retrieved texts; the disease is generally described via **case counts**.
+* Multiple sources report **~250 cases** described in the literature. (pliszka2025severeinsulinresistance pages 17-18, oliveira2016barraquer–simonssyndromea pages 1-2)
+
+### 9.2 Population demographics
+* **Sex ratio:** female predominance ~3–4× in case-based overviews; ~4:1 in literature and 5.5:1 in one cohort; 90% female in a 33-case French APL group. (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6, oliveira2016barraquer–simonssyndromea pages 1-2)
+* **Geography/ancestry:** many reported cases in individuals of European descent (case-based overview). (oliveira2016barraquer–simonssyndromea pages 1-2)
+
+### 9.3 Inheritance
+APL/BSS is an **acquired** disorder and usually lacks family history. (corvillo2020immunologicalfeaturesof pages 1-2, corvillo2021complementfactord pages 1-2)
+
+## 10. Diagnostics
+### 10.1 Clinical recognition
+Diagnosis is primarily clinical based on characteristic fat-loss pattern, supported by complement and renal evaluation. (corvillo2020immunologicalfeaturesof pages 1-2, donadille2024diagnosticandreferral pages 4-6)
+
+### 10.2 Laboratory testing / biomarkers
+Key laboratory markers:
+* **Complement C3:** often low; persistent low C3 tracked with disease progression in an active pediatric case. (corvillo2020evidenceofongoing pages 3-6)
+* **C3 nephritic factor (C3NeF):** frequently present (e.g., 69.2% in one cohort). (corvillo2020immunologicalfeaturesof pages 1-2)
+* **Complement factor D/adipsin (FD):** elevated in BSS and proposed as a diagnostic biomarker. (corvillo2021complementfactord pages 1-2)
+
+Example work-up elements reported in a clinical case-based overview include: CBC; renal/liver function tests; urinalysis and urinary albumin excretion; fasting glucose/insulin; HbA1c; OGTT; lipid profile; endocrine testing; and complement testing (C3, C4; C3NeF context). (oliveira2016barraquer–simonssyndromea pages 1-2)
+
+### 10.3 Renal and ocular evaluation
+Because renal prognosis is critical, renal screening/monitoring (renal function, urinalysis/albumin; nephrology referral) is emphasized in clinical descriptions and implemented in case management. (jeon2020lipotransferprovideseffective pages 1-2, oliveira2016barraquer–simonssyndromea pages 1-2)
+
+### 10.4 Differential diagnosis
+In a rare-disease referral cohort, differential diagnoses (e.g., Cushing syndrome, acromegaly) were explicitly excluded as part of the diagnostic process for lipodystrophy/insulin-resistance presentations. (donadille2024diagnosticandreferral pages 2-4)
+
+## 11. Outcome / prognosis
+* Prognosis is strongly influenced by **renal involvement** (MPGN/C3G/DDD), which can progress to ESRD and may require transplantation. (oliveira2016barraquer–simonssyndromea pages 1-2, corvillo2020immunologicalfeaturesof pages 1-2)
+* Corvillo et al. note C3G outcomes (general C3G context) include progression to ESRD within 10 years in ~70% of affected children and 30–50% of affected adults. (corvillo2020immunologicalfeaturesof pages 1-2)
+
+## 12. Treatment
+Treatment is individualized and typically targets (i) metabolic complications when present and (ii) disfiguring lipoatrophy.
+
+### 12.1 Metabolic management
+Conventional approaches include diet/exercise, antihyperglycemics, and lipid-lowering therapy (general lipodystrophy management). (hussain2016lipodystrophysyndromes. pages 1-3, meehan2016metreleptinforinjection pages 1-3)
+
+### 12.2 Metreleptin (leptin replacement)
+**Evidence in partial lipodystrophy:** In an expanded-access open-label study of 23 partial lipodystrophy patients, 1-year mean changes were HbA1c −0.88%, fasting glucose −42.0 mg/dL, triglycerides −119.8 mg/dL; common TEAEs included nausea 39.1%, hypoglycemia 26.1%, and UTI 26.1%, with no new immune-related safety signals. (ajluni2016efficacyandsafety pages 1-3)
+**Regulatory context:** Metreleptin is FDA-approved for generalized lipodystrophy (not partial), and expert summaries note less predictable efficacy in APL given less marked hypoleptinemia in many cases. (ajluni2016efficacyandsafety pages 1-3, oliveira2016barraquer–simonssyndromea pages 2-4)
+
+**Clinical-trial landscape (recent/active):**
+* **NCT06484868** (posted 2024-07-03; recruiting; Phase IV; open-label; n=12) explicitly includes confirmed familial **or acquired** partial lipodystrophy and uses HbA1c and triglyceride responder endpoints. (NCT06484868 chunk 1)
+* **NCT05164341** (Phase III RCT; n=69) studies metreleptin in partial lipodystrophy but **explicitly excludes acquired/radiation-induced partial lipodystrophy**, limiting direct applicability to classic APL/BSS. (NCT05164341 chunk 1)
+
+### 12.3 Reconstructive interventions (real-world implementation)
+Autologous fat grafting (lipotransfer) is used to restore soft tissue in APL, especially facial lipoatrophy.
+* In a BMJ Case Report (published 2020-05), the patient underwent **four procedures over 3 years**, with average injected volume **~23 mL to the face per sitting** and **~19 mL per breast** in breast procedures; follow-up visits were arranged at 3–6 months and no major complications beyond minor donor-site bruising were reported. (jeon2020lipotransferprovideseffective pages 1-2)
+
+A structured treatment table (with MAXO suggestions and key outcomes) is provided below.
+
+| Intervention | Indication/target problem | Evidence type (trial/case report/review) | Key outcomes/stats | Safety notes | MAXO term suggestions | Citation |
+|---|---|---|---|---|---|---|
+| Diet and exercise / lifestyle modification | Baseline management of insulin resistance, dyslipidemia, hepatic steatosis, overall metabolic burden in APL/partial lipodystrophy | Review / case-based management summary | Recommended as foundational therapy; Oliveira et al. describe hypolipidic diet and regular exercise as part of APL management, especially when metabolic abnormalities are present or to reduce future risk; conventional therapy is often needed because metabolic burden is variable in APL (oliveira2016barraquer–simonssyndromea pages 2-4, hussain2016lipodystrophysyndromes. pages 1-3) | No disease-specific safety signal; effectiveness may be limited in severe metabolic disease | MAXO: dietary modification; exercise recommendation; metabolic disease management | (oliveira2016barraquer–simonssyndromea pages 2-4, hussain2016lipodystrophysyndromes. pages 1-3) |
+| Conventional glucose-lowering therapy (e.g., metformin, insulin when needed) | Diabetes / severe insulin resistance in partial lipodystrophy | Review | Standard-of-care approach used before or alongside leptin therapy; partial lipodystrophy may require conventional antihyperglycemics, and severe cases may need high-dose insulin; benefit is supportive rather than disease-modifying (meehan2016metreleptinforinjection pages 1-3, hussain2016lipodystrophysyndromes. pages 1-3) | High insulin requirements may be needed in lipodystrophy; no APL-specific adverse-event profile reported in gathered evidence | MAXO: antihyperglycemic therapy; insulin therapy | (meehan2016metreleptinforinjection pages 1-3, hussain2016lipodystrophysyndromes. pages 1-3) |
+| Lipid-lowering therapy (e.g., fibrates/statins/fish oil per standard practice) | Hypertriglyceridemia, dyslipidemia, pancreatitis risk reduction | Review / general management guidance | Used as part of conventional management for lipodystrophy-associated dyslipidemia; important because hypertriglyceridemia occurs in a subset of APL patients and may be difficult to normalize with standard therapy alone (hussain2016lipodystrophysyndromes. pages 1-3, meehan2016metreleptinforinjection pages 1-3) | Routine lipid-lowering drug safety considerations; no APL-specific signal in gathered evidence | MAXO: lipid-lowering therapy; hypertriglyceridemia management | (hussain2016lipodystrophysyndromes. pages 1-3, meehan2016metreleptinforinjection pages 1-3) |
+| Thiazolidinediones (e.g., rosiglitazone/pioglitazone) | Insulin resistance and adipose redistribution in partial lipodystrophy | Review / case-based discussion | Reviews note thiazolidinediones have been used with good results in partial lipodystrophy; Oliveira et al. note rosiglitazone may increase fat in some affected areas but can worsen fat accumulation in unaffected areas, so use is individualized (meehan2016metreleptinforinjection pages 1-3, oliveira2016barraquer–simonssyndromea pages 2-4) | Potential to worsen regional fat distribution in APL; standard TZD adverse effects also apply | MAXO: thiazolidinedione therapy; insulin sensitizer therapy | (meehan2016metreleptinforinjection pages 1-3, oliveira2016barraquer–simonssyndromea pages 2-4) |
+| Metreleptin in partial lipodystrophy (expanded access; not FDA-approved for PL/APL) | Diabetes, hypertriglyceridemia, leptin deficiency-related metabolic complications in partial lipodystrophy | Open-label expanded-access study (FHA101; NCT00677313) | In 23 PL patients, 1-year mean changes were HbA1c −0.88%, fasting glucose −42.0 mg/dL, triglycerides −119.8 mg/dL; larger effects in those with worse baseline abnormalities. Authors concluded benefits “may extend to patients with partial lipodystrophy,” but evidence remained preliminary (ajluni2016efficacyandsafety pages 1-3) | TEAEs mostly mild/moderate: nausea 39.1%, hypoglycemia 26.1%, urinary tract infections 26.1%; no new immune-related safety signals reported. Regulatory status: FDA approval is for generalized lipodystrophy, not PL/APL (ajluni2016efficacyandsafety pages 1-3) | MAXO: leptin replacement therapy; recombinant hormone therapy; subcutaneous drug administration | (ajluni2016efficacyandsafety pages 1-3) |
+| Metreleptin in acquired partial lipoatrophy after transplantation / GVHD | Severe insulin resistance, hyperglycemia, hypertriglyceridemia in acquired partial lipoatrophy | Two case reports | In two adult acquired partial lipoatrophy cases, recombinant methionyl human leptin “reversed all of the metabolic abnormalities”; case 1 included TG 968 mg/dL, HbA1c 8.7%, GIR 2.32 mg/kg/min before therapy, with normalization of HbA1c and triglycerides reported after treatment (shibata2018acquiredpartiallipoatrophy pages 1-3) | Long-term treatment described as successful in these cases; detailed AE table not provided in extracted text | MAXO: leptin replacement therapy; insulin resistance treatment; hypertriglyceridemia treatment | (shibata2018acquiredpartiallipoatrophy pages 1-3) |
+| Metreleptin for classic APL/BSS | Metabolic complications in APL/Barraquer–Simons syndrome | Review / expert commentary | Considered less predictably effective in classic APL because leptin levels are often relatively preserved compared with generalized lipodystrophy; Oliveira et al. specifically note lower efficacy in APL than in generalized forms (oliveira2016barraquer–simonssyndromea pages 2-4) | Use remains individualized and off-label in APL; benefit more likely when marked metabolic abnormalities/hypoleptinemia are present | MAXO: leptin replacement therapy | (oliveira2016barraquer–simonssyndromea pages 2-4) |
+| Autologous fat grafting (lipotransfer) | Facial and breast lipoatrophy; psychosocial and cosmetic restoration | Single-patient real-world reconstructive case report | Four procedures over 3 years; mean injected volume about 23 mL to face per sitting and about 19 mL per breast in breast procedures. Report described effective soft-tissue replacement and real-world implementation for visible deformity (jeon2020lipotransferprovideseffective pages 1-2) | No major complications reported aside from minor donor-site bruising; follow-up scheduled at 3–6 months after procedures (jeon2020lipotransferprovideseffective pages 1-2) | MAXO: autologous fat grafting; reconstructive surgery; soft tissue augmentation | (jeon2020lipotransferprovideseffective pages 1-2) |
+| Facial surgical correction / cosmetic reconstruction broadly | Disfiguring facial lipoatrophy and quality-of-life impact | Case report / review | Oliveira et al. emphasize surgical correction can successfully improve facial lipoatrophy and quality of life in APL, reflecting real-world practice when metabolic disease is absent or mild but deformity is substantial (oliveira2016barraquer–simonssyndromea pages 1-2, oliveira2016barraquer–simonssyndromea pages 2-4) | Standard surgical risks; no disease-specific complication pattern detailed in extracted evidence | MAXO: facial reconstructive surgery; cosmetic surgical procedure | (oliveira2016barraquer–simonssyndromea pages 1-2, oliveira2016barraquer–simonssyndromea pages 2-4) |
+| Ongoing trial: metreleptin in partial lipodystrophy (NCT06484868) | Familial or acquired partial lipodystrophy with metabolic endpoints | Ongoing Phase IV open-label post-authorisation study | Recruiting; 24-month, single-group, estimated n=12; includes confirmed familial or acquired partial lipodystrophy. Primary endpoints at Month 12: proportion with ≥0.5% HbA1c reduction (or HbA1c <6.5%) and proportion with ≥30% TG reduction among those with severe baseline abnormalities (NCT06484868 chunk 1) | Safety endpoints include TEAEs, SAEs, deaths, AESIs, and discontinuations; no DMC listed in record (NCT06484868 chunk 1) | MAXO: leptin replacement therapy; clinical trial participation | (NCT06484868 chunk 1) |
+| Ongoing trial: randomized metreleptin in PL (NCT05164341) | Partial lipodystrophy metabolic complications | Phase III randomized double-blind placebo-controlled trial | Actual enrollment 69; primary endpoints are change in HbA1c and percent change in fasting triglycerides at Month 6. Important limitation for APL knowledge base: this trial explicitly excludes acquired or radiation-induced partial lipodystrophy, so it does not directly study classic APL/BSS (NCT05164341 chunk 1, NCT05164341 chunk 2) | Quadruple masking; independent DMC; FDA-regulated drug study. Exclusion of acquired APL limits direct applicability to Barraquer–Simons syndrome (NCT05164341 chunk 1, NCT05164341 chunk 2) | MAXO: leptin replacement therapy; randomized controlled trial participation | (NCT05164341 chunk 1, NCT05164341 chunk 2) |
+
+
+*Table: This table summarizes treatment options and real-world implementations relevant to acquired partial lipodystrophy/Barraquer–Simons syndrome, including metabolic management, metreleptin evidence, reconstructive procedures, and ongoing trials. It is useful for quickly distinguishing what is standard practice, what is off-label or investigational, and which trial data are directly applicable to classic acquired APL.*
+
+## 13. Prevention
+No disease-specific primary prevention is established. Secondary/tertiary prevention focuses on: early recognition to reduce diagnostic delay and early screening for renal and metabolic complications. (donadille2024diagnosticandreferral pages 4-6, oliveira2016barraquer–simonssyndromea pages 1-2)
+
+## 14. Other species / natural disease
+No naturally occurring APL/BSS analog in other species was identified in the retrieved evidence for this run.
+
+## 15. Model organisms
+No dedicated APL/BSS animal model evidence was retrieved in this run. Mechanistic reviews suggest broader experimental work on complement’s terminal cascade effects in adipose tissue (including the concept of complement-induced adipocyte autolysis), but this is not specific to a validated BSS model system in the evidence retrieved here. ()
+
+## Recent developments and latest research (prioritizing 2023–2024)
+1. **Rare-disease pathway quantification (2024):** A French national reference-center analysis (2018–2023) quantified diagnostic/referral delays and included 33 APL/BSS patients, highlighting under-recognition and delayed access to specialized care (median referral delay 15.1 years in the overall cohort). (donadille2024diagnosticandreferral pages 4-6)
+2. **C3 glomerulopathy link (2023):** A 2023 C3 glomerulopathy review explicitly notes that DDD diagnosis may be preceded or followed by APL/BSS and proposes that fat loss “**may be due to the lysis of adipocytes expressing factor D induced by C3 nephritic factor (C3NeF)**.” (ponticelli2023c3glomerulopathiesdense pages 1-2)
+3. **Clinical trial activity (posted 2024):** An open-label Phase IV metreleptin study (NCT06484868) includes both familial and acquired partial lipodystrophy, formalizing real-world evidence collection with metabolic responder endpoints through 24 months. (NCT06484868 chunk 1)
+
+## Notes on citation requirements (PMIDs)
+The retrieved full texts in this run provided DOIs and journal metadata but not PMIDs for many citations; therefore, PMID identifiers cannot be reliably asserted from the available evidence without external database lookup.
+
+
+References
+
+1. (corvillo2020immunologicalfeaturesof pages 1-2): Fernando Corvillo, Giovanni Ceccarini, Pilar Nozal, Silvia Magno, Caterina Pelosini, Sofía Garrido, Alberto López-Lera, Manuela Moraru, Carlos Vilches, Silvia Fornaciari, Sabrina Gabbriellini, Ferruccio Santini, David Araújo-Vilar, and Margarita López-Trascasa. Immunological features of patients affected by barraquer-simons syndrome. Orphanet Journal of Rare Diseases, Jan 2020. URL: https://doi.org/10.1186/s13023-019-1292-1, doi:10.1186/s13023-019-1292-1. This article has 19 citations and is from a peer-reviewed journal.
+
+2. (hussain2016lipodystrophysyndromes. pages 1-3): Iram Hussain and Abhimanyu Garg. Lipodystrophy syndromes. Endocrinology and metabolism clinics of North America, 45 4:783-797, Dec 2016. URL: https://doi.org/10.1016/j.ecl.2016.06.012, doi:10.1016/j.ecl.2016.06.012. This article has 240 citations and is from a peer-reviewed journal.
+
+3. (donadille2024diagnosticandreferral pages 4-6): Bruno Donadille, Sonja Janmaat, Héléna Mosbah, Inès Belalem, Sophie Lamothe, Mariana Nedelcu, Anne-Sophie Jannot, Sophie Christin-Maitre, Bruno Fève, Camille Vatier, and Corinne Vigouroux. Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center. Orphanet Journal of Rare Diseases, 19:1-10, Apr 2024. URL: https://doi.org/10.1186/s13023-024-03173-2, doi:10.1186/s13023-024-03173-2. This article has 9 citations and is from a peer-reviewed journal.
+
+4. (corvillo2021complementfactord pages 1-2): Fernando Corvillo, Laura González-Sánchez, Alberto López-Lera, Emilia Arjona, Giovanni Ceccarini, Ferruccio Santini, David Araújo-Vilar, Rebecca J Brown, Joan Villarroya, Francesc Villarroya, Santiago Rodríguez de Córdoba, Teresa Caballero, Pilar Nozal, and Margarita López-Trascasa. Complement factor d (adipsin) levels are elevated in acquired partial lipodystrophy (barraquer–simons syndrome). International Journal of Molecular Sciences, 22:6608, Jun 2021. URL: https://doi.org/10.3390/ijms22126608, doi:10.3390/ijms22126608. This article has 17 citations.
+
+5. (corvillo2020evidenceofongoing pages 3-6): Fernando Corvillo, Pilar Nozal, Alberto López‐Lera, María P. De Miguel, Juan Alberto Piñero‐Fernández, Raúl De Lucas, María D García‐Concepción, María J. Beato, David Araújo‐Vilar, and Margarita López‐Trascasa. Evidence of ongoing complement activation on adipose tissue from an 11‐year‐old girl with barraquer–simons syndrome. The Journal of Dermatology, 47:1439-1444, Sep 2020. URL: https://doi.org/10.1111/1346-8138.15570, doi:10.1111/1346-8138.15570. This article has 6 citations.
+
+6. (pliszka2025severeinsulinresistance pages 17-18): Monika Pliszka and Leszek Szablewski. Severe insulin resistance syndromes: clinical spectrum and management. International Journal of Molecular Sciences, 26:5669, Jun 2025. URL: https://doi.org/10.3390/ijms26125669, doi:10.3390/ijms26125669. This article has 13 citations.
+
+7. (pliszka2025severeinsulinresistance pages 18-20): Monika Pliszka and Leszek Szablewski. Severe insulin resistance syndromes: clinical spectrum and management. International Journal of Molecular Sciences, 26:5669, Jun 2025. URL: https://doi.org/10.3390/ijms26125669, doi:10.3390/ijms26125669. This article has 13 citations.
+
+8. (fossfreitas2025lipodystrophysyndromesone pages 10-11): Maria Foss-Freitas, Donatella Gilio, and Elif A. Oral. Lipodystrophy syndromes: one name but many diseases highlighting the importance of adipose tissue in metabolism. Current Diabetes Reports, Aug 2025. URL: https://doi.org/10.1007/s11892-025-01602-5, doi:10.1007/s11892-025-01602-5. This article has 5 citations and is from a peer-reviewed journal.
+
+9. (NCT06484868 chunk 1):  Open-label Study to Evaluate Metreleptin in Patients With Partial Lipodystrophy. Amryt Pharma. 2024. ClinicalTrials.gov Identifier: NCT06484868
+
+10. (ceccarini2021autoimmunityinlipodystrophy pages 3-4): Giovanni Ceccarini, Silvia Magno, Donatella Gilio, Caterina Pelosini, and Ferruccio Santini. Autoimmunity in lipodystrophy syndromes. La Presse Médicale, 50:104073, Nov 2021. URL: https://doi.org/10.1016/j.lpm.2021.104073, doi:10.1016/j.lpm.2021.104073. This article has 37 citations.
+
+11. (corvillo2020evidenceofongoing pages 1-3): Fernando Corvillo, Pilar Nozal, Alberto López‐Lera, María P. De Miguel, Juan Alberto Piñero‐Fernández, Raúl De Lucas, María D García‐Concepción, María J. Beato, David Araújo‐Vilar, and Margarita López‐Trascasa. Evidence of ongoing complement activation on adipose tissue from an 11‐year‐old girl with barraquer–simons syndrome. The Journal of Dermatology, 47:1439-1444, Sep 2020. URL: https://doi.org/10.1111/1346-8138.15570, doi:10.1111/1346-8138.15570. This article has 6 citations.
+
+12. (corvillo2021complementfactord pages 2-4): Fernando Corvillo, Laura González-Sánchez, Alberto López-Lera, Emilia Arjona, Giovanni Ceccarini, Ferruccio Santini, David Araújo-Vilar, Rebecca J Brown, Joan Villarroya, Francesc Villarroya, Santiago Rodríguez de Córdoba, Teresa Caballero, Pilar Nozal, and Margarita López-Trascasa. Complement factor d (adipsin) levels are elevated in acquired partial lipodystrophy (barraquer–simons syndrome). International Journal of Molecular Sciences, 22:6608, Jun 2021. URL: https://doi.org/10.3390/ijms22126608, doi:10.3390/ijms22126608. This article has 17 citations.
+
+13. (donadille2024diagnosticandreferral pages 2-4): Bruno Donadille, Sonja Janmaat, Héléna Mosbah, Inès Belalem, Sophie Lamothe, Mariana Nedelcu, Anne-Sophie Jannot, Sophie Christin-Maitre, Bruno Fève, Camille Vatier, and Corinne Vigouroux. Diagnostic and referral pathways in patients with rare lipodystrophy and insulin-resistance syndromes: key milestones assessed from a national reference center. Orphanet Journal of Rare Diseases, 19:1-10, Apr 2024. URL: https://doi.org/10.1186/s13023-024-03173-2, doi:10.1186/s13023-024-03173-2. This article has 9 citations and is from a peer-reviewed journal.
+
+14. (corvillo2018acquiredpartiallipodystrophy pages 2-4): Fernando Corvillo and Margarita López-Trascasa. Acquired partial lipodystrophy and c3 glomerulopathy: dysregulation of the complement system as a common mechanism. Nefrologia, 38:258-266, May 2018. URL: https://doi.org/10.1016/j.nefroe.2018.04.002, doi:10.1016/j.nefroe.2018.04.002. This article has 21 citations and is from a peer-reviewed journal.
+
+15. (oliveira2016barraquer–simonssyndromea pages 1-2): Joana Oliveira, Paula Freitas, Eva Lau, and Davide Carvalho. Barraquer–simons syndrome: a rare form of acquired lipodystrophy. BMC Research Notes, Mar 2016. URL: https://doi.org/10.1186/s13104-016-1975-9, doi:10.1186/s13104-016-1975-9. This article has 32 citations and is from a peer-reviewed journal.
+
+16. (ponticelli2023c3glomerulopathiesdense pages 1-2): Claudio Ponticelli, Marta Calatroni, and Gabriella Moroni. C3 glomerulopathies: dense deposit disease and c3 glomerulonephritis. Frontiers in Medicine, Nov 2023. URL: https://doi.org/10.3389/fmed.2023.1289812, doi:10.3389/fmed.2023.1289812. This article has 19 citations.
+
+17. (jeon2020lipotransferprovideseffective pages 1-2): Faith Hyun Kyung Jeon, Michelle Griffin, Carole Frosdick, and Peter Edward Michael Butler. Lipotransfer provides effective soft tissue replacement for acquired partial lipodystrophy. BMJ Case Reports, 13:e232601, May 2020. URL: https://doi.org/10.1136/bcr-2019-232601, doi:10.1136/bcr-2019-232601. This article has 4 citations and is from a peer-reviewed journal.
+
+18. (oliveira2016barraquer–simonssyndromea pages 2-4): Joana Oliveira, Paula Freitas, Eva Lau, and Davide Carvalho. Barraquer–simons syndrome: a rare form of acquired lipodystrophy. BMC Research Notes, Mar 2016. URL: https://doi.org/10.1186/s13104-016-1975-9, doi:10.1186/s13104-016-1975-9. This article has 32 citations and is from a peer-reviewed journal.
+
+19. (meehan2016metreleptinforinjection pages 1-3): Cristina Adelia Meehan, Elaine Cochran, Andrea Kassai, Rebecca J. Brown, and Phillip Gorden. Metreleptin for injection to treat the complications of leptin deficiency in patients with congenital or acquired generalized lipodystrophy. Expert Review of Clinical Pharmacology, 9:59-68, Jan 2016. URL: https://doi.org/10.1586/17512433.2016.1096772, doi:10.1586/17512433.2016.1096772. This article has 94 citations and is from a peer-reviewed journal.
+
+20. (ajluni2016efficacyandsafety pages 1-3): Nevin Ajluni, M. Dar, John Xu, A. Neidert, and E. Oral. Efficacy and safety of metreleptin in patients with partial lipodystrophy: lessons from an expanded access program. Journal of diabetes & metabolism, Mar 2016. URL: https://doi.org/10.4172/2155-6156.1000659, doi:10.4172/2155-6156.1000659. This article has 62 citations.
+
+21. (NCT05164341 chunk 1):  Study to Evaluate the Safety and Efficacy of Daily Subcutaneous Metreleptin Treatment in Subjects With PL. Amryt Pharma. 2021. ClinicalTrials.gov Identifier: NCT05164341
+
+22. (shibata2018acquiredpartiallipoatrophy pages 1-3): Yusuke Shibata, Atsuko Nakatsuka, Jun Eguchi, Satoshi Miyamoto, Yukari Masuda, Motoharu Awazawa, Akinobu Takaki, Ryuichi Yoshida, Takahito Yagi, and Jun Wada. Acquired partial lipoatrophy as graft-versus-host disease and treatment with metreleptin: two case reports. Journal of Medical Case Reports, Dec 2018. URL: https://doi.org/10.1186/s13256-018-1901-y, doi:10.1186/s13256-018-1901-y. This article has 13 citations and is from a peer-reviewed journal.
+
+23. (NCT05164341 chunk 2):  Study to Evaluate the Safety and Efficacy of Daily Subcutaneous Metreleptin Treatment in Subjects With PL. Amryt Pharma. 2021. ClinicalTrials.gov Identifier: NCT05164341

--- a/research/Acquired_Partial_Lipodystrophy-deep-research-falcon.md.citations.md
+++ b/research/Acquired_Partial_Lipodystrophy-deep-research-falcon.md.citations.md
@@ -1,0 +1,483 @@
+# Citations for Research Query
+
+**Query:** # Disease Characteristics Research Template
+
+## Target Disease
+- **Disease Name:** Acquired Partial Lipodystrophy
+- **MONDO ID:**  (if available)
+- **Category:** Complex
+
+## Research Objectives
+
+Please provide a comprehensive research report on **Acquired Partial Lipodystrophy** covering all of the
+disease characteristics listed below. This report will be used to populate a disease knowledge
+base entry. Be thorough and cite primary literature (PMID preferred) for all claims.
+
+For each section, **suggested databases/resources** are listed. These are the first places
+you should search for information on each topic.
+
+---
+
+### 1. Disease Information
+> **Search first:** OMIM, Orphanet, ICD-10/ICD-11, MeSH, PubMed
+
+- What is the disease? Provide a concise overview.
+- What are the key identifiers? (OMIM, Orphanet, ICD-10/ICD-11, MeSH, Mondo)
+- What are the common synonyms and alternative names?
+- Is the information derived from individual patients (e.g., EHR) or aggregated disease-level resources?
+
+### 2. Etiology
+
+- **Disease Causal Factors**: What are the primary causes? (genetic, environmental, infectious, mechanistic)
+- **Risk Factors**:
+  > **Search first:** PubMed, Cochrane Library, UpToDate, clinical guidelines, ClinVar, ClinGen, GWAS Catalog, PheGenI, CTD, CDC, WHO, epidemiological databases
+  - Genetic risk factors (causal variants, susceptibility loci, modifier genes)
+  - Environmental risk factors (toxins, lifestyle, occupational exposures, age, sex, family history)
+- **Protective Factors**:
+  > **Search first:** PubMed, Cochrane Library, clinical trial databases, GWAS Catalog, gnomAD, WHO, CDC, nutrition databases
+  - Genetic protective factors (protective variants, modifier alleles)
+  - Environmental protective factors (diet, lifestyle, exposures that reduce risk)
+- **Gene-Environment Interactions**: How do genetic and environmental factors interact to influence disease?
+  > **Search first:** CTD, PubMed, PheGenI, GxE databases
+
+### 3. Phenotypes
+> **Search first:** HPO (Human Phenotype Ontology), OMIM, Orphanet, PubMed, clinicaltrials.gov, MedDRA, SNOMED CT, DECIPHER, LOINC
+
+For each phenotype, provide:
+- **Phenotype type**: symptoms, clinical signs, physical manifestations, behavioral changes, or laboratory abnormalities
+  > For symptoms/signs: HPO, OMIM, Orphanet, PubMed
+  > For behavioral changes: HPO, DSM, RDoC (Research Domain Criteria), PubMed
+  > For laboratory abnormalities: LOINC, SNOMED CT, LabTests Online, PubMed
+- **Phenotype characteristics**:
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+  - Age of symptom onset (neonatal, childhood, adult-onset, late-onset)
+  - Symptom severity (mild, moderate, severe, variable)
+  - Symptom progression (stable, progressive, episodic, fluctuating)
+  - Frequency among affected individuals (percentage or qualitative)
+- **Quality of life impact**: Effects on daily functioning and well-being (per-phenotype when possible)
+  > **Search first:** EQ-5D database, SF-36, WHO QOL databases, PubMed
+- Suggest HPO (Human Phenotype Ontology) terms for each phenotype
+
+### 4. Genetic/Molecular Information
+
+- **Causal Genes**: Gene mutations or chromosomal abnormalities responsible for disease (gene symbols, OMIM IDs)
+  > **Search first:** OMIM, ClinVar, HGMD, Ensembl, NCBI Gene
+- **Pathogenic Variants**:
+  - Affected genes (gene symbols, HGNC IDs)
+    > **Search first:** OMIM, NCBI Gene, Ensembl, HGNC, UniProt, GeneCards
+  - Variant classification (pathogenic, likely pathogenic, VUS per ACMG/AMP guidelines)
+    > **Search first:** ClinVar, ClinGen, ACMG/AMP guidelines, VarSome
+  - Variant type/class (missense, frameshift, nonsense, splice-site, structural)
+  - Allele frequency in population databases
+    > **Search first:** gnomAD, 1000 Genomes, ExAC, TOPMed, dbSNP
+  - Somatic vs germline origin
+    > **Search first:** COSMIC (somatic), ClinVar, ICGC, TCGA
+  - Functional consequences (loss of function, gain of function, dominant negative)
+- **Modifier Genes**: Genes that modify disease severity or expression
+- **Epigenetic Information**: DNA methylation, histone modifications, chromatin changes affecting disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Chromosomal Abnormalities**: Large-scale genetic changes (aneuploidy, translocations, inversions)
+  > **Search first:** DECIPHER, ClinVar, ECARUCA, UCSC Genome Browser
+
+### 5. Environmental Information
+
+- **Environmental Factors**: Non-genetic contributing factors (toxins, radiation, pollution, occupational exposure)
+  > **Search first:** CTD (Comparative Toxicogenomics Database), TOXNET, PubMed, EPA databases
+- **Lifestyle Factors**: Behavioral factors (smoking, diet, exercise, alcohol consumption)
+  > **Search first:** CDC databases, WHO, PubMed, NHANES
+- **Infectious Agents**: If applicable, pathogens causing or triggering disease (bacteria, viruses, fungi, parasites)
+  > **Search first:** NCBI Taxonomy, ViPR, BV-BRC, MicrobeDB, GIDEON
+
+### 6. Mechanism / Pathophysiology
+
+- **Molecular Pathways**: Specific signaling cascades or biochemical pathways involved (Wnt, MAPK, mTOR, PI3K-AKT, etc.)
+  > **Search first:** KEGG, Reactome, WikiPathways, PathBank, BioCyc
+- **Cellular Processes**: Cell-level mechanisms (apoptosis, autophagy, cell cycle dysregulation, inflammation, etc.)
+  > **Search first:** Gene Ontology (GO), Reactome, KEGG, PubMed
+- **Protein Dysfunction**: How protein structure or function is altered (misfolding, aggregation, loss of function, gain of function)
+  > **Search first:** UniProt, PDB (Protein Data Bank), InterPro, Pfam, AlphaFold
+- **Metabolic Changes**: Alterations in metabolic processes (energy metabolism, lipid metabolism, amino acid metabolism)
+  > **Search first:** KEGG, BioCyc, HMDB (Human Metabolome Database), BRENDA
+- **Immune System Involvement**: Role of immune response (autoimmunity, immunodeficiency, chronic inflammation)
+  > **Search first:** ImmPort, Immunome Database, IEDB, Gene Ontology
+- **Tissue Damage Mechanisms**: How tissues/ are injured (oxidative stress, ischemia, fibrosis, necrosis)
+  > **Search first:** PubMed, Gene Ontology, Reactome
+- **Biochemical Abnormalities**: Specific molecular defects (enzyme deficiencies, receptor dysfunction, ion channel defects)
+  > **Search first:** BRENDA, UniProt, KEGG, OMIM, PubMed
+- **Epigenetic Changes**: DNA methylation, histone modifications affecting gene expression in disease
+  > **Search first:** ENCODE, Roadmap Epigenomics, MethBase, DiseaseMeth
+- **Molecular Profiling** (if available):
+  - Transcriptomics/gene expression changes
+    > **Search first:** GEO (Gene Expression Omnibus), ArrayExpress, GTEx, Human Cell Atlas, SRA
+  - Proteomics findings
+    > **Search first:** PRIDE, ProteomeXchange, Human Protein Atlas, STRING, BioGRID
+  - Metabolomics signatures
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB, METLIN
+  - Lipidomics alterations
+    > **Search first:** LIPID MAPS, SwissLipids, LipidHome, Metabolomics Workbench
+  - Genomic structural features
+    > **Search first:** UCSC Genome Browser, Ensembl, NCBI, dbVar, DGV
+- **Advanced Technologies** (if applicable):
+  - Single-cell analysis findings (cell-type specific mechanisms, cellular heterogeneity)
+    > **Search first:** Human Cell Atlas, Single Cell Portal, GEO, CELLxGENE
+  - Spatial transcriptomics findings
+    > **Search first:** GEO, Spatial Research, Vizgen, 10x Genomics data
+  - Multi-omics integration results
+    > **Search first:** TCGA, ICGC, cBioPortal, LinkedOmics, PubMed
+  - Functional genomics screens (CRISPR, RNAi)
+    > **Search first:** DepMap, GenomeRNAi, PubMed, BioGRID ORCS
+
+For each mechanism, describe:
+- The causal chain from initial trigger to clinical manifestation
+- Which mechanisms are upstream vs downstream
+- What cell types and biological processes are involved
+- Suggest GO terms for biological processes and CL terms for cell types
+
+### 7. Anatomical Structures Affected
+
+- **Organ Level**:
+  - Primary organs directly affected
+  - Secondary organ involvement (complications, secondary effects)
+  - Body systems involved (cardiovascular, nervous, digestive, respiratory, endocrine, etc.)
+  > **Search first:** Uberon, FMA (Foundational Model of Anatomy), OMIM, HPO, ICD-11, MeSH, SNOMED CT
+- **Tissue and Cell Level**:
+  - Specific tissue types affected (epithelial, connective, muscle, nervous)
+  - Specific cell populations targeted (with Cell Ontology terms)
+  > **Search first:** Uberon, Human Protein Atlas, Cell Ontology, Human Cell Atlas, CellMarker, PanglaoDB
+- **Subcellular Level**:
+  - Cellular compartments involved (mitochondria, nucleus, ER, lysosomes) (with GO Cellular Component terms)
+  > **Search first:** Gene Ontology (Cellular Component), UniProt, Human Protein Atlas
+- **Localization**:
+  - Specific anatomical sites (with UBERON terms)
+    > **Search first:** FMA, Uberon, NeuroNames (for brain), SNOMED CT
+  - Lateralization (unilateral, bilateral, asymmetric)
+    > **Search first:** HPO, clinical literature, imaging databases
+
+### 8. Temporal Development
+
+- **Onset**:
+  - Typical age of onset (congenital, pediatric, adult, geriatric)
+  - Onset pattern (acute, subacute, chronic, insidious)
+  > **Search first:** OMIM, Orphanet, HPO, PubMed
+- **Progression**:
+  - Disease stages (early, intermediate, advanced, end-stage)
+    > **Search first:** Cancer Staging Manual (AJCC), WHO classifications, PubMed
+  - Progression rate (rapid, slow, variable)
+  - Disease course pattern (episodic, relapsing-remitting, progressive, stable)
+  - Disease duration (self-limited, chronic lifelong)
+  > **Search first:** Disease registries, longitudinal cohort databases, natural history studies, PubMed, Orphanet, OMIM
+- **Patterns**:
+  - Remission patterns (spontaneous, treatment-induced)
+    > **Search first:** Clinical trial databases, disease registries, PubMed
+  - Critical periods (time windows of vulnerability or opportunity for intervention)
+    > **Search first:** PubMed, developmental biology databases, clinical guidelines
+
+### 9. Inheritance and Population
+
+- **Epidemiology**:
+  - Prevalence (cases per 100,000 at given time)
+  - Incidence (new cases per 100,000 per year)
+  > **Search first:** Orphanet, CDC, WHO, GBD (Global Burden of Disease), national registries, SEER, disease registries
+- **For Genetic Etiology**:
+  - Inheritance pattern (AD, AR, X-linked, mitochondrial, multifactorial, polygenic)
+    > **Search first:** OMIM, Orphanet, ClinVar, GTR (Genetic Testing Registry)
+  - Penetrance (complete, incomplete, age-dependent)
+    > **Search first:** ClinVar, OMIM, PubMed, ClinGen
+  - Expressivity (variable, consistent)
+    > **Search first:** OMIM, ClinVar, PubMed
+  - Genetic anticipation (increasing severity in successive generations)
+    > **Search first:** OMIM, PubMed (especially for repeat expansion disorders)
+  - Germline mosaicism
+    > **Search first:** ClinVar, OMIM, genetic counseling literature, PubMed
+  - Founder effects (population-specific mutations)
+    > **Search first:** gnomAD, population genetics databases, PubMed
+  - Consanguinity role
+    > **Search first:** OMIM, population studies, genetic counseling resources
+  - Carrier frequency
+    > **Search first:** gnomAD, carrier screening databases, GeneReviews, GTR
+- **Population Demographics**:
+  - Affected populations (ethnic or demographic groups with higher prevalence)
+    > **Search first:** gnomAD, 1000 Genomes, PAGE Study, PubMed, population registries
+  - Geographic distribution (endemic areas, regional variation)
+    > **Search first:** WHO, CDC, GBD, Orphanet, geographic epidemiology databases
+  - Geographic distribution of specific variants
+  - Sex ratio (male:female)
+    > **Search first:** Disease registries, OMIM, PubMed, epidemiological databases
+  - Age distribution of affected individuals
+    > **Search first:** CDC, disease registries, SEER, Orphanet
+
+### 10. Diagnostics
+
+- **Clinical Tests**:
+  - Laboratory tests (blood, urine, tissue chemistry, specific enzyme assays)
+    > **Search first:** LOINC, LabTests Online, PubMed
+  - Biomarkers (proteins, metabolites, genetic markers, circulating biomarkers)
+    > **Search first:** FDA Biomarker List, BEST (Biomarkers, EndpointS, and other Tools), PubMed
+  - Imaging studies (X-ray, CT, MRI, PET, ultrasound)
+    > **Search first:** RadLex, DICOM, Radiopaedia, imaging databases
+  - Functional tests (pulmonary function, cardiac stress tests)
+    > **Search first:** LOINC, clinical guidelines, PubMed
+  - Electrophysiology (EEG, EMG, ECG, nerve conduction studies)
+    > **Search first:** LOINC, clinical neurophysiology databases, PubMed
+  - Biopsy findings (histopathology, immunohistochemistry)
+    > **Search first:** SNOMED CT, College of American Pathologists resources, PubMed
+  - Pathology findings (microscopic examination)
+    > **Search first:** SNOMED CT, Digital Pathology databases, PubMed
+- **Genetic Testing**:
+  > **Search first:** GTR (Genetic Testing Registry), GeneReviews, ClinGen
+  - Overview of recommended genetic testing approach
+  - Whole genome sequencing (WGS) utility
+    > **Search first:** GTR, ClinVar, GEL (Genomics England), gnomAD
+  - Whole exome sequencing (WES) utility
+    > **Search first:** GTR, ClinVar, OMIM, GeneMatcher
+  - Gene panels (which panels, which genes)
+    > **Search first:** GTR, ClinVar, laboratory-specific databases
+  - Single gene testing
+    > **Search first:** GTR, ClinVar, OMIM, GeneReviews
+  - Chromosomal microarray (CMA)
+    > **Search first:** DECIPHER, ClinVar, dbVar, ECARUCA
+  - Karyotyping
+    > **Search first:** Chromosome Abnormality Database, ClinVar, cytogenetics resources
+  - FISH
+    > **Search first:** ClinVar, cytogenetics databases, PubMed
+  - Mitochondrial DNA testing
+    > **Search first:** MITOMAP, MSeqDR, ClinVar, GTR
+  - Repeat expansion testing
+    > **Search first:** GTR, ClinVar, repeat expansion databases, PubMed
+- **Omics-Based Diagnostics** (if applicable):
+  - RNA sequencing / transcriptomics
+    > **Search first:** GEO, ArrayExpress, GTEx, RNA-seq databases
+  - Proteomics
+    > **Search first:** PRIDE, ProteomeXchange, FDA Biomarker database
+  - Metabolomics
+    > **Search first:** MetaboLights, Metabolomics Workbench, HMDB
+  - Epigenomics
+    > **Search first:** GEO, ENCODE, Roadmap Epigenomics, MethBase
+  - Liquid biopsy
+    > **Search first:** COSMIC, ClinVar, liquid biopsy databases, PubMed
+- **Clinical Criteria**:
+  - Standardized diagnostic criteria (DSM, ICD, society guidelines)
+    > **Search first:** DSM-5, ICD-11, clinical society guidelines, UpToDate
+  - Differential diagnosis (other conditions to rule out, with distinguishing features)
+    > **Search first:** DynaMed, UpToDate, clinical decision support systems
+- **Screening**:
+  - Screening methods for asymptomatic individuals (newborn screening, carrier screening, cascade screening)
+    > **Search first:** ACMG recommendations, CDC newborn screening, GTR
+
+### 11. Outcome/Prognosis
+
+- **Survival and Mortality**:
+  - Survival rate (5-year, 10-year, overall)
+    > **Search first:** SEER, cancer registries, disease-specific registries, PubMed
+  - Life expectancy (with and without treatment if applicable)
+    > **Search first:** Orphanet, disease registries, actuarial databases, PubMed
+  - Mortality rate
+    > **Search first:** CDC, WHO, GBD, national mortality databases
+  - Disease-specific mortality (deaths directly attributable to disease)
+    > **Search first:** Disease registries, CDC Wonder, GBD, PubMed
+- **Morbidity and Function**:
+  - Morbidity (disease-related disability and health impacts)
+    > **Search first:** GBD, WHO, disability databases, PubMed
+  - Disability outcomes (long-term functional impairments)
+    > **Search first:** ICF (International Classification of Functioning), disability registries
+  - Quality of life measures (EQ-5D, SF-36, PROMIS, disease-specific tools)
+    > **Search first:** EQ-5D database, SF-36, PROMIS, PubMed
+- **Disease Course**:
+  - Complications (secondary problems: infections, organ failure, etc.)
+    > **Search first:** ICD codes, disease registries, clinical databases, PubMed
+  - Recovery potential (likelihood and extent of recovery, with vs without treatment)
+    > **Search first:** Natural history studies, rehabilitation databases, PubMed
+- **Prediction**:
+  - Prognostic factors (age, disease severity, biomarkers, treatment response)
+    > **Search first:** Prognostic models databases, clinical calculators, PubMed
+  - Prognostic biomarkers (molecular markers predicting disease course)
+    > **Search first:** FDA Biomarker database, PubMed, cancer prognostic databases
+
+### 12. Treatment
+
+- **Pharmacotherapy**:
+  - Pharmacological treatments (drug names, drug classes, mechanisms of action)
+    > **Search first:** DrugBank, RxNorm, ATC classification, DailyMed, FDA databases
+  - Pharmacogenomics (how genetic variants affect drug metabolism, efficacy, toxicity)
+    > **Search first:** PharmGKB, CPIC (Clinical Pharmacogenetics), FDA Table of PGx Biomarkers
+- **Advanced Therapeutics**:
+  - Gene therapy (viral vectors, CRISPR, gene replacement, gene editing)
+    > **Search first:** ClinicalTrials.gov, FDA gene therapy database, ASGCT resources
+  - Cell therapy (stem cell transplant, CAR-T, cellular therapeutics)
+    > **Search first:** ClinicalTrials.gov, FDA cell therapy database, FACT standards
+  - RNA-based therapies (ASOs, siRNA, mRNA therapies)
+    > **Search first:** ClinicalTrials.gov, FDA approvals, PubMed
+  - Targeted therapies (treatments directed at specific molecular targets)
+    > **Search first:** My Cancer Genome, OncoKB, ClinicalTrials.gov, FDA approvals
+  - Immunotherapies (checkpoint inhibitors, monoclonal antibodies)
+    > **Search first:** Cancer Immunotherapy Database, FDA approvals, ClinicalTrials.gov
+- **Surgical and Interventional**:
+  - Surgical interventions (types of surgery, timing, outcomes)
+    > **Search first:** CPT codes, surgical registries, clinical guidelines, PubMed
+- **Supportive and Rehabilitative**:
+  - Supportive care (symptom management, pain control, nutrition)
+    > **Search first:** Clinical guidelines, Cochrane Library, PubMed
+  - Rehabilitation (physical therapy, occupational therapy, speech therapy)
+    > **Search first:** Rehabilitation medicine databases, clinical guidelines, PubMed
+- **Experimental**:
+  - Experimental treatments in clinical trials (with NCT identifiers if available)
+    > **Search first:** ClinicalTrials.gov, EU Clinical Trials Register, WHO ICTRP
+- **Treatment Outcomes**:
+  - Treatment response rates
+    > **Search first:** Clinical trial databases, FDA reviews, systematic reviews, PubMed
+  - Side effects and adverse events
+    > **Search first:** FDA Adverse Event Reporting System (FAERS), MedWatch, PubMed
+- **Treatment Strategy**:
+  - Treatment algorithms (clinical pathways, decision trees)
+    > **Search first:** Clinical practice guidelines, NCCN Guidelines, UpToDate
+  - Combination therapies
+    > **Search first:** ClinicalTrials.gov, treatment guidelines, PubMed
+  - Personalized medicine approaches (genotype-guided treatment)
+    > **Search first:** My Cancer Genome, CIViC, PharmGKB, precision medicine databases
+
+For each treatment, suggest MAXO (Medical Action Ontology) terms where applicable.
+
+### 13. Prevention
+
+- **Prevention Levels**:
+  - Primary prevention (preventing disease occurrence: vaccination, risk factor modification)
+    > **Search first:** CDC, WHO, USPSTF recommendations, Cochrane Library
+  - Secondary prevention (early detection and treatment: screening programs, early intervention)
+    > **Search first:** USPSTF, CDC screening guidelines, WHO
+  - Tertiary prevention (preventing complications in those with disease)
+    > **Search first:** Clinical guidelines, disease management protocols, PubMed
+- **Immunization**: Vaccine strategies (if applicable)
+  > **Search first:** CDC vaccine schedules, WHO immunization, FDA vaccine database
+- **Screening and Early Detection**:
+  - Screening programs (population-based: newborn screening, cancer screening)
+    > **Search first:** CDC screening programs, USPSTF, cancer screening databases
+  - Genetic screening (carrier screening, preimplantation genetic diagnosis, prenatal testing)
+    > **Search first:** ACMG recommendations, ACOG guidelines, GTR
+  - Risk stratification (identifying high-risk individuals for targeted prevention)
+    > **Search first:** Risk prediction models, clinical calculators, PubMed
+- **Behavioral Interventions**: Lifestyle modifications to reduce risk
+  > **Search first:** CDC, WHO, behavioral intervention databases, Cochrane Library
+- **Counseling**: Genetic counseling (risk assessment, family planning guidance)
+  > **Search first:** NSGC resources, ACMG guidelines, GeneReviews
+- **Public Health**:
+  - Public health interventions (sanitation, vector control, health education)
+    > **Search first:** CDC, WHO, public health databases, PubMed
+  - Environmental interventions (reducing environmental risk factors)
+    > **Search first:** EPA databases, WHO environmental health, PubMed
+- **Prophylaxis**: Preventive medications or procedures
+  > **Search first:** Clinical guidelines, FDA approvals, PubMed
+
+### 14. Other Species / Natural Disease
+
+- **Taxonomy**: Species affected (with NCBI Taxon identifiers)
+  > **Search first:** NCBI Taxonomy
+- **Breed**: Specific breeds affected (with VBO identifiers if applicable)
+  > **Search first:** VBO (Vertebrate Breed Ontology)
+- **Gene**: Orthologous genes in other species (with NCBI Gene IDs)
+  > **Search first:** NCBI Gene
+- **Natural Disease**:
+  - Naturally occurring disease in other species (companion animals, wildlife)
+    > **Search first:** OMIA (Online Mendelian Inheritance in Animals), VetCompass, PubMed
+  - Veterinary relevance and importance in animal health
+    > **Search first:** OMIA, veterinary databases, PubMed
+- **Comparative Biology**:
+  - Comparative pathology (similarities and differences across species)
+    > **Search first:** OMIA, comparative pathology databases, PubMed
+  - Evolutionary conservation of disease mechanisms
+    > **Search first:** HomoloGene, OrthoMCL, Alliance of Genome Resources
+- **Transmission** (if applicable):
+  - Zoonotic potential
+    > **Search first:** CDC zoonotic diseases, WHO zoonoses, GIDEON
+  - Cross-species susceptibility
+    > **Search first:** NCBI Taxonomy, veterinary databases, PubMed
+
+### 15. Model Organisms
+
+- **Model Types**:
+  - Model organism type (mammalian, invertebrate, cellular, in vitro)
+    > **Search first:** Alliance of Genome Resources, model organism databases
+  - Specific model systems (mouse, rat, zebrafish, Drosophila, C. elegans, yeast, cell lines, organoids, iPSCs)
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, SGD, ATCC, Cellosaurus
+  - Induced models (drug treatment, surgical intervention, environmental manipulation)
+    > **Search first:** MGI, model organism databases, PubMed
+- **Genetic Models**:
+  - Types available (knockout, knock-in, transgenic, conditional, humanized)
+    > **Search first:** MGI, IMPC, KOMP, EuMMCR, IMSR
+- **Model Characteristics**:
+  - Phenotype recapitulation (how well model reproduces human disease features)
+    > **Search first:** Model organism databases, comparative studies, PubMed
+  - Model limitations (aspects of human disease not captured)
+    > **Search first:** Model organism databases, PubMed, review articles
+- **Applications**:
+  - Research applications (what aspects of disease can be studied)
+    > **Search first:** Model organism databases, PubMed
+- **Resources**:
+  - Model databases
+    > **Search first:** MGI, RGD, ZFIN, FlyBase, WormBase, IMSR, EMMA, MMRRC
+
+---
+
+## Citation Requirements
+
+- Cite primary literature (PMID preferred) for all mechanistic and clinical claims
+- Prioritize recent reviews and landmark papers
+- Include direct quotes from abstracts where possible to support key statements
+- Distinguish evidence source types: human clinical, model organism, in vitro, computational
+
+## Output Format
+
+Structure your response as a comprehensive narrative organized by the sections above.
+For each section, provide:
+- Factual content with specific details (numbers, percentages, gene names, variant nomenclature)
+- Ontology term suggestions (HPO, GO, CL, UBERON, CHEBI, MAXO, MONDO) where applicable
+- Evidence citations with PMIDs
+- Direct quotes from abstracts to support key claims
+- Clear indication when information is not available or not applicable for this disease
+
+This report will be used to populate a disease knowledge base entry with:
+- Pathophysiology descriptions with causal chains
+- Gene/protein annotations (HGNC, GO terms)
+- Phenotype associations (HP terms) with frequencies
+- Cell type involvement (CL terms)
+- Anatomical locations (UBERON terms)
+- Chemical entities (CHEBI terms)
+- Treatment annotations (MAXO terms)
+- Evidence items with PMIDs and exact abstract quotes
+- Epidemiology, prognosis, diagnostic, and prevention information
+- Animal model descriptions with phenotype recapitulation details
+
+**Provider:** falcon
+**Generated:** 2026-05-11T14:17:14.879336
+
+1. corvillo2020immunologicalfeaturesof pages 1-2
+2. pliszka2025severeinsulinresistance pages 17-18
+3. jeon2020lipotransferprovideseffective pages 1-2
+4. donadille2024diagnosticandreferral pages 4-6
+5. fossfreitas2025lipodystrophysyndromesone pages 10-11
+6. corvillo2020evidenceofongoing pages 3-6
+7. corvillo2021complementfactord pages 1-2
+8. donadille2024diagnosticandreferral pages 2-4
+9. ajluni2016efficacyandsafety pages 1-3
+10. shibata2018acquiredpartiallipoatrophy pages 1-3
+11. pliszka2025severeinsulinresistance pages 18-20
+12. ceccarini2021autoimmunityinlipodystrophy pages 3-4
+13. corvillo2020evidenceofongoing pages 1-3
+14. corvillo2021complementfactord pages 2-4
+15. corvillo2018acquiredpartiallipodystrophy pages 2-4
+16. meehan2016metreleptinforinjection pages 1-3
+17. IQR 28.7–58.8
+18. https://doi.org/10.1186/s13023-019-1292-1,
+19. https://doi.org/10.1016/j.ecl.2016.06.012,
+20. https://doi.org/10.1186/s13023-024-03173-2,
+21. https://doi.org/10.3390/ijms22126608,
+22. https://doi.org/10.1111/1346-8138.15570,
+23. https://doi.org/10.3390/ijms26125669,
+24. https://doi.org/10.1007/s11892-025-01602-5,
+25. https://doi.org/10.1016/j.lpm.2021.104073,
+26. https://doi.org/10.1016/j.nefroe.2018.04.002,
+27. https://doi.org/10.1186/s13104-016-1975-9,
+28. https://doi.org/10.3389/fmed.2023.1289812,
+29. https://doi.org/10.1136/bcr-2019-232601,
+30. https://doi.org/10.1586/17512433.2016.1096772,
+31. https://doi.org/10.4172/2155-6156.1000659,
+32. https://doi.org/10.1186/s13256-018-1901-y,


### PR DESCRIPTION
## Summary
- Adds `kb/disorders/Acquired_Partial_Lipodystrophy.yaml` for MONDO:0012104.
- Integrates the Falcon report into phenotype, pathophysiology, genetic association, diagnostic, biochemical, histopathology, and treatment sections.
- Adds cited PMID reference caches generated with `just fetch-reference`, plus Falcon report and citations.

## Validation
- `just validate kb/disorders/Acquired_Partial_Lipodystrophy.yaml`
- `just validate-references kb/disorders/Acquired_Partial_Lipodystrophy.yaml`
- `just validate-terms kb/disorders/Acquired_Partial_Lipodystrophy.yaml`
- `git diff --check`
- `just compliance kb/disorders/Acquired_Partial_Lipodystrophy.yaml` (weighted compliance 100.0%)

Note: generated PMID reference cache files retain whitespace emitted by `just fetch-reference`; they were not manually edited.