### PR TITLE
Clarify worktree branch discipline in CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/worktrees
 **/.DS_Store
 bug_reports
 *.bak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -812,7 +812,11 @@ requesting repository access.
 
 ### Use worktrees
 
-Allows for parallel work. Canonical location is ~/worktrees/
+Use worktrees for parallel feature work. The **primary checkout** (wherever you cloned the repo) must always stay on `main`. Feature branches go in worktrees only.
+
+- Never check out `main` in a worktree — `main` belongs to the primary checkout.
+- Never leave the primary checkout on a feature branch.
+- If `git checkout main` fails with "already checked out at …", find which worktree holds `main` (`git worktree list | grep '\[main\]'`), switch that worktree to a feature branch, then retry.
 
 ### What to commit
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `~/worktrees/` and `~/repos/dismech` paths with generic "primary checkout" language so instructions work for any contributor
- Adds explicit rules: primary checkout stays on `main`, feature branches go in worktrees only
- Adds recovery step for when `git checkout main` fails due to a worktree holding `main`
- Adds `.claude/worktrees` to `.gitignore`

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm `.gitignore` change doesn't affect existing tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)