### PR TITLE
Migrate Bezlotoxumab therapeutic_agent qualifier in Clostridioides_difficile_Infection

### DIFF
--- a/kb/disorders/Clostridioides_difficile_Infection.yaml
+++ b/kb/disorders/Clostridioides_difficile_Infection.yaml
@@ -1,6 +1,6 @@
 name: Clostridioides difficile Infection
 creation_date: '2025-12-19T01:18:09Z'
-updated_date: '2026-02-19T17:30:29Z'
+updated_date: '2026-05-15T00:00:00Z'
 category: Infectious
 disease_term:
   preferred_term: Clostridium difficile colitis
@@ -676,17 +676,11 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
-    qualifiers:
-    - predicate:
-        preferred_term: therapeutic agent
-        term:
-          id: NCIT:C2259
-          label: Therapeutic Agent
-      value:
-        preferred_term: bezlotoxumab
-        term:
-          id: NCIT:C121379
-          label: Bezlotoxumab
+    therapeutic_agent:
+    - preferred_term: bezlotoxumab
+      term:
+        id: NCIT:C153084
+        label: Bezlotoxumab
   evidence:
   - reference: PMID:39282548
     reference_title: "Clostridioides difficile infection: an update."


### PR DESCRIPTION
## Summary

Phase 1b single-block migration on `kb/disorders/Clostridioides_difficile_Infection.yaml`, continuing the qualifiers-field migration from issue #1613.

- Migrates the `Bezlotoxumab` treatment block from the deprecated `qualifiers[predicate=Therapeutic Agent]` pattern to the typed `therapeutic_agent:` slot on `treatment_term`.
- **Also fixes a mislabeled NCIT ID**: the existing file had `NCIT:C121379` (Letetresgene Autoleucel — a T-cell therapy unrelated to bezlotoxumab) as the Bezlotoxumab identifier. The correct NCIT ID is `NCIT:C153084` (Bezlotoxumab), verified via `runoak -i sqlite:obo:ncit`.
- No CHEBI term for bezlotoxumab exists; NCIT is the appropriate ontology for this biologic.

**Intentionally NOT changed**: the `Vancomycin` and `Fidaxomicin` treatment blocks each mix `therapeutic agent` with `route of administration` in a single `qualifiers` list. These require Phase 2 schema work (explicit `route_of_administration` slot) before they can be cleanly migrated.

## Migration details

| Treatment | Action | Old ID | New ID |
|---|---|---|---|
| Bezlotoxumab | `qualifiers` → `therapeutic_agent` | NCIT:C121379 ❌ (Letetresgene Autoleucel) | NCIT:C153084 ✅ (Bezlotoxumab) |
| Vancomycin | deferred (mixed route+agent) | — | — |
| Fidaxomicin | deferred (mixed route+agent) | — | — |

## Validation

```
just validate kb/disorders/Clostridioides_difficile_Infection.yaml
✅ Validation passed
```

Schema validation, term validation, and reference validation all passed.

Closes part of #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)