### PR TITLE
[codex] Link metabolic ammonia endpoints

### DIFF
--- a/cache/ncit/terms.csv
+++ b/cache/ncit/terms.csv
@@ -414,6 +414,7 @@ NCIT:C7383,Bladder Papillary Urothelial Carcinoma,2026-04-11T22:23:31.183602
 NCIT:C74007,Daratumumab,2026-05-10T13:39:50.805787
 NCIT:C74611,Erythrocyte Sedimentation Rate Measurement,2026-02-27T09:18:30.342874
 NCIT:C74625,Sezary Cell Count,2026-04-12T22:38:34.184142
+NCIT:C74799,Ammonia Measurement,2026-05-12T00:12:34.000000
 NCIT:C74866,Leptin Measurement,2026-04-12T18:28:40.121140
 NCIT:C7528,"Follicular Helper T-Cell Lymphoma, Angioimmunoblastic-Type",2026-04-12T22:46:03.751481
 NCIT:C75319,Collagen Alpha-1(II) Chain,2026-04-13T01:12:27.845804

--- a/kb/disorders/Methylmalonic_Acidemia.yaml
+++ b/kb/disorders/Methylmalonic_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Methylmalonic Acidemia
 category: Mendelian
 creation_date: '2026-02-23T22:58:40Z'
-updated_date: '2026-05-11T04:10:35Z'
+updated_date: '2026-05-12T00:12:34Z'
 synonyms:
 - Methylmalonic aciduria
 - MMA
