### PR TITLE
[codex] Link lupus nephritis renal response endpoint

### DIFF
--- a/kb/disorders/Systemic_Lupus_Erythematosus.yaml
+++ b/kb/disorders/Systemic_Lupus_Erythematosus.yaml
@@ -1,6 +1,6 @@
 name: Systemic Lupus Erythematosus
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-30T20:00:00Z'
+updated_date: '2026-05-11T21:26:04Z'
 description: An autoimmune multi-organ disease typically associated with vasculopathy and autoantibody production. Most patients have antinuclear antibodies (ANA). The presence of anti-dsDNA or anti-Smith antibodies are highly-specific
 category: Complex
 parents:
@@ -1324,6 +1324,66 @@ biochemical:
     supports: PARTIAL
     snippet: AHAs, however, are probably less prevalent in DILE than once thought owing to a move away from older DILE drugs to modern biological agents which do not appear to elicit AHAs.
     explanation: While anti-histone antibodies are present in drug-induced lupus, their prevalence is reducing with the use of modern biological agents.
+- name: Urine Protein-to-Creatinine Ratio
+  presence: Elevated
+  context: >-
+    Quantitative proteinuria marker used to monitor lupus-nephritis renal
+    activity and treatment response as part of complete renal response
+    definitions.
+  readouts:
+  - target: Lupus Nephritis
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-061
+    interpretation: >-
+      Higher urine protein-to-creatinine ratio reflects greater protein leakage
+      from lupus-nephritis glomerular injury; immunosuppressive treatment
+      response is expected to lower this ratio as one component of complete
+      renal response.
+    evidence:
+    - reference: PMID:33971155
+      reference_title: "Efficacy and safety of voclosporin versus placebo for lupus nephritis (AURORA 1): a double-blind, randomised, multicentre, placebo-controlled, phase 3 trial."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The primary endpoint was complete renal response at 52 weeks defined as
+        a composite of urine protein creatinine ratio of 0·5 mg/mg or less,
+        stable renal function
+      explanation: >-
+        Phase 3 lupus nephritis trial defines complete renal response using a
+        urine protein-creatinine threshold, supporting this laboratory readout as
+        a treatment-response component.
+- name: Estimated Glomerular Filtration Rate
+  presence: Preserved or improved
+  context: >-
+    Estimated kidney filtration marker used with proteinuria to define complete
+    renal response in active lupus nephritis.
+  readouts:
+  - target: Lupus Nephritis
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-061
+    interpretation: >-
+      Lower eGFR reflects worse renal functional impairment in lupus nephritis;
+      complete renal response definitions require preserved or improved renal
+      filtration during therapy.
+    evidence:
+    - reference: PMID:32937045
+      reference_title: "Two-Year, Randomized, Controlled Trial of Belimumab in Lupus Nephritis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        the major secondary end point was a complete renal response (a ratio of
+        urinary protein to creatinine of <0.5, an eGFR that was no worse than
+        10% below the pre-flare value or ≥90 ml per minute per 1.73 m2
+      explanation: >-
+        Phase 3 belimumab trial defines complete renal response using both
+        proteinuria and preserved eGFR, supporting eGFR as a pharmacodynamic
+        renal-response readout in lupus nephritis.
 genetic:
 - name: HLA-DR2
   presence: Positive

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1652,8 +1652,16 @@ surrogate_endpoints:
     Complete renal response (CRR), defined as 1) a response in the urine proteinuria (protein-creatine
     ratio) and 2) preservation/improvement of renal function (estimated glomerular filtration rate); approval
     context: traditional; drug mechanism: Immunosuppressant.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Systemic Lupus Erythematosus
+  mapped_disease_files:
+  - kb/disorders/Systemic_Lupus_Erythematosus.yaml
+  mapping_notes: >-
+    Curated disease-manifestation mapping: FDA disease/use "Lupus nephritis"
+    maps to the lupus nephritis renal manifestation represented in the
+    Systemic Lupus Erythematosus disease page, with complete renal response
+    bridged through urine protein-creatinine ratio and eGFR readouts.
 - row_id: FDA-SE-adult-noncancer-062
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related

