### PR TITLE
Augment MSUD entry with MATCH cohort gene therapy trial framework

### DIFF
--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1,6 +1,6 @@
 name: Maple Syrup Urine Disease
 creation_date: '2026-01-09T01:00:56Z'
-updated_date: '2026-05-09T09:23:57Z'
+updated_date: '2026-05-15T18:00:00Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -1156,7 +1156,7 @@ treatments:
       snippet: "Metformin-treatment significantly reduced levels of KIC in the muscle (by 69%)"
       explanation: MSUD mouse data support metformin as reducing KIC accumulation and improving metabolic homeostasis.
 - name: Gene Therapy (Preclinical)
-  description: Liver-directed AAV8 gene therapy delivering BCKDHA has rescued lethal MSUD phenotype in Bckdha-knockout mice. Ubiquitous promoter fully rescues the disease; liver-specific expression provides partial but sustained rescue, highlighting both hepatic and extrahepatic requirements for complete correction.
+  description: Liver-directed AAV8 gene therapy delivering BCKDHA has rescued lethal MSUD phenotype in Bckdha-knockout mice. Ubiquitous promoter fully rescues the disease; liver-specific expression provides partial but sustained rescue, highlighting both hepatic and extrahepatic requirements for complete correction. Translation to clinical trials is supported by protocolized natural history cohorts designed as regulatory-grade external controls. The MSUD Age-matched Standard Treatment Cohort (MATCH) provides prespecified outcome measures (proportional intact protein equivalent, crisis management days, blood alloisoleucine concentration) aligned with FDA guidance and ICH E9(R1) for single-arm gene therapy trial design.
   treatment_term:
     preferred_term: gene therapy
     term:
@@ -1169,10 +1169,22 @@ treatments:
     evidence_source: MODEL_ORGANISM
     snippet: "BCKDHA gene transfer rescued the lethal phenotype. While the use of a ubiquitous promoter fully and sustainably rescued the disease (long-term survival, normal phenotype and correction of biochemical abnormalities), liver-specific expression of BCKDHA led to partial, though sustained rescue."
     explanation: Demonstrates efficacy of AAV8 gene therapy for MSUD in a mouse model with complete rescue using ubiquitous expression.
+  - reference: PMID:42127902
+    reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We present the MSUD Age-matched Standard Treatment Cohort (MATCH), a prospective natural history study of 11 infants with classic MSUD followed from neonatal diagnosis to liver transplantation. Aligned with Food and Drug Administration (FDA) guidance and International Council for Harmonisation (ICH) E9(R1), MATCH applies prespecified eligibility criteria, fixed visit cadence, adjudicated outcomes, and explicit handling of intercurrent events."
+    explanation: MATCH cohort provides regulatory-grade natural history data as external controls for single-arm gene therapy trials, supporting FDA-aligned trial design.
+  - reference: PMID:42127902
+    reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Three of six outcome measures—proportional intact protein equivalent (PIPE), crisis management days (CMDs), and blood alloisoleucine concentration—are prespecified as estimands. Monte Carlo simulations show that a single-arm trial comparing 11 treated participants to MATCH controls achieves ≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 μM)."
+    explanation: Demonstrates statistical power of MATCH cohort as external controls for detecting meaningful clinical benefit in single-arm gene therapy trials.
   target_mechanisms:
   - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
     treatment_effect: RESTORES
-    description: BCKDHA gene transfer restores the deficient BCKDH E1-alpha component in preclinical MSUD models.
+    description: BCKDHA gene transfer restores the deficient BCKDH E1-alpha component in preclinical MSUD models and provides the basis for clinical gene therapy trials supported by regulatory-grade external control cohorts.
     evidence:
     - reference: PMID:35672312
       reference_title: "Neonatal gene therapy achieves sustained disease rescue of maple syrup urine disease in mice."
@@ -1180,6 +1192,12 @@ treatments:
       evidence_source: MODEL_ORGANISM
       snippet: "BCKDHA gene transfer rescued the lethal"
       explanation: Mouse-model gene transfer evidence supports restoration of the deficient BCKDHA component.
+    - reference: PMID:42127902
+      reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "MATCH demonstrates how protocolized natural history data serve as regulatory-grade external controls for single-arm trials."
+      explanation: MATCH cohort enables assessment of BCKDHA gene therapy efficacy in clinical trials using external control comparison.
 datasets:
 references:
 - reference: DOI:10.1002/jmd2.12419

