### PR TITLE
[codex] Finalize CAH androstenedione endpoint mapping

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -4113,12 +4113,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Congenital adrenal hyperplasia; population: congenital adrenal hyperplasia;
     endpoint: change in serum androstenedione; approval context: traditional; drug mechanism: corticotropin-releasing
     factor type 1 receptor antagonist; age range: 4 years and older.'
-  mapping_status: EXACT_DISMECH_MATCH
+  mapping_status: CURATED_DISMECH_MAPPING
   mapped_diseases:
   - Congenital Adrenal Hyperplasia
   mapped_disease_files:
   - kb/disorders/Congenital_Adrenal_Hyperplasia.yaml
-  mapping_notes: Exact normalized FDA disease/use label match.
+  mapping_notes: >-
+    Curated pediatric endocrine endpoint mapping: serum androstenedione is
+    represented in the Congenital Adrenal Hyperplasia entry as a pharmacodynamic
+    readout of ACTH-Driven Adrenal Hyperplasia and Androgen Excess.
 - row_id: FDA-SE-pediatric-noncancer-010
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Marks `FDA-SE-pediatric-noncancer-009` as `CURATED_DISMECH_MAPPING`.
- Replaces the generic exact-match note with a pathograph-aware note tying serum androstenedione to the existing Congenital Adrenal Hyperplasia pharmacodynamic readout of ACTH-driven adrenal hyperplasia and androgen excess.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`