### PR TITLE
[codex] Map HH fertility surrogate endpoints

### DIFF
--- a/kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+++ b/kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
@@ -1,6 +1,6 @@
 name: FGFR1-Related Hypogonadotropic Hypogonadism
 creation_date: '2026-04-04T12:00:00Z'
-updated_date: '2026-04-04T18:00:00Z'
+updated_date: '2026-05-12T02:36:47Z'
 category: Mendelian
 description: >-
   Hypogonadotropic hypogonadism 2 with or without anosmia (Kallmann syndrome 2) is caused
@@ -273,6 +273,39 @@ biochemical:
     term:
       id: CHEBI:17347
       label: testosterone
+- name: Serum Estradiol
+  presence: Decreased
+  context: Low in affected females due to absent or partial GnRH-mediated LH and FSH release.
+  readouts:
+  - target: GnRH deficiency and hypogonadism
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-027
+    interpretation: >-
+      Higher serum estradiol indicates correction of the low-sex-steroid
+      component of hypogonadism in affected females during gonadotropin-driven
+      follicular stimulation.
+    evidence:
+    - reference: PMID:20301509
+      reference_title: "Isolated Gonadotropin-Releasing Hormone (GnRH) Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        IGD is typically diagnosed in adolescents presenting with absent or
+        partial puberty using biochemical testing that reveals low serum
+        testosterone or estradiol (hypogonadism) that results from complete or
+        partial absence of GnRH-mediated release of LH and FSH
+      explanation: >-
+        GeneReviews directly links low serum estradiol to hypogonadism in
+        isolated GnRH deficiency, supporting serum estradiol as a disease and
+        treatment-response readout in affected females.
+  biomarker_term:
+    preferred_term: estradiol
+    term:
+      id: CHEBI:23965
+      label: estradiol
 treatments:
 - name: Testosterone replacement therapy
   description: >-

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -753,8 +753,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Female hypogonadotropic hypogonadism; population: Infertile women with
     hypogonadotropic hypogonadism; endpoint: Follicle size, serum estradiol and progesterone#; approval
     context: traditional; drug mechanism: Gonadotropin.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - FGFR1-Related Hypogonadotropic Hypogonadism
+  mapped_disease_files:
+  - kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+  mapping_notes: >
+    Candidate mapping to the local FGFR1-related hypogonadotropic hypogonadism
+    entry because the FDA context covers female hypogonadotropic hypogonadism
+    infertility broadly, while the dismech entry represents one genetic subset.
+    The disease YAML integrates the serum estradiol component as a biochemical
+    treatment-response readout; follicle size and progesterone components remain
+    source-table-only pending non-biochemical/composite endpoint modeling.
 - row_id: FDA-SE-adult-noncancer-028
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1706,8 +1716,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Male hypogonadotropic hypogonadism with inferility; population: Men with
     selected cases of hypogonadotropic hypogonadism with inferility; endpoint: Sperm parameters; approval
     context: traditional; drug mechanism: Gonadotropin.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - FGFR1-Related Hypogonadotropic Hypogonadism
+  mapped_disease_files:
+  - kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+  mapping_notes: >
+    Candidate mapping to the local FGFR1-related hypogonadotropic hypogonadism
+    entry because the FDA context covers male hypogonadotropic hypogonadism
+    infertility broadly, while the dismech entry represents one genetic subset.
+    The sperm-parameter endpoint is a semen-analysis fertility readout rather
+    than a biochemical biomarker, so detailed disease-level endpoint modeling is
+    deferred to the non-biochemical biomarker schema follow-up.
 - row_id: FDA-SE-adult-noncancer-064
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

Maps two hypogonadotropic hypogonadism fertility rows from the FDA surrogate endpoint table to the local `FGFR1-Related Hypogonadotropic Hypogonadism` disease entry as candidate mappings:

- `FDA-SE-adult-noncancer-027` female HH infertility, follicle size/estradiol/progesterone composite
- `FDA-SE-adult-noncancer-063` male HH infertility, sperm parameters

The FDA rows are broader than the local FGFR1-specific disease entry. This PR integrates the biochemical component that fits the current disease schema by adding `Serum Estradiol` as a decreased/treatment-response readout tied to `GnRH deficiency and hypogonadism`. Follicle size, progesterone as part of the composite, and sperm parameters remain source-table notes pending the non-biochemical/composite biomarker modeling follow-up.

## Validation

- `just validate kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml`
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`