### PR TITLE
Fix MAXO node name to use canonical ontology label (#1932)

### DIFF
--- a/src/dismech/export/kgx_export.py
+++ b/src/dismech/export/kgx_export.py
@@ -968,7 +968,10 @@ def extract_nodes(record: dict[str, Any]) -> Iterator[NamedThing]:
     for treatment in record.get("treatments") or []:
         treatment_id = _get_term_id(treatment, ["treatment_term", "term", "id"])
         treatment_label = _get_term_id(treatment, ["treatment_term", "term", "label"])
-        node = _emit(treatment_id, treatment.get("name") or treatment_label, "biolink:Treatment")
+        # Use the canonical ontology label, not the free-text treatment.name —
+        # multiple disorders share one MAXO CURIE with different free-text names,
+        # and dedup would otherwise pick whichever name wins.
+        node = _emit(treatment_id, treatment_label or treatment.get("name"), "biolink:Treatment")
         if node:
             yield node
 

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -941,8 +941,9 @@ class TestExtractNodes:
         assert node_by_id["HP:0000001"].name == "Phenotype A"
         # Cell type uses preferred_term
         assert node_by_id["CL:0000001"].name == "Cell A"
-        # Treatment uses treatment name
-        assert node_by_id["MAXO:0000001"].name == "Treatment A"
+        # Treatment uses the canonical MAXO term label, not the free-text
+        # treatments[].name — see issue #1932.
+        assert node_by_id["MAXO:0000001"].name == "treatment a"
         # Gene uses gene name
         assert node_by_id["HGNC.SYMBOL:GENE1"].name == "GENE1"
 
@@ -1006,6 +1007,27 @@ class TestExtractNodes:
         assert "MONDO:0000001" in ids
         assert "HP:0000001" in ids
         assert len(nodes) == 2  # disease + 1 valid phenotype
+
+    def test_treatment_node_uses_canonical_maxo_label(self):
+        """Treatment node `name` must come from treatment_term.term.label,
+        not the free-text treatments[].name (issue #1932). Different disorders
+        share one MAXO CURIE under different free-text names; dedup must collapse
+        on the canonical ontology label."""
+        disorder = {
+            "name": "Test Disorder",
+            "disease_term": {"term": {"id": "MONDO:0000001"}},
+            "treatments": [
+                {
+                    "name": "Alpelisib (BYL719)",
+                    "treatment_term": {
+                        "term": {"id": "MAXO:0000648", "label": "enzyme inhibitor agent therapy"},
+                    },
+                },
+            ],
+        }
+        nodes = list(extract_nodes(disorder))
+        node_by_id = {n.id: n for n in nodes}
+        assert node_by_id["MAXO:0000648"].name == "enzyme inhibitor agent therapy"
 
     def test_gene_prefers_gene_term_id(self):
         """Test that gene nodes prefer gene_term.term.id over HGNC.SYMBOL."""


### PR DESCRIPTION
Closes #1932.

## Summary

- `extract_nodes()` in `src/dismech/export/kgx_export.py` populated treatment node `name` from `treatments[].name` (a free-text block heading) before falling back to `treatment_term.term.label`. Because many disorders share one MAXO CURIE under different free-text names, dedup picked whichever heading happened to win.
- Flip the precedence so the canonical `treatment_term.term.label` is used; the free-text `name` remains as a defensive fallback.
- Update `test_node_names` to assert canonical-label precedence and add a regression test where the free-text name and canonical label differ.

After this change, `MAXO:0000058` surfaces in `kgx_export_nodes.jsonl` as `name: "pharmacotherapy"` (canonical) rather than the per-disorder free-text name.

## Test plan

- [x] `uv run pytest tests/test_kgx_export.py` — 64 passed
- [x] `just export-kgx` — `MAXO:0000058` node renders as `pharmacotherapy`; spot-checked several other MAXO CURIEs (supportive care, dietary intervention, carnitine supplementation) — all canonical labels.