### PR TITLE
[codex] Link PKU phenylalanine endpoints

### DIFF
--- a/cache/ncit/terms.csv
+++ b/cache/ncit/terms.csv
@@ -428,6 +428,7 @@ NCIT:C80375,"Follicular Helper T-Cell Lymphoma, Follicular-Type",2026-04-12T22:4
 NCIT:C80435,Implantable Cardioverter-Defibrillator Placement,2026-04-13T22:49:10.690799
 NCIT:C80829,Human Immunoglobulin G,2026-05-05T08:40:20.232977
 NCIT:C80971,Canakinumab,2026-04-26T20:18:22.849522
+NCIT:C81280,Phenylalanine Measurement,2026-05-11T23:43:47.000000
 NCIT:C81664,Dornase Alfa,2026-03-08T14:14:40.693543
 NCIT:C81946,ALK Fusion Protein Expression,2026-05-01T07:42:53.426096
 NCIT:C8300,Desmoplastic Small Round Cell Tumor,2026-02-27T09:18:30.342786

--- a/kb/disorders/Phenylketonuria.yaml
+++ b/kb/disorders/Phenylketonuria.yaml
@@ -1,6 +1,6 @@
 name: Phenylketonuria
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-05-11T04:10:35Z'
+updated_date: '2026-05-11T23:43:47Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -1407,18 +1407,36 @@ biochemical:
 - name: Blood Phenylalanine
   presence: Elevated
   context: Greater than 120 micromol/L, often greater than 1200 micromol/L in classic PKU
+  biomarker_term:
+    preferred_term: Phenylalanine Measurement
+    term:
+      id: NCIT:C81280
+      label: Phenylalanine Measurement
+  synonyms:
+  - Plasma phenylalanine
+  - Phe
   readouts:
   - target: Hyperphenylalaninemia
-    relationship: READOUT_OF
+    relationship: PHARMACODYNAMIC_MARKER_OF
     direction: POSITIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
     - FDA-SE-adult-noncancer-087
     - FDA-SE-pediatric-noncancer-057
     interpretation: >-
-      Blood phenylalanine directly measures the systemic
-      hyperphenylalaninemia caused by impaired PAH-dependent phenylalanine
+      Higher blood or plasma phenylalanine directly tracks systemic
+      hyperphenylalaninemia; treatment-induced reductions indicate improved
+      phenylalanine control downstream of PAH activation or phenylalanine
       metabolism.
+    evidence:
+    - reference: PMID:24385074
+      reference_title: "Phenylalanine hydroxylase deficiency: diagnosis and management guideline."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Phenylalanine hydroxylase deficiency, traditionally known as phenylketonuria, results in the accumulation of phenylalanine in the blood of affected individuals and was the first inborn error of metabolism to be identified through population screening."
+      explanation: >-
+        The clinical guideline supports blood phenylalanine accumulation as the
+        defining biochemical readout of PKU-associated hyperphenylalaninemia.
   evidence:
   - reference: PMID:24385074
     reference_title: "Phenylalanine hydroxylase deficiency: diagnosis and management guideline."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2339,12 +2339,15 @@ surrogate_endpoints:
     micromol/L on existing management 3. Pateints with hyperphenylalaninemia due to sepiapterin-responsive
     PKU; endpoint: Plasma phenylalanine; approval context: traditional; drug mechanism: 1/3. Phenylalanine
     hydroxylase activator 2. Phenylalanine-metabolizing enzyme.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Phenylketonuria
   mapped_disease_files:
   - kb/disorders/Phenylketonuria.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated exact disease mapping to the Phenylketonuria blood/plasma
+    phenylalanine pharmacodynamic readout linked to the Hyperphenylalaninemia
+    pathograph node.
 - row_id: FDA-SE-adult-noncancer-088
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5449,12 +5452,15 @@ surrogate_endpoints:
     due to tetrahydrobiopterin-responsive PKU; Pediatrc pateints with hyperphenylalaninemia due to sepiapterin-responsive
     PKU; endpoint: Plasma phenylalanine; approval context: traditional; drug mechanism: Phenylalanine
     hydroxylase activator; age range: 1 month and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Phenylketonuria
   mapped_disease_files:
   - kb/disorders/Phenylketonuria.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated exact disease mapping to the Phenylketonuria blood/plasma
+    phenylalanine pharmacodynamic readout linked to the Hyperphenylalaninemia
+    pathograph node.
 - row_id: FDA-SE-pediatric-noncancer-058
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Tightens the existing Phenylketonuria blood phenylalanine biochemical entry into a pharmacodynamic readout of Hyperphenylalaninemia.
- Adds the NCIT biomarker term for `NCIT:C81280` Phenylalanine Measurement.
- Marks the adult and pediatric FDA plasma phenylalanine rows as curated DisMech mappings.

## Validation

- `just validate kb/disorders/Phenylketonuria.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`