### PR TITLE
[codex] Mark dental endpoint rows source-only

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2264,8 +2264,13 @@ surrogate_endpoints:
   - ANTICIPATED_PRIMARY_EFFICACY_USE
   context_of_use: 'Disease/use: Peri-implantitis; population: Patients with peri-implantitis; endpoint:
     Probing pocket depth ˟; approval context: traditional; drug mechanism: Antimicrobial.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a dental/peri-implant disease treatment context with a clinical
+    periodontal examination endpoint rather than a directly mapped dismech
+    disease entry. Existing disease pages may include periodontal findings as
+    manifestations, but there is no standalone peri-implantitis page or
+    pathograph context for this antimicrobial endpoint.
 - row_id: FDA-SE-adult-noncancer-085
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2288,8 +2293,13 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Periodontitis; population: Patients with chronic periodontitis with a
     mean probing pocket depth of greater than 5mm; endpoint: Probing pocket depth; approval context: traditional;
     drug mechanism: Antimicrobial.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    FDA row is a dental/periodontal disease treatment context with a clinical
+    periodontal examination endpoint rather than a directly mapped dismech
+    disease entry. Existing disease pages may include periodontitis as a
+    manifestation, but there is no standalone chronic periodontitis page or
+    pathograph context for this antimicrobial endpoint.
 - row_id: FDA-SE-adult-noncancer-086
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary

- Marks the peri-implantitis probing-pocket-depth FDA row as source-table-only / not disease-specific.
- Marks the chronic periodontitis probing-pocket-depth FDA row the same way.
- Leaves disease YAML unchanged because the KB has syndromic periodontal manifestations but no standalone peri-implantitis or chronic periodontitis disease page/pathograph for these antimicrobial dental exam endpoints.

## Validation

- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`