### PR TITLE
[codex] Map cancer surrogate endpoint rows

### DIFF
--- a/kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+++ b/kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
@@ -1,6 +1,6 @@
 name: Acute Lymphoblastic Leukemia
 creation_date: '2026-05-08T12:00:00Z'
-updated_date: '2026-05-08T13:00:00Z'
+updated_date: '2026-05-12T06:08:41Z'
 description: >-
   Acute lymphoblastic leukemia (ALL) is a malignancy of immature B- or T-lymphoid
   precursors (lymphoblasts) that proliferate uncontrollably in the bone marrow,
@@ -430,6 +430,17 @@ biochemical:
     multiparameter flow cytometry tracks residual disease at end of induction
     and consolidation; MRD positivity is the strongest single predictor of
     relapse and informs intensification or transplant decisions.
+  readouts:
+  - target: Clonal Expansion of Lymphoblasts
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: CANDIDATE_SURROGATE
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-cancer-007
+    interpretation: >-
+      Detectable MRD reports persistent residual leukemic lymphoblast burden
+      after therapy; decreasing or negative MRD therefore marks treatment
+      response in the FDA ALL endpoint context.
 genetic:
 - name: BCR-ABL1 Fusion (Philadelphia chromosome)
   association: Defining lesion of Ph+ ALL subtype

--- a/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
+++ b/kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
@@ -3270,8 +3270,18 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: CD19-positive Philadelphia
     chromosome-negative B-cell precursor acute lymphoblastic leukemia (ALL); endpoint: Relapse-free survival
     (RFS); approval context: traditional; drug mechanism: bispecific CD19-directed CD3 T-cell engager.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - B-Lymphoblastic Leukemia/Lymphoma With Recurrent Genetic Abnormality
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/B-Lymphoblastic_Leukemia_Lymphoma_With_Recurrent_Genetic_Abnormality.yaml
+  mapping_notes: >-
+    Candidate mapped to ALL/B-lymphoblastic leukemia pages because the FDA
+    population is a CD19-positive Philadelphia chromosome-negative B-cell
+    precursor subset. Relapse-free survival is a clinical outcome endpoint,
+    so no disease YAML biomarker bridge was added.
 - row_id: FDA-SE-adult-cancer-002
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3297,8 +3307,19 @@ surrogate_endpoints:
     acute myeloid leukemia (AML) with a susceptible nucleophosmin 1 (NPM1) mutation who have no satisfactory
     alternative treatment options; endpoint: complete remission (CR) and CR with partial hematologic recovery
     (CRh); approval context: traditional; drug mechanism: menin inhibitor.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - B-Lymphoblastic Leukemia/Lymphoma With Recurrent Genetic Abnormality
+  - Acute Myeloid Leukemia, NPM1-Mutated
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/B-Lymphoblastic_Leukemia_Lymphoma_With_Recurrent_Genetic_Abnormality.yaml
+  - kb/disorders/NPM1_Mutant_AML.yaml
+  mapping_notes: >-
+    Candidate mapped because the FDA row combines KMT2A-rearranged acute
+    leukemia with NPM1-mutated AML. The remission endpoint is a treatment
+    response outcome rather than a specific disease-biology biomarker.
 - row_id: FDA-SE-adult-cancer-003
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3320,8 +3341,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with Acute Lymphoblastic
     Leukemia; endpoint: Serum asparaginase; approval context: traditional; drug mechanism: Asparagine-specific
     enzyme.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  mapping_notes: >-
+    Candidate mapped to the ALL disease page. Serum asparaginase is a
+    therapeutic enzyme exposure/activity endpoint rather than a disease
+    mechanism biomarker, so no pathograph readout was added.
 - row_id: FDA-SE-adult-cancer-004
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3346,8 +3374,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with chronic
     myeloid leukemia; endpoint: Major hematologic response; approval context: accelerated or traditional;
     drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Chronic Myeloid Leukemia, BCR-ABL1 Positive
