### PR TITLE
[codex] Link PAH pulmonary vascular resistance endpoint

### DIFF
--- a/kb/disorders/Pulmonary_hypertension.yaml
+++ b/kb/disorders/Pulmonary_hypertension.yaml
@@ -1,6 +1,6 @@
 name: Pulmonary_hypertension
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-05-03T00:00:00Z'
+updated_date: '2026-05-11T21:50:04Z'
 category: Cardiovascular Disorder
 parents:
 - Heart Disease
@@ -390,6 +390,33 @@ biochemical:
       label: N-Terminal Fragment Brain Natriuretic Protein
   presence: Elevated
   notes: Indicator of right ventricular strain
+- name: Pulmonary Vascular Resistance
+  presence: Elevated
+  context: >-
+    Hemodynamic readout from right heart catheterization; higher PVR reflects
+    greater pulmonary vascular obstruction/resistance, and treatment-induced
+    reductions report pharmacodynamic improvement in PAH.
+  readouts:
+  - target: Increased Pulmonary Vascular Resistance
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-pediatric-noncancer-064
+    interpretation: >-
+      PVR directly reports the pulmonary vascular resistance node; decreases
+      after endothelin receptor antagonist therapy indicate hemodynamic
+      improvement in the FDA PAH context of use.
+    evidence:
+    - reference: PMID:12709727
+      reference_title: Pharmacokinetics, safety, and efficacy of bosentan in pediatric patients with pulmonary arterial hypertension.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: that in pulmonary vascular resistance index was -300 dyne x s x m(2)/cm(5)
+      explanation: >-
+        Pediatric PAH patients treated with the endothelin receptor antagonist
+        bosentan had reduced pulmonary vascular resistance index, supporting
+        PVR as a pharmacodynamic hemodynamic endpoint in this context.
 diagnosis:
 - name: Echocardiogram
   diagnosis_term:

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -5643,8 +5643,17 @@ surrogate_endpoints:
     Pulmonary vascular resistance; approval context: traditional; drug mechanism: Endothelin receptor
     antagonist; age range: Any age children if there is an approved use in adults and the drug lowers
     PVR in adults..'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Pulmonary_hypertension
+  mapped_disease_files:
+  - kb/disorders/Pulmonary_hypertension.yaml
+  mapping_notes: >-
+    Curated subtype mapping: FDA row names pulmonary arterial hypertension,
+    represented as the Pulmonary Arterial Hypertension (PAH) subtype in the
+    broader Pulmonary_hypertension entry. Pulmonary vascular resistance is
+    linked as a hemodynamic pharmacodynamic readout for the Increased Pulmonary
+    Vascular Resistance pathograph node.
 - row_id: FDA-SE-pediatric-noncancer-065
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related

