### PR TITLE
[codex] Map AF heart rate surrogate endpoint row

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2951,8 +2951,19 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Supraventricular tachycardia; population: adults with supraventricular
     tachycardia including atrial fibrillation and atrial flutter.; endpoint: Heart rate **; approval context:
     traditional; drug mechanism: beta-1 adrenergic receptor antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Atrial Fibrillation
+  mapped_disease_files:
+  - kb/disorders/Atrial_Fibrillation.yaml
+  mapping_notes: >
+    Candidate mapping to the local atrial fibrillation entry because the FDA
+    context of use covers supraventricular tachycardia including atrial
+    fibrillation and atrial flutter, while dismech currently has an atrial
+    fibrillation disease entry but no broader supraventricular tachycardia
+    entry. Heart rate is a physiologic endpoint rather than a biochemical
+    biomarker, so disease-level biomarker/readout modeling is deferred to the
+    non-biochemical biomarker schema follow-up.
 - row_id: FDA-SE-adult-noncancer-111
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

Maps FDA surrogate endpoint row `FDA-SE-adult-noncancer-110` to the local `Atrial Fibrillation` disease entry as a candidate dismech mapping.

The FDA context is broader than the local disease entry, covering supraventricular tachycardia including atrial fibrillation and atrial flutter. Heart rate is also a physiological endpoint rather than a biochemical marker, so this PR keeps the change source-table-only and notes that detailed disease-level readout modeling belongs in the non-biochemical biomarker follow-up.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`