### PR TITLE
[codex] Finalize parasite endpoint mappings

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -4056,12 +4056,16 @@ surrogate_endpoints:
     G antibody negative or least 20% decrease in optical density on two different IgG antibody tests against
     antigens of T. cruzi; approval context: accelerated; drug mechanism: Antimicrobial; age range: Birth
     to less than 18 years of age.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Chagas disease
   mapped_disease_files:
   - kb/disorders/Chagas_Disease.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: anti-T. cruzi IgG negative conversion or
+    optical-density decrease is linked to the Chagas disease intracellular
+    amastigote replication pathograph node as an indirect pharmacodynamic
+    serologic readout after antimicrobial therapy.
 - row_id: FDA-SE-pediatric-noncancer-008
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5394,12 +5398,15 @@ surrogate_endpoints:
     endpoint: Skin microfilarial density (microfilariae/mg skin) from the mean of 4 skin snips per person
     per time point; approval context: traditional; drug mechanism: Anthelmintic; age range: 4 to 12 and
     weighting at least 13 kg.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Onchocerciasis
   mapped_disease_files:
   - kb/disorders/Onchocerciasis.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated disease-level mapping: skin microfilarial density is linked to the
+    Cutaneous microfilarial burden pathograph node as a direct pharmacodynamic
+    parasite-burden readout after anthelmintic therapy.
 - row_id: FDA-SE-pediatric-noncancer-056
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Mark the Chagas IgG serologic response endpoint row as a curated mapping to the existing Chagas disease readout.
- Mark the onchocerciasis skin microfilarial density endpoint row as a curated mapping to the existing parasite-burden readout.
- Keep this source-table-only because the disease YAML already contains the pathograph links and regulatory endpoint refs.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`