### PR TITLE
[codex] Map cardiopulmonary endpoint rows

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2951,8 +2951,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Supraventricular tachycardia; population: adults with supraventricular
     tachycardia including atrial fibrillation and atrial flutter.; endpoint: Heart rate **; approval context:
     traditional; drug mechanism: beta-1 adrenergic receptor antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Atrial Fibrillation
+  mapped_disease_files:
+  - kb/disorders/Atrial_Fibrillation.yaml
+  mapping_notes: >-
+    Candidate partial mapping: the FDA supraventricular tachycardia population
+    explicitly includes atrial fibrillation and atrial flutter, but the KB does
+    not have a standalone supraventricular tachycardia page. Heart rate is a
+    physiologic response endpoint, so no biochemical/pathograph biomarker
+    bridge was added.
 - row_id: FDA-SE-adult-noncancer-111
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related
@@ -5643,8 +5652,17 @@ surrogate_endpoints:
     Pulmonary vascular resistance; approval context: traditional; drug mechanism: Endothelin receptor
     antagonist; age range: Any age children if there is an approved use in adults and the drug lowers
     PVR in adults..'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Pulmonary_hypertension
+  mapped_disease_files:
+  - kb/disorders/Pulmonary_hypertension.yaml
+  mapping_notes: >-
+    Curated subtype mapping: the local Pulmonary_hypertension page includes a
+    Pulmonary Arterial Hypertension (PAH) subtype and already models elevated
+    pulmonary vascular resistance in the disease biology. PVR is a hemodynamic
+    endpoint rather than a biochemical marker, so this row was not integrated
+    into the biochemical section.
 - row_id: FDA-SE-pediatric-noncancer-065
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related


### PR DESCRIPTION
## Summary
- Marked the supraventricular tachycardia heart-rate endpoint as a candidate partial mapping to `Atrial_Fibrillation.yaml`.
- Marked the pediatric PAH pulmonary vascular resistance endpoint as a curated subtype mapping to `Pulmonary_hypertension.yaml`.
- Did not edit disease YAML because these endpoints are physiologic/hemodynamic rather than biochemical markers under the current biomarker section.

## Validation
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`