### PR TITLE
[codex] Finalize DMD and Fabry tissue endpoint mappings

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -605,12 +605,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Duchenne muscular dystrophy (DMD); population: Patients with DMD who have
     a confirmed mutation of the DMD gene that is amenable to exon skipping; endpoint: Skeletal muscle
     dystrophin; approval context: accelerated; drug mechanism: Antisense oligonucleotide.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Duchenne Muscular Dystrophy
   mapped_disease_files:
   - kb/disorders/Duchenne_Muscular_Dystrophy.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: skeletal muscle dystrophin is linked to the
+    DMD Dystrophin Deficiency pathograph node as a pharmacodynamic tissue
+    biomarker for exon-skipping antisense oligonucleotide therapy.
 - row_id: FDA-SE-adult-noncancer-023
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -666,12 +669,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Fabry disease; population: Patients with confirmed Fabry disease; endpoint:
     Complete/near complete clearance of GL-3 inclusions in biopsied renal peritubular capillaries (using
     the Fabrazyme Scoring System); approval context: traditional; drug mechanism: Enzyme replacement therapy.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases: &id001
   - Fabry disease
   mapped_disease_files: &id002
   - kb/disorders/Fabry_Disease.yaml
-  mapping_notes: Exact disease label match.
+  mapping_notes: >-
+    Curated disease-level mapping: renal peritubular capillary GL-3 inclusion
+    clearance is linked to the Fabry lysosomal Gb3 accumulation pathograph node
+    as a treatment-responsive tissue biomarker for enzyme replacement therapy.
 - row_id: FDA-SE-adult-noncancer-025
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -695,10 +701,14 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Fabry disease; population: Patients with confirmed Fabry disease and amenable
     GLA gene variants; endpoint: Reduction of GL-3 inclusions in biopsied renal peritubular capillaries
     (using the BLISS methodology); approval context: accelerated; drug mechanism: Pharmacological chaperone.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases: *id001
   mapped_disease_files: *id002
-  mapping_notes: Exact disease label match.
+  mapping_notes: >-
+    Curated disease-level mapping: renal peritubular capillary GL-3 inclusion
+    reduction is linked to the Fabry lysosomal Gb3 accumulation pathograph node
+    as a treatment-responsive tissue biomarker for pharmacological chaperone
+    therapy.
 - row_id: FDA-SE-adult-noncancer-026
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4327,12 +4337,15 @@ surrogate_endpoints:
     a confirmed mutation of the DMD gene that is amenable to exon skipping; endpoint: Skeletal muscle
     dystrophin; approval context: accelerated; drug mechanism: Antisense oligonucleotide; age range: 4
     years and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Duchenne Muscular Dystrophy
   mapped_disease_files:
   - kb/disorders/Duchenne_Muscular_Dystrophy.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: skeletal muscle dystrophin is linked to the
+    DMD Dystrophin Deficiency pathograph node as a pharmacodynamic tissue
+    biomarker for exon-skipping antisense oligonucleotide therapy.
 - row_id: FDA-SE-pediatric-noncancer-018
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4389,10 +4402,13 @@ surrogate_endpoints:
     Complete/near complete clearance of GL-3 inclusions in biopsied renal peritubular capillaries (using
     the Fabrazyme Scoring System); approval context: traditional; drug mechanism: Enzyme replacement therapy;
     age range: 2 years and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases: *id001
   mapped_disease_files: *id002
-  mapping_notes: Exact disease label match.
+  mapping_notes: >-
+    Curated disease-level mapping: renal peritubular capillary GL-3 inclusion
+    clearance is linked to the Fabry lysosomal Gb3 accumulation pathograph node
+    as a treatment-responsive tissue biomarker for enzyme replacement therapy.
 - row_id: FDA-SE-pediatric-noncancer-020
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Mark the adult and pediatric DMD skeletal-muscle dystrophin endpoint rows as curated mappings to the existing DMD dystrophin-deficiency readout.
- Mark the adult and pediatric Fabry renal GL-3 inclusion endpoint rows as curated mappings to the existing Fabry Gb3-accumulation readout.
- Keep this as a source-table-only status update because the disease YAML already carries the pathograph links and regulatory endpoint refs.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`