--- a/references_cache/PMID_12709727.md
+++ b/references_cache/PMID_12709727.md
@@ -1,0 +1,87 @@
+---
+reference_id: "PMID:12709727"
+title: "Pharmacokinetics, safety, and efficacy of bosentan in pediatric patients with pulmonary arterial hypertension."
+authors:
+- Barst RJ
+- Ivy D
+- Dingemanse J
+- Widlitz A
+- Schmitt K
+- Doran A
+- Bingaman D
+- Nguyen N
+- Gaitonde M
+- van Giersbergen PL
+journal: Clin Pharmacol Ther
+year: '2003'
+doi: 10.1016/s0009-9236(03)00005-5
+keywords:
+- Adolescent
+- Analysis of Variance
+- "Antihypertensive Agents/blood, pharmacokinetics, therapeutic use"
+- Body Weight
+- Bosentan
+- Child
+- "Child, Preschool"
+- Drug Administration Schedule
+- Female
+- Half-Life
+- Hemodynamics/drug effects
+- Humans
+- "Hypertension, Pulmonary/drug therapy"
+- Male
+- "Sulfonamides/blood, pharmacokinetics, therapeutic use"
+content_type: abstract_only
+---
+
+# Pharmacokinetics, safety, and efficacy of bosentan in pediatric patients with pulmonary arterial hypertension.
+**Authors:** Barst RJ, Ivy D, Dingemanse J, Widlitz A, Schmitt K, Doran A, Bingaman D, Nguyen N, Gaitonde M, van Giersbergen PL
+**Journal:** Clin Pharmacol Ther (2003)
+**DOI:** [10.1016/s0009-9236(03)00005-5](https://doi.org/10.1016/s0009-9236(03)00005-5)
+
+## Content
+
+1. Clin Pharmacol Ther. 2003 Apr;73(4):372-82. doi:
+10.1016/s0009-9236(03)00005-5.
+
+Pharmacokinetics, safety, and efficacy of bosentan in pediatric patients with
+pulmonary arterial hypertension.
+
+Barst RJ(1), Ivy D, Dingemanse J, Widlitz A, Schmitt K, Doran A, Bingaman D,
+Nguyen N, Gaitonde M, van Giersbergen PL.
+
+Author information:
+(1)Actelion Pharmaceuticals Ltd, Department of Clinical Pharmacology,
+Gewerbestrasse, Allscwil, Switzerland. paul.cangiersbergen@actelion.com
+
+BACKGROUND: Bosentan, a dual endothelin-receptor antagonist, is registered for
+the treatment of pulmonary arterial hypertension. Little is known about the
+effects of bosentan in children. This study was conducted to investigate the
+pharmacokinetics, safety, and efficacy of bosentan in pediatric patients with
+pulmonary arterial hypertension.
+METHODS: In this 2-center, open-label study, 19 pediatric patients with
+pulmonary arterial hypertension were enrolled and stratified for body weight and
+epoprostenol use. Patients weighing between 10 and 20 kg, between 20 and 40 kg,
+or greater than 40 kg received a single dose of 31.25, 62.5, or 125 mg,
+respectively, on day 1, followed by 4 weeks of treatment with the initial dose.
+The dose was then up-titrated to the target dose (31.25, 62.5, or 125 mg twice
+daily). Pharmacokinetic and hemodynamic parameters were obtained at baseline and
+after 12 weeks of treatment. Six-minute walk distance and cardiopulmonary
+exercise testing results were measured at baseline and at week 12 in children
+aged 8 years or older.
+RESULTS: The variability in exposure among the 3 groups was less than 2-fold
+after single- and multiple-dose administration. The exposure to bosentan
+decreased over time in all groups. The covariates body weight, gender, age, and
+the use of epoprostenol had no significant effect on the pharmacokinetics of
+bosentan. Bosentan produced hemodynamic improvement and was well tolerated. The
+mean change from baseline in mean pulmonary artery pressure was -8.0 mm Hg (95%
+confidence interval, -12.2 to -3.7 mm Hg), and that in pulmonary vascular
+resistance index was -300 dyne x s x m(2)/cm(5) (95% confidence interval, -576
+to -24 dyne x s x m(2)/cm(5)).
+CONCLUSIONS: The pharmacokinetics of bosentan in pediatric patients with
+pulmonary arterial hypertension and healthy adults are similar, and treatment
+with bosentan resulted in hemodynamic improvement. These results suggest that
+the applied dosing regimens may be appropriate to treat pediatric patients.
+
+DOI: 10.1016/s0009-9236(03)00005-5
+PMID: 12709727 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Adds pulmonary vascular resistance as a hemodynamic biomarker/readout in `Pulmonary_hypertension.yaml`.
- Links the readout to the existing `Increased Pulmonary Vascular Resistance` pathograph node with FDA row `FDA-SE-pediatric-noncancer-064`.
- Marks the FDA pediatric PAH PVR row as a curated subtype mapping and adds the fetched pediatric bosentan reference cache.

## Validation

- `just validate kb/disorders/Pulmonary_hypertension.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`