### PR TITLE
[codex] Mark source-only endpoint rows curated

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -1806,8 +1806,12 @@ surrogate_endpoints:
     NASH patients with liver fibrosis; endpoint: Histopathologic findings of either 1) resolution of steatohepatitis
     with no worsening of fibrosis OR 2) improvement of fibrosis with no worsening of steatohepatitis OR
     3) Both#; approval context: accelerated; drug mechanism: Anti-fibrotic; Anti-inflammatory.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: no standalone dismech MASH/NASH disease entry exists. The
+    existing Liver Cirrhosis entry includes NASH as an etiology, but this FDA
+    context is precirrhotic MASH with a histopathologic steatohepatitis/fibrosis
+    composite endpoint, so no pathograph biomarker bridge was added.
 - row_id: FDA-SE-adult-noncancer-068
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1881,8 +1885,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Mycobacterium avium complex (MAC) lung disease; population: Patients with
     MAC lung disease; endpoint: Sputum culture conversion to negative by six months; approval context:
     accelerated; drug mechanism: Antimicrobial.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: no standalone dismech MAC lung disease entry exists.
+    Mycobacterium avium complex is mentioned as a pathogen in cystic fibrosis,
+    but the FDA row is a general MAC lung disease antimicrobial endpoint, so no
+    disease YAML mapping was assigned.
 - row_id: FDA-SE-adult-noncancer-071
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2240,8 +2248,12 @@ surrogate_endpoints:
   retrieved_date: '2026-05-11'
   context_of_use: 'Disease/use: Paget''s disease; population: Patients with Paget''s disease; endpoint:
     Serum alkaline phosphatase; approval context: traditional; drug mechanism: Bisphosphonate.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: the KB has Paget disease as a manifestation within
+    VCP-associated/IBMPFD multisystem disease entries, but no standalone Paget
+    disease of bone page matching the FDA bisphosphonate/alkaline phosphatase
+    context of use.
 - row_id: FDA-SE-adult-noncancer-084
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2447,8 +2459,12 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Preterm birth; population: Women with a singleton pregnancy who have a
     history of singleton spontaneous preterm birth; endpoint: Delivery prior to 37 weeks gestation; approval
     context: accelerated; drug mechanism: Progesterone analog.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: no standalone pregnancy or recurrent spontaneous preterm
+    birth disease entry exists. Preterm birth appears as a phenotype or
+    complication in other disease pages, not as the FDA row's progesterone
+    prevention context.
 - row_id: FDA-SE-adult-noncancer-092
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5501,8 +5517,11 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Precocious puberty; population: Patients with central precocious puberty;
     endpoint: Serum luteinizing hormone; approval context: traditional; drug mechanism: Gonadotropin releasing
     hormone (GnRH) agonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: central precocious puberty is represented locally only as
+    a manifestation of other disorders, not as a standalone disease page for the
+    GnRH agonist/luteinizing hormone endpoint context.
 - row_id: FDA-SE-pediatric-noncancer-060
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -5784,8 +5803,11 @@ surrogate_endpoints:
     (SR-aGvHD); endpoint: Overall response rate (ORR); approval context: traditional; drug mechanism:
     The mechanism of action is not clear but may be related to immunomodulatory effects.; age range: 2
     months and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: no dismech acute graft-versus-host disease entry exists,
+    and the FDA row uses an overall response-rate clinical endpoint rather than
+    a disease biology marker suitable for pathograph integration.
 - row_id: FDA-SE-pediatric-noncancer-070
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Marked six reviewed FDA endpoint rows as source-table only (`NOT_DISEASE_SPECIFIC`) with explicit mapping notes.
- Covered MASH/NASH, MAC lung disease, Paget disease, preterm birth, central precocious puberty, and steroid-refractory acute GVHD contexts.
- Did not edit disease YAML because the local overlaps are only etiologies, manifestations, complications, or absent disease pages rather than direct pathograph/biomarker contexts.

## Validation
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`