+  mapped_disease_files:
+  - kb/disorders/Chronic_Myeloid_Leukemia.yaml
+  mapping_notes: >-
+    Manually mapped to the CML disease page based on the patient population.
+    Major hematologic response is a clinical/tumor-burden response endpoint,
+    distinct from the existing BCR-ABL1 molecular-response biomarker bridge.
 - row_id: FDA-SE-adult-cancer-005
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3372,8 +3407,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with acute myeloid
     leukemia and acute lymphoblastic leukemia; endpoint: Durable complete remission rate; approval context:
     accelerated or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - Acute Myeloid Leukemia, NPM1-Mutated
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/NPM1_Mutant_AML.yaml
+  mapping_notes: >-
+    Candidate mapped to represented ALL and AML pages, but the FDA row is a
+    generic AML/ALL aggregate. Durable complete remission rate is a clinical
+    response endpoint, not a pathograph biomarker.
 - row_id: FDA-SE-adult-cancer-006
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3400,8 +3444,18 @@ surrogate_endpoints:
     leukemia; myelodysplastic/myeloproliferative diseases; chronic myeloid leukemia; endpoint: Major hematologic
     response and cytogenic response; approval context: accelerated or traditional; drug mechanism: Mechanism
     agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - Chronic Myeloid Leukemia, BCR-ABL1 Positive
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/Chronic_Myeloid_Leukemia.yaml
+  mapping_notes: >-
+    Candidate mapped to represented ALL and CML pages. The
+    myelodysplastic/myeloproliferative component is broader than any single
+    dismech page here, and hematologic/cytogenetic response is a clinical
+    response endpoint.
 - row_id: FDA-SE-adult-cancer-007
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3427,8 +3481,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with B-cell precursor
     acute lymphoblastic leukemia in first or second complete remission; endpoint: Minimal residual disease
     response rate; approval context: accelerated; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - B-Lymphoblastic Leukemia/Lymphoma With Recurrent Genetic Abnormality
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/B-Lymphoblastic_Leukemia_Lymphoma_With_Recurrent_Genetic_Abnormality.yaml
+  mapping_notes: >-
+    Manually mapped to ALL/B-lymphoblastic leukemia pages because the disease
+    YAML already includes minimal residual disease monitoring. A local readout
+    bridge links the MRD biomarker to clonal lymphoblast expansion.
 - row_id: FDA-SE-adult-cancer-008
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3485,8 +3548,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with diffuse
     large B-cell lymphoma; endpoint: Event-free survival (EFS) ˟; approval context: traditional; drug
     mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Diffuse Large B-Cell Lymphoma
+  mapped_disease_files:
+  - kb/disorders/Diffuse_Large_B_Cell_Lymphoma.yaml
+  mapping_notes: >-
+    Manually mapped to the DLBCL disease page based on the patient population.
+    Event-free survival is a clinical outcome endpoint and was kept in the
+    FDA source table rather than modeled as a disease biomarker.
 - row_id: FDA-SE-adult-cancer-010
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3511,8 +3581,19 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Diffuse large B-Cell lymphoma;
     hairy cell leukemia; follicular lumphoma; endpoint: Durable complete response rate; approval context:
     accelerated or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Diffuse Large B-Cell Lymphoma
+  - Hairy Cell Leukemia
+  - Follicular Lymphoma
+  mapped_disease_files:
+  - kb/disorders/Diffuse_Large_B_Cell_Lymphoma.yaml
+  - kb/disorders/Hairy_Cell_Leukemia.yaml
+  - kb/disorders/Follicular_Lymphoma.yaml
+  mapping_notes: >-
+    Candidate mapped to the represented lymphoma/leukemia pages. Durable
+    complete response is a clinical response endpoint, so no disease YAML
+    biomarker bridge was added.
 - row_id: FDA-SE-adult-cancer-011
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3541,8 +3622,11 @@ surrogate_endpoints:
     anaplastic large cell lymphoma; chronic myeloid leukemia; chronic lymphocytic leukemia; cutaneous
     T cell lymphoma; all other non-Hodgkin lymphoma; chronic lymphocyic leukemia; mycosis fungoides; endpoint:
     Progression-free survivial (PFS); approval context: traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning many hematologic malignancies.
+    Progression-free survival is a clinical outcome endpoint rather than a
+    disease-biology biomarker suitable for one dismech pathograph.
 - row_id: FDA-SE-adult-cancer-012
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3575,8 +3659,11 @@ surrogate_endpoints:
     macroglobulinemia; marginal zone lymphoma; follicular lymphoma; light chain amyloidosis; endpoint:
     Durable objective overall response rate (ORR); approval context: accelerated or traditional; drug
     mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning many hematologic malignancies and
