### PR TITLE
Map environmental `effect` polarity to a Biolink predicate (#2098)

### DIFF
--- a/src/dismech/export/kgx_export.py
+++ b/src/dismech/export/kgx_export.py
@@ -5,6 +5,7 @@ Transforms disorder YAML files into KGX-format edges for the knowledge graph.
 Each function extracts edges from a specific collection type within the disorder.
 """
 
+import re
 import uuid
 from typing import Any, Iterator
 
@@ -374,12 +375,32 @@ def gene_to_edge(disease_id: str, gene: dict[str, Any]) -> GeneToDiseaseAssociat
     )
 
 
+# Protective-effect patterns. Matched against environmental[].effect to flip the
+# predicate from contributes_to → associated_with_decreased_likelihood_of when the
+# curated text indicates the exposure reduces disease risk (see #2098).
+_PROTECTIVE_EFFECT_PATTERNS = (
+    re.compile(r"\breduces?\s+risk\b", re.IGNORECASE),
+    re.compile(r"\bdecreased?\s+(odds|risk|chance|incidence|likelihood)\b", re.IGNORECASE),
+    re.compile(r"\bprotect(s|ive|ion)?\s+against\b", re.IGNORECASE),
+    re.compile(r"\blower(s|ed)?\s+(odds|risk|chance|incidence|likelihood)\b", re.IGNORECASE),
+)
+
+
+def _exposure_predicate(effect: str | None) -> str:
+    """Map an environmental `effect` free-text field to a Biolink predicate."""
+    if effect and any(p.search(effect) for p in _PROTECTIVE_EFFECT_PATTERNS):
+        return "biolink:associated_with_decreased_likelihood_of"
+    return "biolink:contributes_to"
+
+
 def exposure_to_edge(disease_id: str, environmental: dict[str, Any]) -> ExposureEventToOutcomeAssociation | None:
     """
     Convert an environmental exposure entry to a KGX edge.
 
-    Exposure → Disease using contributes_to (risk factor relationship).
-    Uses ExposureEventToOutcomeAssociation since Disease is-a Outcome in Biolink.
+    Exposure → Disease. Predicate is `biolink:contributes_to` by default;
+    if `effect` indicates a protective relationship (e.g., "Reduces risk
+    of X"), use `biolink:associated_with_decreased_likelihood_of` instead.
+    See #2098.
 
     Args:
         disease_id: The disease term ID
@@ -395,7 +416,7 @@ def exposure_to_edge(disease_id: str, environmental: dict[str, Any]) -> Exposure
     # Format evidence (direct - attached to environmental entry)
     publications, supporting_text = _format_evidence(environmental.get("evidence"), indirect=False)
 
-    predicate = "biolink:contributes_to"
+    predicate = _exposure_predicate(environmental.get("effect"))
     return ExposureEventToOutcomeAssociation(
         id=_make_edge_id(),
         subject=exposure_id,

--- a/src/dismech/export/kgx_export.py
+++ b/src/dismech/export/kgx_export.py
@@ -387,7 +387,23 @@ _PROTECTIVE_EFFECT_PATTERNS = (
 
 
 def _exposure_predicate(effect: str | None) -> str:
-    """Map an environmental `effect` free-text field to a Biolink predicate."""
+    """Map an environmental `effect` free-text field to a Biolink predicate.
+
+    Returns `biolink:associated_with_decreased_likelihood_of` when the curated
+    `effect` text matches one of the protective phrasings below (case-insensitive,
+    word-boundary matched):
+
+      - `reduces? risk`
+      - `decreased? (odds|risk|chance|incidence|likelihood)`
+      - `protect(s|ive|ion)? against`
+      - `lower(s|ed)? (odds|risk|chance|incidence|likelihood)`
+
+    Any other `effect` value (including `None`, causal phrasings such as
+    "TRIGGERS" / "Increases risk", or text that mentions reduction of a
+    non-risk noun like "reduced HDL") falls through to the default
+    `biolink:contributes_to`. Curators adding new protective environmental
+    entries should phrase the `effect` text to match one of the patterns
+    above; see #2098 for context."""
     if effect and any(p.search(effect) for p in _PROTECTIVE_EFFECT_PATTERNS):
         return "biolink:associated_with_decreased_likelihood_of"
     return "biolink:contributes_to"

--- a/tests/test_kgx_export.py
+++ b/tests/test_kgx_export.py
@@ -269,6 +269,43 @@ class TestExposureToEdge:
         }
         assert exposure_to_edge("MONDO:0004979", environmental) is None
 
+    def test_protective_effect_flips_predicate(self):
+        """Protective `effect` text should yield decreased-likelihood predicate (#2098).
+        Reproduces the Marfan Syndrome physical-activity-restriction case."""
+        environmental = {
+            "name": "Physical Activity Restrictions",
+            "effect": "Reduces risk of aortic dissection.",
+            "exposure_term": {"term": {"id": "XCO:0000059", "label": "physical activity"}},
+        }
+        edge = exposure_to_edge("MONDO:0007947", environmental)
+        assert edge is not None
+        assert edge.predicate == "biolink:associated_with_decreased_likelihood_of"
+
+    def test_protective_effect_decreased_odds(self):
+        """`decreased odds for developing X` is protective polarity."""
+        environmental = {
+            "effect": "Associated with decreased odds for developing rheumatoid vasculitis.",
+            "exposure_term": {"term": {"id": "ECTO:0000001"}},
+        }
+        edge = exposure_to_edge("MONDO:0004979", environmental)
+        assert edge.predicate == "biolink:associated_with_decreased_likelihood_of"
+
+    def test_causal_effect_keeps_default(self):
+        """Causal `effect` text keeps biolink:contributes_to."""
+        for effect in [
+            "TRIGGERS",
+            "Increases sensitization risk",
+            "Contributes to cardiovascular risk through reduced HDL and impaired endothelial function",
+            "Lower threshold for repair and heightened rupture-risk concern",
+            None,
+        ]:
+            environmental = {
+                "effect": effect,
+                "exposure_term": {"term": {"id": "ECTO:0000001"}},
+            }
+            edge = exposure_to_edge("MONDO:0004979", environmental)
+            assert edge.predicate == "biolink:contributes_to", f"got non-default for {effect!r}"
+
 
 class TestMolecularFunctionToEdge:
     """Tests for molecular_function_to_edge function."""


### PR DESCRIPTION
Closes #2098.

## Summary

The exporter previously emitted `biolink:contributes_to` for every `environmental` → disease edge regardless of the curated `effect` polarity. Protective exposures (e.g., Marfan physical-activity restrictions, whose `effect: Reduces risk of aortic dissection.`) therefore surfaced as causal in the released graph.

- Add `_exposure_predicate(effect)` to `src/dismech/export/kgx_export.py`. It matches a small set of protective phrasings (`reduces? risk`, `decreased? (odds|risk|chance|incidence|likelihood)`, `protect(s|ive|ion)? against`, `lower(s|ed)? (odds|risk|chance|incidence|likelihood)`) and returns `biolink:associated_with_decreased_likelihood_of`. Causal and absent effects fall through to the existing `biolink:contributes_to` default.
- A scan of `kb/disorders/*.yaml` finds exactly two protective entries that flip — Marfan physical-activity restrictions and Rheumatoid Vasculitis "decreased odds for developing" — out of 108 environmental edges total, so behaviour change for already-correct edges is minimal.
- New tests in `TestExposureToEdge` cover protective phrasings ("Reduces risk of aortic dissection", "decreased odds for developing") and several causal/default cases (TRIGGERS, "Increases sensitization risk", "Contributes to ... reduced HDL", "Lower threshold ...", `None`) to guard against false positives.

## Test plan

- [x] `uv run pytest tests/test_kgx_export.py` — 66 passed (was 63, three new tests added).
- [x] `just export-kgx` — `XCO:0000059 → biolink:associated_with_decreased_likelihood_of → MONDO:0007947` is now emitted; one such edge in the graph, matching the single protective entry in the KB.

## Follow-up (not in this PR)

The schema currently types `effect` as free-text `string`. Once polarity-aware predicates are common across exporters it may be worth adding a structured `effect_polarity` enum so curators don't have to phrase the free-text carefully — and so a typo doesn't silently re-introduce the bug.