### PR TITLE
Stop flagging skos:exactMatch MONDO mappings as "Not Yet Curated" (#1307)

### DIFF
--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -3276,15 +3276,18 @@
                 {% set mapping_term_id = mapping.term.id if mapping.term and mapping.term.id else None %}
                 {% set mapping_has_local_page = (mapping_term_id | has_local_disorder_page) if mapping_term_id else False %}
                 {% set mapping_dismech_href = (mapping_term_id | dismech_page_url) if mapping_term_id else None %}
+                {# skos:exactMatch denotes the same disease as this page's disease_term: ontology grounding only, never a separate curation target (#1307). #}
+                {% set mapping_is_exact = mapping.mapping_predicate == "skos:exactMatch" %}
+                {% set mapping_flag_missing = mapping_term_id and not mapping_has_local_page and not mapping_is_exact %}
                 <div class="mapping-item">
                     <div class="mapping-title">
                         {% if mapping_term_id %}
-                        <a href="{{ mapping_term_id | curie_to_url }}" target="_blank"{% if not mapping_has_local_page %} class="missing-ontology-link"{% endif %}>{{ mapping_term_id }}</a>
+                        <a href="{{ mapping_term_id | curie_to_url }}" target="_blank"{% if mapping_flag_missing %} class="missing-ontology-link"{% endif %}>{{ mapping_term_id }}</a>
                         {% endif %}
                         {% if mapping.term and mapping.term.label %}
-                        <span class="mapping-label{% if mapping_term_id and not mapping_has_local_page %} missing-disease-name{% endif %}"{% if mapping_term_id and not mapping_has_local_page %} title="No Dismech page yet for this disease"{% endif %}>{{ mapping.term.label }}</span>
+                        <span class="mapping-label{% if mapping_flag_missing %} missing-disease-name{% endif %}"{% if mapping_flag_missing %} title="No Dismech page yet for this disease"{% endif %}>{{ mapping.term.label }}</span>
                         {% endif %}
-                        {% if mapping_term_id and not mapping_has_local_page %}
+                        {% if mapping_flag_missing %}
                         <span class="curation-gap-badge">Not Yet Curated</span>
                         {% endif %}
                         {% if mapping_dismech_href %}

--- a/tests/test_render_differential_links.py
+++ b/tests/test_render_differential_links.py
@@ -238,6 +238,71 @@ def test_render_mondo_mapping_highlights_missing_disorder_page(tmp_path: Path) -
     assert 'href="http://purl.obolibrary.org/obo/MONDO_0099999"' in html
 
 
+def test_render_mondo_mapping_exactmatch_is_grounding_only(tmp_path: Path) -> None:
+    """skos:exactMatch MONDO mappings denote the same disease as this page's
+    disease_term, so they are ontology grounding only and must not be flagged
+    as an uncurated disease (#1307)."""
+    acne_path = tmp_path / "Acne_Vulgaris.yaml"
+    _write_disorder(
+        acne_path,
+        {
+            "name": "Acne Vulgaris",
+            "disease_term": {"term": {"id": "MONDO:0000001", "label": "acne vulgaris"}},
+            "mappings": {
+                "mondo_mappings": [
+                    {
+                        "term": {"id": "MONDO:0099999", "label": "acne vulgaris"},
+                        "mapping_source": "MONDO",
+                        "mapping_predicate": "skos:exactMatch",
+                    }
+                ]
+            },
+        },
+    )
+
+    output_path = tmp_path / "pages" / "disorders" / "Acne_Vulgaris.html"
+    render_disorder(acne_path, output_path=output_path)
+
+    html = output_path.read_text()
+    assert "Not Yet Curated" not in html
+    assert '<span class="curation-gap-badge"' not in html
+    assert 'class="mapping-label missing-disease-name"' not in html
+    assert 'class="missing-ontology-link"' not in html
+    # External ontology grounding link is still rendered.
+    assert 'href="http://purl.obolibrary.org/obo/MONDO_0099999"' in html
+
+
+def test_render_mondo_mapping_closematch_still_flagged(tmp_path: Path) -> None:
+    """Non-exact predicates (closeMatch/relatedMatch/broadMatch) may point to a
+    genuinely distinct disease, so the curation-gap signal is preserved until a
+    maintainer decides otherwise (#1307)."""
+    acne_path = tmp_path / "Acne_Vulgaris.yaml"
+    _write_disorder(
+        acne_path,
+        {
+            "name": "Acne Vulgaris",
+            "disease_term": {"term": {"id": "MONDO:0000001", "label": "acne vulgaris"}},
+            "mappings": {
+                "mondo_mappings": [
+                    {
+                        "term": {"id": "MONDO:0099999", "label": "uncurated disease"},
+                        "mapping_source": "MONDO",
+                        "mapping_predicate": "skos:closeMatch",
+                    }
+                ]
+            },
+        },
+    )
+
+    output_path = tmp_path / "pages" / "disorders" / "Acne_Vulgaris.html"
+    render_disorder(acne_path, output_path=output_path)
+
+    html = output_path.read_text()
+    assert '<span class="curation-gap-badge">Not Yet Curated</span>' in html
+    assert 'class="mapping-label missing-disease-name"' in html
+    assert 'href="http://purl.obolibrary.org/obo/MONDO_0099999"' in html
+
+
 def test_render_subtype_terms_are_grounding_only(tmp_path: Path) -> None:
     """Subtype ontology grounding should not imply local disorder pages."""
     acne_path = tmp_path / "Acne_Vulgaris.yaml"


### PR DESCRIPTION
## Summary

Scoped renderer fix for the disease-level half of #1307. The "Not Yet Curated" curation-gap badge was being emitted for **every** `mappings.mondo_mappings` entry whose MONDO ID lacks a local Dismech page — regardless of `mapping_predicate`.

A `skos:exactMatch` mapping is, by definition, an equivalent ontology ID for the **same disease** as the page's own `disease_term`. The disease *is* curated — it is the page you are looking at. Flagging it as "Not Yet Curated" is the exact ontology-grounding-vs-curation-target conflation @cmungall raised in #1307 for subtypes, already fixed for the subtype side by merged PR #1236.

This PR narrows the badge so it is suppressed only for `skos:exactMatch` mappings. `skos:closeMatch` / `relatedMatch` / `broadMatch` and the `differential_diagnoses` block are **intentionally left unchanged** — those may point to a genuinely distinct disease, and that is a maintainer policy call (see the assessment comment on #1307).

## Empirical motivation

Across `kb/disorders/` (1,098 non-history files):

| `mapping_predicate` | count | currently badged "Not Yet Curated" |
|---|---|---|
| `skos:exactMatch` | 157 | 157 |
| `skos:closeMatch` | 22 | 22 |
| `skos:relatedMatch` | 2 | 2 |
| `skos:broadMatch` | 1 | 1 |
| **total** | **182** | **182 / 182** |

100% of `mondo_mappings` entries were falsely flagged; 86% are `exactMatch` (provably the same disease as the page).

## Changes

- `src/dismech/templates/disorder.html.j2`: gate the missing-page styling/badge in the `mondo_mappings` block on a new `mapping_flag_missing` that excludes `skos:exactMatch`.
- `tests/test_render_differential_links.py`: add `test_render_mondo_mapping_exactmatch_is_grounding_only` (badge suppressed) and `test_render_mondo_mapping_closematch_still_flagged` (signal preserved for non-exact predicates).

## Validation

- `tests/test_render_differential_links.py`: 11 passed (incl. pre-existing `test_render_mondo_mapping_highlights_missing_disorder_page`, which has no predicate and still shows the badge).
- Broader render/mapping/subtype/differential suite: 2283 passed, 1 skipped, 0 failed.
- Sanity render of a real entry (`46_XX_Gonadal_Dysgenesis.yaml`, `skos:exactMatch` → `MONDO:0009299`): plain `mapping-label`, 0 badges, external MONDO link retained.
- No generated HTML committed (per CLAUDE.md).

## Why draft

The `closeMatch`/`relatedMatch` scope and whether to extend this to `differential_diagnoses` is an unresolved maintainer policy decision (open on #1307 since 2026-04-26). This PR deliberately addresses only the unambiguous `exactMatch` subset. Promote out of draft once a maintainer confirms the broader scope (or confirms this scoping is correct as-is).

Refs #1307. Pattern mirrors #1236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)