### PR TITLE
[codex] Mark broad hematology endpoint rows source-only

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -38,8 +38,13 @@ surrogate_endpoints:
     first 24 hours after termination of cardiopulmonary bypass (CPB).; approval context: traditional;
     drug mechanism: Replacement for fibrinogen, a critical soluble plasma protein in the coagulation cascade,
     is provided.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is a perioperative bleeding/product-use context for fibrinogen
+    replacement after cardiopulmonary bypass rather than a directly mappable
+    dismech disease entry. The endpoint is allogeneic blood-product transfusion
+    burden, not a disease-mechanism biomarker, and no local acquired
+    hypofibrinogenemia disease page is currently available.
 - row_id: FDA-SE-adult-noncancer-002
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1998,8 +2003,13 @@ surrogate_endpoints:
     kidney disease, (2) chemotherapy-induced anemia, (3) zidoviduine in patients with HIV-infection; endpoint:
     Hematologic response and reduction in transfusion; approval context: traditional; drug mechanism:
     Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is a broad nonmalignant-hematology treatment-use context spanning
+    anemia due to chronic kidney disease, chemotherapy, and zidovudine-treated
+    HIV infection. Because the row is multi-condition and product-contextual
+    rather than a single disease mechanism, no disease-level dismech mapping was
+    assigned.
 - row_id: FDA-SE-adult-noncancer-075
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2078,8 +2088,12 @@ surrogate_endpoints:
     effects for emergency surgery/urgent procedures and in life-threatening or uncontrolled bleeding.;
     endpoint: Change in coagulation parameters; approval context: traditional; drug mechanism: Humanized
     monoclonal antibody fragment.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is an emergency reversal-of-anticoagulation use context for surgery,
+    urgent procedures, or life-threatening bleeding. Change in coagulation
+    parameters is a treatment-response endpoint for a broad product-use setting,
+    not a directly mappable dismech disease entry.
 - row_id: FDA-SE-adult-noncancer-078
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -3918,8 +3932,13 @@ surrogate_endpoints:
     first 24 hours after termination of cardiopulmonary bypass (CPB).; approval context: traditional;
     drug mechanism: Replacement for fibrinogen, a critical soluble plasma protein in the coagulation cascade,
     is provided; age range: any age.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >
+    FDA row is a perioperative bleeding/product-use context for fibrinogen
+    replacement after cardiopulmonary bypass rather than a directly mappable
+    dismech disease entry. The endpoint is allogeneic blood-product transfusion
+    burden, not a disease-mechanism biomarker, and no local acquired
+    hypofibrinogenemia disease page is currently available.
 - row_id: FDA-SE-pediatric-noncancer-003
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

Marks broad hematology/product-use FDA rows as `NOT_DISEASE_SPECIFIC`:

- `FDA-SE-adult-noncancer-001`
- `FDA-SE-pediatric-noncancer-002`
- `FDA-SE-adult-noncancer-074`
- `FDA-SE-adult-noncancer-077`

These rows represent perioperative fibrinogen replacement/transfusion burden, multi-condition anemia treatment response, or emergency anticoagulation reversal contexts. They do not map cleanly to a single dismech disease mechanism page, so this PR keeps them source-table-only.

Intentionally left the severe aplastic anemia row out of this batch because that should be reviewed separately against the existing inherited aplastic anemia page.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`