### PR TITLE
[codex] Mark electrolyte endpoint rows source-only

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1192,8 +1192,13 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hyperkalemia; population: Patients with hyperkalemia; endpoint: Serum
     potassium; approval context: traditional; drug mechanism: Potassium binder.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a broad electrolyte-abnormality treatment context rather than a
+    directly mapped dismech disease entry. Existing disease pages may include
+    hyperkalemia as a downstream biochemical or clinical finding, but the source
+    row does not identify a specific disease biology context for pathograph
+    integration.
 - row_id: FDA-SE-adult-noncancer-045
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1335,8 +1340,13 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hyponatremia; population: Patients with hypervolemic and euvolemic hyponatremia;
     endpoint: Serum sodium; approval context: traditional; drug mechanism: Vasopressin receptor antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a broad electrolyte-abnormality treatment context rather than a
+    directly mapped dismech disease entry. Existing disease pages may include
+    hyponatremia as a downstream biochemical or clinical finding, but the source
+    row does not identify a specific disease biology context for pathograph
+    integration.
 - row_id: FDA-SE-adult-noncancer-050
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -4741,8 +4751,13 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hyperkalemia; population: Patients with hyperkalemia; endpoint: Serum
     potassium; approval context: traditional; drug mechanism: Potassium binder.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a broad electrolyte-abnormality treatment context rather than a
+    directly mapped dismech disease entry. Existing disease pages may include
+    hyperkalemia as a downstream biochemical or clinical finding, but the source
+    row does not identify a specific disease biology context for pathograph
+    integration.
 - row_id: FDA-SE-pediatric-noncancer-033
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -4854,8 +4869,13 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Hyponatremia; population: Patients with hypervolemic and euvolemic hyponatremia;
     endpoint: Serum sodium; approval context: traditional; drug mechanism: Vasopressin receptor antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a broad electrolyte-abnormality treatment context rather than a
+    directly mapped dismech disease entry. Existing disease pages may include
+    hyponatremia as a downstream biochemical or clinical finding, but the source
+    row does not identify a specific disease biology context for pathograph
+    integration.
 - row_id: FDA-SE-pediatric-noncancer-037
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary

- Marks the adult and pediatric hyperkalemia FDA rows as source-table-only / not disease-specific mappings.
- Marks the adult and pediatric hyponatremia FDA rows the same way.
- Leaves disease YAML unchanged because these rows are broad electrolyte-abnormality treatment contexts; existing disease pages mention hyperkalemia or hyponatremia as downstream findings, but the FDA rows do not identify a specific disease biology context for pathograph integration.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`