### PR TITLE
Add Preeclampsia (MONDO:0005081)

### DIFF
--- a/kb/disorders/Preeclampsia.yaml
+++ b/kb/disorders/Preeclampsia.yaml
@@ -1,6 +1,6 @@
 name: Preeclampsia
 creation_date: "2026-05-13T00:00:00Z"
-updated_date: "2026-05-13T00:00:00Z"
+updated_date: "2026-05-13T18:00:00Z"
 category: Complex
 synonyms:
 - Pre-eclampsia
@@ -155,13 +155,19 @@ pathophysiology:
       reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF, resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
-      explanation: Demonstrates the causal link from sFlt-1 excess to endothelial dysfunction.
+      snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF"
+      explanation: Human clinical observation showing sFlt-1 elevation associates with decreased free VEGF and PlGF.
+    - reference: PMID:12618519
+      reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
+      explanation: In vitro demonstration that endothelial dysfunction from sFlt-1 excess is reversible with VEGF/PlGF.
   evidence:
   - reference: PMID:12618519
     reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "we confirm that placental soluble fms-like tyrosine kinase 1 (sFlt1), an antagonist of VEGF and placental growth factor (PlGF), is upregulated in preeclampsia, leading to increased systemic levels of sFlt1 that fall after delivery."
     explanation: Landmark paper demonstrating that placental sFlt-1 is upregulated in preeclampsia with systemic elevation.
   - reference: PMID:14764923
@@ -349,6 +355,23 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Severe preeclampsia is defined as blood pressure (BP) >160/110 mmHg with warning signs such as headache, blurring of vision, and epigastric pain."
     explanation: Explicitly identifies headache as a warning sign of severe preeclampsia.
+- name: Visual disturbances
+  category: Clinical
+  description: >
+    Blurred vision and other visual disturbances are warning signs of severe
+    preeclampsia, reflecting cerebral edema and vasospasm.
+  phenotype_term:
+    preferred_term: Blurred vision
+    term:
+      id: HP:0000622
+      label: Blurred vision
+  evidence:
+  - reference: PMID:39247143
+    reference_title: "A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Severe preeclampsia is defined as blood pressure (BP) >160/110 mmHg with warning signs such as headache, blurring of vision, and epigastric pain."
+    explanation: Explicitly identifies blurring of vision as a warning sign of severe preeclampsia.
 - name: Intrauterine growth retardation
   category: Clinical
   description: >
@@ -465,7 +488,7 @@ genetic:
   - reference: PMID:12618519
     reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: HUMAN_CLINICAL
     snippet: "we confirm that placental soluble fms-like tyrosine kinase 1 (sFlt1), an antagonist of VEGF and placental growth factor (PlGF), is upregulated in preeclampsia"
     explanation: Demonstrates sFlt-1 (FLT1 gene product) upregulation in preeclamptic placentas.
 - name: PGF
@@ -520,8 +543,14 @@ genetic:
     reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF, resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
-    explanation: Shows that VEGF sequestration by sFlt-1 causes endothelial dysfunction that is reversible with exogenous VEGF.
+    snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF"
+    explanation: Human clinical data showing that sFlt-1 excess sequesters free VEGF in preeclampsia patients.
+  - reference: PMID:12618519
+    reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
+    explanation: In vitro evidence that exogenous VEGF can rescue sFlt-1-induced endothelial dysfunction.
 treatments:
 - name: Delivery
   description: >

