### PR TITLE
[codex] Map systemic sclerosis ILD endpoint row

### DIFF
--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -2976,8 +2976,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Systemic sclerosis-interstitial lung disease; population: Patents with
     systemic sclerosis-interstitial lung disease; endpoint: Forced vital capacity (FVC); approval context:
     traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Systemic Sclerosis
+  mapped_disease_files:
+  - kb/disorders/Systemic_Sclerosis.yaml
+  mapping_notes: >-
+    Curated disease-context mapping: the FDA row is specifically systemic
+    sclerosis-associated interstitial lung disease, and the local Systemic
+    Sclerosis page includes ILD/fibrotic lung biology. Forced vital capacity is
+    a pulmonary function endpoint rather than a biochemical marker, so no
+    disease YAML biomarker bridge was added.
 - row_id: FDA-SE-adult-noncancer-112
   source_table: ADULT_NONCANCER
   source_sheet: Adult SE Non-cancer Related


### PR DESCRIPTION
## Summary
- Marked the systemic sclerosis-interstitial lung disease FDA row as a curated mapping to `Systemic_Sclerosis.yaml`.
- Kept the change source-table-only because forced vital capacity is a pulmonary function endpoint rather than a biochemical marker.
- Did not edit disease YAML.

## Validation
- `uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`
- `uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q`
- `git diff --check`