### PR TITLE
Add low-effort literature scan workflow

### DIFF
--- a/.github/workflows/curation-scanner.yml
+++ b/.github/workflows/curation-scanner.yml
@@ -5,28 +5,40 @@ on:
     - cron: "0 */8 * * *"
   workflow_dispatch:
     inputs:
-      model:
-        description: "Claude model to use"
-        default: claude-opus-4-7
-        type: choice
-        options:
-          - claude-sonnet-4-6
-          - claude-haiku-4-5-20251001
-          - claude-opus-4-7
-
-concurrency:
-  group: curation-scanner
-  cancel-in-progress: true
+      note:
+        description: "Optional note for the manual scanner run"
+        required: false
+        default: ""
+        type: string
 
 jobs:
   curation-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - effort: low_effort
+            model: claude-haiku-4-5-20251001
+            selector: "label:curation label:low_effort"
+          - effort: medium_effort
+            model: claude-sonnet-4-6
+            selector: "label:curation label:medium_effort -label:low_effort"
+          - effort: high_effort
+            model: claude-opus-4-7
+            selector: "label:curation -label:low_effort -label:medium_effort"
+    concurrency:
+      group: curation-scanner-${{ matrix.effort }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      EFFORT_TIER: ${{ matrix.effort }}
+      EFFORT_SELECTOR: ${{ matrix.selector }}
 
     steps:
       - name: Checkout repository
@@ -58,16 +70,35 @@ jobs:
           claude_args: |
             --dangerously-skip-permissions
             --mcp-config '{"mcpServers": {"ols": {"command": "uvx", "args": ["ols-mcp"]}}}'
-            --model ${{ inputs.model || 'claude-opus-4-7' }}
+            --model ${{ matrix.model }}
           prompt: |
             REPO: ${{ github.repository }}
             TRIGGER: ${{ github.event_name }}
+            EFFORT TIER: ${{ matrix.effort }}
+            EFFORT SELECTOR: ${{ matrix.selector }}
+            MANUAL NOTE: ${{ inputs.note || '' }}
 
             You are running an automated curation scanner for the dismech repository.
 
-            Scan for open issues and pull requests labeled `curation` that are unassigned.
-            Start by gathering candidate items with `gh issue list` and `gh pr list`, including
-            metadata such as labels, assignees, updated time, review state, and reaction counts.
+            Scan only for open issues and pull requests that are unassigned and match
+            EFFORT SELECTOR. Start by gathering candidate items with `gh issue list`
+            and `gh pr list`, including metadata such as labels, assignees, updated
+            time, review state, and reaction counts.
+
+            Use searches equivalent to:
+            - `is:open is:issue no:assignee label:curation ...effort selector...`
+            - `is:open is:pr no:assignee label:curation ...effort selector...`
+
+            Effort tier routing:
+            - `low_effort`: suitable for bounded augmentation of existing disease
+              entries and low-risk issue follow-up. Do not create new disease
+              entries from this tier. If a task requires new disease curation,
+              leave a brief comment and ensure the work is routed to `high_effort`.
+            - `medium_effort`: suitable for bounded but less mechanical updates.
+            - `high_effort`: default for curation work without lower-effort labels
+              and for new disease entry creation.
+
+            If an item has more than one effort label, skip it rather than guessing.
 
             You may scan multiple candidates, but you must choose exactly one issue or pull request
             to actively work on in this run. Leave all other items untouched.

--- a/.github/workflows/haiku-literature-scan.yml
+++ b/.github/workflows/haiku-literature-scan.yml
@@ -1,0 +1,138 @@
+name: Haiku Literature Scan
+
+on:
+  schedule:
+    # Weekly Friday scan after the UTC publication week has mostly settled.
+    - cron: "0 13 * * 5"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days back to scan"
+        required: false
+        default: "7"
+        type: string
+      max_records:
+        description: "Maximum Europe PMC records to include in the packet"
+        required: false
+        default: "100"
+        type: string
+      max_issues:
+        description: "Maximum GitHub issues to create"
+        required: false
+        default: "5"
+        type: string
+      create_issues:
+        description: "Create GitHub handoff issues after generating the packet"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: haiku-literature-scan
+  cancel-in-progress: true
+
+jobs:
+  literature-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+
+    env:
+      SCAN_DAYS: ${{ inputs.days || '7' }}
+      MAX_RECORDS: ${{ inputs.max_records || '100' }}
+      MAX_ISSUES: ${{ inputs.max_issues || '5' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install python tools
+        run: uv sync
+
+      - name: Generate deterministic literature packet
+        run: |
+          uv run python scripts/literature_scan.py \
+            --days "$SCAN_DAYS" \
+            --max-records "$MAX_RECORDS" \
+            --output-json output/literature_scan/literature_scan.json \
+            --output-md output/literature_scan/literature_scan.md
+
+      - name: Upload literature packet
+        uses: actions/upload-artifact@v4
+        with:
+          name: literature-scan-packet
+          path: |
+            output/literature_scan/literature_scan.json
+            output/literature_scan/literature_scan.md
+
+      - name: Create low-effort curation handoff issues
+        if: ${{ github.event_name == 'schedule' || inputs.create_issues }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          show_full_output: true
+          claude_args: |
+            --model claude-haiku-4-5-20251001
+            --allowedTools "Bash(gh label list:*),Bash(gh issue list:*),Bash(gh issue create:*),Bash(cat:*),Bash(sed:*),Bash(rg:*),Bash(head:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            MAX ISSUES: ${{ env.MAX_ISSUES }}
+
+            You are running the low-effort literature-scan handoff for dismech.
+
+            Read `CLAUDE.md` and `output/literature_scan/literature_scan.md`.
+            You may inspect relevant `kb/disorders/*.yaml` files that the packet names.
+
+            Your only allowed write action is creating GitHub issues. Do not edit files.
+            Do not create pull requests. Do not fetch or edit `references_cache/*.md`.
+            Do not use the `@dragon-ai-agent please` phrase.
+
+            For each candidate, first check for an existing open issue that already
+            mentions the PMID:
+
+            `gh issue list --repo "$REPO" --search "PMID:<ID> in:body is:open" --json number,title`
+
+            Skip candidates that already have an open issue.
+
+            Create at most MAX ISSUES total, prioritizing:
+            - papers with a deterministic existing disease-file match
+              where the disease name or synonym appears in the title
+            - papers whose abstract suggests disease mechanism, genetics, treatment,
+              trial, or clinically relevant therapeutic resistance
+            - papers not already cited in the matched YAML file
+
+            The deterministic candidate-file matches are suggestions, not proof.
+            Skip candidate matches that are only secondary phenotypes, broad disease
+            categories, treatment settings, or incidental abstract mentions.
+
+            For an existing disease augmentation issue:
+            - labels: `curation,low_effort`
+            - title: `[lit-scan] <Disease name>: <short paper title>`
+            - body must include the publication details from the packet verbatim:
+              PMID, title, journal/date, DOI, Europe PMC/PubMed links, and abstract
+            - body must include a clearly separated `Low-Effort Assessment` section
+              explaining the likely YAML file, potential update area, and why this
+              may or may not add information beyond the current entry
+            - body must include this instruction:
+              `Augment only the existing disease entry. If this requires creating
+              a new disease entry, stop and open a separate curation + high_effort
+              issue instead.`
+
+            For a missing-disease issue:
+            - create it only when the publication clearly concerns a disease not
+              already represented in `kb/disorders`
+            - labels: `curation,high_effort`
+            - title: `[lit-scan:new] <Disease name>: recent literature signal`
+            - body must include the same publication details and say that new disease
+              entry creation is high effort by default
+
+            If no candidate is strong enough, create no issues and finish quietly.

--- a/.github/workflows/literature-scan.yml
+++ b/.github/workflows/literature-scan.yml
@@ -1,4 +1,4 @@
-name: Haiku Literature Scan
+name: Literature Scan
 
 on:
   schedule:
@@ -21,6 +21,15 @@ on:
         required: false
         default: "5"
         type: string
+      model:
+        description: "Claude model to use for issue handoff"
+        required: false
+        default: claude-haiku-4-5-20251001
+        type: choice
+        options:
+          - claude-haiku-4-5-20251001
+          - claude-sonnet-4-6
+          - claude-opus-4-7
       create_issues:
         description: "Create GitHub handoff issues after generating the packet"
         required: false
@@ -28,7 +37,7 @@ on:
         type: boolean
 
 concurrency:
-  group: haiku-literature-scan
+  group: literature-scan
   cancel-in-progress: true
 
 jobs:
@@ -44,6 +53,7 @@ jobs:
       SCAN_DAYS: ${{ inputs.days || '7' }}
       MAX_RECORDS: ${{ inputs.max_records || '100' }}
       MAX_ISSUES: ${{ inputs.max_issues || '5' }}
+      ISSUE_HANDOFF_MODEL: ${{ inputs.model || 'claude-haiku-4-5-20251001' }}
 
     steps:
       - name: Checkout repository
@@ -73,7 +83,7 @@ jobs:
             output/literature_scan/literature_scan.json
             output/literature_scan/literature_scan.md
 
-      - name: Create low-effort curation handoff issues
+      - name: Create literature scan handoff issues
         if: ${{ github.event_name == 'schedule' || inputs.create_issues }}
         uses: anthropics/claude-code-action@v1
         with:
@@ -81,11 +91,12 @@ jobs:
           github_token: ${{ github.token }}
           show_full_output: true
           claude_args: |
-            --model claude-haiku-4-5-20251001
+            --model ${{ env.ISSUE_HANDOFF_MODEL }}
             --allowedTools "Bash(gh label list:*),Bash(gh issue list:*),Bash(gh issue create:*),Bash(cat:*),Bash(sed:*),Bash(rg:*),Bash(head:*)"
           prompt: |
             REPO: ${{ github.repository }}
             MAX ISSUES: ${{ env.MAX_ISSUES }}
+            MODEL: ${{ env.ISSUE_HANDOFF_MODEL }}
 
             You are running the low-effort literature-scan handoff for dismech.
 

--- a/project.justfile
+++ b/project.justfile
@@ -1470,6 +1470,11 @@ check-research disorder:
 list-research:
     @for f in research/*-deep-research-*.md; do [ -f "$f" ] && basename "$f"; done | grep -v '\.citations\.md$$' | sort || echo "No research files found"
 
+# Generate a deterministic Europe PMC literature-scan packet for recent papers
+[group('Research')]
+literature-scan days='7' max_records='100':
+    uv run python scripts/literature_scan.py --days {{days}} --max-records {{max_records}}
+
 # Generate a disorder review report (markdown + PDF) for expert review
 # Example: just disorder-report kb/disorders/Kleefstra_Syndrome.yaml
 # Output: Kleefstra_Syndrome_review.md and Kleefstra_Syndrome_review.pdf

--- a/scripts/literature_scan.py
+++ b/scripts/literature_scan.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Generate deterministic weekly literature-scan packets from Europe PMC."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+import yaml
+
+
+EUROPE_PMC_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+
+PROFILE_QUERIES = {
+    "mechanisms": (
+        "(("
+        + " OR ".join(
+            [
+                "TITLE:pathogenesis",
+                "TITLE:pathophysiology",
+                'TITLE:"molecular mechanism"',
+                "TITLE:mechanism",
+            ]
+        )
+        + ") AND (TITLE_ABS:disease OR TITLE_ABS:syndrome OR TITLE_ABS:disorder))"
+        + " OR "
+        + "(("
+        + " OR ".join(
+            [
+                "TITLE:variant",
+                "TITLE:mutation",
+                "TITLE:genetic",
+                "TITLE:gene",
+            ]
+        )
+        + ") AND (TITLE_ABS:disease OR TITLE_ABS:syndrome OR TITLE_ABS:disorder))"
+        + " OR "
+        + "(("
+        + " OR ".join(
+            [
+                "TITLE:treatment",
+                "TITLE:therapy",
+                "TITLE:therapeutic",
+                "TITLE:trial",
+            ]
+        )
+        + ") AND (TITLE_ABS:disease OR TITLE_ABS:syndrome OR TITLE_ABS:disorder))"
+    )
+}
+
+EXCLUDED_TITLE_TERMS = (
+    "TITLE:corrigendum",
+    "TITLE:erratum",
+    "TITLE:retraction",
+    "TITLE:withdrawn",
+)
+
+GENERIC_DISEASE_TERMS = {
+    "autosomal dominant",
+    "autosomal recessive",
+    "cancer",
+    "carcinoma",
+    "classic",
+    "disease",
+    "disorder",
+    "genetic disease",
+    "leukemia",
+    "lung cancer",
+    "missense",
+    "moderate",
+    "neonatal",
+    "severe",
+    "syndrome",
+    "systemic",
+    "tumor",
+}
+
+
+@dataclass(frozen=True)
+class DiseaseTerm:
+    normalized: str
+    label: str
+    path: str
+    disease_name: str
+    kind: str
+
+
+@dataclass
+class Publication:
+    id: str
+    source: str
+    pmid: str
+    doi: str
+    title: str
+    journal: str
+    publication_date: str
+    authors: str
+    abstract: str
+    europe_pmc_url: str
+    pubmed_url: str
+
+
+def normalize_text(value: Any) -> str:
+    text = html.unescape(str(value or ""))
+    text = re.sub(r"<[^>]+>", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def normalize_for_match(value: str) -> str:
+    value = normalize_text(value).lower()
+    return re.sub(r"[^a-z0-9]+", " ", value).strip()
+
+
+def canonical_ref(raw: str) -> str | None:
+    value = raw.strip()
+    if not value:
+        return None
+    if value.upper().startswith("PMID:"):
+        digits = re.sub(r"\D", "", value.split(":", 1)[1])
+        return f"PMID:{digits}" if digits else None
+    if value.upper().startswith("DOI:"):
+        doi = value.split(":", 1)[1].strip().lower()
+        return f"DOI:{doi}" if doi else None
+    return None
+
+
+def build_query(date_from: str, date_to: str, profile: str = "mechanisms") -> str:
+    if profile not in PROFILE_QUERIES:
+        profiles = ", ".join(sorted(PROFILE_QUERIES))
+        raise ValueError(f"unknown profile {profile!r}; choose one of: {profiles}")
+    profile_query = PROFILE_QUERIES[profile]
+    excluded = " OR ".join(EXCLUDED_TITLE_TERMS)
+    return (
+        f"SRC:MED AND FIRST_PDATE:[{date_from} TO {date_to}] "
+        f"AND ({profile_query}) NOT ({excluded})"
+    )
+
+
+def default_date_range(days: int) -> tuple[str, str]:
+    today = dt.datetime.now(dt.UTC).date()
+    return (today - dt.timedelta(days=days)).isoformat(), today.isoformat()
+
+
+def fetch_europe_pmc(
+    query: str,
+    *,
+    max_records: int,
+    page_size: int,
+    timeout: float,
+) -> tuple[int, list[dict[str, Any]]]:
+    records: list[dict[str, Any]] = []
+    hit_count = 0
+    page = 1
+    with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+        while len(records) < max_records:
+            current_page_size = min(page_size, max_records - len(records))
+            response = client.get(
+                EUROPE_PMC_SEARCH_URL,
+                params={
+                    "query": query,
+                    "format": "json",
+                    "pageSize": current_page_size,
+                    "page": page,
+                    "resultType": "core",
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if page == 1:
+                hit_count = int(payload.get("hitCount") or 0)
+            page_records = payload.get("resultList", {}).get("result", [])
+            if not page_records:
+                break
+            records.extend(page_records)
+            if len(page_records) < current_page_size:
+                break
+            page += 1
+    return hit_count, records
+
+
+def collect_refs(node: Any, out: set[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "reference" and isinstance(value, str):
+                ref = canonical_ref(value)
+                if ref:
+                    out.add(ref)
+            else:
+                collect_refs(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            collect_refs(item, out)
+
+
+def iter_term_values(data: dict[str, Any], path: Path) -> Iterable[tuple[str, str]]:
+    name = data.get("name")
+    if isinstance(name, str):
+        yield name, "name"
+
+    yield path.stem.replace("_", " "), "filename"
+
+    synonyms = data.get("synonyms")
+    if isinstance(synonyms, list):
+        for synonym in synonyms:
+            if isinstance(synonym, str):
+                yield synonym, "synonym"
+
+    subtypes = data.get("has_subtypes")
+    if isinstance(subtypes, list):
+        for subtype in subtypes:
+            if not isinstance(subtype, dict):
+                continue
+            for key in ("name", "display_name"):
+                value = subtype.get(key)
+                if isinstance(value, str):
+                    yield value, f"subtype.{key}"
+
+
+def keep_disease_term(term: str, kind: str) -> bool:
+    normalized = normalize_for_match(term)
+    if not normalized or normalized in GENERIC_DISEASE_TERMS:
+        return False
+    if kind.startswith("subtype.") and len(normalized.split()) < 2:
+        return False
+    return len(normalized) >= 6
+
+
+def load_disease_terms(kb_dir: Path) -> tuple[list[DiseaseTerm], dict[str, set[str]]]:
+    terms: list[DiseaseTerm] = []
+    references_by_path: dict[str, set[str]] = {}
+    for path in sorted(kb_dir.glob("*.yaml")):
+        if path.name.endswith(".history.yaml"):
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            continue
+        path_string = str(path)
+        disease_name = str(data.get("name") or path.stem.replace("_", " "))
+        refs: set[str] = set()
+        collect_refs(data, refs)
+        references_by_path[path_string] = refs
+        seen: set[str] = set()
+        for label, kind in iter_term_values(data, path):
+            normalized = normalize_for_match(label)
+            if normalized in seen or not keep_disease_term(label, kind):
+                continue
+            seen.add(normalized)
+            terms.append(
+                DiseaseTerm(
+                    normalized=normalized,
+                    label=label,
+                    path=path_string,
+                    disease_name=disease_name,
+                    kind=kind,
+                )
+            )
+    terms.sort(key=lambda term: len(term.normalized), reverse=True)
+    return terms, references_by_path
+
+
+def publication_from_record(record: dict[str, Any]) -> Publication:
+    source = normalize_text(record.get("source"))
+    record_id = normalize_text(record.get("id"))
+    pmid = normalize_text(record.get("pmid"))
+    if not pmid and source == "MED" and re.fullmatch(r"\d+", record_id):
+        pmid = record_id
+    europe_pmc_url = f"https://europepmc.org/article/{source}/{record_id}"
+    pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/" if pmid else ""
+    return Publication(
+        id=record_id,
+        source=source,
+        pmid=pmid,
+        doi=normalize_text(record.get("doi")),
+        title=normalize_text(record.get("title")),
+        journal=normalize_text(record.get("journalTitle")),
+        publication_date=normalize_text(record.get("firstPublicationDate")),
+        authors=normalize_text(record.get("authorString")),
+        abstract=normalize_text(record.get("abstractText")),
+        europe_pmc_url=europe_pmc_url,
+        pubmed_url=pubmed_url,
+    )
+
+
+def match_publication(
+    publication: Publication,
+    terms: list[DiseaseTerm],
+    references_by_path: dict[str, set[str]],
+    max_matches: int,
+) -> list[dict[str, Any]]:
+    normalized_title = normalize_for_match(publication.title)
+    normalized_abstract = normalize_for_match(publication.abstract)
+    padded_title = f" {normalized_title} "
+    padded_all = f" {normalized_title} {normalized_abstract} "
+    matches_by_path: dict[str, dict[str, Any]] = {}
+
+    for term in terms:
+        term_pattern = f" {term.normalized} "
+        in_title = term_pattern in padded_title
+        in_text = term_pattern in padded_all
+        if not in_text:
+            continue
+        score = (4 if in_title else 1) + min(len(term.normalized) / 30, 3)
+        existing = matches_by_path.get(term.path)
+        if existing is None:
+            existing_refs = references_by_path.get(term.path, set())
+            references = set()
+            if publication.pmid:
+                references.add(f"PMID:{publication.pmid}")
+            if publication.doi:
+                references.add(f"DOI:{publication.doi.lower()}")
+            matches_by_path[term.path] = {
+                "path": term.path,
+                "disease_name": term.disease_name,
+                "score": round(score, 3),
+                "matched_terms": [
+                    {
+                        "label": term.label,
+                        "kind": term.kind,
+                        "in_title": in_title,
+                    }
+                ],
+                "already_cited": bool(references & existing_refs),
+            }
+            continue
+
+        existing["score"] = round(max(float(existing["score"]), score), 3)
+        existing["matched_terms"].append(
+            {"label": term.label, "kind": term.kind, "in_title": in_title}
+        )
+
+    matches = sorted(
+        matches_by_path.values(),
+        key=lambda item: (-float(item["score"]), item["path"]),
+    )
+    return matches[:max_matches]
+
+
+def build_packet(
+    records: list[dict[str, Any]],
+    *,
+    hit_count: int,
+    query: str,
+    date_from: str,
+    date_to: str,
+    profile: str,
+    kb_dir: Path,
+    max_matches: int,
+) -> dict[str, Any]:
+    terms, references_by_path = load_disease_terms(kb_dir)
+    publications = [publication_from_record(record) for record in records]
+    seen_keys: set[str] = set()
+    packet_records: list[dict[str, Any]] = []
+    for publication in publications:
+        key = publication.pmid or f"{publication.source}:{publication.id}"
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        item = publication.__dict__.copy()
+        item["candidate_existing_diseases"] = match_publication(
+            publication,
+            terms,
+            references_by_path,
+            max_matches,
+        )
+        packet_records.append(item)
+
+    return {
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "profile": profile,
+        "date_from": date_from,
+        "date_to": date_to,
+        "query": query,
+        "hit_count": hit_count,
+        "record_count": len(packet_records),
+        "records": packet_records,
+    }
+
+
+def markdown_blockquote(text: str) -> str:
+    if not text:
+        return "> No abstract available."
+    return "\n".join(f"> {line}" if line else ">" for line in text.splitlines())
+
+
+def render_markdown(packet: dict[str, Any]) -> str:
+    lines = [
+        "# Weekly Literature Scan Packet",
+        "",
+        f"- Generated: {packet['generated_at']}",
+        f"- Profile: {packet['profile']}",
+        f"- Date range: {packet['date_from']} to {packet['date_to']}",
+        f"- Europe PMC hit count: {packet['hit_count']}",
+        f"- Records in packet: {packet['record_count']}",
+        "",
+        "## Query",
+        "",
+        "```text",
+        packet["query"],
+        "```",
+        "",
+        "## Records",
+        "",
+    ]
+
+    for index, record in enumerate(packet["records"], start=1):
+        pmid = record.get("pmid") or "no PMID"
+        title = record.get("title") or "Untitled"
+        lines.extend(
+            [
+                f"### {index}. {title}",
+                "",
+                f"- PMID: {pmid}",
+                f"- DOI: {record.get('doi') or ''}",
+                f"- Journal: {record.get('journal') or ''}",
+                f"- Publication date: {record.get('publication_date') or ''}",
+                f"- Authors: {record.get('authors') or ''}",
+                f"- Europe PMC: {record.get('europe_pmc_url') or ''}",
+                f"- PubMed: {record.get('pubmed_url') or ''}",
+                "",
+                "Abstract:",
+                "",
+                markdown_blockquote(record.get("abstract") or ""),
+                "",
+                "Candidate existing disease files:",
+                "",
+            ]
+        )
+        matches = record.get("candidate_existing_diseases") or []
+        if not matches:
+            lines.append("- None found deterministically.")
+        for match in matches:
+            terms = ", ".join(
+                item["label"] for item in match.get("matched_terms", [])[:4]
+            )
+            cited = "yes" if match.get("already_cited") else "no"
+            title_match = (
+                "yes"
+                if any(item.get("in_title") for item in match.get("matched_terms", []))
+                else "no"
+            )
+            lines.append(
+                f"- `{match['path']}` ({match['disease_name']}); "
+                f"matched terms: {terms}; title match: {title_match}; "
+                f"score: {match['score']}; already cited: {cited}"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_outputs(packet: dict[str, Any], output_json: Path, output_md: Path) -> None:
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+    output_md.write_text(render_markdown(packet), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a deterministic Europe PMC literature-scan packet."
+    )
+    parser.add_argument(
+        "--profile", default="mechanisms", choices=sorted(PROFILE_QUERIES)
+    )
+    parser.add_argument("--days", type=int, default=7)
+    parser.add_argument("--date-from", default="")
+    parser.add_argument("--date-to", default="")
+    parser.add_argument("--max-records", type=int, default=100)
+    parser.add_argument("--page-size", type=int, default=100)
+    parser.add_argument("--max-matches", type=int, default=5)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--kb-dir", type=Path, default=Path("kb/disorders"))
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("output/literature_scan/literature_scan.json"),
+    )
+    parser.add_argument(
+        "--output-md",
+        type=Path,
+        default=Path("output/literature_scan/literature_scan.md"),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.date_from and args.date_to:
+        date_from, date_to = args.date_from, args.date_to
+    elif args.date_from or args.date_to:
+        print("--date-from and --date-to must be provided together", file=sys.stderr)
+        return 2
+    else:
+        date_from, date_to = default_date_range(args.days)
+
+    query = build_query(date_from, date_to, args.profile)
+    hit_count, records = fetch_europe_pmc(
+        query,
+        max_records=args.max_records,
+        page_size=args.page_size,
+        timeout=args.timeout,
+    )
+    packet = build_packet(
+        records,
+        hit_count=hit_count,
+        query=query,
+        date_from=date_from,
+        date_to=date_to,
+        profile=args.profile,
+        kb_dir=args.kb_dir,
+        max_matches=args.max_matches,
+    )
+    write_outputs(packet, args.output_json, args.output_md)
+    print(
+        f"Wrote {packet['record_count']} records from {hit_count} Europe PMC hits "
+        f"to {args.output_json} and {args.output_md}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_literature_scan.py
+++ b/tests/test_literature_scan.py
@@ -1,0 +1,129 @@
+"""Tests for the weekly literature-scan packet generator."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "literature_scan.py"
+SPEC = importlib.util.spec_from_file_location("literature_scan", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+literature_scan = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = literature_scan
+SPEC.loader.exec_module(literature_scan)
+
+
+def test_build_query_is_pubmed_title_focused_and_not_cancer_hardwired() -> None:
+    query = literature_scan.build_query("2026-05-08", "2026-05-15")
+
+    assert "SRC:MED" in query
+    assert "FIRST_PDATE:[2026-05-08 TO 2026-05-15]" in query
+    assert "TITLE:pathogenesis" in query
+    assert "TITLE:treatment" in query
+    assert "NOT (TITLE:corrigendum" in query
+    assert "cancer" not in query.lower()
+
+
+def test_load_disease_terms_and_references(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    (kb_dir / "Wilsons_Disease.yaml").write_text(
+        """
+name: Wilson Disease
+synonyms:
+- Hepatolenticular degeneration
+pathophysiology:
+- name: Copper Accumulation
+  evidence:
+  - reference: PMID:12345
+    snippet: copper
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    terms, references_by_path = literature_scan.load_disease_terms(kb_dir)
+
+    labels = {term.label for term in terms}
+    assert "Wilson Disease" in labels
+    assert "Hepatolenticular degeneration" in labels
+    assert references_by_path[str(kb_dir / "Wilsons_Disease.yaml")] == {"PMID:12345"}
+
+
+def test_match_publication_marks_already_cited(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    yaml_path = kb_dir / "Wilsons_Disease.yaml"
+    yaml_path.write_text(
+        """
+name: Wilson Disease
+pathophysiology:
+- name: Copper Transport Defect
+  evidence:
+  - reference: PMID:42126658
+    snippet: ATP7B
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    terms, references_by_path = literature_scan.load_disease_terms(kb_dir)
+    publication = literature_scan.Publication(
+        id="42126658",
+        source="MED",
+        pmid="42126658",
+        doi="10.1007/example",
+        title="Exploring a compound heterozygous variant in ATP7B associated with Wilson disease",
+        journal="Example Journal",
+        publication_date="2026-05-13",
+        authors="A. Author",
+        abstract="This paper reports Wilson disease in an Iranian family.",
+        europe_pmc_url="https://europepmc.org/article/MED/42126658",
+        pubmed_url="https://pubmed.ncbi.nlm.nih.gov/42126658/",
+    )
+
+    matches = literature_scan.match_publication(
+        publication,
+        terms,
+        references_by_path,
+        max_matches=5,
+    )
+
+    assert matches
+    assert matches[0]["path"] == str(yaml_path)
+    assert matches[0]["already_cited"] is True
+
+
+def test_build_packet_includes_candidate_existing_diseases(tmp_path: Path) -> None:
+    kb_dir = tmp_path / "kb"
+    kb_dir.mkdir()
+    (kb_dir / "Maple_Syrup_Urine_Disease.yaml").write_text(
+        "name: Maple Syrup Urine Disease\n",
+        encoding="utf-8",
+    )
+    records = [
+        {
+            "id": "42127902",
+            "source": "MED",
+            "pmid": "42127902",
+            "title": "Trial-ready external controls for gene therapy in maple syrup urine disease",
+            "abstractText": "A cohort relevant to maple syrup urine disease.",
+            "firstPublicationDate": "2026-05-12",
+        }
+    ]
+
+    packet = literature_scan.build_packet(
+        records,
+        hit_count=1,
+        query="SRC:MED",
+        date_from="2026-05-08",
+        date_to="2026-05-15",
+        profile="mechanisms",
+        kb_dir=kb_dir,
+        max_matches=5,
+    )
+
+    matches = packet["records"][0]["candidate_existing_diseases"]
+    assert matches[0]["path"] == str(kb_dir / "Maple_Syrup_Urine_Disease.yaml")


### PR DESCRIPTION
## Summary

Partial implementation of #2723: this PR covers only the low-effort literature-surveillance handoff and effort-label scanner routing. It does not attempt to solve the full model-tiering policy or all candidate lower-effort workflows from the issue.

- add a deterministic Europe PMC literature-scan packet generator for recent mechanism/genetics/treatment papers
- add a weekly Literature Scan workflow that defaults its issue-handoff model to Haiku but can be manually run with another model
- have the Literature Scan workflow read the packet and open review-gated curation issues only
- matrix the curation scanner by effort labels so low_effort uses Haiku, medium_effort uses Sonnet, and high/default uses Opus

## Validation

- uv run pytest tests/test_literature_scan.py -v
- uv run ruff check scripts/literature_scan.py tests/test_literature_scan.py
- git diff --check
- parsed updated workflow YAML with PyYAML
- live smoke test: scripts/literature_scan.py over 2026-05-08..2026-05-15 with max-records 5 returned 497 Europe PMC hits and generated packet output under /tmp

## Notes

The literature scan workflow has read-only contents permission and issue write permission. It is instructed not to edit KB YAML, create PRs, fetch references, or use the dragon magic phrase. Generated existing-disease augmentation issues are labeled curation + low_effort; missing-disease signals are curation + high_effort.