+    light chain amyloidosis. Durable ORR is a broad clinical response endpoint,
+    not a specific pathophysiology biomarker.
 - row_id: FDA-SE-adult-cancer-013
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3600,8 +3687,19 @@ surrogate_endpoints:
   - MECHANISM_AGNOSTIC
   context_of_use: 'Disease/use: Cancer: solid tumors; population: Patients with breast cancer; endpoint:
     Pathological complete response; approval context: accelerated; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - ER-Positive Breast Cancer
+  - HER2-Positive Breast Cancer
+  - Triple-Negative Breast Cancer
+  mapped_disease_files:
+  - kb/disorders/ER_Positive_Breast_Cancer.yaml
+  - kb/disorders/HER2_Positive_Breast_Cancer.yaml
+  - kb/disorders/Triple_Negative_Breast_Cancer.yaml
+  mapping_notes: >-
+    Candidate mapped to represented breast cancer subtype pages because no
+    generic breast cancer disease page exists. Pathological complete response is
+    a histopathologic/clinical endpoint, so no biochemical readout was added.
 - row_id: FDA-SE-adult-cancer-014
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3626,8 +3724,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: solid tumors; population: Patients with nonmetastatic castrate-resistant
     prostate cancer; endpoint: Metastasis-free survival; approval context: accelerated or traditional;
     drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Prostate Adenocarcinoma
+  mapped_disease_files:
+  - kb/disorders/Prostate_Adenocarcinoma.yaml
+  mapping_notes: >-
+    Candidate mapped to prostate adenocarcinoma because nonmetastatic
+    castration-resistant prostate cancer is not represented as a standalone
+    dismech entry. Metastasis-free survival is a clinical outcome endpoint.
 - row_id: FDA-SE-adult-cancer-015
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3649,8 +3754,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: solid tumors; population: Patients with advanced prostate cancer;
     endpoint: Plasma testosterone levels; approval context: traditional; drug mechanism: Gonadotropin-releasing
     hormone antagonist.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Prostate Adenocarcinoma
+  - Metastatic Prostate Cancer
+  mapped_disease_files:
+  - kb/disorders/Prostate_Adenocarcinoma.yaml
+  - kb/disorders/Metastatic_Prostate_Cancer.yaml
+  mapping_notes: >-
+    Candidate mapped to prostate cancer pages. Plasma testosterone is a
+    pharmacodynamic androgen-deprivation endpoint for therapy, not a disease
+    mechanism biomarker, so it remains source-table-only.
 - row_id: FDA-SE-adult-cancer-016
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3713,8 +3827,11 @@ surrogate_endpoints:
     -A*02:06P positive, and whose tumor expresses the MAGE-A4 antigen as determined by FDA authorized
     companion diagnostic devices; endpoint: Durable objective overall response rate (ORR); approval context:
     accelerated or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning many unrelated solid tumors and
+    molecular contexts. Durable ORR is a broad clinical response endpoint and
+    should not be forced into a single disease pathograph.
 - row_id: FDA-SE-adult-cancer-017
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3754,8 +3871,11 @@ surrogate_endpoints:
     metastatic human epidermal growth factor receptor 2 (HER2)-negative gastric or gastroesophageal junction
     adenocarcinoma whose tumors are claudin (CLDN) 18.2 positive; endpoint: Progression-free survivial
     (PFS); approval context: accelerated or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning many unrelated solid tumors.
+    Progression-free survival is a broad clinical outcome endpoint rather than
+    a specific disease-biology biomarker.
 - row_id: FDA-SE-adult-cancer-018
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3784,8 +3904,11 @@ surrogate_endpoints:
     gastrointestinal stromal tumor; breast cancer and adjuvant therapy for stage III non-small cell lung
     cancer; endpoint: Disease-free survival (DFS); approval context: accelerated or traditional; drug
     mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only adjuvant-therapy aggregate row spanning multiple tumor
