### PR TITLE
[codex] Finalize ITP platelet count endpoint mappings

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1934,15 +1934,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with Thrombocytopenia due
     to immune (idiopathic) thrombocytopenia or chronic hepatitis C; endpoint: Platelet count response;
     approval context: traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Immune Thrombocytopenia
   mapped_disease_files:
   - kb/disorders/Immune_Thrombocytopenia.yaml
   mapping_notes: >-
-    Manually reviewed for ITP platelet-count biomarker integration. The FDA row
-    is broader than the disease page because it covers thrombocytopenia due to
-    immune/idiopathic thrombocytopenia or chronic hepatitis C.
+    Curated partial mapping to the Immune Thrombocytopenia platelet-count
+    pharmacodynamic readout. The FDA row is broader than the disease page
+    because it covers thrombocytopenia due to immune/idiopathic
+    thrombocytopenia or chronic hepatitis C.
 - row_id: FDA-SE-adult-noncancer-073
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5237,15 +5238,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with thrombocytopenia due
     to immune (idiopathic) thrombocytopenia or chronic hepatitis C; endpoint: Platelet count; approval
     context: traditional; drug mechanism: Thrombopoietin receptor agonist; age range: 1 year and older.'
-  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Immune Thrombocytopenia
   mapped_disease_files:
   - kb/disorders/Immune_Thrombocytopenia.yaml
   mapping_notes: >-
-    Manually reviewed for ITP platelet-count biomarker integration. The FDA row
-    is broader than the disease page because it covers thrombocytopenia due to
-    immune/idiopathic thrombocytopenia or chronic hepatitis C.
+    Curated partial mapping to the Immune Thrombocytopenia platelet-count
+    pharmacodynamic readout. The FDA row is broader than the disease page
+    because it covers thrombocytopenia due to immune/idiopathic
+    thrombocytopenia or chronic hepatitis C.
 - row_id: FDA-SE-pediatric-noncancer-051
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Upgrades the adult and pediatric FDA platelet-count rows for immune thrombocytopenia from candidate to curated mappings.
- Keeps the mapping notes explicit that the FDA rows are broader than the ITP disease page because they also include chronic hepatitis C thrombocytopenia.
- No disease YAML changes here; `Immune_Thrombocytopenia.yaml` already has the platelet-count pharmacodynamic readout and regulatory row references from the prior merged ITP endpoint PR.

## Validation

- `just validate kb/disorders/Immune_Thrombocytopenia.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`