### PR TITLE
[codex] Finalize AATD hepatic fibrosis endpoint mapping

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2619,8 +2619,19 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Pulmonary disease; population: Patients with congenital alpha-1 antitrypsin
     deficiency; endpoint: reduction in hepatic fibrosis; approval context: traditional; drug mechanism:
     Alpha-1 protease inhibitor augmentation.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Alpha-1 Antitrypsin Deficiency
+  mapped_disease_files:
+  - kb/disorders/Alpha_1_Antitrypsin_Deficiency.yaml
+  mapping_notes: >-
+    Curated population-based mapping: although the FDA disease/use label says
+    pulmonary disease, the patient population is congenital alpha-1 antitrypsin
+    deficiency and the endpoint is reduction in hepatic fibrosis. The disease
+    entry already represents hepatic fibrosis as a phenotype, biopsy finding,
+    and downstream effect of Hepatocyte Injury and Stellate Cell Activation;
+    detailed regulatory readout linkage is deferred with other non-biochemical
+    biomarkers until issue #2506.
 - row_id: FDA-SE-adult-noncancer-098
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- Marks `FDA-SE-adult-noncancer-097` as `CURATED_DISMECH_MAPPING`.
- Maps the FDA row to `Alpha_1_Antitrypsin_Deficiency.yaml` because the patient population is congenital alpha-1 antitrypsin deficiency, even though the FDA disease/use label says pulmonary disease.
- Notes that hepatic fibrosis is already represented in the disease entry as phenotype, biopsy finding, and downstream pathophysiology, while detailed non-biochemical regulatory readout linkage remains deferred under #2506.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`