### PR TITLE
[codex] Link hyperlipidemia LDL-C endpoint

### DIFF
--- a/kb/disorders/Hyperlipidemia.yaml
+++ b/kb/disorders/Hyperlipidemia.yaml
@@ -1,6 +1,6 @@
 name: Hyperlipidemia
 creation_date: "2026-03-03T12:00:00Z"
-updated_date: "2026-05-11T09:43:34Z"
+updated_date: "2026-05-11T21:34:48Z"
 description: >
   Hyperlipidemia is a heterogeneous dyslipidemia state characterized by elevated
   apoB-containing lipoproteins and/or triglyceride-rich lipoproteins. This entry
@@ -470,6 +470,30 @@ biochemical:
     term:
       id: NCIT:C105588
       label: Low Density Lipoprotein Cholesterol Measurement
+  readouts:
+  - target: Increased LDL Cholesterol
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-042
+    interpretation: >-
+      Higher serum LDL-C reflects greater LDL particle burden in broad
+      hypercholesterolemia; LDL-C reduction during lipid-lowering therapy
+      reports pharmacodynamic suppression of this atherogenic lipid-abnormality
+      node.
+    evidence:
+    - reference: PMID:28444290
+      reference_title: "Low-density lipoproteins cause atherosclerotic cardiovascular disease. 1. Evidence from genetic, epidemiologic, and clinical studies. A consensus statement from the European Atherosclerosis Society Consensus Panel."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        randomized intervention trials consistently demonstrate that any
+        mechanism of lowering plasma LDL particle concentration should reduce
+        the risk of ASCVD events proportional to the absolute reduction in LDL-C
+      explanation: >-
+        Supports LDL-C lowering as a pharmacodynamic readout of lipid-lowering
+        therapy in hypercholesterolemia.
   evidence:
   - reference: PMID:28444290
     reference_title: "Low-density lipoproteins cause atherosclerotic cardiovascular disease. 1. Evidence from genetic, epidemiologic, and clinical studies. A consensus statement from the European Atherosclerosis Society Consensus Panel."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1133,16 +1133,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Hypercholesterolemia; population: Patients with heterozygous familial
     and nonfamilial hypercholesterolemia; endpoint: Serum LDL cholesterol; approval context: traditional;
     drug mechanism: Lipid-lowering.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Familial Hypercholesterolemia
+  - Hyperlipidemia
   mapped_disease_files:
   - kb/disorders/Familial_Hypercholesterolemia.yaml
+  - kb/disorders/Hyperlipidemia.yaml
   mapping_notes: >-
-    Curated familial-component mapping: serum LDL cholesterol is linked to the
-    FH elevated circulating LDL cholesterol pathograph node. The FDA population
-    also includes nonfamilial hypercholesterolemia, which can be linked to the
-    broad Hyperlipidemia entry in a separate non-conflicting batch.
+    Curated split mapping: serum LDL cholesterol is linked to the FH elevated
+    circulating LDL cholesterol pathograph node for the heterozygous familial
+    component and to the broad Hyperlipidemia LDL-C readout for the nonfamilial
+    hypercholesterolemia component.
 - row_id: FDA-SE-adult-noncancer-043
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- add an LDL-C pharmacodynamic readout to the broad Hyperlipidemia disease page
- upgrade FDA-SE-adult-noncancer-042 from candidate to curated split mapping across FH and broad Hyperlipidemia
- keep the existing familial hypercholesterolemia mapping intact while adding the nonfamilial hypercholesterolemia bridge

## Validation

- `just validate kb/disorders/Hyperlipidemia.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`