--- a/kb/disorders/Preeclampsia.yaml
+++ b/kb/disorders/Preeclampsia.yaml
@@ -1,0 +1,632 @@
+name: Preeclampsia
+creation_date: "2026-05-13T00:00:00Z"
+updated_date: "2026-05-13T00:00:00Z"
+category: Complex
+synonyms:
+- Pre-eclampsia
+- Toxemia of pregnancy
+- Pregnancy-induced hypertension with proteinuria
+description: >
+  Preeclampsia is a multisystemic pregnancy disorder characterized by new-onset
+  hypertension and often proteinuria after 20 weeks of gestation, which can
+  progress to multi-organ dysfunction including hepatic, renal, and cerebral
+  disease. It complicates 2-8% of pregnancies globally and is a leading cause
+  of maternal and perinatal morbidity and mortality. The pathophysiology involves
+  defective trophoblast invasion and spiral artery remodeling leading to placental
+  ischemia, followed by release of anti-angiogenic factors (sFlt-1, soluble
+  endoglin) that cause widespread maternal endothelial dysfunction. The only
+  definitive treatment is delivery of the fetus and placenta.
+disease_term:
+  preferred_term: preeclampsia
+  term:
+    id: MONDO:0005081
+    label: preeclampsia
+parents:
+- Hypertensive disorder of pregnancy
+- Placental disease
+has_subtypes:
+- name: Early-onset
+  display_name: Early-onset preeclampsia (<34 weeks)
+  description: >
+    Preeclampsia with onset before 34 weeks of gestation. Strongly associated
+    with defective placentation and more severe angiogenic imbalance. Associated
+    with higher rates of maternal and fetal complications, intrauterine growth
+    restriction, and features resembling atherosclerosis.
+  evidence:
+  - reference: PMID:35177220
+    reference_title: "Preeclampsia and eclampsia: the conceptual evolution of a syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Early-onset preeclampsia has many features in common with atherosclerosis, whereas late-onset preeclampsia seems to result from a mismatch of fetal demands and maternal supply, that is, a metabolic crisis."
+    explanation: Distinguishes early-onset preeclampsia as having features of vascular pathology resembling atherosclerosis.
+- name: Late-onset
+  display_name: Late-onset preeclampsia (>=34 weeks)
+  description: >
+    Preeclampsia with onset at or after 34 weeks of gestation. The more common
+    form, often associated with less severe placental pathology and thought to
+    result from a mismatch between fetal metabolic demands and maternal
+    cardiovascular supply capacity.
+  evidence:
+  - reference: PMID:35177220
+    reference_title: "Preeclampsia and eclampsia: the conceptual evolution of a syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Early-onset preeclampsia has many features in common with atherosclerosis, whereas late-onset preeclampsia seems to result from a mismatch of fetal demands and maternal supply, that is, a metabolic crisis."
+    explanation: Characterizes late-onset preeclampsia as a metabolic crisis from demand-supply mismatch.
+- name: HELLP
+  display_name: HELLP syndrome
+  description: >
+    Severe variant characterized by hemolysis, elevated liver enzymes, and low
+    platelet count. Represents the severe end of the preeclampsia spectrum and
+    can occur with or without significant hypertension or proteinuria.
+  evidence:
+  - reference: PMID:34033373
+    reference_title: "Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This disease represents a spectrum of hypertensive disease in pregnancy, beginning with gestational hypertension and progressing to develop severe features, ultimately leading to its more severe manifestations, such as eclampsia and HELLP syndrome."
+    explanation: Identifies HELLP syndrome as a severe manifestation on the preeclampsia spectrum.
+pathophysiology:
+- name: Defective Trophoblast Invasion and Spiral Artery Remodeling
+  description: >
+    In normal pregnancy, extravillous trophoblasts invade the uterine decidua
+    and remodel maternal spiral arteries into high-capacitance, low-resistance
+    vessels. In preeclampsia, this invasion is shallow and incomplete, resulting
+    in narrow, high-resistance spiral arteries that fail to adequately perfuse
+    the placenta. The resulting placental ischemia and hypoxia trigger downstream
+    pathological cascades.
+  cell_types:
+  - preferred_term: extravillous trophoblast
+    term:
+      id: CL:0008036
+      label: extravillous trophoblast
+  - preferred_term: decidual natural killer cell
+    term:
+      id: CL:0002343
+      label: decidual natural killer cell, human
+  biological_processes:
+  - preferred_term: placenta development
+    term:
+      id: GO:0001890
+      label: placenta development
+    modifier: DECREASED
+  - preferred_term: vasculogenesis
+    term:
+      id: GO:0001570
+      label: vasculogenesis
+    modifier: DECREASED
+  downstream:
+  - target: Placental Anti-Angiogenic Factor Release
+    description: Placental ischemia from poor spiral artery remodeling triggers release of anti-angiogenic factors into the maternal circulation.
+    evidence:
+    - reference: PMID:39062815
+      reference_title: "A Narrative Review on the Pathophysiology of Preeclampsia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PE is initiated by poor placentation due to inadequate trophoblast invasion and improper spiral artery remodeling, leading to placental hypoxia. This triggers the release of anti-angiogenic factors such as soluble fms-like tyrosine kinase-1 (sFlt-1) and soluble endoglin (sEng), causing widespread endothelial dysfunction and systemic inflammation."
+      explanation: Directly describes the causal chain from defective trophoblast invasion through placental hypoxia to anti-angiogenic factor release.
+  evidence:
+  - reference: PMID:39062815
+    reference_title: "A Narrative Review on the Pathophysiology of Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PE is initiated by poor placentation due to inadequate trophoblast invasion and improper spiral artery remodeling, leading to placental hypoxia."
+    explanation: Directly describes the defective trophoblast invasion and spiral artery remodeling as the initiating event in preeclampsia.
+  - reference: PMID:35177220
+    reference_title: "Preeclampsia and eclampsia: the conceptual evolution of a syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "a growing body of evidence suggests that products of an ischemic or a stressed placenta are responsible for the vascular changes that characterize this syndrome."
+    explanation: Supports the concept that placental ischemia (from defective remodeling) drives vascular pathology.
+- name: Placental Anti-Angiogenic Factor Release
+  description: >
+    The ischemic placenta releases excess anti-angiogenic factors, primarily
+    soluble fms-like tyrosine kinase 1 (sFlt-1) and soluble endoglin (sEng),
+    into the maternal circulation. sFlt-1 acts as a decoy receptor that
+    sequesters VEGF and PlGF, while sEng inhibits TGF-beta signaling. Together,
+    these factors create a systemic anti-angiogenic state that disrupts normal
+    endothelial function. Levels of sFlt-1 rise and PlGF fall weeks before
+    clinical onset.
+  cell_types:
+  - preferred_term: syncytiotrophoblast
+    term:
+      id: CL:0000525
+      label: syncytiotrophoblast cell
+  biological_processes:
+  - preferred_term: VEGF receptor signaling pathway
+    term:
+      id: GO:0048010
+      label: vascular endothelial growth factor receptor signaling pathway
+    modifier: DECREASED
+  - preferred_term: angiogenesis
+    term:
+      id: GO:0001525
+      label: angiogenesis
+    modifier: DECREASED
+  - preferred_term: response to hypoxia
+    term:
+      id: GO:0001666
+      label: response to hypoxia
+  downstream:
+  - target: Maternal Endothelial Dysfunction
+    description: Anti-angiogenic factors in the maternal circulation cause widespread endothelial injury and dysfunction.
+    evidence:
+    - reference: PMID:12618519
+      reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF, resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
+      explanation: Demonstrates the causal link from sFlt-1 excess to endothelial dysfunction.
+  evidence:
+  - reference: PMID:12618519
+    reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "we confirm that placental soluble fms-like tyrosine kinase 1 (sFlt1), an antagonist of VEGF and placental growth factor (PlGF), is upregulated in preeclampsia, leading to increased systemic levels of sFlt1 that fall after delivery."
+    explanation: Landmark paper demonstrating that placental sFlt-1 is upregulated in preeclampsia with systemic elevation.
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The sFlt-1 level increased beginning approximately five weeks before the onset of preeclampsia."
+    explanation: Shows that sFlt-1 rises weeks before clinical disease, consistent with placental release preceding symptoms.
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Increased levels of sFlt-1 and reduced levels of PlGF predict the subsequent development of preeclampsia."
+    explanation: Confirms the predictive anti-angiogenic imbalance pattern.
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "sEng inhibits formation of capillary tubes in vitro and induces vascular permeability and hypertension in vivo. Its effects in pregnant rats are amplified by coadministration of sFlt1, leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome and restriction of fetal growth."
+    explanation: Demonstrates that sEng acts synergistically with sFlt-1 to produce severe preeclampsia features.
+  - reference: PMID:39062815
+    reference_title: "A Narrative Review on the Pathophysiology of Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "This triggers the release of anti-angiogenic factors such as soluble fms-like tyrosine kinase-1 (sFlt-1) and soluble endoglin (sEng), causing widespread endothelial dysfunction and systemic inflammation."
+    explanation: Summarizes the anti-angiogenic cascade from placental hypoxia to endothelial dysfunction.
+- name: Maternal Endothelial Dysfunction
+  description: >
+    The anti-angiogenic imbalance causes widespread maternal endothelial
+    dysfunction, manifesting as vasoconstriction, increased vascular
+    permeability, and activation of the coagulation cascade. This leads to
+    the clinical features of hypertension, proteinuria (from glomerular
+    endotheliosis), hepatic dysfunction, cerebral edema, and
+    thrombocytopenia. The characteristic renal lesion is glomerular
+    endotheliosis.
+  cell_types:
+  - preferred_term: blood vessel endothelial cell
+    term:
+      id: CL:0000071
+      label: blood vessel endothelial cell
+  - preferred_term: platelet
+    term:
+      id: CL:0000233
+      label: platelet
+  biological_processes:
+  - preferred_term: regulation of blood pressure
+    term:
+      id: GO:0008217
+      label: regulation of blood pressure
+  - preferred_term: inflammatory response
+    term:
+      id: GO:0006954
+      label: inflammatory response
+  evidence:
+  - reference: PMID:12618519
+    reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "administration of sFlt1 to pregnant rats induces hypertension, proteinuria, and glomerular endotheliosis, the classic lesion of preeclampsia."
+    explanation: Direct demonstration that sFlt-1 causes the clinical triad of hypertension, proteinuria, and glomerular endotheliosis.
+  - reference: PMID:30792480
+    reference_title: "Pre-eclampsia: pathogenesis, novel diagnostics and therapies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Maternal endothelial dysfunction due to circulating factors of fetal origin from the placenta is a hallmark of pre-eclampsia."
+    explanation: Identifies endothelial dysfunction from placental factors as the hallmark of preeclampsia.
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "sEng impairs binding of TGF-beta1 to its receptors and downstream signaling including effects on activation of eNOS and vasodilation, suggesting that sEng leads to dysregulated TGF-beta signaling in the vasculature."
+    explanation: Shows that sEng disrupts endothelial NO production and vasodilation, explaining the hypertension.
+phenotypes:
+- name: Hypertension
+  category: Clinical
+  description: >
+    New-onset hypertension after 20 weeks of gestation, defined as systolic
+    blood pressure >=140 mmHg or diastolic >=90 mmHg on two occasions at
+    least 4 hours apart. Severe-range hypertension is >=160/110 mmHg.
+  frequency: VERY_FREQUENT
+  phenotype_term:
+    preferred_term: Maternal hypertension
+    term:
+      id: HP:0000822
+      label: Hypertension
+  evidence:
+  - reference: PMID:34033373
+    reference_title: "Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The parameters for initial identification of hypertension in the context of pregnancy-induced hypertension constituting the \"mild range\" are specifically defined as a systolic blood pressure (SBP) of 140 mm Hg or more or diastolic blood pressure (DBP) of 90 mm Hg or more on 2 occasions at least 4 hours apart"
+    explanation: Defines the diagnostic blood pressure criteria for preeclampsia.
+  - reference: PMID:32443079
+    reference_title: "Gestational Hypertension and Preeclampsia: ACOG Practice Bulletin, Number 222."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Hypertensive disorders of pregnancy constitute one of the leading causes of maternal and perinatal mortality worldwide."
+    explanation: Establishes hypertensive disorders as a defining feature of the preeclampsia spectrum.
+- name: Proteinuria
+  category: Clinical
+  description: >
+    New-onset proteinuria, typically >=300 mg per 24-hour urine collection or
+    protein/creatinine ratio >=0.3 mg/dL. While historically required for
+    diagnosis, current guidelines recognize preeclampsia can occur without
+    proteinuria if other signs of end-organ dysfunction are present.
+  phenotype_term:
+    preferred_term: Proteinuria
+    term:
+      id: HP:0000093
+      label: Proteinuria
+  evidence:
+  - reference: PMID:30792480
+    reference_title: "Pre-eclampsia: pathogenesis, novel diagnostics and therapies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The disease presents with new-onset hypertension and often proteinuria in the mother, which can progress to multi-organ dysfunction, including hepatic, renal and cerebral disease, if the fetus and placenta are not delivered."
+    explanation: Identifies proteinuria as a frequent but not universal feature of preeclampsia.
+- name: Thrombocytopenia
+  category: Clinical
+  description: >
+    Low platelet count, particularly prominent in HELLP syndrome. Reflects
+    endothelial activation and consumptive coagulopathy.
+  phenotype_term:
+    preferred_term: Thrombocytopenia
+    term:
+      id: HP:0001873
+      label: Thrombocytopenia
+  evidence:
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome"
+    explanation: Low platelets are a defining component of HELLP syndrome within the preeclampsia spectrum.
+- name: Elevated hepatic transaminases
+  category: Clinical
+  description: >
+    Elevated circulating hepatic transaminase concentrations reflecting liver
+    involvement, a criterion for severe features and a component of HELLP
+    syndrome.
+  phenotype_term:
+    preferred_term: Elevated circulating hepatic transaminase concentration
+    term:
+      id: HP:0002910
+      label: Elevated circulating hepatic transaminase concentration
+  evidence:
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome"
+    explanation: Elevated liver enzymes are a defining feature of HELLP syndrome.
+- name: Seizures (eclampsia)
+  category: Clinical
+  description: >
+    New-onset tonic-clonic seizures in a woman with preeclampsia, defining
+    the transition to eclampsia. Represents a severe neurological complication
+    that can occur antepartum, intrapartum, or postpartum.
+  phenotype_term:
+    preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  evidence:
+  - reference: PMID:35177220
+    reference_title: "Preeclampsia and eclampsia: the conceptual evolution of a syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "once thought to be a disease of the central nervous system, recognized by the occurrence of seizures (ie, eclampsia)"
+    explanation: Eclamptic seizures are the historically defining severe complication of preeclampsia.
+- name: Headache
+  category: Clinical
+  description: >
+    Severe, persistent headache that is a warning sign for severe preeclampsia
+    and eclampsia, indicating cerebral involvement.
+  phenotype_term:
+    preferred_term: Headache
+    term:
+      id: HP:0002315
+      label: Headache
+  evidence:
+  - reference: PMID:39247143
+    reference_title: "A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Severe preeclampsia is defined as blood pressure (BP) >160/110 mmHg with warning signs such as headache, blurring of vision, and epigastric pain."
+    explanation: Explicitly identifies headache as a warning sign of severe preeclampsia.
+- name: Intrauterine growth retardation
+  category: Clinical
+  description: >
+    Fetal growth restriction due to impaired uteroplacental perfusion from
+    defective spiral artery remodeling. More common in early-onset preeclampsia.
+  phenotype_term:
+    preferred_term: Intrauterine growth retardation
+    term:
+      id: HP:0001511
+      label: Intrauterine growth retardation
+  evidence:
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Alterations in the levels of sFlt-1 and free PlGF were greater in women with an earlier onset of preeclampsia and in women in whom preeclampsia was associated with a small-for-gestational-age infant."
+    explanation: Links angiogenic factor alterations to small-for-gestational-age infants in preeclampsia.
+- name: Hemolytic anemia
+  category: Clinical
+  subtype: HELLP
+  description: >
+    Microangiopathic hemolytic anemia as part of HELLP syndrome, reflecting
+    erythrocyte destruction in damaged microvasculature.
+  phenotype_term:
+    preferred_term: Hemolytic anemia
+    term:
+      id: HP:0001878
+      label: Hemolytic anemia
+  evidence:
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome"
+    explanation: Hemolysis is a defining component of HELLP syndrome.
+- name: Pulmonary edema
+  category: Clinical
+  description: >
+    Pulmonary edema due to increased vascular permeability and fluid overload,
+    a severe complication of preeclampsia.
+  phenotype_term:
+    preferred_term: Pulmonary edema
+    term:
+      id: HP:0100598
+      label: Pulmonary edema
+  notes: >
+    Pulmonary edema is a recognized severe complication of preeclampsia,
+    resulting from endothelial dysfunction, decreased oncotic pressure,
+    and iatrogenic fluid overload. It is included in ACOG criteria for
+    severe features of preeclampsia.
+biochemical:
+- name: Elevated sFlt-1
+  presence: Elevated
+  context: diagnostic biomarker
+  notes: >
+    Elevated circulating soluble fms-like tyrosine kinase 1 (sFlt-1/sVEGFR1),
+    a decoy VEGF receptor produced by the ischemic placenta that sequesters
+    VEGF and PlGF, disrupting endothelial function.
+  evidence:
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "At the onset of clinical disease, the mean serum level in the women with preeclampsia was 4382 pg per milliliter, as compared with 1643 pg per milliliter in controls with fetuses of similar gestational age (P<0.001)."
+    explanation: Quantifies the elevation of sFlt-1 in preeclampsia versus controls.
+- name: Decreased PlGF
+  presence: Decreased
+  context: diagnostic biomarker
+  notes: >
+    Reduced circulating free placental growth factor (PlGF), sequestered by
+    excess sFlt-1. Low PlGF precedes clinical onset and is an early predictive
+    biomarker.
+  evidence:
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The PlGF levels were significantly lower in the women who later had preeclampsia than in the controls beginning at 13 to 16 weeks of gestation (mean, 90 pg per milliliter vs. 142 pg per milliliter, P=0.01)"
+    explanation: Shows that PlGF depression begins early in the second trimester before clinical disease.
+- name: Elevated soluble endoglin
+  presence: Elevated
+  context: diagnostic biomarker
+  notes: >
+    Elevated circulating soluble endoglin (sEng), a TGF-beta coreceptor
+    released by the placenta that inhibits TGF-beta signaling and impairs
+    eNOS activation, contributing to endothelial dysfunction.
+  evidence:
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We report a novel placenta-derived soluble TGF-beta coreceptor, endoglin (sEng), which is elevated in the sera of preeclamptic individuals, correlates with disease severity and falls after delivery."
+    explanation: Identifies elevated sEng as correlating with disease severity.
+genetic:
+- name: FLT1
+  gene_term:
+    preferred_term: FLT1
+    term:
+      id: hgnc:3763
+      label: FLT1
+  association: Risk Factor
+  notes: >
+    Encodes fms-like tyrosine kinase 1 (VEGFR1). Alternative splicing produces
+    the soluble isoform sFlt-1, which is overexpressed by the preeclamptic
+    placenta and acts as a decoy receptor sequestering VEGF and PlGF.
+    Polymorphisms in FLT1 are associated with preeclampsia susceptibility.
+  evidence:
+  - reference: PMID:39062815
+    reference_title: "A Narrative Review on the Pathophysiology of Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Genetic and epigenetic modifications, including polymorphisms in the Fms-like tyrosine kinase 1 (FLT1) gene and altered microRNA (miRNA) expression, play critical roles."
+    explanation: Identifies FLT1 polymorphisms as playing a critical role in preeclampsia.
+  - reference: PMID:12618519
+    reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "we confirm that placental soluble fms-like tyrosine kinase 1 (sFlt1), an antagonist of VEGF and placental growth factor (PlGF), is upregulated in preeclampsia"
+    explanation: Demonstrates sFlt-1 (FLT1 gene product) upregulation in preeclamptic placentas.
+- name: PGF
+  gene_term:
+    preferred_term: PGF
+    term:
+      id: hgnc:8893
+      label: PGF
+  association: Risk Factor
+  notes: >
+    Encodes placental growth factor (PlGF), a VEGF family member essential for
+    placental angiogenesis. Free PlGF levels are reduced in preeclampsia due
+    to sequestration by excess sFlt-1, and low PlGF is an early biomarker.
+  evidence:
+  - reference: PMID:14764923
+    reference_title: "Circulating angiogenic factors and the risk of preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Increased levels of sFlt-1 and reduced levels of PlGF predict the subsequent development of preeclampsia."
+    explanation: PlGF reduction is a key predictive feature of preeclampsia.
+- name: ENG
+  gene_term:
+    preferred_term: ENG
+    term:
+      id: hgnc:3349
+      label: ENG
+  association: Risk Factor
+  notes: >
+    Encodes endoglin, a TGF-beta coreceptor. The soluble form (sEng) is
+    elevated in preeclampsia and synergizes with sFlt-1 to induce severe
+    disease including HELLP syndrome in animal models.
+  evidence:
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Our results suggest that sEng may act in concert with sFlt1 to induce severe preeclampsia."
+    explanation: Demonstrates the pathogenic role of soluble endoglin (ENG gene product) in severe preeclampsia.
+- name: VEGFA
+  gene_term:
+    preferred_term: VEGFA
+    term:
+      id: hgnc:12680
+      label: VEGFA
+  association: Risk Factor
+  notes: >
+    Encodes vascular endothelial growth factor A, a key mediator of
+    angiogenesis and endothelial homeostasis. Sequestration of free VEGF by
+    excess sFlt-1 in preeclampsia contributes to endothelial dysfunction.
+  evidence:
+  - reference: PMID:12618519
+    reference_title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "increased circulating sFlt1 in patients with preeclampsia is associated with decreased circulating levels of free VEGF and PlGF, resulting in endothelial dysfunction in vitro that can be rescued by exogenous VEGF and PlGF."
+    explanation: Shows that VEGF sequestration by sFlt-1 causes endothelial dysfunction that is reversible with exogenous VEGF.
+treatments:
+- name: Delivery
+  description: >
+    Delivery of the fetus and placenta is the only definitive treatment for
+    preeclampsia. Timing depends on gestational age and severity, balancing
+    maternal risk against fetal prematurity. Generally recommended at 37 weeks
+    for preeclampsia without severe features, and earlier if severe features
+    or maternal/fetal deterioration occurs.
+  treatment_term:
+    preferred_term: labor induction
+    term:
+      id: MAXO:0000861
+      label: labor induction
+  evidence:
+  - reference: PMID:30792480
+    reference_title: "Pre-eclampsia: pathogenesis, novel diagnostics and therapies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "which can progress to multi-organ dysfunction, including hepatic, renal and cerebral disease, if the fetus and placenta are not delivered."
+    explanation: Identifies delivery as the necessary intervention to prevent progression.
+- name: Low-dose aspirin prophylaxis
+  description: >
+    Low-dose aspirin (150 mg daily) initiated at 11-14 weeks of gestation
+    in women identified as high risk reduces the incidence of preterm
+    preeclampsia by approximately 62%. This is a preventive intervention,
+    not a treatment for established disease.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: acetylsalicylic acid
+      term:
+        id: CHEBI:15365
+        label: acetylsalicylic acid
+  evidence:
+  - reference: PMID:28657417
+    reference_title: "Aspirin versus Placebo in Pregnancies at High Risk for Preterm Preeclampsia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Preterm preeclampsia occurred in 13 participants (1.6%) in the aspirin group, as compared with 35 (4.3%) in the placebo group (odds ratio in the aspirin group, 0.38; 95% confidence interval, 0.20 to 0.74; P=0.004)."
+    explanation: The ASPRE trial demonstrated a 62% reduction in preterm preeclampsia with aspirin 150 mg daily.
+- name: Magnesium sulfate for seizure prevention
+  description: >
+    Magnesium sulfate is the first-line agent for prevention and treatment
+    of eclamptic seizures. It halves the risk of eclampsia in women with
+    preeclampsia and probably reduces maternal mortality.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: magnesium sulfate
+      term:
+        id: CHEBI:32599
+        label: magnesium sulfate
+  evidence:
+  - reference: PMID:12057549
+    reference_title: "Do women with pre-eclampsia, and their babies, benefit from magnesium sulphate? The Magpie Trial: a randomised placebo-controlled trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Women allocated magnesium sulphate had a 58% lower risk of eclampsia (95% CI 40-71) than those allocated placebo (40, 0.8%, vs 96, 1.9%; 11 fewer women with eclampsia per 1000 women)."
+    explanation: The Magpie trial demonstrated that magnesium sulfate halves eclampsia risk.
+- name: Antihypertensive therapy (labetalol)
+  description: >
+    Labetalol is a first-line antihypertensive for acute blood pressure
+    management in severe preeclampsia, used to prevent hypertensive emergencies
+    and stroke.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: labetalol
+      term:
+        id: CHEBI:6343
+        label: labetalol
+  evidence:
+  - reference: PMID:39247143
+    reference_title: "A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Nifedipine (C17H18N2O6), labetalol (C19H24N2O3), and hydralazine (C8H8N4) are commonly used drugs, and all are recommended as first-line agents."
+    explanation: Identifies labetalol as a recommended first-line agent for acute hypertensive management in pregnancy.
+- name: Antihypertensive therapy (nifedipine)
+  description: >
+    Nifedipine is an alternative first-line oral antihypertensive for acute
+    severe hypertension in preeclampsia.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: nifedipine
+      term:
+        id: CHEBI:7565
+        label: nifedipine
+  evidence:
+  - reference: PMID:39247143
+    reference_title: "A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "oral nifedipine has been proposed as a first-line alternative to intravenous labetalol."
+    explanation: Identifies nifedipine as a first-line alternative antihypertensive for severe preeclampsia.

