### PR TITLE
[codex] Map hypogonadotropic endpoint rows as candidates

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -753,8 +753,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Female hypogonadotropic hypogonadism; population: Infertile women with
     hypogonadotropic hypogonadism; endpoint: Follicle size, serum estradiol and progesterone#; approval
     context: traditional; drug mechanism: Gonadotropin.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - FGFR1-Related Hypogonadotropic Hypogonadism
+  mapped_disease_files:
+  - kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+  mapping_notes: >-
+    Candidate subtype mapping only: the local page models FGFR1-related
+    isolated GnRH deficiency, while the FDA row covers infertile women with
+    hypogonadotropic hypogonadism broadly. The follicle size/estradiol/
+    progesterone endpoint is a fertility-treatment response context and was
+    not integrated into disease YAML as a pathograph biomarker.
 - row_id: FDA-SE-adult-noncancer-028
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -1706,8 +1715,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Male hypogonadotropic hypogonadism with inferility; population: Men with
     selected cases of hypogonadotropic hypogonadism with inferility; endpoint: Sperm parameters; approval
     context: traditional; drug mechanism: Gonadotropin.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - FGFR1-Related Hypogonadotropic Hypogonadism
+  mapped_disease_files:
+  - kb/disorders/FGFR1_Hypogonadotropic_Hypogonadism.yaml
+  mapping_notes: >-
+    Candidate subtype mapping only: the local page models FGFR1-related
+    isolated GnRH deficiency, while the FDA row covers selected male
+    hypogonadotropic hypogonadism infertility cases broadly. Sperm parameters
+    are a fertility-treatment response endpoint and were not integrated into
+    disease YAML as a pathograph biomarker.
 - row_id: FDA-SE-adult-noncancer-064
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary
- Marked the female and male hypogonadotropic hypogonadism FDA rows as candidate mappings to `FGFR1_Hypogonadotropic_Hypogonadism.yaml`.
- Kept the mapping source-table-only because the FDA rows cover broader infertility treatment contexts and use fertility response endpoints, not FGFR1-specific biology markers.
- Did not edit disease YAML.

## Validation
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`

Note: the first parallel pytest attempt hit a fresh-venv install race, then passed cleanly when rerun.