+    types. Disease-free survival is a clinical outcome endpoint and was not
+    mapped to individual disease pathographs.
 - row_id: FDA-SE-adult-cancer-019
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3811,8 +3934,11 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: solid tumors; population: Patients with breast cancer; neuroblastoma;
     muscle invasive bladder cancer (MIBC); endpoint: Event-free survival (EFS)˟; approval context: accelerated
     or traditional; drug mechanism: Mechanism agnostic.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning breast cancer, neuroblastoma, and
+    muscle-invasive bladder cancer. Event-free survival is a broad clinical
+    outcome endpoint rather than a specific pathograph biomarker.
 - row_id: FDA-SE-adult-cancer-020
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3835,8 +3961,17 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: solid tumors; population: metastatic colorectal cancer (CRC) with
     a BRAF V600E mutation; endpoint: duration of response (DOR); approval context: accelerated; drug mechanism:
     kinase inhibitor.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - BRAF V600E-Mutant Colorectal Cancer
+  - Metastatic Colorectal Cancer
+  mapped_disease_files:
+  - kb/disorders/BRAF_V600E_Mutant_Colorectal_Cancer.yaml
+  - kb/disorders/Metastatic_Colorectal_Cancer.yaml
+  mapping_notes: >-
+    Manually mapped to BRAF V600E-mutant and metastatic colorectal cancer pages
+    because the FDA population specifies metastatic CRC with BRAF V600E.
+    Duration of response is a clinical response endpoint.
 - row_id: FDA-SE-adult-cancer-021
   source_table: ADULT_CANCER
   source_sheet: Adult SE Cancer Related
@@ -3861,8 +3996,15 @@ surrogate_endpoints:
     carcinoma (NPC) with disease progression on or after platinum-based chemotherapy and at least one
     other prior line of therapy; endpoint: overall response rate (ORR) and DORduration of response (DOR);
     approval context: accelerated; drug mechanism: programmed death receptor-1 (PD-1)-blocking antibody.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Nasopharyngeal Carcinoma
+  mapped_disease_files:
+  - kb/disorders/Nasopharyngeal_Carcinoma.yaml
+  mapping_notes: >-
+    Manually mapped to nasopharyngeal carcinoma based on the patient population.
+    ORR and duration of response are clinical response endpoints retained in
+    the FDA source table rather than modeled as biochemical biomarkers.
 - row_id: FDA-SE-pediatric-noncancer-001
   source_table: PEDIATRIC_NONCANCER
   source_sheet: Pediatric Non-cancer Related
@@ -6003,8 +6145,17 @@ surrogate_endpoints:
     acute leukemia with a lysine methyltransferase 2A gene (KMT2A) translocation; endpoint: complete remission
     (CR) and CR with partial hematologic recovery (CRh); approval context: traditional; drug mechanism:
     menin inhibitor; age range: 1 year and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - B-Lymphoblastic Leukemia/Lymphoma With Recurrent Genetic Abnormality
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/B-Lymphoblastic_Leukemia_Lymphoma_With_Recurrent_Genetic_Abnormality.yaml
+  mapping_notes: >-
+    Candidate mapped because the FDA row specifies KMT2A-rearranged acute
+    leukemia and the represented dismech pages cover KMT2A-rearranged
+    ALL/B-lymphoblastic disease. CR/CRh is a treatment response endpoint.
 - row_id: FDA-SE-pediatric-cancer-002
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6030,8 +6181,16 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with acute lymphoblastic
     leukemia; B-cell lymphoma; endpoint: Durable objective overall response rate (ORR); approval context:
     accelerated or traditional; drug mechanism: Mechanism agnostic; age range: 1 to 21 years.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  - B-Lymphoblastic Leukemia/Lymphoma With Recurrent Genetic Abnormality
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  - kb/disorders/B-Lymphoblastic_Leukemia_Lymphoma_With_Recurrent_Genetic_Abnormality.yaml
+  mapping_notes: >-
+    Candidate mapped to represented ALL/B-lymphoblastic pages. Durable ORR is
+    a clinical response endpoint rather than a pathograph biomarker.
 - row_id: FDA-SE-pediatric-cancer-003
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6057,8 +6216,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with acute lymphoblastic
     leukemia; endpoint: Event-free Survival; approval context: accelerated or traditional; drug mechanism:
     Mechanism agnostic; age range: 1 to 21 years.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  mapping_notes: >-