@@ -1160,23 +1160,47 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: kidney injury (lipocalin-2
     explanation: Identifies LCN2 as a kidney injury biomarker in MMA.
-- name: Ammonia
+- name: Plasma ammonia
   presence: INCREASED
   context: 'Secondary hyperammonemia occurs during acute decompensation due to inhibition of N-acetylglutamate synthase by propionyl-CoA, impairing the urea cycle.
 
     '
+  biomarker_term:
+    preferred_term: Ammonia Measurement
+    term:
+      id: NCIT:C74799
+      label: Ammonia Measurement
+  synonyms:
+  - Ammonia
+  - NH3
   readouts:
   - target: Hyperammonemia
-    relationship: READOUT_OF
+    relationship: PHARMACODYNAMIC_MARKER_OF
     direction: POSITIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
     - FDA-SE-adult-noncancer-068
     - FDA-SE-pediatric-noncancer-048
     interpretation: >-
       Circulating ammonia is the laboratory readout of the acute
       hyperammonemia that can accompany methylmalonic acidemia
-      decompensation.
+      decompensation; reduced ammonia after carglumic acid reports
+      pharmacodynamic correction of the secondary urea-cycle block.
+    evidence:
+    - reference: PMID:39695809
+      reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Carglumic acid (CGA) is a synthetic structural analog of human NAG and
+        is approved for the treatment of patients with hyperammonemia due to PA
+        or MMA. CGA is well tolerated and its use in normalizing ammonia levels
+        during acute hyperammonemic episodes in patients with PA and MMA is
+        well established.
+      explanation: >-
+        Expert-review evidence supports ammonia normalization as the
+        pharmacodynamic endpoint for carglumic acid treatment in MMA-associated
+        hyperammonemia.
   evidence:
   - reference: PMID:25205257
     reference_title: "Proposed guidelines for the diagnosis and management of methylmalonic and propionic acidemia."

--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: N-Acetylglutamate Synthase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-11T04:10:35Z'
+updated_date: '2026-05-12T00:12:34Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -594,20 +594,36 @@ biochemical:
     '
   readouts:
   - target: Systemic hyperammonemia and glutamine diversion
-    relationship: READOUT_OF
+    relationship: PHARMACODYNAMIC_MARKER_OF
     direction: POSITIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
     - FDA-SE-adult-noncancer-071
     - FDA-SE-pediatric-noncancer-049
     interpretation: >-
       Plasma ammonia reports the systemic proximal urea-cycle biochemical
-      state caused by impaired NAG-dependent CPS1 activation.
+      state caused by impaired NAG-dependent CPS1 activation; reduced ammonia
+      after carglumic acid reports pharmacodynamic restoration of CPS1
+      activation.
+    evidence:
+    - reference: PMID:38637895
+      reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        All patients responded well to carbamylglutamate therapy, as indicated
+        by normalization of plasma ammonia and citrulline
+      explanation: >-
+        Case-series evidence supports plasma ammonia normalization as a
+        pharmacodynamic readout of carglumic acid response in NAGS deficiency.
   biomarker_term:
-    preferred_term: ammonium
+    preferred_term: Ammonia Measurement
     term:
-      id: CHEBI:28938
-      label: ammonium
+      id: NCIT:C74799
+      label: Ammonia Measurement
+  synonyms:
+  - Ammonia
+  - NH3
   evidence:
   - reference: PMID:38637895
     reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."

--- a/kb/disorders/Propionic_Acidemia.yaml
+++ b/kb/disorders/Propionic_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Propionic Acidemia
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-11T04:10:35Z'
+updated_date: '2026-05-12T00:12:34Z'
 synonyms:
 - Propionic aciduria
 - PA
@@ -848,17 +848,42 @@ biochemical:
   context: >-
     Secondary hyperammonemia can occur during propionic acidemia
     decompensation through NAG/CPS1 pathway inhibition.
+  biomarker_term:
+    preferred_term: Ammonia Measurement
+    term:
+      id: NCIT:C74799
+      label: Ammonia Measurement
+  synonyms:
+  - Ammonia
+  - NH3
   readouts:
   - target: Secondary NAG deficiency and hyperammonemia
-    relationship: READOUT_OF
+    relationship: PHARMACODYNAMIC_MARKER_OF
     direction: POSITIVE
-    endpoint_context: MONITORING
+    endpoint_context: PHARMACODYNAMIC
     regulatory_endpoint_refs:
     - FDA-SE-adult-noncancer-096
     - FDA-SE-pediatric-noncancer-063
     interpretation: >-
       Plasma ammonia reports the secondary hyperammonemic state caused by
-      impaired urea-cycle activation during propionic acidemia decompensation.
+      impaired urea-cycle activation during propionic acidemia decompensation;
+      reduced ammonia after carglumic acid reports pharmacodynamic correction
+      of the secondary NAG/CPS1 block.
+    evidence:
+    - reference: PMID:39695809
+      reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Carglumic acid (CGA) is a synthetic structural analog of human NAG and
+        is approved for the treatment of patients with hyperammonemia due to PA
+        or MMA. CGA is well tolerated and its use in normalizing ammonia levels
+        during acute hyperammonemic episodes in patients with PA and MMA is
+        well established.
+      explanation: >-
+        Expert-review evidence supports ammonia normalization as the
+        pharmacodynamic endpoint for carglumic acid treatment in PA-associated
+        hyperammonemia.
   evidence:
   - reference: PMID:39695809
     reference_title: "Role of carglumic acid in the long-term management of propionic and methylmalonic acidurias."

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1829,12 +1829,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Methylmalonic acidemia; population: Patients with acute hyperammonemia
     due to methylmalonic acidemia; endpoint: Plasma ammonia; approval context: traditional; drug mechanism:
     Carbamoyl Phosphate Synthetase 1 activator.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Methylmalonic Acidemia
   mapped_disease_files:
   - kb/disorders/Methylmalonic_Acidemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the MMA acute
+    hyperammonemia readout and carglumic acid/CPS1 activation pharmacodynamic
+    correction.
 - row_id: FDA-SE-adult-noncancer-069
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1904,12 +1907,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: N-acetylglutamate Synthase (NAGS) deficiency; population: Patients with
     hyperammonemia due to NAGS deficiency; endpoint: Plasma ammonia; approval context: traditional; drug
     mechanism: Carbamoyl Phosphate Synthetase 1 activator.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - N-Acetylglutamate Synthase Deficiency
   mapped_disease_files:
   - kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the NAGS
+    proximal urea-cycle hyperammonemia pathograph node and carglumic
+    acid/CPS1 activation pharmacodynamic correction.
 - row_id: FDA-SE-adult-noncancer-072
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2592,12 +2598,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Propionic acidemia; population: Patients with acute hyperammonemia due
     to propionc acidemia; endpoint: Plasma ammonia; approval context: traditional; drug mechanism: Carbamoyl
     Phosphate Synthetase 1 activator.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Propionic Acidemia
   mapped_disease_files:
   - kb/disorders/Propionic_Acidemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the PA
+    secondary NAG deficiency and hyperammonemia pathograph node and carglumic
+    acid/CPS1 activation pharmacodynamic correction.
 - row_id: FDA-SE-adult-noncancer-097
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5180,12 +5189,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Methylmalonic acidemia; population: Patients with acute hyperammonemia
     due to methylmalonic acidemia; endpoint: Plasma ammonia; approval context: traditional; drug mechanism:
     Carbamoyl Phosphate Synthetase 1 activator; age range: Birth to less than 18 years of age.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Methylmalonic Acidemia
   mapped_disease_files:
   - kb/disorders/Methylmalonic_Acidemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the pediatric
+    MMA acute hyperammonemia readout and carglumic acid/CPS1 activation
+    pharmacodynamic correction.
 - row_id: FDA-SE-pediatric-noncancer-049
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5208,12 +5220,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: N-acetylglutamate Synthase (NAGS) deficiency; population: Patients with
     hyperammonemia due to NAGS deficiency; endpoint: Plasma ammonia; approval context: traditional; drug
     mechanism: Carbamoyl Phosphate Synthetase 1 activator; age range: Birth to less than 18 years of age.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - N-Acetylglutamate Synthase Deficiency
   mapped_disease_files:
   - kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the pediatric
+    NAGS proximal urea-cycle hyperammonemia pathograph node and carglumic
+    acid/CPS1 activation pharmacodynamic correction.
 - row_id: FDA-SE-pediatric-noncancer-050
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5614,12 +5629,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Propionic acidemia; population: Patients with acute hyperammonemia due
     to propionc acidemia; endpoint: Plasma ammonia; approval context: traditional; drug mechanism: Carbamoyl
     Phosphate Synthetase 1 activator; age range: Birth and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Propionic Acidemia
   mapped_disease_files:
   - kb/disorders/Propionic_Acidemia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: plasma ammonia is linked to the PA
+    secondary NAG deficiency and hyperammonemia pathograph node and
+    carglumic acid/CPS1 activation pharmacodynamic correction.
 - row_id: FDA-SE-pediatric-noncancer-064
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- normalize plasma ammonia biomarkers to the NCIT ammonia measurement term in NAGS deficiency, MMA, and PA
- make the plasma ammonia readouts pharmacodynamic for CPS1 activation/carglumic acid contexts and attach treatment-response evidence
- mark the adult and pediatric FDA plasma ammonia rows for NAGS deficiency, MMA, and PA as curated DisMech mappings

## Validation

- `just validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`
- `just validate kb/disorders/Methylmalonic_Acidemia.yaml`
- `just validate kb/disorders/Propionic_Acidemia.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`