### PR TITLE
[codex] Map diabetes severe hypoglycemia endpoint rows

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -556,8 +556,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Diabetes patients with severe hypoglycemia; population: Diabetes patients
     with severe hypoglycemia; endpoint: a glucose increase of ≥20 mg/dL from glucose nadir within 30 minutes;
     approval context: traditional; drug mechanism: antihypoglycemic agent.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Diabetes mellitus
+  mapped_disease_files:
+  - kb/disorders/Diabetes_Mellitus.yaml
+  mapping_notes: >
+    Candidate mapping to the generic diabetes mellitus entry because the FDA
+    row is an acute severe-hypoglycemia rescue-treatment context in diabetes
+    patients rather than a stable disease entity. The disease YAML already
+    represents glucose dysregulation and blood-glucose biomarkers; no additional
+    disease-level readout was added for this acute antihypoglycemic response
+    endpoint.
 - row_id: FDA-SE-adult-noncancer-021
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4247,8 +4257,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Diabetes patients with severe hypoglycemia; population: 1-year and older
     pediatric patients; endpoint: a glucose increase of ≥20 mg/dL from glucose nadir within 30 minutes;
     approval context: traditional; drug mechanism: Antihypoglycemic agent; age range: 1 year and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Diabetes mellitus
+  mapped_disease_files:
+  - kb/disorders/Diabetes_Mellitus.yaml
+  mapping_notes: >
+    Candidate mapping to the generic diabetes mellitus entry because the FDA
+    row is an acute severe-hypoglycemia rescue-treatment context in pediatric
+    diabetes patients rather than a stable disease entity. The disease YAML
+    already represents glucose dysregulation and blood-glucose biomarkers; no
+    additional disease-level readout was added for this acute antihypoglycemic
+    response endpoint.
 - row_id: FDA-SE-pediatric-noncancer-015
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

Maps the adult and pediatric FDA severe-hypoglycemia rescue endpoint rows to the generic `Diabetes mellitus` disease entry as candidate mappings:

- `FDA-SE-adult-noncancer-020`
- `FDA-SE-pediatric-noncancer-014`

These rows are acute antihypoglycemic treatment-response contexts, not stable disease entities. The generic diabetes disease YAML already represents glucose dysregulation and blood-glucose biomarkers, so this PR keeps the change source-table-only and records why no additional disease-level readout was added.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`