### PR TITLE
Add MATCH cohort evidence to Maple Syrup Urine Disease gene therapy

### DIFF
--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1,6 +1,6 @@
 name: Maple Syrup Urine Disease
 creation_date: '2026-01-09T01:00:56Z'
-updated_date: '2026-05-09T09:23:57Z'
+updated_date: '2026-05-16T07:15:00Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -1175,6 +1175,12 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "MSUD Age-matched Standard Treatment Cohort (MATCH), a prospective natural history study of 11 infants with classic MSUD followed from neonatal diagnosis to liver transplantation. Aligned with Food and Drug Administration (FDA) guidance and International Council for Harmonisation (ICH) E9(R1), MATCH applies prespecified eligibility criteria, fixed visit cadence, adjudicated outcomes, and explicit handling of intercurrent events."
     explanation: The MATCH cohort provides regulatory-grade natural history baseline and prespecified outcome measures for single-arm gene therapy trials in MSUD, bridging preclinical models to clinical development.
+  - reference: PMID:42127902
+    reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Three of six outcome measures—proportional intact protein equivalent (PIPE), crisis management days (CMDs), and blood alloisoleucine concentration—are prespecified as estimands. Monte Carlo simulations show that a single-arm trial comparing 11 treated participants to MATCH controls achieves ≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 μM)."
+    explanation: MATCH provides prespecified outcome measures (PIPE, CMDs, alloisoleucine) as estimands with statistical power to detect clinically meaningful improvements in a single-arm gene therapy trial, supporting trial design and regulatory strategy for MSUD gene therapy development.
   target_mechanisms:
   - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency
     treatment_effect: RESTORES

--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1179,7 +1179,7 @@ treatments:
     reference_title: "Trial-ready external controls for gene therapy: The MATCH cohort in maple syrup urine disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Three of six outcome measures—proportional intact protein equivalent (PIPE), crisis management days (CMDs), and blood alloisoleucine concentration—are prespecified as estimands. Monte Carlo simulations show that a single-arm trial comparing 11 treated participants to MATCH controls achieves ≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 μM)."
+    snippet: "Three of six outcome measures-proportional intact protein equivalent (PIPE), crisis management days (CMDs), and blood alloisoleucine concentration-are prespecified as estimands. Monte Carlo simulations show that a single-arm trial comparing 11 treated participants to MATCH controls achieves ≥90% power (p ≤ 0.025) to detect 64% fewer CMDs (3.0% vs. 8.4%), a 57% increase in PIPE (19.3% vs. 12.3%), and a 36% reduction in alloisoleucine (117 vs. 183 μM)."
     explanation: MATCH provides prespecified outcome measures (PIPE, CMDs, alloisoleucine) as estimands with statistical power to detect clinically meaningful improvements in a single-arm gene therapy trial, supporting trial design and regulatory strategy for MSUD gene therapy development.
   target_mechanisms:
   - target: Branched-Chain Alpha-Ketoacid Dehydrogenase Complex Deficiency


### PR DESCRIPTION
## Summary

Enhanced the Gene Therapy (Preclinical) treatment section of the Maple Syrup Urine Disease entry with detailed evidence from the MSUD Age-matched Standard Treatment Cohort (MATCH) study (PMID:42127902).

## Changes

Added new evidence item documenting:
- **Prespecified outcome measures**: PIPE (proportional intact protein equivalent), CMDs (crisis management days), and blood alloisoleucine concentration
- **Trial design parameters**: ≥90% statistical power to detect clinically meaningful improvements in a single-arm gene therapy trial
  - 64% reduction in CMDs (3.0% vs. 8.4%)
  - 57% increase in PIPE (19.3% vs. 12.3%)
  - 36% reduction in alloisoleucine (117 vs. 183 μM)
- **Regulatory alignment**: FDA guidance and ICH E9(R1) framework for external controls

## Why This Matters

The MATCH cohort provides a regulatory-grade natural history baseline and standardized outcome measures that are essential for designing and powering single-arm gene therapy trials in MSUD. This complements the existing Gene Therapy (Preclinical) section which documented mouse model efficacy from PMID:35672312.

## Test Plan

- ✅ Schema validation passed
- ✅ Reference validation passed (snippet matches abstract from PMID:42127902)
- ✅ Updated `updated_date` timestamp (2026-05-16)

🤖 Generated with [Claude Code](https://claude.ai/code)