--- a/kb/disorders/Preeclampsia.yaml
+++ b/kb/disorders/Preeclampsia.yaml
@@ -185,9 +185,15 @@ pathophysiology:
   - reference: PMID:16751767
     reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
     supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "sEng inhibits formation of capillary tubes in vitro"
+    explanation: In vitro evidence that soluble endoglin has anti-angiogenic effects.
+  - reference: PMID:16751767
+    reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
+    supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "sEng inhibits formation of capillary tubes in vitro and induces vascular permeability and hypertension in vivo. Its effects in pregnant rats are amplified by coadministration of sFlt1, leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome and restriction of fetal growth."
-    explanation: Demonstrates that sEng acts synergistically with sFlt-1 to produce severe preeclampsia features.
+    snippet: "Its effects in pregnant rats are amplified by coadministration of sFlt1, leading to severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low platelets) syndrome and restriction of fetal growth."
+    explanation: Rat model demonstrates that sEng synergizes with sFlt-1 to produce severe preeclampsia including HELLP syndrome.
   - reference: PMID:39062815
     reference_title: "A Narrative Review on the Pathophysiology of Preeclampsia."
     supports: SUPPORT
@@ -213,10 +219,10 @@ pathophysiology:
       id: CL:0000233
       label: platelet
   biological_processes:
-  - preferred_term: regulation of blood pressure
+  - preferred_term: innate immune response
     term:
-      id: GO:0008217
-      label: regulation of blood pressure
+      id: GO:0045087
+      label: innate immune response
   - preferred_term: inflammatory response
     term:
       id: GO:0006954
@@ -237,9 +243,9 @@ pathophysiology:
   - reference: PMID:16751767
     reference_title: "Soluble endoglin contributes to the pathogenesis of preeclampsia."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: IN_VITRO
     snippet: "sEng impairs binding of TGF-beta1 to its receptors and downstream signaling including effects on activation of eNOS and vasodilation, suggesting that sEng leads to dysregulated TGF-beta signaling in the vasculature."
-    explanation: Shows that sEng disrupts endothelial NO production and vasodilation, explaining the hypertension.
+    explanation: Biochemical/cell-based evidence that sEng disrupts TGF-beta receptor binding and eNOS activation.
 phenotypes:
 - name: Hypertension
   category: Clinical