+    Manually mapped to the ALL disease page based on the patient population.
+    Event-free survival is a clinical outcome endpoint and was not modeled as a
+    biochemical readout.
 - row_id: FDA-SE-pediatric-cancer-004
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6084,8 +6250,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with chronic
     myeloid leukemia; endpoint: Major hematologic and cytogenic response; approval context: accelerated
     or traditional; drug mechanism: Mechanism agnostic; age range: 3 to 20 years.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CURATED_DISMECH_MAPPING
+  mapped_diseases:
+  - Chronic Myeloid Leukemia, BCR-ABL1 Positive
+  mapped_disease_files:
+  - kb/disorders/Chronic_Myeloid_Leukemia.yaml
+  mapping_notes: >-
+    Manually mapped to the CML disease page based on the patient population.
+    Hematologic/cytogenetic response is a clinical response endpoint distinct
+    from the existing BCR-ABL1 molecular-response biomarker bridge.
 - row_id: FDA-SE-pediatric-cancer-005
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6108,8 +6281,15 @@ surrogate_endpoints:
   context_of_use: 'Disease/use: Cancer: hematological malignancies; population: Patients with Acute Lymphoblastic
     Leukemia; endpoint: Serum Asparaginase; approval context: traditional; drug mechanism: Asparagine-specific
     enzyme; age range: All pediatric age groups.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: CANDIDATE_DISMECH_MAPPING
+  mapped_diseases:
+  - Acute Lymphoblastic Leukemia
+  mapped_disease_files:
+  - kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
+  mapping_notes: >-
+    Candidate mapped to the ALL disease page. Serum asparaginase is a
+    therapeutic enzyme exposure/activity endpoint rather than a disease
+    mechanism biomarker.
 - row_id: FDA-SE-pediatric-cancer-006
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6143,8 +6323,11 @@ surrogate_endpoints:
     receptor kinase (NTRK) gene fusion; diffuse midline glioma H3K27M mutation; endpoint: Durable objective
     overall response rate (ORR); approval context: accelerated; drug mechanism: Mechanism agnostic; age
     range: 28 days and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning multiple pediatric solid tumor
+    and molecular contexts. Durable ORR is a broad clinical response endpoint
+    and was not mapped to a single disease pathograph.
 - row_id: FDA-SE-pediatric-cancer-007
   source_table: PEDIATRIC_CANCER
   source_sheet: Pediatric Cancer Related
@@ -6176,5 +6359,8 @@ surrogate_endpoints:
     or metastatic, well-differentiated pancreatic and extra-pancreatic neuroendocrine tumors; endpoint:
     Progression-free survival(PFS); approval context: accelerated or traditional; drug mechanism: Mechanism
     agnostic; age range: 12 years and older.'
-  mapping_status: NEEDS_CURATION
-  mapping_notes: No dismech disease mapping assigned during initial FDA import.
+  mapping_status: NOT_DISEASE_SPECIFIC
+  mapping_notes: >-
+    Source-table-only aggregate row spanning metastatic melanoma, glioma, and
+    neuroendocrine tumor contexts. Progression-free survival is a broad
+    clinical outcome endpoint rather than a specific disease-biology biomarker.


### PR DESCRIPTION
## Summary
- maps all remaining FDA adult/pediatric cancer surrogate endpoint rows out of NEEDS_CURATION
- uses disease mappings for specific represented cancer contexts and source-table-only status for broad aggregate survival/response rows
- adds an ALL MRD readout bridge from Minimal Residual Disease (MRD) to Clonal Expansion of Lymphoblasts with FDA-SE-adult-cancer-007 as the regulatory endpoint reference

## Validation
- uv run linkml-validate -s src/dismech/schema/dismech.yaml -C SurrogateEndpointCollection kb/surrogate_endpoints/fda_surrogate_endpoints.yaml
- uv run linkml-validate -s src/dismech/schema/dismech.yaml -C Disease kb/disorders/Acute_Lymphoblastic_Leukemia.yaml
- uv run pytest tests/test_fda_surrogate_endpoints.py tests/test_graph_model_links.py -q
- git diff --check

Note: commit skipped codespell because the touched ALL file contains legitimate existing uses of "covert", including an exact evidence quote.