### PR TITLE
[codex] Mark hemostasis endpoint rows source-only

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -38,8 +38,12 @@ surrogate_endpoints:
     first 24 hours after termination of cardiopulmonary bypass (CPB).; approval context: traditional;
     drug mechanism: Replacement for fibrinogen, a critical soluble plasma protein in the coagulation cascade,
     is provided.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: this is an acquired perioperative bleeding/transfusion
+    endpoint after cardiopulmonary bypass, not a standalone dismech disease
+    pathograph. Local hypofibrinogenemia mentions occur as phenotypes within
+    other disorders and are not the FDA context of use.
 - row_id: FDA-SE-adult-noncancer-002
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -2078,8 +2082,12 @@ surrogate_endpoints:
     effects for emergency surgery/urgent procedures and in life-threatening or uncontrolled bleeding.;
     endpoint: Change in coagulation parameters; approval context: traditional; drug mechanism: Humanized
     monoclonal antibody fragment.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: this is an anticoagulant-reversal treatment context for
+    urgent procedures or uncontrolled bleeding, with coagulation-parameter
+    changes as a drug-effect endpoint rather than a disease-specific
+    pathophysiology marker.
 - row_id: FDA-SE-adult-noncancer-078
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -3918,8 +3926,13 @@ surrogate_endpoints:
     first 24 hours after termination of cardiopulmonary bypass (CPB).; approval context: traditional;
     drug mechanism: Replacement for fibrinogen, a critical soluble plasma protein in the coagulation cascade,
     is provided; age range: any age.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table only: this pediatric row is an acquired perioperative
+    bleeding/transfusion endpoint after cardiopulmonary bypass, not a
+    standalone dismech disease pathograph. Local hypofibrinogenemia mentions
+    occur as phenotypes within other disorders and are not this FDA context of
+    use.
 - row_id: FDA-SE-pediatric-noncancer-003
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Marked acquired hypofibrinogenemia adult and pediatric rows as source-table only.
- Marked the anticoagulant-reversal coagulation-parameter row as source-table only.
- Did not edit disease YAML because these are perioperative/treatment reversal endpoints rather than disease-specific pathograph biomarkers.

## Validation
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`