--- a/references_cache/PMID_32937045.md
+++ b/references_cache/PMID_32937045.md
@@ -1,0 +1,127 @@
+---
+reference_id: "PMID:32937045"
+title: "Two-Year, Randomized, Controlled Trial of Belimumab in Lupus Nephritis."
+authors:
+- Furie R
+- Rovin BH
+- Houssiau F
+- Malvar A
+- Teng YKO
+- Contreras G
+- Amoura Z
+- Yu X
+- Mok CC
+- Santiago MB
+- Saxena A
+- Green Y
+- Ji B
+- Kleoudis C
+- Burriss SW
+- Barnett C
+- Roth DA
+journal: N Engl J Med
+year: '2020'
+doi: 10.1056/NEJMoa2001180
+keywords:
+- Adult
+- "Antibodies, Monoclonal, Humanized/adverse effects, therapeutic use"
+- Azathioprine/therapeutic use
+- Creatinine/urine
+- Cyclophosphamide/therapeutic use
+- Double-Blind Method
+- "Drug Therapy, Combination"
+- Enzyme Inhibitors/therapeutic use
+- Female
+- Glomerular Filtration Rate
+- Humans
+- "Immunosuppressive Agents/adverse effects, therapeutic use"
+- "Infusions, Intravenous"
+- Intention to Treat Analysis
+- "Lupus Nephritis/drug therapy, mortality"
+- Male
+- Mycophenolic Acid/therapeutic use
+- Remission Induction
+content_type: abstract_only
+---
+
+# Two-Year, Randomized, Controlled Trial of Belimumab in Lupus Nephritis.
+**Authors:** Furie R, Rovin BH, Houssiau F, Malvar A, Teng YKO, Contreras G, Amoura Z, Yu X, Mok CC, Santiago MB, Saxena A, Green Y, Ji B, Kleoudis C, Burriss SW, Barnett C, Roth DA
+**Journal:** N Engl J Med (2020)
+**DOI:** [10.1056/NEJMoa2001180](https://doi.org/10.1056/NEJMoa2001180)
+
+## Content
+
+1. N Engl J Med. 2020 Sep 17;383(12):1117-1128. doi: 10.1056/NEJMoa2001180.
+
+Two-Year, Randomized, Controlled Trial of Belimumab in Lupus Nephritis.
+
+Furie R(1), Rovin BH(1), Houssiau F(1), Malvar A(1), Teng YKO(1), Contreras
+G(1), Amoura Z(1), Yu X(1), Mok CC(1), Santiago MB(1), Saxena A(1), Green Y(1),
+Ji B(1), Kleoudis C(1), Burriss SW(1), Barnett C(1), Roth DA(1).
+
+Author information:
+(1)From the Division of Rheumatology, Northwell Health, Donald and Barbara
+Zucker School of Medicine at Hofstra-Northwell, Great Neck, NY (R.F.); the
+Division of Nephrology, Ohio State University, Columbus (B.H.R.); Pôle de
+Pathologies Rhumatismales Inflammatoires et Systémiques, Institut de Recherche
+Expérimentale et Clinique, Université Catholique de Louvain, and Service de
+Rhumatologie, Cliniques Universitaires Saint-Luc - both in Brussels (F.H.);
+Organización Médica de Investigación, Buenos Aires (A.M.); the Department of
+Internal Medicine, Section of Nephrology, Leiden University Medical Center,
+Leiden, the Netherlands (Y.K.O.T.); the Division of Nephrology, Division of
+Hypertension, Department of Medicine, University of Miami Miller School of
+Medicine, Miami (G.C.); Sorbonne Université, INSERM Unité 1135 (Z.A.), and
+Assistance Publique-Hôpitaux de Paris Sorbonne Université, Service de Médecine
+Interne 2, Institut Endocrinologie, Maladies Métaboliques et Médecine Interne,
+Centre de Référence National du Lupus et Syndrome des Antiphospholipides,
+Hôpital Pitié-Salpêtrière (Z.A.) - both in Paris; the Department of Nephrology,
+Guangdong Provincial People's Hospital and Guangdong Academy of Medical
+Sciences, Guangzhou (X.Y.), and the Department of Medicine, Tuen Mun Hospital,
+Hong Kong (C.C.M.) - both in China; Escola Bahiana de Medicina e Saúde Pública,
+Salvador, Brazil (M.B.S.); the Division of Rheumatology, New York University
+School of Medicine, New York (A.S.); GlaxoSmithKline, Stockley Park, Uxbridge,
+United Kingdom (Y.G., B.J.); Parexel, Durham, NC (C.K.); and GlaxoSmithKline,
+Collegeville, PA (S.W.B., C.B., D.A.R.).
+
+Comment in
+    N Engl J Med. 2020 Sep 17;383(12):1184-1185. doi: 10.1056/NEJMe2027516.
+    Nat Rev Rheumatol. 2020 Nov;16(11):601. doi: 10.1038/s41584-020-00520-y.
+    Nat Rev Nephrol. 2020 Dec;16(12):702. doi: 10.1038/s41581-020-00362-7.
+    N Engl J Med. 2021 Jan 14;384(2):187. doi: 10.1056/NEJMc2032520.
+    N Engl J Med. 2021 Jan 14;384(2):187-188. doi: 10.1056/NEJMc2032520.
+    Kidney Int. 2021 Feb;99(2):298-300. doi: 10.1016/j.kint.2020.11.020.
+
+BACKGROUND: In adults with active lupus nephritis, the efficacy and safety of
+intravenous belimumab as compared with placebo, when added to standard therapy
+(mycophenolate mofetil or cyclophosphamide-azathioprine), are unknown.
+METHODS: In a phase 3, multinational, multicenter, randomized, double-blind,
+placebo-controlled, 104-week trial conducted at 107 sites in 21 countries, we
+assigned adults with biopsy-proven, active lupus nephritis in a 1:1 ratio to
+receive intravenous belimumab (at a dose of 10 mg per kilogram of body weight)
+or matching placebo, in addition to standard therapy. The primary end point at
+week 104 was a primary efficacy renal response (a ratio of urinary protein to
+creatinine of ≤0.7, an estimated glomerular filtration rate [eGFR] that was no
+worse than 20% below the value before the renal flare (pre-flare value) or ≥60
+ml per minute per 1.73 m2 of body-surface area, and no use of rescue therapy),
+and the major secondary end point was a complete renal response (a ratio of
+urinary protein to creatinine of <0.5, an eGFR that was no worse than 10% below
+the pre-flare value or ≥90 ml per minute per 1.73 m2, and no use of rescue
+therapy). The time to a renal-related event or death was assessed.
+RESULTS: A total of 448 patients underwent randomization (224 to the belimumab
+group and 224 to the placebo group). At week 104, significantly more patients in
+the belimumab group than in the placebo group had a primary efficacy renal
+response (43% vs. 32%; odds ratio, 1.6; 95% confidence interval [CI], 1.0 to
+2.3; P = 0.03) and a complete renal response (30% vs. 20%; odds ratio, 1.7; 95%
+CI, 1.1 to 2.7; P = 0.02). The risk of a renal-related event or death was lower
+among patients who received belimumab than among those who received placebo
+(hazard ratio, 0.51; 95% CI, 0.34 to 0.77; P = 0.001). The safety profile of
+belimumab was consistent with that in previous trials.
+CONCLUSIONS: In this trial involving patients with active lupus nephritis, more
+patients who received belimumab plus standard therapy had a primary efficacy
+renal response than those who received standard therapy alone. (Funded by
+GlaxoSmithKline; BLISS-LN ClinicalTrials.gov number, NCT01639339.).
+
+Copyright © 2020 Massachusetts Medical Society.
+
+DOI: 10.1056/NEJMoa2001180
+PMID: 32937045 [Indexed for MEDLINE]

--- a/references_cache/PMID_33971155.md
+++ b/references_cache/PMID_33971155.md
@@ -1,0 +1,160 @@
+---
+reference_id: "PMID:33971155"
+title: "Efficacy and safety of voclosporin versus placebo for lupus nephritis (AURORA 1): a double-blind, randomised, multicentre, placebo-controlled, phase 3 trial."
+authors:
+- Rovin BH
+- Teng YKO
+- Ginzler EM
+- Arriens C
+- Caster DJ
+- Romero-Diaz J
+- Gibson K
+- Kaplan J
+- Lisk L
+- Navarra S
+- Parikh SV
+- Randhawa S
+- Solomons N
+- Huizinga RB
+journal: Lancet
+year: '2021'
+doi: 10.1016/S0140-6736(21)00578-X
+keywords:
+- Adult
+- Aged
+- "Calcineurin Inhibitors/administration & dosage, adverse effects"
+- Creatinine/urine
+- "Cyclosporine/administration & dosage, adverse effects"
+- Double-Blind Method
+- Female
+- Glomerular Filtration Rate/drug effects
+- "Glucocorticoids/administration & dosage"
+- Humans
+- "Lupus Erythematosus, Systemic"
+- Lupus Nephritis/drug therapy
+- Male
+- Middle Aged
+- Mycophenolic Acid/therapeutic use
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Efficacy and safety of voclosporin versus placebo for lupus nephritis (AURORA 1): a double-blind, randomised, multicentre, placebo-controlled, phase 3 trial.
+**Authors:** Rovin BH, Teng YKO, Ginzler EM, Arriens C, Caster DJ, Romero-Diaz J, Gibson K, Kaplan J, Lisk L, Navarra S, Parikh SV, Randhawa S, Solomons N, Huizinga RB
+**Journal:** Lancet (2021)
+**DOI:** [10.1016/S0140-6736(21)00578-X](https://doi.org/10.1016/S0140-6736(21)00578-X)
+
+## Content
+
+1. Lancet. 2021 May 29;397(10289):2070-2080. doi: 10.1016/S0140-6736(21)00578-X.
+Epub 2021 May 7.
+
+Efficacy and safety of voclosporin versus placebo for lupus nephritis (AURORA
+1): a double-blind, randomised, multicentre, placebo-controlled, phase 3 trial.
+
+Rovin BH(1), Teng YKO(2), Ginzler EM(3), Arriens C(4), Caster DJ(5), Romero-Diaz
+J(6), Gibson K(7), Kaplan J(8), Lisk L(9), Navarra S(10), Parikh SV(1), Randhawa
+S(9), Solomons N(9), Huizinga RB(11).
+
+Author information:
+(1)Department of Nephrology, The Ohio State University Wexner Medical Center,
+Columbus, OH, USA.
+(2)Department of Nephrology, Leiden University Medical Centre, Leiden, The
+Netherlands.
+(3)Department of Medicine, SUNY Downstate Health Sciences University, Brooklyn,
+NY, USA.
+(4)Department of Arthritis & Clinical Immunology, Rheumatology, Oklahoma Medical
+Research Foundation, Oklahoma City, OK, USA.
+(5)Department of Medicine, Division of Nephrology and Hypertension, University
+of Louisville School of Medicine, Louisville, KY, USA.
+(6)Department of Immunology and Rheumatology, Instituto Nacional de Ciencias
+Medicas y Nutricion Salvador Zubiran, Mexico City, Mexico.
+(7)Department of Medicine, UNC Kidney Center, Chapel Hill, NC, United States.
+(8)Department of Medicine, Rutgers University, Newark, NJ, USA.
+(9)Clinical Development, Aurinia Pharmaceuticals, Victoria, BC, Canada.
+(10)University of Santo Tomas, Manila and St Luke's Medical Center, Quezon City,
+Philippines.
+(11)Research, Aurinia Pharmaceuticals, Victoria, BC, Canada. Electronic address:
+rhuizinga@auriniapharma.com.
+
+Erratum in
+    Lancet. 2021 May 29;397(10289):2048. doi: 10.1016/S0140-6736(21)01160-0.
+
+Comment in
+    Lancet. 2021 May 29;397(10289):2027-2029. doi:
+10.1016/S0140-6736(21)00663-2.
+    Nat Rev Rheumatol. 2021 Jul;17(7):378. doi: 10.1038/s41584-021-00638-7.
+
+BACKGROUND: Voclosporin, a novel calcineurin inhibitor approved for the
+treatment of adults with lupus nephritis, improved complete renal response rates
+in patients with lupus nephritis in a phase 2 trial. This study aimed to
+evaluate the efficacy and safety of voclosporin for the treatment of lupus
+nephritis.
+METHODS: This multicentre, double-blind, randomised phase 3 trial was done in
+142 hospitals and clinics across 27 countries. Patients with a diagnosis of
+systemic lupus erythematosus with lupus nephritis according to the American
+College of Rheumatology criteria, and a kidney biopsy within 2 years that showed
+class III, IV, or V (alone or in combination with class III or IV) were
+eligible. Patients were randomly assigned (1:1) to oral voclosporin (23·7 mg
+twice daily) or placebo, on a background of mycophenolate mofetil (1 g twice
+daily) and rapidly tapered low-dose oral steroids, by use of an interactive web
+response system. The primary endpoint was complete renal response at 52 weeks
+defined as a composite of urine protein creatinine ratio of 0·5 mg/mg or less,
+stable renal function (defined as estimated glomerular filtration rate [eGFR]
+≥60 mL/min/1·73 m2 or no confirmed decrease from baseline in eGFR of >20%), no
+administration of rescue medication, and no more than 10 mg prednisone
+equivalent per day for 3 or more consecutive days or for 7 or more days during
+weeks 44 through 52, just before the primary endpoint assessment. Safety was
+also assessed. Efficacy analysis was by intention-to-treat and safety analysis
+by randomised patients receiving at least one dose of study treatment. The trial
+is registered with ClinicalTrials.gov, NCT03021499.
+FINDINGS: Between April 13, 2017, and Oct 10, 2019, 179 patients were assigned
+to the voclosporin group and 178 to the placebo group. The primary endpoint of
+complete renal response at week 52 was achieved in significantly more patients
+in the voclosporin group than in the placebo group (73 [41%] of 179 patients vs
+40 [23%] of 178 patients; odds ratio 2·65; 95% CI 1·64-4·27; p<0·0001). The
+adverse event profile was balanced between the two groups; serious adverse
+events occurred in 37 (21%) of 178 in the voclosporin group and 38 (21%) of 178
+patients in the placebo group. The most frequent serious adverse event involving
+infection was pneumonia, occurring in 7 (4%) patients in the voclosporin group
+and in 8 (4%) patients in the placebo group. A total of six patients died during
+the study or study follow-up period (one [<1%] patient in the voclosporin group
+and five [3%] patients in the placebo group). None of the events leading to
+death were considered by the investigators to be related to the study
+treatments.
+INTERPRETATION: Voclosporin in combination with MMF and low-dose steroids led to
+a clinically and statistically superior complete renal response rate versus MMF
+and low-dose steroids alone, with a comparable safety profile. This finding is
+an important advancement in the treatment of patients with active lupus
+nephritis.
+FUNDING: Aurinia Pharmaceuticals.
+
+Copyright © 2021 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/S0140-6736(21)00578-X
+PMID: 33971155 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests BHR reports personal
+fees from Aurinia, Callidatis, ChemoCentryx, Retrophin, Novartis, Morphosys, EMD
+Serono, Bristol Myers Squibb, Janssen, Omeros, and AstraZeneca; non-financial
+support from Lupus Foundation of America; and grants from National Institutes of
+Health (NIH), outside the submitted work. YKOT reports consultancy fees from
+Aurinia, during the conduct of the study. EMG was a site primary investigator
+for clinical trials funded by Aurinia. CA reports personal fees from Aurinia,
+during the conduct of the study; grants and personal fees from Bristol Myers
+Squibb and GlaxoSmithKline; and grants from Exagen, outside the submitted work.
+DJC reports grants from NIH; and personal fees from Aurinia, Calliditas,
+GlaxoSmithKline, and Retrophin, outside the submitted work. JR-D participated in
+Aurinia clinical trials. KG reports grants and personal fees from Aurinia, and
+Retrophin; grants from Bristol Meyer Squibb; and personal fees from Reata,
+outside the submitted work. JK reports personal fees from and is a stakeholder
+of Aurinia Pharmaceuticals, outside the submitted work. SN was a consultant or
+participated in speaker bureau for Astellas, Pfizer, Novartis, Boehringer
+Ingelheim, and Johnson and Johnson; received educational and research grants
+from Astellas and Aurinia; and participated in Aurinia clinical trials. SVP was
+a consultant for Aurinia, GlaxoSmithKline, Bristol Myers Squibb; received
+research funding from National Institute of Diabetes and Digestive and Kidney
+Diseases, EMD Serono, Aurinia, and Mallinckrodt; and participated in clinical
+trials of Aurinia. NS is an employee and stockholder of Aurinia and has an
+issued patent (number 10286036, on a voclosporin dosing protocol). LL, SR, and
+RBH are employees and stockholders of Aurinia.


### PR DESCRIPTION
## Summary

- add urine protein-to-creatinine ratio and eGFR readouts to the Systemic Lupus Erythematosus biochemical marker section for lupus nephritis complete renal response
- map FDA-SE-adult-noncancer-061 to the SLE disease page and bridge the FDA row through those renal-response readouts
- cache PMID evidence for the belimumab BLISS-LN and voclosporin AURORA 1 phase 3 trials via `just fetch-reference`

## Validation

- `just validate kb/disorders/Systemic_Lupus_Erythematosus.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`
