### PR TITLE
[codex] Map severe aplastic anemia endpoint rows

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2022,8 +2022,18 @@ surrogate_endpoints:
   - MECHANISM_AGNOSTIC
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with severe aplastic anemia;
     endpoint: Hematologic response; approval context: traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Inherited Aplastic Anemia
+  mapped_disease_files:
+  - kb/disorders/Inherited_Aplastic_Anemia.yaml
+  mapping_notes: >-
+    Candidate mapping to the local inherited aplastic anemia page. The FDA row
+    is a broad severe aplastic anemia/nonmalignant hematology treatment-response
+    context, while the dismech page is limited to inherited/genetic aplastic
+    anemia. Hematologic response is a broad clinical/composite endpoint, so no
+    disease-level biochemical marker was added here pending explicit modeling
+    for non-biochemical and composite endpoints.
 - row_id: FDA-SE-adult-noncancer-076
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5303,8 +5313,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Nonmalignant hematology; population: Patients with severe aplastic anemia;
     endpoint: Hematologic response; approval context: traditional; drug mechanism: Thrombopoietin receptor
     agonist; age range: 1 year and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Inherited Aplastic Anemia
+  mapped_disease_files:
+  - kb/disorders/Inherited_Aplastic_Anemia.yaml
+  mapping_notes: >-
+    Candidate mapping to the local inherited aplastic anemia page. The FDA row
+    is a broad severe aplastic anemia/nonmalignant hematology treatment-response
+    context, while the dismech page is limited to inherited/genetic aplastic
+    anemia. Hematologic response is a broad clinical/composite endpoint, so no
+    disease-level biochemical marker was added here pending explicit modeling
+    for non-biochemical and composite endpoints.
 - row_id: FDA-SE-pediatric-noncancer-053
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Maps the adult and pediatric FDA severe aplastic anemia hematologic-response rows to the local inherited aplastic anemia disease page as candidate mappings.
- Leaves disease YAML unchanged because the local page is inherited/genetic aplastic anemia, while the FDA context is broad severe aplastic anemia/nonmalignant hematology.
- Notes that hematologic response is a broad clinical/composite endpoint rather than a biochemical marker, so no pathograph or marker integration is added in this batch.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`