### PR TITLE
Add MATCH cohort regulatory framework to MSUD gene therapy section

### DIFF
--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1169,6 +1169,12 @@ treatments:
     evidence_source: MODEL_ORGANISM
     snippet: "BCKDHA gene transfer rescued the lethal phenotype. While the use of a ubiquitous promoter fully and sustainably rescued the disease (long-term survival, normal phenotype and correction of biochemical abnormalities), liver-specific expression of BCKDHA led to partial, though sustained rescue."
     explanation: Demonstrates efficacy of AAV8 gene therapy for MSUD in a mouse model with complete rescue using ubiquitous expression.
+  - reference: PMID:42127902
+    reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "MATCH applies prespecified eligibility criteria, fixed visit cadence, adjudicated outcomes, and explicit handling of intercurrent events."
+    explanation: The MSUD Age-matched Standard Treatment Cohort (MATCH) provides an FDA and ICH-aligned natural history framework for designing single-arm gene therapy trials with regulatory-grade external controls.
   target_mechanisms:
   - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
     treatment_effect: RESTORES

--- a/references_cache/PMID_42127902.md
+++ b/references_cache/PMID_42127902.md
@@ -1,0 +1,69 @@
+---
+reference_id: "PMID:42127902"
+title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+authors:
+- Brigatti KW
+- Rodrigues A
+- Sweigert E
+- Williamson J
+- Koehler A
+- Meier GL
+- Poskitt LE
+- Carson VJ
+- Robinson D
+- Strauss KA
+journal: Cell Rep Med
+year: '2026'
+doi: 10.1016/j.xcrm.2026.102799
+content_type: abstract_only
+---
+
+# Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease.
+**Authors:** Brigatti KW, Rodrigues A, Sweigert E, Williamson J, Koehler A, Meier GL, Poskitt LE, Carson VJ, Robinson D, Strauss KA
+**Journal:** Cell Rep Med (2026)
+**DOI:** [10.1016/j.xcrm.2026.102799](https://doi.org/10.1016/j.xcrm.2026.102799)
+
+## Content
+
+1. Cell Rep Med. 2026 May 12:102799. doi: 10.1016/j.xcrm.2026.102799. Online
+ahead  of print.
+
+Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup 
+urine disease.
+
+Brigatti KW(1), Rodrigues A(1), Sweigert E(1), Williamson J(1), Koehler A(1), 
+Meier GL(1), Poskitt LE(1), Carson VJ(1), Robinson D(1), Strauss KA(2).
+
+Author information:
+(1)Clinic for Special Children, Gordonville, PA 17529, USA.
+(2)Clinic for Special Children, Gordonville, PA 17529, USA; Plowshare Therapies, 
+Lancaster, PA 17603, USA. Electronic address: kastrauss@plowsharetherapies.com.
+
+Maple syrup urine disease (MSUD) is a life-threatening metabolic disorder for 
+which randomized trials are infeasible. We present the MSUD Age-matched Standard 
+Treatment Cohort (MATCH), a prospective natural history study of 11 infants with 
+classic MSUD followed from neonatal diagnosis to liver transplantation. Aligned 
+with Food and Drug Administration (FDA) guidance and International Council for 
+Harmonisation (ICH) E9(R1), MATCH applies prespecified eligibility criteria, 
+fixed visit cadence, adjudicated outcomes, and explicit handling of intercurrent 
+events. Three of six outcome measures-proportional intact protein equivalent 
+(PIPE), crisis management days (CMDs), and blood alloisoleucine 
+concentration-are prespecified as estimands. Monte Carlo simulations show that a 
+single-arm trial comparing 11 treated participants to MATCH controls achieves 
+≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase 
+in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 
+μM). MATCH demonstrates how protocolized natural history data serve as 
+regulatory-grade external controls for single-arm trials.
+
+Copyright © 2026 The Authors. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.xcrm.2026.102799
+PMID: 42127902
+
+Conflict of interest statement: Declaration of interests K.A.S. is listed as a 
+co-inventor on a patent application filed by the University of Massachusetts 
+Chan Medical School concerning a gene therapy product mentioned in this paper 
+(WO2020210595—AAV-mediated gene therapy for maple syrup urine disease). K.A.S. 
+is the founder of Plowshare Therapies LLC, a biotechnology company in 
+Pennsylvania developing gene therapy for MSUD. Plowshare Therapies provided no 
+direct or indirect funding for this study.


### PR DESCRIPTION
## Summary

Augmented the Maple Syrup Urine Disease entry with evidence from the MSUD Age-matched Standard Treatment Cohort (MATCH) study. This prospective natural history study provides a regulatory-grade external control framework for single-arm gene therapy trials.

## Changes

- **File:** kb/disorders/Maple_Syrup_Urine_Disease.yaml
- **Section:** Gene Therapy (Preclinical) treatment  
- **Addition:** Evidence item documenting MATCH as FDA and ICH-aligned trial design framework with prespecified outcomes (PIPE, CMDs, alloisoleucine concentration)

## References Cached

- PMID:42127902: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease" (Cell Rep Med, 2026)

## Validation

✅ Schema validation passed
✅ Reference validation passed  
✅ Term validation passed

## Context

Issue #2745 requested augmentation of MSUD with recent literature on gene therapy trial design. The MATCH cohort provides important context on regulatory requirements and outcome measures for evaluating gene therapies, complementing the existing preclinical gene therapy section.

🤖 Generated with [Claude Code](https://claude.ai/code)