### PR TITLE
[codex] Mark CMV prophylaxis endpoint rows source-only

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -533,8 +533,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cytomegalovirus (CMV); population: CMV seropositive and hematopoietic
     transplant recipients requiring prophylaxis; endpoint: Plasma CMV-DNA exceeding threshold for starting
     treatment; approval context: traditional; drug mechanism: Antiviral.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is a prophylaxis/monitoring context for CMV-seropositive
+    hematopoietic transplant recipients rather than a directly mappable
+    dismech disease entry. No local cytomegalovirus disease page is currently
+    available for disease-level biomarker integration.
 - row_id: FDA-SE-adult-noncancer-020
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4223,8 +4227,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cytomegalovirus (CMV); population: CMV seropositive and hemotopoietic
     transplant recipients requiring prophylaxis; endpoint: Plasma CMV-DNA exceeding threshold for starting
     treatment; approval context: traditional; drug mechanism: Antiviral; age range: 12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is a prophylaxis/monitoring context for CMV-seropositive
+    hematopoietic transplant recipients rather than a directly mappable
+    dismech disease entry. No local cytomegalovirus disease page is currently
+    available for disease-level biomarker integration.
 - row_id: FDA-SE-pediatric-noncancer-014
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

Marks the adult and pediatric CMV-DNA prophylaxis/monitoring rows as `NOT_DISEASE_SPECIFIC`:

- `FDA-SE-adult-noncancer-019`
- `FDA-SE-pediatric-noncancer-013`

These contexts are CMV-seropositive hematopoietic transplant recipient prophylaxis/use rows, and there is no local cytomegalovirus disease page available for disease-level biomarker integration. The endpoint remains represented in the FDA source table without adding a disease YAML mapping.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`