### PR TITLE
Add immune-checkpoint-blockade conformance to Bladder Urothelial Carcinoma (#1113)

### DIFF
--- a/kb/disorders/Bladder_Urothelial_Carcinoma.yaml
+++ b/kb/disorders/Bladder_Urothelial_Carcinoma.yaml
@@ -1,6 +1,6 @@
 name: Bladder Urothelial Carcinoma
 creation_date: "2026-04-12T05:10:24Z"
-updated_date: "2026-04-27T22:00:00Z"
+updated_date: "2026-05-15T00:00:00Z"
 description: >-
   Bladder urothelial carcinoma is the dominant histologic form of bladder cancer
   and arises from the transitional urothelium lining the urinary bladder. It
@@ -188,6 +188,58 @@ pathophysiology:
     explanation: >-
       Supports treatment-relevant genomic stratification in advanced urothelial
       carcinoma, including FGFR3 and DNA repair-associated predictors.
+- name: Adaptive Immune Resistance and PD-L1-Mediated Immune Evasion
+  conforms_to: "immune_checkpoint_blockade#Adaptive Immune Resistance"
+  description: >-
+    Bladder urothelial carcinoma is an immunogenic tumor in which tumor cells
+    and the immunosuppressive tumor microenvironment co-opt the PD-1/PD-L1
+    homeostatic axis. Interferon-gamma from infiltrating effector T cells
+    drives adaptive PD-L1 upregulation, and PD-1 engagement on CD8+ T cells
+    suppresses cytotoxic anti-tumor activity, enabling immune escape. This
+    actively suppressed but pre-existing anti-tumor immunity is the
+    mechanistic rationale for PD-1/PD-L1 checkpoint blockade across
+    non-muscle-invasive and advanced urothelial carcinoma.
+  cell_types:
+  - preferred_term: CD8-positive, alpha-beta T cell
+    term:
+      id: CL:0000625
+      label: CD8-positive, alpha-beta T cell
+  biological_processes:
+  - preferred_term: Negative Regulation of T Cell Mediated Immunity
+    term:
+      id: GO:0002710
+      label: negative regulation of T cell mediated immunity
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:38762484
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      The interaction of PD-1 and PD-L1 negatively regulates adaptive
+      immune response mainly by inhibiting the activity of effector T cells
+      while enhancing the function of immunosuppressive regulatory T cells
+      (Tregs), largely contributing to the maintenance of immune homeostasis
+      that prevents dysregulated immunity and harmful immune responses.
+      However, cancer cells exploit the PD-1/PD-L1 axis to cause immune
+      escape in cancer development and progression.
+    explanation: >-
+      Review describing how tumors co-opt PD-1/PD-L1 signaling to suppress
+      anti-tumor T cell activity; this adaptive immune resistance mechanism
+      underlies checkpoint inhibitor responsiveness in advanced urothelial
+      carcinoma.
+  - reference: PMID:41919257
+    reference_title: "Recent advances in immunotherapy for bladder cancer: mechanisms, clinical applications, and future perspectives."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Key determinants of the tumor microenvironment (TME)-such as
+      immunosuppressive cell populations, regulatory cytokines, and metabolic
+      barriers-are examined in the context of their roles in mediating
+      therapeutic resistance.
+    explanation: >-
+      Bladder-cancer-specific review establishing immunosuppressive
+      tumor-microenvironment determinants as drivers of immune evasion and
+      therapeutic resistance in urothelial carcinoma.
 histopathology:
 - name: Urothelial Carcinoma
   finding_term:
@@ -478,6 +530,29 @@ treatments:
     explanation: >-
       Supports checkpoint blockade as a major component of modern bladder cancer
       treatment.
+  target_mechanisms:
+  - target: Adaptive Immune Resistance and PD-L1-Mediated Immune Evasion
+    treatment_effect: INHIBITS
+    description: >-
+      Anti-PD-1 (pembrolizumab) and anti-PD-L1 (atezolizumab) antibodies block
+      checkpoint-mediated immune evasion, releasing the brake on pre-existing
+      effector T cell cytotoxicity against urothelial tumor cells across
+      non-muscle-invasive and advanced urothelial carcinoma.
+    evidence:
+    - reference: PMID:41919257
+      reference_title: "Recent advances in immunotherapy for bladder cancer: mechanisms, clinical applications, and future perspectives."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Immune checkpoint inhibitors (ICIs) targeting PD-1/PD-L1 and CTLA-4,
+        adoptive cellular therapies including chimeric antigen receptor T-cell
+        (CAR-T) therapy, oncolytic viruses, and novel immunomodulatory agents
+        have transformed the therapeutic landscape for both non-muscle-invasive
+        bladder cancer (NMIBC) and advanced urothelial carcinoma (UC).
+      explanation: >-
+        Establishes PD-1/PD-L1-directed checkpoint blockade as a transformative
+        therapy that reverses immune evasion in NMIBC and advanced urothelial
+        carcinoma.
 - name: FGFR Inhibitor Therapy
   description: >-
     Selected patients with FGFR2/3-altered advanced urothelial carcinoma may


### PR DESCRIPTION
## Summary

Targeted augmentation of the existing `Bladder_Urothelial_Carcinoma.yaml` entry, addressing a specific gap called out in the curation notes of #1113.

The entry already existed (created via #1127, mappings added via #1805) and is comprehensive, **but** it had an `Immune Checkpoint Inhibitors` treatment with **no** corresponding immune-evasion pathophysiology node and **no** conformance to the `immune_checkpoint_blockade` module — despite the issue notes stating that module is "directly applicable here … adaptive immune resistance → PD-L1 upregulation → T cell exhaustion is central to BUC biology."

This PR closes that gap:

- Adds an **`Adaptive Immune Resistance and PD-L1-Mediated Immune Evasion`** pathophysiology node with `conforms_to: "immune_checkpoint_blockade#Adaptive Immune Resistance"` (cell type `CL:0000625`, biological process `GO:0002710` INCREASED).
- Wires the existing **`Immune Checkpoint Inhibitors`** treatment to that node via `target_mechanisms` (`treatment_effect: INHIBITS`).
- Bumps `updated_date`.

Mirrors the established **ccRCC** (`Clear_Cell_Renal_Cell_Carcinoma.yaml`) conformance pattern exactly (standalone conforming node, same GO term). All evidence reuses **already-cached, already-validated** PMIDs (`38762484` from the module/ccRCC; `41919257` already cited in this entry) — no new reference cache files created.

## Validation

- `just validate` — schema ✅, terms ✅, references ✅
- `just validate-terms` — ✅
- `just validate-references` — ✅
- `just check-reference-cache-frontmatter` — OK
- `just validate-graphs` — Bladder Urothelial Carcinoma: **no graph errors** (pre-existing failures in other unrelated files are not touched by this PR)

## What I intentionally did NOT do

The #1113 notes also suggest TCGA molecular subtypes, additional drivers (TERT/CDKN2A/PIK3CA/ERBB2/ARID1A/KDM6A), and basal/luminal pathway nodes. Those are larger, separable enhancements; this PR is deliberately scoped to the single highest-value, lowest-risk gap (module conformance) so it can land safely. Left as draft for review and to allow follow-up curation.

Closes #1113 once reviewers agree the entry is sufficiently complete; otherwise treat as incremental progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)