### PR TITLE
[codex] Link XLH serum phosphate endpoints

### DIFF
--- a/kb/disorders/X-Linked_Hypophosphatemia.yaml
+++ b/kb/disorders/X-Linked_Hypophosphatemia.yaml
@@ -1,6 +1,6 @@
 name: X-Linked Hypophosphatemia
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: '2026-05-11T04:10:35Z'
+updated_date: '2026-05-11T23:54:41Z'
 category: Mendelian
 description: >
   X-linked hypophosphatemia (XLH) is the most common hereditary form of rickets,
@@ -455,18 +455,30 @@ biochemical:
   - target: Renal Phosphate Wasting via FGF23 Excess
     relationship: PHARMACODYNAMIC_MARKER_OF
     direction: NEGATIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
     - FDA-SE-adult-noncancer-120
     - FDA-SE-pediatric-noncancer-075
     interpretation: >-
       Serum phosphate reports the downstream effect of FGF23-driven renal
       phosphate wasting and pharmacodynamic correction by anti-FGF23 therapy.
+    evidence:
+    - reference: PMID:29947083
+      reference_title: "A Randomized, Double-Blind, Placebo-Controlled, Phase 3 Trial Evaluating the Efficacy of Burosumab, an Anti-FGF23 Antibody, in Adults With X-Linked Hypophosphatemia: Week 24 Primary Analysis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "94.1% of burosumab-treated participants attained mean serum phosphate concentration above the lower limit of normal compared with 7.6% of those receiving placebo"
+      explanation: >-
+        Adult phase 3 trial data support serum phosphate normalization as a
+        pharmacodynamic readout of anti-FGF23 treatment response in XLH.
   biomarker_term:
-    preferred_term: phosphate
+    preferred_term: Phosphate Measurement
     term:
-      id: CHEBI:26020
-      label: phosphate
+      id: NCIT:C64857
+      label: Phosphate Measurement
+  synonyms:
+  - Serum phosphorus
+  - Serum phosphate concentration
   evidence:
   - reference: PMID:29947083
     reference_title: "A Randomized, Double-Blind, Placebo-Controlled, Phase 3 Trial Evaluating the Efficacy of Burosumab, an Anti-FGF23 Antibody, in Adults With X-Linked Hypophosphatemia: Week 24 Primary Analysis."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -3218,12 +3218,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: X-linked hypophosphatemia; population: Patients with X-linked hypophosphatemia;
     endpoint: Serum phosphate; approval context: traditional; drug mechanism: Fibroblast growth factor
     23 inhibitor.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - X-Linked Hypophosphatemia
   mapped_disease_files:
   - kb/disorders/X-Linked_Hypophosphatemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: serum phosphate is linked to the XLH
+    FGF23-driven renal phosphate wasting pathograph node and anti-FGF23
+    pharmacodynamic correction.
 - row_id: FDA-SE-adult-noncancer-121
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5948,12 +5951,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: X-linked hypophosphatemia; population: Patients with X-linked hypophosphatemia;
     endpoint: Serum phosphate; approval context: traditional; drug mechanism: Fibroblast growth factor
     23 inhibitor; age range: 1 year and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - X-Linked Hypophosphatemia
   mapped_disease_files:
   - kb/disorders/X-Linked_Hypophosphatemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: serum phosphate is linked to the XLH
+    FGF23-driven renal phosphate wasting pathograph node and anti-FGF23
+    pharmacodynamic correction in patients 1 year and older.
 - row_id: FDA-SE-pediatric-noncancer-076
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- normalize the XLH serum phosphate biomarker term to the NCIT phosphate measurement term
- make the serum phosphate readout explicitly pharmacodynamic and attach trial evidence to the readout link
- mark the adult and pediatric FDA XLH serum phosphate rows as curated DisMech mappings

## Validation

- `just validate kb/disorders/X-Linked_Hypophosphatemia.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`