### PR TITLE
Add TMPRSS2:ERG fusion pathophysiology node to Prostate Adenocarcinoma (#1115)

### DIFF
--- a/kb/disorders/Prostate_Adenocarcinoma.yaml
+++ b/kb/disorders/Prostate_Adenocarcinoma.yaml
@@ -1,6 +1,6 @@
 name: Prostate Adenocarcinoma
 creation_date: '2026-04-12T05:10:57Z'
-updated_date: '2026-04-28T19:30:00Z'
+updated_date: '2026-05-16T11:11:46Z'
 description: >-
   Prostate adenocarcinoma is the predominant histologic form of prostate cancer,
   arising from prostatic glandular epithelium and maintained by androgen
@@ -71,6 +71,58 @@ pathophysiology:
     description: AR activation promotes anabolic lipid metabolism that supports tumor growth.
   - target: Signaling Bypass and Castration Resistance
     description: Treatment pressure selects AR-reactivated and AR-bypass states.
+  - target: TMPRSS2:ERG Fusion-Driven ETS Activation
+    description: >-
+      Androgen-responsive TMPRSS2 promoter elements drive aberrant ERG
+      overexpression in the roughly half of tumors carrying the fusion.
+- name: TMPRSS2:ERG Fusion-Driven ETS Activation
+  description: >-
+    In approximately half of prostate adenocarcinomas an androgen-responsive
+    TMPRSS2 promoter is fused to the ETS transcription factor ERG, placing ERG
+    under androgen control and driving its aberrant overexpression. The
+    resulting ETS transcriptional program promotes an invasion-associated,
+    less-differentiated phenotype and defines the predominant molecular subtype
+    of the disease.
+  evidence:
+  - reference: PMID:16254181
+    reference_title: 'Recurrent fusion of TMPRSS2 and ETS transcription factor genes in prostate cancer.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "we demonstrated that 23 of 29 prostate cancer samples harbor rearrangements in ERG or ETV1"
+    explanation: Fluorescence in situ hybridization in human prostate cancer tissue established recurrent ERG/ETV1 rearrangements as a frequent somatic event.
+  - reference: PMID:16254181
+    reference_title: 'Recurrent fusion of TMPRSS2 and ETS transcription factor genes in prostate cancer.'
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Cell line experiments suggest that the androgen-responsive promoter elements of TMPRSS2 mediate the overexpression of ETS family members in prostate cancer."
+    explanation: This identifies the androgen-driven TMPRSS2 promoter as the mechanism placing ETS factors such as ERG under aberrant transcriptional control.
+  - reference: PMID:18283340
+    reference_title: 'Role of the TMPRSS2-ERG gene fusion in prostate cancer.'
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Introduction of the ERG gene fusion product into primary or immortalized benign prostate epithelial cells induced an invasion-associated transcriptional program but did not increase cellular proliferation or anchorage-independent growth."
+    explanation: Functional introduction of the ERG fusion product activates an invasion-associated transcriptional program, indicating the fusion contributes to invasion rather than proliferation.
+  cell_types:
+  - preferred_term: epithelial cell of prostate
+    term:
+      id: CL:0002231
+      label: epithelial cell of prostate
+  biological_processes:
+  - preferred_term: ETS (ERG) target gene transcriptional activation
+    modifier: INCREASED
+    term:
+      id: GO:0045944
+      label: positive regulation of transcription by RNA polymerase II
+  locations:
+  - preferred_term: prostate gland
+    term:
+      id: UBERON:0002367
+      label: prostate gland
+  downstream:
+  - target: Epithelial-Mesenchymal Transition
+    description: >-
+      ERG-driven invasion-associated transcriptional reprogramming promotes the
+      invasive cellular phenotype that precedes distant spread.
 - name: Lipogenic Metabolic Reprogramming
   description: >-
     Prostate adenocarcinoma shows unusually strong dependence on de novo fatty

--- a/references_cache/PMID_16254181.md
+++ b/references_cache/PMID_16254181.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:16254181"
+title: Recurrent fusion of TMPRSS2 and ETS transcription factor genes in prostate cancer.
+authors:
+- Tomlins SA
+- Rhodes DR
+- Perner S
+- Dhanasekaran SM
+- Mehra R
+- Sun XW
+- Varambally S
+- Cao X
+- Tchinda J
+- Kuefer R
+- Lee C
+- Montie JE
+- Shah RB
+- Pienta KJ
+- Rubin MA
+- Chinnaiyan AM
+journal: Science
+year: '2005'
+doi: 10.1126/science.1117679
+keywords:
+- Androgens/metabolism
+- "Cell Line, Tumor"
+- DNA-Binding Proteins/genetics
+- "Gene Expression Regulation, Neoplastic"
+- Gene Rearrangement
+- Humans
+- "In Situ Hybridization, Fluorescence"
+- Male
+- Membrane Proteins/genetics
+- Molecular Sequence Data
+- Neoplasm Proteins/genetics
+- "Oncogene Proteins, Fusion/genetics"
+- Polymerase Chain Reaction
+- Prostatic Neoplasms/genetics
+- Serine Endopeptidases/genetics
+- Trans-Activators/genetics
+- Transcription Factors/genetics
+- Transcriptional Regulator ERG
+- "Translocation, Genetic"
+content_type: abstract_only
+---
+
+# Recurrent fusion of TMPRSS2 and ETS transcription factor genes in prostate cancer.
+**Authors:** Tomlins SA, Rhodes DR, Perner S, Dhanasekaran SM, Mehra R, Sun XW, Varambally S, Cao X, Tchinda J, Kuefer R, Lee C, Montie JE, Shah RB, Pienta KJ, Rubin MA, Chinnaiyan AM
+**Journal:** Science (2005)
+**DOI:** [10.1126/science.1117679](https://doi.org/10.1126/science.1117679)
+
+## Content
+
+1. Science. 2005 Oct 28;310(5748):644-8. doi: 10.1126/science.1117679.
+
+Recurrent fusion of TMPRSS2 and ETS transcription factor genes in prostate 
+cancer.
+
+Tomlins SA(1), Rhodes DR, Perner S, Dhanasekaran SM, Mehra R, Sun XW, Varambally 
+S, Cao X, Tchinda J, Kuefer R, Lee C, Montie JE, Shah RB, Pienta KJ, Rubin MA, 
+Chinnaiyan AM.
+
+Author information:
+(1)Department of Pathology, University of Michigan Medical School, 1301 
+Catherine Street, Ann Arbor, MI 48109-0602, USA.
+
+Comment in
+    Science. 2005 Oct 28;310(5748):603. doi: 10.1126/science.310.5748.603a.
+    Eur Urol. 2007 May;51(5):1443-4. doi: 10.1016/j.eururo.2007.02.021.
+
+Recurrent chromosomal rearrangements have not been well characterized in common 
+carcinomas. We used a bioinformatics approach to discover candidate oncogenic 
+chromosomal aberrations on the basis of outlier gene expression. Two ETS 
+transcription factors, ERG and ETV1, were identified as outliers in prostate 
+cancer. We identified recurrent gene fusions of the 5' untranslated region of 
+TMPRSS2 to ERG or ETV1 in prostate cancer tissues with outlier expression. By 
+using fluorescence in situ hybridization, we demonstrated that 23 of 29 prostate 
+cancer samples harbor rearrangements in ERG or ETV1. Cell line experiments 
+suggest that the androgen-responsive promoter elements of TMPRSS2 mediate the 
+overexpression of ETS family members in prostate cancer. These results have 
+implications in the development of carcinomas and the molecular diagnosis and 
+treatment of prostate cancer.
+
+DOI: 10.1126/science.1117679
+PMID: 16254181 [Indexed for MEDLINE]

--- a/references_cache/PMID_18283340.md
+++ b/references_cache/PMID_18283340.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:18283340"
+title: Role of the TMPRSS2-ERG gene fusion in prostate cancer.
+authors:
+- Tomlins SA
+- Laxman B
+- Varambally S
+- Cao X
+- Yu J
+- Helgeson BE
+- Cao Q
+- Prensner JR
+- Rubin MA
+- Shah RB
+- Mehra R
+- Chinnaiyan AM
+journal: Neoplasia
+year: '2008'
+doi: 10.1593/neo.07822
+keywords:
+- Animals
+- Cell Line
+- "Cell Line, Tumor"
+- DNA-Binding Proteins/genetics
+- Gene Fusion
+- Humans
+- Male
+- Mice
+- "Mice, Transgenic"
+- Neoplasm Invasiveness
+- "Oncogene Proteins, Fusion/genetics"
+- Plasminogen Activators/metabolism
+- Prostate/cytology
+- "Prostatic Intraepithelial Neoplasia/genetics, metabolism, pathology"
+- "Prostatic Neoplasms/genetics, metabolism, pathology"
+- Trans-Activators/genetics
+- Transcriptional Regulator ERG
+content_type: abstract_only
+---
+
+# Role of the TMPRSS2-ERG gene fusion in prostate cancer.
+**Authors:** Tomlins SA, Laxman B, Varambally S, Cao X, Yu J, Helgeson BE, Cao Q, Prensner JR, Rubin MA, Shah RB, Mehra R, Chinnaiyan AM
+**Journal:** Neoplasia (2008)
+**DOI:** [10.1593/neo.07822](https://doi.org/10.1593/neo.07822)
+
+## Content
+
+1. Neoplasia. 2008 Feb;10(2):177-88. doi: 10.1593/neo.07822.
+
+Role of the TMPRSS2-ERG gene fusion in prostate cancer.
+
+Tomlins SA(1), Laxman B, Varambally S, Cao X, Yu J, Helgeson BE, Cao Q, Prensner 
+JR, Rubin MA, Shah RB, Mehra R, Chinnaiyan AM.
+
+Author information:
+(1)Michigan Center for Translational Pathology, Department of Pathology, 
+University of Michigan Medical School, Ann Arbor, MI 48109, USA.
+
+TMPRSS2-ERG gene fusions are the predominant molecular subtype of prostate 
+cancer. Here, we explored the role of TMPRSS2-ERG gene fusion product using in 
+vitro and in vivo model systems. Transgenic mice expressing the ERG gene fusion 
+product under androgen-regulation develop mouse prostatic intraepithelial 
+neoplasia (PIN), a precursor lesion of prostate cancer. Introduction of the ERG 
+gene fusion product into primary or immortalized benign prostate epithelial 
+cells induced an invasion-associated transcriptional program but did not 
+increase cellular proliferation or anchorage-independent growth. These results 
+suggest that TMPRSS2-ERG may not be sufficient for transformation in the absence 
+of secondary molecular lesions. Transcriptional profiling of ERG knockdown in 
+the TMPPRSS2-ERG-positive prostate cancer cell line VCaP revealed decreased 
+expression of genes over-expressed in prostate cancer versus PIN and genes 
+overexpressed in ETS-positive versus -negative prostate cancers in addition to 
+inhibiting invasion. ERG knockdown in VCaP cells also induced a transcriptional 
+program consistent with prostate differentiation. Importantly, VCaP cells and 
+benign prostate cells overexpressing ERG directly engage components of the 
+plasminogen activation pathway to mediate cellular invasion, potentially 
+representing a downstream ETS target susceptible to therapeutic intervention. 
+Our results support previous work suggesting that TMPRSS2-ERG fusions mediate 
+invasion, consistent with the defining histologic distinction between PIN and 
+prostate cancer.
+
+DOI: 10.1593/neo.07822
+PMCID: PMC2244693
+PMID: 18283340 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Promotes **TMPRSS2:ERG** from the `genetic` block (where it was the only representation) to a dedicated **pathophysiology node** in `kb/disorders/Prostate_Adenocarcinoma.yaml`. This was the top enrichment gap flagged by the 2026-04-24 curation-scanner triage on #1115 ("TMPRSS2:ERG pathophysiology node — promoted from gene-level entry to a discrete node given its ~50% prevalence and mechanistic role").

### What changed

- New pathophysiology node **"TMPRSS2:ERG Fusion-Driven ETS Activation"**:
  - `cell_types`: epithelial cell of prostate (`CL:0002231`)
  - `biological_processes`: positive regulation of transcription by RNA polymerase II (`GO:0045944`, INCREASED) — the aberrant ETS/ERG transcriptional program
  - `locations`: prostate gland (`UBERON:0002367`)
  - 3 evidence items (2 PMIDs), split by `evidence_source`:
    - `PMID:16254181` (Tomlins 2005, *Science*) — **HUMAN_CLINICAL**: recurrent ERG/ETV1 rearrangements in 23/29 prostate cancer tissue samples
    - `PMID:16254181` — **IN_VITRO**: androgen-responsive TMPRSS2 promoter mediates ETS overexpression
    - `PMID:18283340` (Tomlins 2008, *Neoplasia*) — **IN_VITRO**: ERG fusion product induces an invasion-associated transcriptional program
- Causal-graph wiring: AR Signaling Dependence → (new node) → Epithelial-Mesenchymal Transition, integrating the node rather than leaving it orphaned.
- Bumped `updated_date`.

### Validation

- `just validate kb/disorders/Prostate_Adenocarcinoma.yaml` — ✅ schema + references pass
- `just validate-terms kb/disorders/Prostate_Adenocarcinoma.yaml` — ✅ pass
- `just check-reference-cache-frontmatter` — ✅ cache contract OK
- `just validate-graphs` — Prostate Adenocarcinoma has **no** graph errors (the recipe-level failure is from pre-existing dangling targets in unrelated files such as Vulvar Adenocarcinoma)
- All three snippets manually verified as verbatim substrings of the freshly fetched cached abstracts (`just fetch-reference`, never hand-edited).

### Intentionally NOT done

Other 2026-04-24 triage enrichment items (dedicated cell-cycle RB1/TP53 node, neuroendocrine trans-differentiation node, expanded gene set, `conforms_to: immune_checkpoint_blockade#Adaptive Immune Resistance` on the immune-suppressive TME node) require broader evidence work and are best batched separately, ideally after the cancer-curation SOP (#1198) settles.

Closes part of #1115.

🤖 Generated by the automated curation scanner