### PR TITLE
Phase 1b: migrate Melkersson-Rosenthal syndrome drug-agent qualifiers (#1613)

### DIFF
--- a/kb/disorders/Melkersson_Rosenthal_syndrome.yaml
+++ b/kb/disorders/Melkersson_Rosenthal_syndrome.yaml
@@ -485,17 +485,11 @@ treatments:
     term:
       id: MAXO:0000640
       label: corticosteroid agent therapy
-    qualifiers:
-    - predicate:
-        preferred_term: therapeutic agent
-        term:
-          id: NCIT:C2259
-          label: Therapeutic Agent
-      value:
-        preferred_term: triamcinolone
-        term:
-          id: NCIT:C901
-          label: Triamcinolone
+    therapeutic_agent:
+    - preferred_term: triamcinolone
+      term:
+        id: CHEBI:9667
+        label: triamcinolone
   evidence:
   - reference: PMID:32782477
     reference_title: "Recurrent granulomatous cheilitis associated with Crohn's disease successfully treated with ustekinumab: case report and literature review."
@@ -532,17 +526,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
-    qualifiers:
-    - predicate:
-        preferred_term: therapeutic agent
-        term:
-          id: NCIT:C2259
-          label: Therapeutic Agent
-      value:
-        preferred_term: infliximab
-        term:
-          id: NCIT:C1789
-          label: Infliximab
+    therapeutic_agent:
+    - preferred_term: infliximab
+      term:
+        id: NCIT:C1789
+        label: Infliximab
   evidence:
   - reference: PMID:32782477
     reference_title: "Recurrent granulomatous cheilitis associated with Crohn's disease successfully treated with ustekinumab: case report and literature review."
@@ -563,12 +551,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
-    qualifiers:
-    - predicate:
-        preferred_term: therapeutic agent class
-        term:
-          id: NCIT:C20401
-          label: Monoclonal Antibody
+    therapeutic_agent:
+    - preferred_term: monoclonal antibody
+      term:
+        id: NCIT:C20401
+        label: Monoclonal Antibody
   evidence:
   - reference: PMID:32782477
     reference_title: "Recurrent granulomatous cheilitis associated with Crohn's disease successfully treated with ustekinumab: case report and literature review."


### PR DESCRIPTION
## Summary

Phase 1b qualifiers-migration continuation. Migrates the 3 `qualifiers[predicate=Therapeutic Agent / Therapeutic Agent Class]` rows in `kb/disorders/Melkersson_Rosenthal_syndrome.yaml` to the typed `therapeutic_agent:` slot.

This is the **last remaining single-predicate-only Phase 1b foothold** flagged by the prior scanner comment on #1613 after #2638 (Sengers) merged.

## Substitutions

Per CLAUDE.md guidance (CHEBI for small-molecule drugs, NCIT for biologics and drug classes):

| Block (treatment) | YAML claimed | OAK `info` confirmed | Substitution |
|---|---|---|---|
| Intralesional corticosteroid injection | `NCIT:C901` Triamcinolone | ✅ Triamcinolone | `CHEBI:9667` triamcinolone (small-molecule glucocorticoid; same CHEBI ID used in `Pars_Planitis.yaml`) |
| Anti-TNF therapy (infliximab) | `NCIT:C1789` Infliximab | ✅ Infliximab | `NCIT:C1789` Infliximab (kept — biologic; same NCIT ID used in `Pars_Planitis.yaml`) |
| Anti-IL-12/23 therapy (ustekinumab) — class-only annotation | `NCIT:C20401` Monoclonal Antibody | ✅ Monoclonal Antibody | `NCIT:C20401` Monoclonal Antibody (kept — drug class) |

Defense-in-depth: every NCIT ID was run through `runoak -i sqlite:obo:ncit info <ID>` before substitution. NCIT mislabel rate this file: **0/3**.

## Note on ustekinumab block

The third block (Anti-IL-12/23 therapy) had only a class-level predicate (`therapeutic agent class` → `Monoclonal Antibody`) and no specific drug value in the original record. The migration preserves that semantics by emitting the class term as the lone `therapeutic_agent`. Enriching this entry with a specific ustekinumab agent term is out of scope for this mechanical migration; flagging as a possible follow-up.

## Validation

- `just validate kb/disorders/Melkersson_Rosenthal_syndrome.yaml` → ✅ schema + terms + references all pass.
- `grep -n "qualifiers:" kb/disorders/Melkersson_Rosenthal_syndrome.yaml` returns no matches after the migration.
- No new cache rows required (CHEBI:9667 already cached from #2616 Pars_Planitis; NCIT:C1789 and NCIT:C20401 already in use elsewhere).

## Status snapshot after this merges

| Phase | Predicate | Files migrated | Remaining |
|---|---|---:|---:|
| 1a | `pharmacologic substance` | ✅ done | 0 |
| 1b | `therapeutic agent` | #2184 + #2207 + #2260 + #2361 + #2410 + #2576 + #2616 + #2638 + **this (Melkersson_Rosenthal)** | 0 single-predicate files + 16 mixed-predicate files |
| 2 | schema-design predicates | ⏸️ awaiting design issue | ~312 |
| 3 | `clinical course` | ✅ done | 0 |

After this merges, **all single-predicate-only Phase 1b footholds are complete**. The remaining ~16 mixed-predicate files will need a different approach (they mix `therapeutic agent` rows with predicates that still await schema design in Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)