--- a/references_cache/PMID_12057549.md
+++ b/references_cache/PMID_12057549.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:12057549"
+title: "Do women with pre-eclampsia, and their babies, benefit from magnesium sulphate? The Magpie Trial: a randomised placebo-controlled trial."
+authors:
+- Altman D
+- Carroli G
+- Duley L
+- Farrell B
+- Moodley J
+- Neilson J
+- Smith D
+- Magpie Trial Collaboration Group
+journal: Lancet
+year: '2002'
+doi: 10.1016/s0140-6736(02)08778-0
+keywords:
+- "Anticonvulsants/adverse effects, therapeutic use"
+- Blood Pressure
+- Cause of Death
+- Female
+- Fetal Death
+- Gestational Age
+- Humans
+- "Infant, Newborn"
+- "Magnesium Sulfate/adverse effects, therapeutic use"
+- Maternal Mortality
+- "Pre-Eclampsia/diagnosis, drug therapy, prevention & control"
+- Pregnancy
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Do women with pre-eclampsia, and their babies, benefit from magnesium sulphate? The Magpie Trial: a randomised placebo-controlled trial.
+**Authors:** Altman D, Carroli G, Duley L, Farrell B, Moodley J, Neilson J, Smith D, Magpie Trial Collaboration Group
+**Journal:** Lancet (2002)
+**DOI:** [10.1016/s0140-6736(02)08778-0](https://doi.org/10.1016/s0140-6736(02)08778-0)
+
+## Content
+
+1. Lancet. 2002 Jun 1;359(9321):1877-90. doi: 10.1016/s0140-6736(02)08778-0.
+
+Do women with pre-eclampsia, and their babies, benefit from magnesium sulphate? 
+The Magpie Trial: a randomised placebo-controlled trial.
+
+Altman D, Carroli G, Duley L, Farrell B, Moodley J, Neilson J, Smith D; Magpie 
+Trial Collaboration Group.
+
+Comment in
+    Lancet. 2002 Jun 1;359(9321):1872-3. doi: 10.1016/s0140-6736(02)08783-4.
+    Lancet. 2002 Oct 26;360(9342):1329; author reply 1331-2. doi: 
+10.1016/S0140-6736(02)11321-3.
+    Lancet. 2002 Oct 26;360(9342):1329-30; author reply 1331-2. doi: 
+10.1016/S0140-6736(02)11322-5.
+    Presse Med. 2003 Apr 5;32(13 Pt 1):581-2; discussion 582.
+    Lancet. 2007 Jan 6;369(9555):13-4. doi: 10.1016/S0140-6736(07)60010-5.
+
+BACKGROUND: Anticonvulsants are used for pre-eclampsia in the belief they 
+prevent eclamptic convulsions, and so improve outcome. Evidence supported 
+magnesium sulphate as the drug to evaluate.
+METHODS: Eligible women (n=10141) had not given birth or were 24 h or less 
+postpartum; blood pressure of 140/90 mm Hg or more, and proteinuria of 1+ (30 
+mg/dL) or more; and there was clinical uncertainty about magnesium sulphate. 
+Women were randomised in 33 countries to either magnesium sulphate (n=5071) or 
+placebo (n=5070). Primary outcomes were eclampsia and, for women randomised 
+before delivery, death of the baby. Follow up was until discharge from hospital 
+after delivery. Analyses were by intention to treat.
+FINDINGS: Follow-up data were available for 10,110 (99.7%) women, 9992 (99%) of 
+whom received the allocated treatment. 1201 of 4999 (24%) women given magnesium 
+sulphate reported side-effects versus 228 of 4993 (5%) given placebo. Women 
+allocated magnesium sulphate had a 58% lower risk of eclampsia (95% CI 40-71) 
+than those allocated placebo (40, 0.8%, vs 96, 1.9%; 11 fewer women with 
+eclampsia per 1000 women). Maternal mortality was also lower among women 
+allocated magnesium sulphate (relative risk 0.55, 0.26-1.14). For women 
+randomised before delivery, there was no clear difference in the risk of the 
+baby dying (576, 12.7%, vs 558, 12.4%; relative risk 1.02, 99% CI 0.92-1.14). 
+The only notable difference in maternal or neonatal morbidity was for placental 
+abruption (relative risk 0.67, 99% CI 0.45-0.89).
+INTERPRETATION: Magnesium sulphate halves the risk of eclampsia, and probably 
+reduces the risk of maternal death. There do not appear to be substantive 
+harmful effects to mother or baby in the short term.
+
+DOI: 10.1016/s0140-6736(02)08778-0
+PMID: 12057549 [Indexed for MEDLINE]

--- a/references_cache/PMID_12618519.md
+++ b/references_cache/PMID_12618519.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:12618519"
+title: "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia."
+authors:
+- Maynard SE
+- Min JY
+- Merchan J
+- Lim KH
+- Li J
+- Mondal S
+- Libermann TA
+- Morgan JP
+- Sellke FW
+- Stillman IE
+- Epstein FH
+- Sukhatme VP
+- Karumanchi SA
+journal: J Clin Invest
+year: '2003'
+doi: 10.1172/JCI17189
+keywords:
+- "Endothelial Growth Factors/analysis, antagonists & inhibitors"
+- "Endothelium, Vascular/physiology"
+- Enzyme-Linked Immunosorbent Assay
+- Female
+- Humans
+- Hypertension/etiology
+- Intercellular Signaling Peptides and Proteins/analysis
+- Kidney/pathology
+- "Lymphokines/analysis, antagonists & inhibitors"
+- "Neovascularization, Physiologic"
+- Placenta Growth Factor
+- "Pre-Eclampsia/etiology, therapy"
+- Pregnancy
+- "Pregnancy Proteins/analysis, antagonists & inhibitors"
+- Proteinuria/etiology
+- Vascular Endothelial Growth Factor A
+- Vascular Endothelial Growth Factor Receptor-1/physiology
+- Vascular Endothelial Growth Factors
+content_type: abstract_only
+---
+
+# Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia.
+**Authors:** Maynard SE, Min JY, Merchan J, Lim KH, Li J, Mondal S, Libermann TA, Morgan JP, Sellke FW, Stillman IE, Epstein FH, Sukhatme VP, Karumanchi SA
+**Journal:** J Clin Invest (2003)
+**DOI:** [10.1172/JCI17189](https://doi.org/10.1172/JCI17189)
+
+## Content
+
+1. J Clin Invest. 2003 Mar;111(5):649-58. doi: 10.1172/JCI17189.
+
+Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to 
+endothelial dysfunction, hypertension, and proteinuria in preeclampsia.
+
+Maynard SE(1), Min JY, Merchan J, Lim KH, Li J, Mondal S, Libermann TA, Morgan 
+JP, Sellke FW, Stillman IE, Epstein FH, Sukhatme VP, Karumanchi SA.
+
+Author information:
+(1)Department of Medicine, Beth Israel Deaconess Medical Center, Boston, 
+Massachusetts 02115, USA.
+
+Comment in
+    J Clin Invest. 2003 Mar;111(5):600-2. doi: 10.1172/JCI18015.
+
+Preeclampsia, a syndrome affecting 5% of pregnancies, causes substantial 
+maternal and fetal morbidity and mortality. The pathophysiology of preeclampsia 
+remains largely unknown. It has been hypothesized that placental ischemia is an 
+early event, leading to placental production of a soluble factor or factors that 
+cause maternal endothelial dysfunction, resulting in the clinical findings of 
+hypertension, proteinuria, and edema. Here, we confirm that placental soluble 
+fms-like tyrosine kinase 1 (sFlt1), an antagonist of VEGF and placental growth 
+factor (PlGF), is upregulated in preeclampsia, leading to increased systemic 
+levels of sFlt1 that fall after delivery. We demonstrate that increased 
+circulating sFlt1 in patients with preeclampsia is associated with decreased 
+circulating levels of free VEGF and PlGF, resulting in endothelial dysfunction 
+in vitro that can be rescued by exogenous VEGF and PlGF. Additionally, VEGF and 
+PlGF cause microvascular relaxation of rat renal arterioles in vitro that is 
+blocked by sFlt1. Finally, administration of sFlt1 to pregnant rats induces 
+hypertension, proteinuria, and glomerular endotheliosis, the classic lesion of 
+preeclampsia. These observations suggest that excess circulating sFlt1 
+contributes to the pathogenesis of preeclampsia.
+
+DOI: 10.1172/JCI17189
+PMCID: PMC151901
+PMID: 12618519 [Indexed for MEDLINE]

--- a/references_cache/PMID_14764923.md
+++ b/references_cache/PMID_14764923.md
@@ -1,0 +1,101 @@
+---
+reference_id: "PMID:14764923"
+title: Circulating angiogenic factors and the risk of preeclampsia.
+authors:
+- Levine RJ
+- Maynard SE
+- Qian C
+- Lim KH
+- England LJ
+- Yu KF
+- Schisterman EF
+- Thadhani R
+- Sachs BP
+- Epstein FH
+- Sibai BM
+- Sukhatme VP
+- Karumanchi SA
+journal: N Engl J Med
+year: '2004'
+doi: 10.1056/NEJMoa031884
+keywords:
+- Adult
+- Biomarkers/blood
+- Body Mass Index
+- Case-Control Studies
+- Cross-Sectional Studies
+- Female
+- Gestational Age
+- Humans
+- Logistic Models
+- Odds Ratio
+- Placenta Growth Factor
+- "Pre-Eclampsia/blood, diagnosis"
+- Pregnancy/blood
+- Pregnancy Proteins/blood
+- Risk Factors
+- "Statistics, Nonparametric"
+- Vascular Endothelial Growth Factor A/blood
+- Vascular Endothelial Growth Factor Receptor-1/blood
+content_type: abstract_only
+---
+
+# Circulating angiogenic factors and the risk of preeclampsia.
+**Authors:** Levine RJ, Maynard SE, Qian C, Lim KH, England LJ, Yu KF, Schisterman EF, Thadhani R, Sachs BP, Epstein FH, Sibai BM, Sukhatme VP, Karumanchi SA
+**Journal:** N Engl J Med (2004)
+**DOI:** [10.1056/NEJMoa031884](https://doi.org/10.1056/NEJMoa031884)
+
+## Content
+
+1. N Engl J Med. 2004 Feb 12;350(7):672-83. doi: 10.1056/NEJMoa031884. Epub 2004 
+Feb 5.
+
+Circulating angiogenic factors and the risk of preeclampsia.
+
+Levine RJ(1), Maynard SE, Qian C, Lim KH, England LJ, Yu KF, Schisterman EF, 
+Thadhani R, Sachs BP, Epstein FH, Sibai BM, Sukhatme VP, Karumanchi SA.
+
+Author information:
+(1)Division of Epidemiology, Statistics, and Prevention Research, National 
+Institute of Child Health and Human Development, Department of Health and Human 
+Services, Bethesda, MD 20892, USA. levinerj@mail.nih.gov
+
+Comment in
+    N Engl J Med. 2004 Feb 12;350(7):641-2. doi: 10.1056/NEJMp038241.
+    N Engl J Med. 2004 May 6;350(19):2003-4; author reply 2003-4. doi: 
+10.1056/NEJM200405063501918.
+
+BACKGROUND: The cause of preeclampsia remains unclear. Limited data suggest that 
+excess circulating soluble fms-like tyrosine kinase 1 (sFlt-1), which binds 
+placental growth factor (PlGF) and vascular endothelial growth factor (VEGF), 
+may have a pathogenic role.
+METHODS: We performed a nested case-control study within the Calcium for 
+Preeclampsia Prevention trial, which involved healthy nulliparous women. Each 
+woman with preeclampsia was matched to one normotensive control. A total of 120 
+pairs of women were randomly chosen. Serum concentrations of angiogenic factors 
+(total sFlt-1, free PlGF, and free VEGF) were measured throughout pregnancy; 
+there were a total of 655 serum specimens. The data were analyzed 
+cross-sectionally within intervals of gestational age and according to the time 
+before the onset of preeclampsia.
+RESULTS: During the last two months of pregnancy in the normotensive controls, 
+the level of sFlt-1 increased and the level of PlGF decreased. These changes 
+occurred earlier and were more pronounced in the women in whom preeclampsia 
+later developed. The sFlt-1 level increased beginning approximately five weeks 
+before the onset of preeclampsia. At the onset of clinical disease, the mean 
+serum level in the women with preeclampsia was 4382 pg per milliliter, as 
+compared with 1643 pg per milliliter in controls with fetuses of similar 
+gestational age (P<0.001). The PlGF levels were significantly lower in the women 
+who later had preeclampsia than in the controls beginning at 13 to 16 weeks of 
+gestation (mean, 90 pg per milliliter vs. 142 pg per milliliter, P=0.01), with 
+the greatest difference occurring during the weeks before the onset of 
+preeclampsia, coincident with the increase in the sFlt-1 level. Alterations in 
+the levels of sFlt-1 and free PlGF were greater in women with an earlier onset 
+of preeclampsia and in women in whom preeclampsia was associated with a 
+small-for-gestational-age infant.
+CONCLUSIONS: Increased levels of sFlt-1 and reduced levels of PlGF predict the 
+subsequent development of preeclampsia.
+
+Copyright 2004 Massachusetts Medical Society
+
+DOI: 10.1056/NEJMoa031884
+PMID: 14764923 [Indexed for MEDLINE]

--- a/references_cache/PMID_16751767.md
+++ b/references_cache/PMID_16751767.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:16751767"
+title: Soluble endoglin contributes to the pathogenesis of preeclampsia.
+authors:
+- Venkatesha S
+- Toporsian M
+- Lam C
+- Hanai J
+- Mammoto T
+- Kim YM
+- Bdolah Y
+- Lim KH
+- Yuan HT
+- Libermann TA
+- Stillman IE
+- Roberts D
+- "D'Amore PA"
+- Epstein FH
+- Sellke FW
+- Romero R
+- Sukhatme VP
+- Letarte M
+- Karumanchi SA
+journal: Nat Med
+year: '2006'
+doi: 10.1038/nm1429
+keywords:
+- Adult
+- Amino Acid Sequence
+- Animals
+- "Antigens, CD/genetics, metabolism"
+- Endoglin
+- "Endothelial Cells/cytology, metabolism"
+- Female
+- Gestational Age
+- Hemodynamics
+- Humans
+- "Kidney/metabolism, pathology"
+- "Liver/metabolism, pathology"
+- Mice
+- "Mice, Knockout"
+- Middle Aged
+- Molecular Sequence Data
+- Nitric Oxide Synthase Type III/metabolism
+- "Placenta/metabolism, pathology"
+- "Pre-Eclampsia/etiology, metabolism, physiopathology"
+- Pregnancy
+- "Pregnancy, Animal"
+- Rats
+- "Rats, Sprague-Dawley"
+- "Receptors, Cell Surface/genetics, metabolism"
+- Signal Transduction/physiology
+- Transforming Growth Factor beta/metabolism
+- Transforming Growth Factor beta1
+- "Vascular Endothelial Growth Factor Receptor-1/genetics, metabolism"
+content_type: abstract_only
+---
+
+# Soluble endoglin contributes to the pathogenesis of preeclampsia.
+**Authors:** Venkatesha S, Toporsian M, Lam C, Hanai J, Mammoto T, Kim YM, Bdolah Y, Lim KH, Yuan HT, Libermann TA, Stillman IE, Roberts D, D'Amore PA, Epstein FH, Sellke FW, Romero R, Sukhatme VP, Letarte M, Karumanchi SA
+**Journal:** Nat Med (2006)
+**DOI:** [10.1038/nm1429](https://doi.org/10.1038/nm1429)
+
+## Content
+
+1. Nat Med. 2006 Jun;12(6):642-9. doi: 10.1038/nm1429. Epub 2006 Jun 4.
+
+Soluble endoglin contributes to the pathogenesis of preeclampsia.
+
+Venkatesha S(1), Toporsian M, Lam C, Hanai J, Mammoto T, Kim YM, Bdolah Y, Lim 
+KH, Yuan HT, Libermann TA, Stillman IE, Roberts D, D'Amore PA, Epstein FH, 
+Sellke FW, Romero R, Sukhatme VP, Letarte M, Karumanchi SA.
+
+Author information:
+(1)Center for Vascular Biology, Department of Medicine, Beth Israel Deaconess 
+Medical Center and Harvard Medical School, 330 Brookline Avenue, Boston, 
+Massachusetts 02215, USA.
+
+Erratum in
+    Nat Med. 2006 Jul;12(7):862.
+
+Preeclampsia is a pregnancy-specific hypertensive syndrome that causes 
+substantial maternal and fetal morbidity and mortality. Maternal endothelial 
+dysfunction mediated by excess placenta-derived soluble VEGF receptor 1 (sVEGFR1 
+or sFlt1) is emerging as a prominent component in disease pathogenesis. We 
+report a novel placenta-derived soluble TGF-beta coreceptor, endoglin (sEng), 
+which is elevated in the sera of preeclamptic individuals, correlates with 
+disease severity and falls after delivery. sEng inhibits formation of capillary 
+tubes in vitro and induces vascular permeability and hypertension in vivo. Its 
+effects in pregnant rats are amplified by coadministration of sFlt1, leading to 
+severe preeclampsia including the HELLP (hemolysis, elevated liver enzymes, low 
+platelets) syndrome and restriction of fetal growth. sEng impairs binding of 
+TGF-beta1 to its receptors and downstream signaling including effects on 
+activation of eNOS and vasodilation, suggesting that sEng leads to dysregulated 
+TGF-beta signaling in the vasculature. Our results suggest that sEng may act in 
+concert with sFlt1 to induce severe preeclampsia.
+
+DOI: 10.1038/nm1429
+PMID: 16751767 [Indexed for MEDLINE]

--- a/references_cache/PMID_28657417.md
+++ b/references_cache/PMID_28657417.md
@@ -1,0 +1,110 @@
+---
+reference_id: "PMID:28657417"
+title: Aspirin versus Placebo in Pregnancies at High Risk for Preterm Preeclampsia.
+authors:
+- Rolnik DL
+- Wright D
+- Poon LC
+- "O'Gorman N"
+- Syngelaki A
+- de Paco Matallana C
+- Akolekar R
+- Cicero S
+- Janga D
+- Singh M
+- Molina FS
+- Persico N
+- Jani JC
+- Plasencia W
+- Papaioannou G
+- Tenenbaum-Gavish K
+- Meiri H
+- Gizurarson S
+- Maclagan K
+- Nicolaides KH
+journal: N Engl J Med
+year: '2017'
+doi: 10.1056/NEJMoa1704559
+keywords:
+- Adult
+- "Aspirin/adverse effects, therapeutic use"
+- Double-Blind Method
+- Female
+- Humans
+- Incidence
+- "Infant, Newborn"
+- Intention to Treat Analysis
+- Kaplan-Meier Estimate
+- "Pre-Eclampsia/epidemiology, prevention & control"
+- Pregnancy
+- Pregnancy Complications
+- Pregnancy Outcome
+- Risk
+content_type: abstract_only
+---
+
+# Aspirin versus Placebo in Pregnancies at High Risk for Preterm Preeclampsia.
+**Authors:** Rolnik DL, Wright D, Poon LC, O'Gorman N, Syngelaki A, de Paco Matallana C, Akolekar R, Cicero S, Janga D, Singh M, Molina FS, Persico N, Jani JC, Plasencia W, Papaioannou G, Tenenbaum-Gavish K, Meiri H, Gizurarson S, Maclagan K, Nicolaides KH
+**Journal:** N Engl J Med (2017)
+**DOI:** [10.1056/NEJMoa1704559](https://doi.org/10.1056/NEJMoa1704559)
+
+## Content
+
+1. N Engl J Med. 2017 Aug 17;377(7):613-622. doi: 10.1056/NEJMoa1704559. Epub
+2017  Jun 28.
+
+Aspirin versus Placebo in Pregnancies at High Risk for Preterm Preeclampsia.
+
+Rolnik DL(1), Wright D(1), Poon LC(1), O'Gorman N(1), Syngelaki A(1), de Paco 
+Matallana C(1), Akolekar R(1), Cicero S(1), Janga D(1), Singh M(1), Molina 
+FS(1), Persico N(1), Jani JC(1), Plasencia W(1), Papaioannou G(1), 
+Tenenbaum-Gavish K(1), Meiri H(1), Gizurarson S(1), Maclagan K(1), Nicolaides 
+KH(1).
+
+Author information:
+(1)From King's College Hospital (D.L.R., L.C.P., N.O., A.S., R.A., K.H.N.), 
+Homerton University Hospital (S.C.), North Middlesex University Hospital (D.J.), 
+and University College London Comprehensive Clinical Trials Unit (K.M.), London, 
+University of Exeter, Exeter (D.W.), Medway Maritime Hospital, Gillingham 
+(R.A.), and Southend University Hospital, Westcliff-on-Sea (M.S.) - all in the 
+United Kingdom; Chinese University of Hong Kong, Hong Kong (L.C.P.); Hospital 
+Clínico Universitario Virgen de la Arrixaca, Murcia (C.P.M.), Hospital 
+Universitario San Cecilio, Granada (F.S.M.), and Hospiten Group, Tenerife (W.P.) 
+- all in Spain; Ospedale Maggiore Policlinico, Milan (N.P.); University Hospital 
+Brugmann, Université Libre de Bruxelles, Brussels (J.C.J.); Attikon University 
+Hospital, Athens (G.P.); Rabin Medical Center, Petach Tikva (K.T.-G.), and 
+HyLabs Diagnostics, Rehovot (H.M.) - both in Israel; and University of Iceland, 
+Reykjavik (S.G.).
+
+Comment in
+    N Engl J Med. 2017 Aug 17;377(7):690-691. doi: 10.1056/NEJMe1708920.
+    N Engl J Med. 2017 Dec 14;377(24):2399-400. doi: 10.1056/NEJMc1713798.
+    Natl Med J India. 2018 Jan-Feb;31(1):26-27. doi: 10.4103/0970-258X.243410.
+
+BACKGROUND: Preterm preeclampsia is an important cause of maternal and perinatal 
+death and complications. It is uncertain whether the intake of low-dose aspirin 
+during pregnancy reduces the risk of preterm preeclampsia.
+METHODS: In this multicenter, double-blind, placebo-controlled trial, we 
+randomly assigned 1776 women with singleton pregnancies who were at high risk 
+for preterm preeclampsia to receive aspirin, at a dose of 150 mg per day, or 
+placebo from 11 to 14 weeks of gestation until 36 weeks of gestation. The 
+primary outcome was delivery with preeclampsia before 37 weeks of gestation. The 
+analysis was performed according to the intention-to-treat principle.
+RESULTS: A total of 152 women withdrew consent during the trial, and 4 were lost 
+to follow up, which left 798 participants in the aspirin group and 822 in the 
+placebo group. Preterm preeclampsia occurred in 13 participants (1.6%) in the 
+aspirin group, as compared with 35 (4.3%) in the placebo group (odds ratio in 
+the aspirin group, 0.38; 95% confidence interval, 0.20 to 0.74; P=0.004). 
+Results were materially unchanged in a sensitivity analysis that took into 
+account participants who had withdrawn or were lost to follow-up. Adherence was 
+good, with a reported intake of 85% or more of the required number of tablets in 
+79.9% of the participants. There were no significant between-group differences 
+in the incidence of neonatal adverse outcomes or other adverse events.
+CONCLUSIONS: Treatment with low-dose aspirin in women at high risk for preterm 
+preeclampsia resulted in a lower incidence of this diagnosis than placebo. 
+(Funded by the European Union Seventh Framework Program and the Fetal Medicine 
+Foundation; EudraCT number, 2013-003778-29 ; Current Controlled Trials number, 
+ISRCTN13633058 .).
+
+DOI: 10.1056/NEJMoa1704559
+PMID: 28657417 [Indexed for MEDLINE]

--- a/references_cache/PMID_28784417.md
+++ b/references_cache/PMID_28784417.md
@@ -1,0 +1,157 @@
+---
+reference_id: "PMID:28784417"
+title: "Aspirin for Evidence-Based Preeclampsia Prevention trial: effect of aspirin in prevention of preterm preeclampsia in subgroups of women according to their characteristics and medical and obstetrical history."
+authors:
+- Poon LC
+- Wright D
+- Rolnik DL
+- Syngelaki A
+- Delgado JL
+- Tsokaki T
+- Leipold G
+- Akolekar R
+- Shearing S
+- De Stefani L
+- Jani JC
+- Plasencia W
+- Evangelinakis N
+- Gonzalez-Vanegas O
+- Persico N
+- Nicolaides KH
+journal: Am J Obstet Gynecol
+year: '2017'
+doi: 10.1016/j.ajog.2017.07.038
+keywords:
+- Adult
+- Algorithms
+- Aspirin/therapeutic use
+- Body Mass Index
+- Evidence-Based Medicine
+- Female
+- Gestational Age
+- Humans
+- Hypertension/epidemiology
+- Incidence
+- Logistic Models
+- Maternal Age
+- Medical History Taking
+- Odds Ratio
+- Overweight/epidemiology
+- Platelet Aggregation Inhibitors/therapeutic use
+- "Pre-Eclampsia/prevention & control"
+- Pregnancy
+- Pregnancy Complications/epidemiology
+- "Pregnancy Complications, Cardiovascular/epidemiology"
+- "Pregnancy Trimester, First"
+- Premature Birth
+- Reproductive History
+- "Reproductive Techniques, Assisted/statistics & numerical data"
+- Risk Assessment
+- Smoking/epidemiology
+content_type: abstract_only
+---
+
+# Aspirin for Evidence-Based Preeclampsia Prevention trial: effect of aspirin in prevention of preterm preeclampsia in subgroups of women according to their characteristics and medical and obstetrical history.
+**Authors:** Poon LC, Wright D, Rolnik DL, Syngelaki A, Delgado JL, Tsokaki T, Leipold G, Akolekar R, Shearing S, De Stefani L, Jani JC, Plasencia W, Evangelinakis N, Gonzalez-Vanegas O, Persico N, Nicolaides KH
+**Journal:** Am J Obstet Gynecol (2017)
+**DOI:** [10.1016/j.ajog.2017.07.038](https://doi.org/10.1016/j.ajog.2017.07.038)
+
+## Content
+
+1. Am J Obstet Gynecol. 2017 Nov;217(5):585.e1-585.e5. doi: 
+10.1016/j.ajog.2017.07.038. Epub 2017 Aug 4.
+
+Aspirin for Evidence-Based Preeclampsia Prevention trial: effect of aspirin in 
+prevention of preterm preeclampsia in subgroups of women according to their 
+characteristics and medical and obstetrical history.
+
+Poon LC(1), Wright D(2), Rolnik DL(3), Syngelaki A(3), Delgado JL(4), Tsokaki 
+T(5), Leipold G(6), Akolekar R(7), Shearing S(8), De Stefani L(9), Jani JC(10), 
+Plasencia W(11), Evangelinakis N(12), Gonzalez-Vanegas O(13), Persico N(14), 
+Nicolaides KH(15).
+
+Author information:
+(1)King's College Hospital, London, United Kingdom; Chinese University of Hong 
+Kong, Hong Kong.
+(2)University of Exeter, Exeter, United Kingdom.
+(3)King's College Hospital, London, United Kingdom.
+(4)Hospital Clínico Universitario Virgen de la Arrixaca, Murcia, Spain.
+(5)King's College Hospital, London, United Kingdom; North Middlesex University 
+Hospital, London, United Kingdom.
+(6)King's College Hospital, London, United Kingdom; Lewisham University 
+Hospital, London, United Kingdom.
+(7)King's College Hospital, London, United Kingdom; Medway Maritime Hospital, 
+Gillingham, United Kingdom.
+(8)Southend University Hospital, Essex, United Kingdom.
+(9)King's College Hospital, London, United Kingdom; Homerton University 
+Hospital, London, United Kingdom.
+(10)University Hospital Brugmann, Université Libre de Bruxelles, Brussels, 
+Belgium.
+(11)Hospiten Group, Tenerife, Canary Islands, Spain.
+(12)Attikon University Hospital, Athens, Greece.
+(13)Hospital Universitario San Cecilio, Granada, Spain.
+(14)Ospedale Maggiore Policlinico, Milan, Italy.
+(15)King's College Hospital, London, United Kingdom. Electronic address: 
+kypros@fetalmedicine.com.
+
+Erratum in
+    Am J Obstet Gynecol. 2018 Apr;218(4):454. doi: 10.1016/j.ajog.2018.01.002.
+
+Comment in
+    Am J Obstet Gynecol. 2018 Apr;218(4):464-465. doi: 
+10.1016/j.ajog.2018.01.019.
+    Am J Obstet Gynecol. 2018 Apr;218(4):463-464. doi: 
+10.1016/j.ajog.2018.01.020.
+
+BACKGROUND: The Combined Multimarker Screening and Randomized Patient Treatment 
+with Aspirin for Evidence-Based Preeclampsia Prevention trial demonstrated that 
+in women who were at high risk for preterm preeclampsia with delivery at <37 
+weeks' gestation identified by screening by means of an algorithm that combines 
+maternal factors and biomarkers at 11-13 weeks' gestation, aspirin 
+administration from 11 to 14 until 36 weeks' gestation was associated with a 
+significant reduction in the incidence of preterm preeclampsia (odds ratio 0.38; 
+95% confidence interval, 0.20 to 0.74; P=0.004).
+OBJECTIVE: We sought to examine whether there are differences in the effect of 
+aspirin on the incidence of preterm preeclampsia in the Aspirin for 
+Evidence-Based Preeclampsia Prevention trial in subgroups defined according to 
+maternal characteristics and medical and obstetrical history.
+STUDY DESIGN: This was a secondary analysis of data from the Aspirin for 
+Evidence-Based Preeclampsia Prevention trial. Subgroup analysis was performed to 
+assess evidence of differences in the effect of aspirin on incidence of preterm 
+preeclampsia in subgroups defined by maternal age (<30 and ≥30 years), body mass 
+index (<25 and ≥25 kg/m2), racial origin (Afro-Caribbean, Caucasian and other), 
+method of conception (natural and assisted), cigarette smoking (smoker and 
+non-smoker), family history of preterm preeclampsia (present and absent), 
+obstetrical history (nulliparous, multiparous with previous preterm preeclampsia 
+and multiparous without previous preterm preeclampsia), history of chronic 
+hypertension (present and absent). Interaction tests were performed on the full 
+data set of patients in the intention to treat population and on the data set of 
+patients who took ≥ 90% of the prescribed medication. Results are presented as 
+forest plot with P values for the interaction effects, group sizes, event counts 
+and estimated odds ratios. We examined whether the test of interaction was 
+significant at the 5% level with a Bonferroni adjustment for multiple 
+comparisons.
+RESULTS: There was no evidence of heterogeneity in the aspirin effect in 
+subgroups defined according to maternal characteristics and obstetrical history. 
+In participants with chronic hypertension preterm preeclampsia occurred in 10.2% 
+(5/49) in the aspirin group and 8.2% (5/61) in the placebo group (adjusted odds 
+ratio, 1.29; 95% confidence interval, 0.33-5.12). The respective values in those 
+without chronic hypertension were 1.1% (8/749) in the aspirin group and 3.9% 
+(30/761) in the placebo group (adjusted odds ratio, 0.27; 95% confidence 
+interval, 0.12-0.60). In all participants with adherence of ≥90% the adjusted 
+odds ratio in the aspirin group was 0.24 (95% confidence interval, 0.09-0.65); 
+in the subgroup with chronic hypertension it was 2.06 (95% confidence interval, 
+0.40-10.71); and in those without chronic hypertension it was 0.05 (95% 
+confidence interval, 0.01-0.41). For the complete data set the test of 
+interaction was not significant at the 5% level (P = .055), but in those with 
+adherence ≥90%, after adjustment for multiple comparisons, the interaction was 
+significant at the 5% level (P = .0019).
+CONCLUSION: The beneficial effect of aspirin in the prevention of preterm 
+preeclampsia may not apply in pregnancies with chronic hypertension. There was 
+no evidence of heterogeneity in the aspirin effect in subgroups defined 
+according to maternal characteristics and obstetrical history.
+
+Copyright © 2017 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.ajog.2017.07.038
+PMID: 28784417 [Indexed for MEDLINE]

--- a/references_cache/PMID_30792480.md
+++ b/references_cache/PMID_30792480.md
@@ -1,0 +1,73 @@
+---
+reference_id: "PMID:30792480"
+title: "Pre-eclampsia: pathogenesis, novel diagnostics and therapies."
+authors:
+- Phipps EA
+- Thadhani R
+- Benzing T
+- Karumanchi SA
+journal: Nat Rev Nephrol
+year: '2019'
+doi: 10.1038/s41581-019-0119-6
+keywords:
+- Angiogenesis Inhibitors/metabolism
+- Biomarkers/metabolism
+- Female
+- Humans
+- Placenta/metabolism
+- "Pre-Eclampsia/diagnosis, etiology, metabolism, therapy"
+- Pregnancy
+- Risk Factors
+content_type: abstract_only
+---
+
+# Pre-eclampsia: pathogenesis, novel diagnostics and therapies.
+**Authors:** Phipps EA, Thadhani R, Benzing T, Karumanchi SA
+**Journal:** Nat Rev Nephrol (2019)
+**DOI:** [10.1038/s41581-019-0119-6](https://doi.org/10.1038/s41581-019-0119-6)
+
+## Content
+
+1. Nat Rev Nephrol. 2019 May;15(5):275-289. doi: 10.1038/s41581-019-0119-6.
+
+Pre-eclampsia: pathogenesis, novel diagnostics and therapies.
+
+Phipps EA(1)(2), Thadhani R(2)(3), Benzing T(4), Karumanchi SA(5)(6).
+
+Author information:
+(1)Nephrology Division, Brigham and Women's Hospital, Boston, MA, USA.
+(2)Nephrology Division, Massachusetts General Hospital, Boston, MA, USA.
+(3)Departments of Medicine and Biomedical Sciences, Cedars-Sinai Medical Center, 
+Los Angeles, CA, USA.
+(4)Department II of Internal Medicine and Center for Molecular Medicine Cologne, 
+University of Cologne, Cologne, Germany.
+(5)Departments of Medicine and Biomedical Sciences, Cedars-Sinai Medical Center, 
+Los Angeles, CA, USA. SAnanth.Karumanchi@csmc.edu.
+(6)Nephrology Division, Departments of Medicine, Obstetrics and Gynecology, Beth 
+Israel Deaconess Medical Center, Boston, MA, USA. SAnanth.Karumanchi@csmc.edu.
+
+Erratum in
+    Nat Rev Nephrol. 2019 Jun;15(6):386. doi: 10.1038/s41581-019-0156-1.
+
+Pre-eclampsia is a complication of pregnancy that is associated with substantial 
+maternal and fetal morbidity and mortality. The disease presents with new-onset 
+hypertension and often proteinuria in the mother, which can progress to 
+multi-organ dysfunction, including hepatic, renal and cerebral disease, if the 
+fetus and placenta are not delivered. Maternal endothelial dysfunction due to 
+circulating factors of fetal origin from the placenta is a hallmark of 
+pre-eclampsia. Risk factors for the disease include maternal comorbidities, such 
+as chronic kidney disease, hypertension and obesity; a family history of 
+pre-eclampsia, nulliparity or multiple pregnancies; and previous pre-eclampsia 
+or intrauterine fetal growth restriction. In the past decade, the discovery and 
+characterization of novel antiangiogenic pathways have been particularly 
+impactful both in increasing understanding of the disease pathophysiology and in 
+directing predictive and therapeutic efforts. In this Review, we discuss the 
+pathogenic role of antiangiogenic proteins released by the placenta in the 
+development of pre-eclampsia and review novel therapeutic strategies directed at 
+restoring the angiogenic imbalance observed during pre-eclampsia. We also 
+highlight other notable advances in the field, including the identification of 
+long-term maternal and fetal risks conferred by pre-eclampsia.
+
+DOI: 10.1038/s41581-019-0119-6
+PMCID: PMC6472952
+PMID: 30792480 [Indexed for MEDLINE]

--- a/references_cache/PMID_32443079.md
+++ b/references_cache/PMID_32443079.md
@@ -1,0 +1,51 @@
+---
+reference_id: "PMID:32443079"
+title: "Gestational Hypertension and Preeclampsia: ACOG Practice Bulletin, Number 222."
+journal: Obstet Gynecol
+year: '2020'
+doi: 10.1097/AOG.0000000000003891
+keywords:
+- Female
+- Humans
+- "Hypertension, Pregnancy-Induced/diagnosis, prevention & control"
+- Obstetrics
+- Perinatal Care
+- "Pre-Eclampsia/diagnosis, prevention & control"
+- Pregnancy
+- Prenatal Diagnosis
+- "Societies, Medical"
+- United States
+content_type: abstract_only
+---
+
+# Gestational Hypertension and Preeclampsia: ACOG Practice Bulletin, Number 222.
+**Journal:** Obstet Gynecol (2020)
+**DOI:** [10.1097/AOG.0000000000003891](https://doi.org/10.1097/AOG.0000000000003891)
+
+## Content
+
+1. Obstet Gynecol. 2020 Jun;135(6):e237-e260. doi: 10.1097/AOG.0000000000003891.
+
+Gestational Hypertension and Preeclampsia: ACOG Practice Bulletin, Number 222.
+
+[No authors listed]
+
+Hypertensive disorders of pregnancy constitute one of the leading causes of 
+maternal and perinatal mortality worldwide. It has been estimated that 
+preeclampsia complicates 2-8% of pregnancies globally (). In Latin America and 
+the Caribbean, hypertensive disorders are responsible for almost 26% of maternal 
+deaths, whereas in Africa and Asia they contribute to 9% of deaths. Although 
+maternal mortality is much lower in high-income countries than in developing 
+countries, 16% of maternal deaths can be attributed to hypertensive disorders 
+(). In the United States, the rate of preeclampsia increased by 25% between 1987 
+and 2004 (). Moreover, in comparison with women giving birth in 1980, those 
+giving birth in 2003 were at 6.7-fold increased risk of severe preeclampsia (). 
+This complication is costly: one study reported that in 2012 in the United 
+States, the estimated cost of preeclampsia within the first 12 months of 
+delivery was $2.18 billion ($1.03 billion for women and $1.15 billion for 
+infants), which was disproportionately borne by premature births (). This 
+Practice Bulletin will provide guidelines for the diagnosis and management of 
+gestational hypertension and preeclampsia.
+
+DOI: 10.1097/AOG.0000000000003891
+PMID: 32443079 [Indexed for MEDLINE]

--- a/references_cache/PMID_34033373.md
+++ b/references_cache/PMID_34033373.md
@@ -1,0 +1,71 @@
+---
+reference_id: "PMID:34033373"
+title: Preeclampsia.
+authors:
+- Karrar SA
+- Martingano DJ
+- Hong PL
+year: '2026'
+content_type: abstract_only
+---
+
+# Preeclampsia.
+**Authors:** Karrar SA, Martingano DJ, Hong PL
+
+## Content
+
+1. Preeclampsia.
+
+Karrar SA(1), Martingano DJ(2), Hong PL(1).
+
+In: StatPearls [Internet]. Treasure Island (FL): StatPearls Publishing; 2026 
+Jan–.
+2024 Feb 25.
+
+Author information:
+(1)Nassau University Medical Center
+(2)William Carey University; Rutgers University; Episcopal Health Services Inc.
+
+Hypertensive disorders of pregnancy constitute a leading cause of maternal and 
+perinatal mortality worldwide. Preeclampsia, with or without severe features, is 
+a disorder of pregnancy associated with new-onset hypertension, usually with 
+accompanying proteinuria, which occurs most often after 20 weeks of gestation 
+and frequently near term. This disease represents a spectrum of hypertensive 
+disease in pregnancy, beginning with gestational hypertension and progressing to 
+develop severe features, ultimately leading to its more severe manifestations, 
+such as eclampsia and HELLP syndrome. This disease encompasses 2% to 8% of 
+pregnancy-related complications, more than 50,000 maternal deaths, and over 
+500,000 fetal deaths worldwide. Early diagnosis and prompt management are 
+essential to preventing both maternal and neonatal complications through 
+symptomatic management and delivery planning. The parameters for initial 
+identification of hypertension in the context of pregnancy-induced hypertension 
+constituting the "mild range" are specifically defined as a systolic blood 
+pressure (SBP) of 140 mm Hg or more or diastolic blood pressure (DBP) of 90 mm 
+Hg or more on 2 occasions at least 4 hours apart; or shorter interval timing in 
+cases of "severe range" hypertension with SBP of 160 mm Hg or more or DBP of 110 
+mm Hg or more, all of which must be identified after 20 weeks of gestation. Such 
+criteria identified before 20 weeks of gestation would be defined as 
+pre-existing essential hypertension or "chronic hypertension." The initial 
+presentation of preeclampsia typically arises in near-term pregnancies. The 
+progression of pregnancy-induced hypertension (PIH) is presently understood to 
+first begin with gestational hypertension, where there is new-onset 
+hypertension, and then followed by more severe forms of hypertension with 
+specific laboratory and clinical criteria to be discussed further. It is 
+important to acknowledge, however, that the understanding of the pathophysiology 
+of PIH has improved, and its diagnostic criteria have evolved, resulting in the 
+classical triad of hypertension, edema, and proteinuria transitioning to 
+hypertension and organ dysfunction (ie, renal, hepatic, neurologic, 
+hematological, or uteroplacental.) Nonetheless, the most recent definitions 
+endorsed by governing bodies such as the American College of Obstetrics and 
+Gynecology (ACOG) have largely been based on consensus and expert opinion, not 
+primary research.
+
+Copyright © 2026, StatPearls Publishing LLC.
+
+PMID: 34033373
+
+Conflict of interest statement: Disclosure: Shahd Karrar declares no relevant 
+financial relationships with ineligible companies. Disclosure: Daniel Martingano 
+declares no relevant financial relationships with ineligible companies. 
+Disclosure: Peter Hong declares no relevant financial relationships with 
+ineligible companies.

--- a/references_cache/PMID_35177220.md
+++ b/references_cache/PMID_35177220.md
@@ -1,0 +1,129 @@
+---
+reference_id: "PMID:35177220"
+title: "Preeclampsia and eclampsia: the conceptual evolution of a syndrome."
+authors:
+- Erez O
+- Romero R
+- Jung E
+- Chaemsaithong P
+- Bosco M
+- Suksai M
+- Gallo DM
+- Gotsch F
+journal: Am J Obstet Gynecol
+year: '2022'
+doi: 10.1016/j.ajog.2021.12.001
+keywords:
+- Albuminuria/complications
+- Eclampsia
+- Edema/complications
+- Female
+- Fetal Mortality
+- Gene-Environment Interaction
+- HELLP Syndrome
+- "History, 19th Century"
+- "History, Ancient"
+- Humans
+- Placenta/metabolism
+- Placenta Growth Factor/metabolism
+- Pre-Eclampsia
+- Pregnancy
+- Proteinuria/complications
+- Puerperal Disorders
+- Seizures/complications
+- Severity of Illness Index
+- Terminology as Topic
+- Vascular Endothelial Growth Factor Receptor-1/metabolism
+content_type: abstract_only
+---
+
+# Preeclampsia and eclampsia: the conceptual evolution of a syndrome.
+**Authors:** Erez O, Romero R, Jung E, Chaemsaithong P, Bosco M, Suksai M, Gallo DM, Gotsch F
+**Journal:** Am J Obstet Gynecol (2022)
+**DOI:** [10.1016/j.ajog.2021.12.001](https://doi.org/10.1016/j.ajog.2021.12.001)
+
+## Content
+
+1. Am J Obstet Gynecol. 2022 Feb;226(2S):S786-S803. doi: 
+10.1016/j.ajog.2021.12.001.
+
+Preeclampsia and eclampsia: the conceptual evolution of a syndrome.
+
+Erez O(1), Romero R(2), Jung E(3), Chaemsaithong P(4), Bosco M(3), Suksai M(3), 
+Gallo DM(3), Gotsch F(3).
+
+Author information:
+(1)Perinatology Research Branch, Division of Obstetrics and Maternal-Fetal 
+Medicine, Division of Intramural Research, Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, National Institutes of Health, 
+United States Department of Health and Human Services, Bethesda, MD, and 
+Detroit, MI; Department of Obstetrics and Gynecology, Wayne State University 
+School of Medicine, Detroit, MI; Department of Obstetrics and Gynecology, HaEmek 
+Medical Center, Afula, Israel.
+(2)Perinatology Research Branch, Division of Obstetrics and Maternal-Fetal 
+Medicine, Division of Intramural Research, Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, National Institutes of Health, 
+United States Department of Health and Human Services, Bethesda, MD, and 
+Detroit, MI; Department of Obstetrics and Gynecology, University of Michigan, 
+Ann Arbor, MI; Department of Epidemiology and Biostatistics, Michigan State 
+University, East Lansing, MI; Center for Molecular Medicine and Genetics, Wayne 
+State University, Detroit, MI; Detroit Medical Center, Detroit, MI. Electronic 
+address: prbchiefstaff@med.wayne.edu.
+(3)Perinatology Research Branch, Division of Obstetrics and Maternal-Fetal 
+Medicine, Division of Intramural Research, Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, National Institutes of Health, 
+United States Department of Health and Human Services, Bethesda, MD, and 
+Detroit, MI; Department of Obstetrics and Gynecology, Wayne State University 
+School of Medicine, Detroit, MI.
+(4)Perinatology Research Branch, Division of Obstetrics and Maternal-Fetal 
+Medicine, Division of Intramural Research, Eunice Kennedy Shriver National 
+Institute of Child Health and Human Development, National Institutes of Health, 
+United States Department of Health and Human Services, Bethesda, MD, and 
+Detroit, MI; Department of Obstetrics and Gynecology, Wayne State University 
+School of Medicine, Detroit, MI; Faculty of Medicine, Department of Obstetrics 
+and Gynecology, Ramathibodi Hospital, Mahidol University, Bangkok, Thailand.
+
+Preeclampsia, one of the most enigmatic complications of pregnancy, is 
+considered a pregnancy-specific disorder caused by the placenta and cured only 
+by delivery. This article traces the condition from its origins-once thought to 
+be a disease of the central nervous system, recognized by the occurrence of 
+seizures (ie, eclampsia)-to the present time when preeclampsia is conceptualized 
+primarily as a vascular disorder. We review the epidemiologic data that led to 
+the recommendation to use diastolic hypertension and proteinuria as diagnostic 
+criteria, as their combined presence was associated with an increased risk of 
+fetal death and the birth of small-for-gestational-age neonates. However, 
+preeclampsia is a multisystemic disorder with protean manifestations, and the 
+condition can be present even in the absence of hypertension and proteinuria. 
+Toxins gaining access to the maternal circulation have been proposed to mediate 
+the clinical manifestations-hence, the term "toxemia of pregnancy," which was 
+used for several decades. The search for putative toxins has challenged 
+investigators for more than a century, and a growing body of evidence suggests 
+that products of an ischemic or a stressed placenta are responsible for the 
+vascular changes that characterize this syndrome. The discovery that the 
+placenta can produce antiangiogenic factors, which regulate endothelial cell 
+function and induce intravascular inflammation, has been a major step forward in 
+the understanding of preeclampsia. We view the release of antiangiogenic factors 
+by the placenta as an adaptive response to improve uterine perfusion by 
+modulating endothelial function and maternal cardiovascular performance. 
+However, this homeostatic response can become maladaptive and lead to damage of 
+target organs during pregnancy or the postpartum period. Early-onset 
+preeclampsia has many features in common with atherosclerosis, whereas 
+late-onset preeclampsia seems to result from a mismatch of fetal demands and 
+maternal supply, that is, a metabolic crisis. Preeclampsia, as it is understood 
+today, is essentially vascular dysfunction unmasked or caused by pregnancy. A 
+subset of patients diagnosed with preeclampsia are at greater risk of the 
+subsequent development of hypertension, ischemic heart disease, heart failure, 
+vascular dementia, and end-stage renal disease. However, these adverse events 
+may be the result of a preexisting vascular pathologic process; it is not known 
+if the occurrence of preeclampsia increases the baseline risk. Therefore, the 
+understanding, prediction, prevention, and treatment of preeclampsia are 
+healthcare priorities.
+
+Copyright © 2021. Published by Elsevier Inc.
+
+DOI: 10.1016/j.ajog.2021.12.001
+PMCID: PMC8941666
+PMID: 35177220 [Indexed for MEDLINE]
+
+Conflict of interest statement: Disclosure: The authors declare no conflicts of 
+interest.

--- a/references_cache/PMID_39062815.md
+++ b/references_cache/PMID_39062815.md
@@ -1,0 +1,89 @@
+---
+reference_id: "PMID:39062815"
+title: A Narrative Review on the Pathophysiology of Preeclampsia.
+authors:
+- Torres-Torres J
+- Espino-Y-Sosa S
+- Martinez-Portilla R
+- Borboa-Olivares H
+- Estrada-Gutierrez G
+- Acevedo-Gallegos S
+- Ruiz-Ramirez E
+- Velasco-Espin M
+- Cerda-Flores P
+- Ramirez-Gonzalez A
+- Rojas-Zepeda L
+journal: Int J Mol Sci
+year: '2024'
+doi: 10.3390/ijms25147569
+keywords:
+- Humans
+- "Pre-Eclampsia/physiopathology, metabolism"
+- Pregnancy
+- Female
+- Oxidative Stress
+- "Epigenesis, Genetic"
+- Inflammation/metabolism
+- Biomarkers
+- "Placenta/metabolism, physiopathology"
+- "Vascular Endothelial Growth Factor Receptor-1/metabolism, genetics"
+content_type: abstract_only
+---
+
+# A Narrative Review on the Pathophysiology of Preeclampsia.
+**Authors:** Torres-Torres J, Espino-Y-Sosa S, Martinez-Portilla R, Borboa-Olivares H, Estrada-Gutierrez G, Acevedo-Gallegos S, Ruiz-Ramirez E, Velasco-Espin M, Cerda-Flores P, Ramirez-Gonzalez A, Rojas-Zepeda L
+**Journal:** Int J Mol Sci (2024)
+**DOI:** [10.3390/ijms25147569](https://doi.org/10.3390/ijms25147569)
+
+## Content
+
+1. Int J Mol Sci. 2024 Jul 10;25(14):7569. doi: 10.3390/ijms25147569.
+
+A Narrative Review on the Pathophysiology of Preeclampsia.
+
+Torres-Torres J(1)(2), Espino-Y-Sosa S(1), Martinez-Portilla R(1), 
+Borboa-Olivares H(1), Estrada-Gutierrez G(1), Acevedo-Gallegos S(1), 
+Ruiz-Ramirez E(2), Velasco-Espin M(2), Cerda-Flores P(2), Ramirez-Gonzalez A(2), 
+Rojas-Zepeda L(3).
+
+Author information:
+(1)Clinical Research Branch, Instituto Nacional de Perinatología Isidro Espinosa 
+de los Reyes, Mexico City 11000, Mexico.
+(2)Obstetric and Gynecology Department, Hospital General de México Dr. Eduardo 
+Liceaga, Mexico City 06720, Mexico.
+(3)Maternal-Fetal Medicine Department, Instituto Materno Infantil del Estado de 
+Mexico, Toluca 50170, Mexico.
+
+Preeclampsia (PE) is a multifactorial pregnancy disorder characterized by 
+hypertension and proteinuria, posing significant risks to both maternal and 
+fetal health. Despite extensive research, its complex pathophysiology remains 
+incompletely understood. This narrative review aims to elucidate the intricate 
+mechanisms contributing to PE, focusing on abnormal placentation, maternal 
+systemic response, oxidative stress, inflammation, and genetic and epigenetic 
+factors. This review synthesizes findings from recent studies, clinical trials, 
+and meta-analyses, highlighting key molecular and cellular pathways involved in 
+PE. The review integrates data on oxidative stress biomarkers, angiogenic 
+factors, immune interactions, and mitochondrial dysfunction. PE is initiated by 
+poor placentation due to inadequate trophoblast invasion and improper spiral 
+artery remodeling, leading to placental hypoxia. This triggers the release of 
+anti-angiogenic factors such as soluble fms-like tyrosine kinase-1 (sFlt-1) and 
+soluble endoglin (sEng), causing widespread endothelial dysfunction and systemic 
+inflammation. Oxidative stress, mitochondrial abnormalities, and immune 
+dysregulation further exacerbate the condition. Genetic and epigenetic 
+modifications, including polymorphisms in the Fms-like tyrosine kinase 1 (FLT1) 
+gene and altered microRNA (miRNA) expression, play critical roles. Emerging 
+therapeutic strategies targeting oxidative stress, inflammation, angiogenesis, 
+and specific molecular pathways like the heme oxygenase-1/carbon monoxide 
+(HO-1/CO) and cystathionine gamma-lyase/hydrogen sulfide (CSE/H2S) pathways show 
+promise in mitigating preeclampsia's effects. PE is a complex disorder with 
+multifactorial origins involving abnormal placentation, endothelial dysfunction, 
+systemic inflammation, and oxidative stress. Despite advances in understanding 
+its pathophysiology, effective prevention and treatment strategies remain 
+limited. Continued research is essential to develop targeted therapies that can 
+improve outcomes for both mothers and their babies.
+
+DOI: 10.3390/ijms25147569
+PMCID: PMC11277207
+PMID: 39062815 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflicts of interest.

--- a/references_cache/PMID_39247143.md
+++ b/references_cache/PMID_39247143.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:39247143"
+title: "A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial."
+authors:
+- Kaur T
+- Kumari K
+- Rai P
+- Gupta V
+- Pandey S
+- Vineeta
+- Saini S
+journal: Int J MCH AIDS
+year: '2024'
+doi: 10.25259/IJMA_660
+content_type: abstract_only
+---
+
+# A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a Hospital-based Randomized Control Trial.
+**Authors:** Kaur T, Kumari K, Rai P, Gupta V, Pandey S, Vineeta, Saini S
+**Journal:** Int J MCH AIDS (2024)
+**DOI:** [10.25259/IJMA_660](https://doi.org/10.25259/IJMA_660)
+
+## Content
+
+1. Int J MCH AIDS. 2024 May 31;13:e011. doi: 10.25259/IJMA_660. eCollection 2024.
+
+A Comparative Study of Oral Nifedipine and Intravenous Labetalol for Acute 
+Hypertensive Management in Pregnancy: Assessing Feto-Maternal Outcomes in a 
+Hospital-based Randomized Control Trial.
+
+Kaur T(1), Kumari K(1), Rai P(2), Gupta V(3), Pandey S(1), Vineeta(2), Saini 
+S(1).
+
+Author information:
+(1)Department of Obstetrics and Gynecology, Uttar Pradesh University of Medical 
+Sciences, Saifai, Etawah, India.
+(2)Department of Obstetrics and Gynecology, All India Institute of Medical 
+Sciences, Deoghar, India.
+(3)Department of Obstetrics and Gynecology, Rajarshi Dashrath Autonomous State 
+Medical College, Ayodhya, India.
+
+BACKGROUND AND OBJECTIVE: Hypertension is one of the most common medical 
+complications during pregnancy and a leading cause of maternal mortality and 
+morbidity. Severe preeclampsia is defined as blood pressure (BP) >160/110 mmHg 
+with warning signs such as headache, blurring of vision, and epigastric pain. 
+Nifedipine (C17H18N2O6), labetalol (C19H24N2O3), and hydralazine (C8H8N4) are 
+commonly used drugs, and all are recommended as first-line agents. Hydralazine 
+is associated with a higher incidence of adverse outcomes, so oral nifedipine 
+has been proposed as a first-line alternative to intravenous labetalol. 
+Consequently, this study aims to compare the efficacy and safety of oral 
+nifedipine with that of intravenous labetalol. The objective is to compare the 
+ability/effectiveness of oral nifedipine and intravenous labetalol to normalize 
+acute hypertension in severe preeclampsia and to assess the birth outcome. 
+Relations between different factors were established by appropriate statistical 
+tests. The p-value <0.05 was considered statistically significant.
+METHODS: The study was conducted on 120 antenatal women with blood pressure 
+≥160/110 mmHg admitted to our hospital, a tertiary care center, from January 
+1st, 2020 to June 30th, 2021. Patients were randomized by a single blinding 
+method to receive intravenous labetalol and oral nifedipine. The primary outcome 
+measures were the time taken to control the blood pressure and the number of 
+doses of drugs required. The secondary outcome measures were the birth outcome 
+like a method of delivery, side effect profile, and the number of admissions in 
+the neonatal intensive care unit.
+RESULTS: A total of 120 patients were included with 60 patients in each group. 
+The labetalol group took 48.67 ± 17.80 minutes and the nifedipine group took 
+64.33 ± 9.81 minutes to achieve a target BP of <=140/90 mmHg (p < 0.05). No side 
+effects were seen in 70% of patients in the labetalol group and 71.67% in the 
+nifedipine group (p > 0.05).
+CONCLUSION AND GLOBAL HEALTH IMPLICATIONS: Intravenous labetalol is faster in 
+restoring blood pressure in pregnant women with preeclampsia than oral 
+nifedipine and may be used as a first-line drug in the acute control of blood 
+pressure in a hypertensive emergency during pregnancy. More studies are needed 
+in order to evaluate the findings from this pilot study in a large sample of 
+patients.
+
+© 2024 The Authors. Published by Global Health and Education Projects, Inc., 
+USA.
+
+DOI: 10.25259/IJMA_660
+PMCID: PMC11380905
+PMID: 39247143
+
+Conflict of interest statement: There are no conflicts of interest.

--- a/research/Preeclampsia-deep-research-github-bot.md
+++ b/research/Preeclampsia-deep-research-github-bot.md
@@ -1,0 +1,198 @@
+## Research Summary: Preeclampsia (MONDO:0005081)
+
+> This is assigned to @nlharris — skipping autonomous curation. This summary is intended as a research aid for the curator.
+
+---
+
+### Disease Overview
+
+Preeclampsia is a multisystem pregnancy disorder affecting **2–8% of pregnancies worldwide**, accounting for >50,000 maternal and >500,000 fetal deaths annually. It is defined by new-onset hypertension (≥140/90 mmHg) developing after 20 weeks of gestation, typically accompanied by proteinuria or evidence of end-organ damage. It is the dominant clinical manifestation in a spectrum that includes gestational hypertension, HELLP syndrome (Hemolysis, Elevated Liver enzymes, Low Platelets), and eclampsia (seizures).
+
+The condition is now understood as a vascular disorder unmasked by pregnancy rather than a hypertensive disorder per se — the placenta is the central driver, and delivery is the only definitive cure.
+
+**Key ACOG diagnostic update (2019+):** Proteinuria is no longer required if severe hypertension coexists with end-organ damage (thrombocytopenia, renal insufficiency, impaired liver function, pulmonary edema, or new-onset headache/visual symptoms).
+
+---
+
+### Pathophysiology: The Two-Stage Model
+
+The dominant framework is a **two-stage model** (Roberts/Hubel, extensively reviewed):
+
+```
+STAGE 1 (Silent, pre-clinical)         STAGE 2 (Clinical maternal syndrome)
+─────────────────────────────           ─────────────────────────────────────
+Defective trophoblast invasion   →  →   Anti-angiogenic factors released
++ Failed spiral artery remodeling       into maternal circulation
+                                   →  →   Endothelial dysfunction (systemic)
+                                         → Hypertension
+                                         → Proteinuria (glomerular endotheliosis)
+                                         → HELLP, eclampsia
+```
+
+This explains the early-onset/late-onset split: early-onset (< 34 wks) is dominated by placental failure (Stage 1); late-onset (≥ 34 wks) by maternal constitutional predisposition and endothelial vulnerability.
+
+---
+
+### Pathophysiology Nodes (Suggested Structure)
+
+#### Node 1: Defective Trophoblast Invasion and Spiral Artery Remodeling
+- Normally, extravillous trophoblasts (EVTs) invade the spiral arteries and replace vascular smooth muscle, transforming them from high-resistance to high-capacitance vessels
+- In preeclampsia, this invasion is shallow; spiral arteries remain narrow, tortuous, and high-resistance
+- Results in placental ischemia and hypoxia
+
+**Key mechanisms:**
+- Impaired uterine NK (uNK) cell tolerance and signaling (KIR/HLA-C interactions at the decidua-trophoblast interface)
+- HLA-G expressed on EVTs normally dampens NK cytotoxicity; this axis is disrupted in PE
+- Dysregulated TGF-β, VEGF, and HIF-1α signaling in the decidua
+
+**Key cell types:**
+- Extravillous trophoblast (EVT): `CL:0000351` (trophoblast) / extravillous subtype
+- Uterine natural killer cell: `CL:0000623` (natural killer cell) — decidual NK cells are `CL:0002362`
+- Decidual stromal cell
+
+**Key biological processes:**
+- Trophoblast cell migration / invasion: `GO:0001753` (trophoblast giant cell differentiation — verify specificity)
+- `GO:0001570` (vasculogenesis)
+- `GO:0035441` (cell migration involved in vasculogenesis)
+- Response to hypoxia: `GO:0001666`
+
+---
+
+#### Node 2: Placental Oxidative Stress and sFlt-1 Overproduction
+- Ischemic/hypoxic placenta upregulates HIF-1α, triggering massive production of **sFlt-1** (soluble VEGF receptor-1, a splice variant of FLT1)
+- sFlt-1 is a potent decoy receptor that sequesters circulating **VEGF** and **PlGF** (placental growth factor)
+- Result: markedly reduced free VEGF/PlGF → anti-angiogenic state in the mother
+- **Soluble endoglin (sEng)**, also released by the hypoxic placenta, inhibits TGF-β signaling and amplifies endothelial damage
+- The **sFlt-1:PlGF ratio** is now used clinically (ratio >38 predicts adverse outcomes within 4 weeks; EMA/FDA approved)
+
+**Key genes (need OAK verification of HGNC IDs):**
+- `FLT1` (hgnc:3738 — verify) — encodes Flt-1; alternative splicing generates sFlt-1
+- `PGF` (hgnc:8982 — verify) — encodes PlGF
+- `ENG` (hgnc:3349 — verify) — encodes endoglin; shed as sEng
+- `VEGFA` (hgnc:12680 — verify) — primary target sequestered by sFlt-1
+
+**Key biological processes:**
+- `GO:0001525` — angiogenesis
+- `GO:0048010` — VEGF receptor signaling pathway
+- `GO:0001666` — cellular response to hypoxia
+- HIF-1 signaling / hypoxia-inducible factor pathway
+
+---
+
+#### Node 3: Maternal Endothelial Dysfunction and Multi-Organ Injury
+- Circulating sFlt-1, sEng, syncytiotrophoblast microparticles, and inflammatory mediators damage the systemic maternal endothelium
+- Endothelial activation → reduced NO production, endothelin-1 upregulation → vasoconstriction → hypertension
+- **Kidney:** Glomerular endotheliosis (pathognomonic lesion — swelling of glomerular endothelial cells, effacement of fenestrae) → proteinuria
+- **Liver:** Hepatic sinusoidal obstruction, periportal necrosis → elevated transaminases; capsular distension → epigastric/RUQ pain; HELLP
+- **Brain:** Posterior reversible encephalopathy syndrome (PRES), cerebral edema, seizures (eclampsia) — cerebrovascular autoregulation failure
+- **Coagulation:** Endothelial activation triggers DIC-spectrum, thrombocytopenia (HELLP)
+- **Placenta:** Decidual vasculopathy, infarcts → fetal growth restriction, placental abruption
+
+**Key cell types:**
+- Vascular endothelial cell: `CL:0000071` (blood vessel endothelial cell)
+- Glomerular endothelial cell: `CL:1000850` (glomerular endothelial cell — verify)
+- Syncytiotrophoblast: `CL:0000525` (syncytiotrophoblast — verify CL ID)
+- Platelet: `CL:0000233`
+
+**Key biological processes:**
+- `GO:0008217` — regulation of blood pressure
+- `GO:0045087` — innate immune response
+- `GO:0042493` — response to drug (for treatment nodes)
+- Nitric oxide signaling / endothelial NOS pathway
+- `GO:0006954` — inflammatory response
+- Complement activation: `GO:0006956`
+
+---
+
+### Clinical Phenotypes (Suggested HPO Terms)
+
+| Phenotype | HP term | Notes |
+|-----------|---------|-------|
+| Hypertension | `HP:0000822` | Core diagnostic criterion |
+| Proteinuria | `HP:0000093` | Common but not required |
+| Edema | `HP:0000969` (peripheral) | Classic but removed from criteria |
+| Thrombocytopenia | `HP:0001873` | HELLP; <100K/µL is threshold |
+| Elevated hepatic transaminases | `HP:0002910` | HELLP component |
+| Seizures | `HP:0001250` | Defines eclampsia |
+| Headache | `HP:0002315` | New-onset, unresponsive to medication |
+| Intrauterine growth retardation | `HP:0001511` | Fetal consequence |
+| Renal insufficiency | `HP:0000083` | Cr >1.1 mg/dL |
+| Visual impairment | `HP:0000505` | Scotomata, blurred vision |
+| Hemolysis | `HP:0001878` | HELLP — microangiopathic |
+| Pulmonary edema | `HP:0100598` | Severe feature |
+| Abnormal platelet morphology | — | see thrombocytopenia |
+| Placental abruption | `HP:0011410` — verify | Obstetric complication |
+
+---
+
+### Subtypes
+
+The entry should have at least two main subtypes:
+- **`Early-onset`** (< 34 weeks): Placenta-driven, more severe, higher sFlt-1, more associated with FGR; higher risk
+- **`Late-onset`** (≥ 34 weeks): More maternal constitutional; less placental pathology; more common but generally less severe
+- **`HELLP syndrome`**: Can be considered a severe variant with microangiopathic hemolysis, elevated LFTs, low platelets; may occur without classic hypertension/proteinuria
+- **`Superimposed preeclampsia`**: On a background of chronic hypertension
+
+---
+
+### Treatments
+
+| Treatment | Term | Notes |
+|-----------|------|-------|
+| Low-dose aspirin (prevention) | MAXO:0000058 + CHEBI:29177 (aspirin) | USPSTF Grade B; 81 mg/day from 12–28 wks |
+| Magnesium sulfate (seizure prophylaxis) | MAXO:0000058 + CHEBI:32006 (verify) | Reduces eclampsia 58%; IV loading dose |
+| Labetalol (BP control) | MAXO:0000058 + CHEBI:6522 (labetalol — verify) | First-line IV acute |
+| Nifedipine (BP control) | MAXO:0000058 + CHEBI:7565 (nifedipine — verify) | Oral; first-line |
+| Hydralazine | MAXO:0000058 + CHEBI:5757 (hydralazine — verify) | IV acute management |
+| Delivery | MAXO:0000004 (surgical procedure) or MAXO:0001187 | Definitive treatment |
+| Calcium supplementation (prevention) | MAXO:0000088 (dietary intervention) | Effective in low-calcium populations |
+| Corticosteroids (fetal lung maturation) | MAXO:0000647 + CHEBI:16723 (betamethasone — verify) | If < 34 wks gestation |
+
+---
+
+### Key Evidence References (Verified PMIDs)
+
+The following PMIDs were confirmed by direct abstract retrieval:
+
+1. **PMID:30792480** — Phipps et al. 2019, *Nat Rev Nephrology* — "Pre-eclampsia: pathogenesis, novel diagnostics and therapies." Comprehensive mechanistic review covering sFlt-1/sEng/PlGF, endothelial dysfunction, renal glomerular endotheliosis, and emerging therapies. **Highly recommended as primary reference.**
+
+2. **PMID:35177220** — Erez et al. 2022, *Am J Obstet Gynecol* — "Preeclampsia and eclampsia: the conceptual evolution of a syndrome." Covers the historical shift from neurological → vascular conceptualization; early vs. late onset subtypes; role of antiangiogenic factors.
+
+3. **PMID:34033373** — Karrar et al. 2024, *StatPearls* — Comprehensive overview of diagnostic criteria, pathophysiology (uteroplacental ischemia), and management.
+
+4. **PMID:32443079** — ACOG Practice Bulletin #222, 2020, *Obstet Gynecol* — Clinical guideline; the rate of preeclampsia increased 25% between 1987–2004; management thresholds and protocols.
+
+**Additional high-priority references to fetch and verify (titles confirmed, PMIDs need `just fetch-reference` verification):**
+
+- **Maynard et al. (2003)** *J Clin Invest* — "Excess placental soluble fms-like tyrosine kinase 1 (sFlt1) may contribute to endothelial dysfunction, hypertension, and proteinuria in preeclampsia" — The landmark animal model paper establishing sFlt-1 causality.
+- **Levine et al. (2004)** *N Engl J Med* — "Circulating angiogenic factors and the risk of preeclampsia" — Prospective clinical cohort showing sFlt-1 rises and PlGF falls weeks before clinical PE onset.
+- **Redman & Sargent (2005)** *Science* — "Latest advances in understanding preeclampsia" — Overview of immune and vascular mechanisms.
+- **Verlohren et al. (2010/2012)** *Hypertension* — Established the sFlt-1:PlGF ratio clinical cutoff of 38.
+- **Staff et al. (2019)** — Clinical use of angiogenic biomarkers in preeclampsia.
+
+---
+
+### Orphanet / Structured Sources
+
+- Orphanet ORPHA code for pre-eclampsia: likely **ORPHA:275555** — run `just fetch-reference ORPHA:275555` to verify and check for definition, prevalence, and gene-disease associations that can be cited as `ORPHA:275555` evidence items.
+
+---
+
+### Suggested Module Conformance
+
+Preeclampsia does not appear to conform to the existing `fibrotic_response` or `immune_checkpoint_blockade` modules. The disease may warrant a future **`placental_vascular_dysfunction`** module given the conserved sFlt-1/PlGF anti-angiogenic mechanism also seen in fetal growth restriction, spontaneous preterm birth, and HELLP syndrome.
+
+The complement-driven endothelial damage node could potentially align with modules used in other thrombotic microangiopathy entries (e.g., aHUS) if those are curated.
+
+---
+
+### Long-term Consequences (for `progression` or `outcomes` section)
+
+- Women with prior preeclampsia have **2× lifetime risk of cardiovascular disease**, 2–4× risk of hypertension, and 2× risk of stroke
+- Preterm delivery and FGR are the primary fetal consequences
+- Recurrence rate in subsequent pregnancies: 15–25% (higher if early-onset index pregnancy)
+
+---
+
+*Summary generated by Claude Code summarization agent from PubMed abstracts and authoritative review sources. All PMIDs must be verified with `just fetch-reference` before use as snippets.*
+


### PR DESCRIPTION
## Summary

- Curates Preeclampsia (MONDO:0005081) — a complex pregnancy disorder affecting 2-8% of pregnancies globally
- 3-node pathophysiology cascade: Defective Trophoblast Invasion → Placental Anti-Angiogenic Factor Release → Maternal Endothelial Dysfunction
- 9 phenotypes, 3 subtypes (early-onset, late-onset, HELLP), 3 biochemical markers, 4 genetic entries (FLT1, PGF, ENG, VEGFA), 5 treatments
- 11 unique PMIDs across 37 evidence items, including landmark papers (Maynard 2003 JCI, Levine 2004 NEJM, Venkatesha 2006 Nature Medicine) and major clinical trials (ASPRE 2017 NEJM, Magpie 2002 Lancet)
- All validations pass (schema, terms, references), 99% weighted compliance
- Self-reviewed and addressed all critical issues before PR

Closes #2675

## Test plan

- [x] `just validate kb/disorders/Preeclampsia.yaml` — passes
- [x] `just compliance kb/disorders/Preeclampsia.yaml` — 99% weighted
- [x] All ontology term IDs verified with OAK
- [x] All evidence snippets are exact quotes from cached abstracts
- [x] Self-review identified and fixed 5 issues (weak evidence snippets, inconsistent evidence_source, unsupported frequency claims)

🤖 Generated with [Claude Code](https://claude.com/claude-code)