--- a/references_cache/PMID_42127902.md
+++ b/references_cache/PMID_42127902.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:42127902"
+title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+authors:
+- Brigatti KW
+- Rodrigues A
+- Sweigert E
+- Williamson J
+- Koehler A
+- Meier GL
+- Poskitt LE
+- Carson VJ
+- Robinson D
+- Strauss KA
+journal: Cell Rep Med
+year: '2026'
+doi: 10.1016/j.xcrm.2026.102799
+content_type: abstract_only
+---
+
+# Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease.
+**Authors:** Brigatti KW, Rodrigues A, Sweigert E, Williamson J, Koehler A, Meier GL, Poskitt LE, Carson VJ, Robinson D, Strauss KA
+**Journal:** Cell Rep Med (2026)
+**DOI:** [10.1016/j.xcrm.2026.102799](https://doi.org/10.1016/j.xcrm.2026.102799)
+
+## Content
+
+1. Cell Rep Med. 2026 May 12:102799. doi: 10.1016/j.xcrm.2026.102799. Online
+ahead  of print.
+
+Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup 
+urine disease.
+
+Brigatti KW(1), Rodrigues A(1), Sweigert E(1), Williamson J(1), Koehler A(1), 
+Meier GL(1), Poskitt LE(1), Carson VJ(1), Robinson D(1), Strauss KA(2).
+
+Author information:
+(1)Clinic for Special Children, Gordonville, PA 17529, USA.
+(2)Clinic for Special Children, Gordonville, PA 17529, USA; Plowshare Therapies, 
+Lancaster, PA 17603, USA. Electronic address: kastrauss@plowsharetherapies.com.
+
+Maple syrup urine disease (MSUD) is a life-threatening metabolic disorder for 
+which randomized trials are infeasible. We present the MSUD Age-matched Standard 
+Treatment Cohort (MATCH), a prospective natural history study of 11 infants with 
+classic MSUD followed from neonatal diagnosis to liver transplantation. Aligned 
+with Food and Drug Administration (FDA) guidance and International Council for 
+Harmonisation (ICH) E9(R1), MATCH applies prespecified eligibility criteria, 
+fixed visit cadence, adjudicated outcomes, and explicit handling of intercurrent 
+events. Three of six outcome measures-proportional intact protein equivalent 
+(PIPE), crisis management days (CMDs), and blood alloisoleucine 
+concentration-are prespecified as estimands. Monte Carlo simulations show that a 
+single-arm trial comparing 11 treated participants to MATCH controls achieves 
+≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase 
+in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 
+μM). MATCH demonstrates how protocolized natural history data serve as 
+regulatory-grade external controls for single-arm trials.
+
+Copyright © 2026 The Authors. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.xcrm.2026.102799
+PMID: 42127902
+
+Conflict of interest statement: Declaration of interests K.A.S. is listed as a 
+co-inventor on a patent application filed by the University of Massachusetts 
+Chan Medical School concerning a gene therapy product mentioned in this paper 
+(WO2020210595—AAV-mediated gene therapy for maple syrup urine disease). K.A.S. 
+is the founder of Plowshare Therapies LLC, a biotechnology company in 
+Pennsylvania developing gene therapy for MSUD. Plowshare Therapies provided no 
+direct or indirect funding for this study.


### PR DESCRIPTION
## Summary

Augmented Maple Syrup Urine Disease entry with regulatory framework and clinical trial design context for gene therapy trials, specifically addressing issue #2745.

## Changes

- **Enhanced Gene Therapy (Preclinical) section**: Updated description to include regulatory context (FDA guidance and ICH E9(R1)) and MATCH cohort natural history study
- **Added clinical trial design evidence**: 
  - MATCH cohort as regulatory-grade external controls for single-arm trials
  - Prespecified outcome measures: proportional intact protein equivalent (PIPE), crisis management days (CMDs), blood alloisoleucine concentration
  - Statistical power analysis showing effectiveness (≥90% power to detect meaningful clinical differences)
- **Enhanced target mechanism evidence**: Added MATCH cohort reference to show clinical trial applications
- **Updated metadata**: Set updated_date to reflect curation date

## References Validated

- PMID:42127902: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease" (Brigatti et al., 2026, Cell Rep Med)
- Reference cache fetched and validated via `just fetch-reference`

## Test Plan

- [x] Schema validation (`just validate kb/disorders/Maple_Syrup_Urine_Disease.yaml`)
- [x] Reference validation (`just validate-references kb/disorders/Maple_Syrup_Urine_Disease.yaml`)
- [x] All references in cache exist and match snippets
- [x] Updated YAML maintains valid structure

## Related Issue

Closes #2745

🤖 Generated with Claude Code