### PR TITLE
Conform AAT Hepatic Protein Aggregation node to er_protein_storage_disease module (#2727)

### DIFF
--- a/kb/disorders/Alpha_1_Antitrypsin_Deficiency.yaml
+++ b/kb/disorders/Alpha_1_Antitrypsin_Deficiency.yaml
@@ -108,6 +108,7 @@ pathophysiology:
         This mechanistic review directly links functional AAT deficiency to
         lost neutrophil elastase inhibition and elastin breakdown in lung tissue.
 - name: Hepatic Protein Aggregation
+  conforms_to: "er_protein_storage_disease#Hepatic Protein Aggregation"
   description: >
     The Z variant of AAT (E342K, PiZZ genotype) causes misfolding of AAT protein in
     hepatocytes. Approximately 85% of mutant Z protein is retained in the


### PR DESCRIPTION
## Summary

Adds a single `conforms_to` annotation to the existing **Hepatic Protein Aggregation** node in `kb/disorders/Alpha_1_Antitrypsin_Deficiency.yaml`:

```yaml
- name: Hepatic Protein Aggregation
  conforms_to: "er_protein_storage_disease#Hepatic Protein Aggregation"
```

This is the module-integration half of **task 2** in #2727. It completes the wiring between the existing flagship AATD entry and the new shared ER protein storage disease module.

## Context / dependency

This is part of the staged delivery for #2727:

- ✅ PR #2764 — `Congenital_Hypofibrinogenemia.yaml` (task 1)
- ✅ PR #2772 — `kb/modules/er_protein_storage_disease.yaml` (task 3, the module this PR references)
- 🟢 **This PR** — AATD `conforms_to` refactor (the second half of task 2)
- ⏳ Remaining — `Hepatic_Fibrinogen_Storage_Disease.yaml` (task 2 entry): still **blocked** because `MONDO:7770747` resolves to `None` in the local OAK `sqlite:obo:mondo` cache (verified this run), so `linkml-term-validator` would reject its `disease_term:` block.

> **Merge ordering:** this PR should merge **after #2772**, which introduces `kb/modules/er_protein_storage_disease.yaml`. There is no automated validation that resolves `conforms_to` module references (confirmed: no test in `tests/` and no `just` target dereferences them), so this passes CI independently — but the reference is only semantically meaningful once the module is on `main`. Kept as **draft** until #2772 lands.

## Consistency verification

Per CLAUDE.md, a conforming node should reflect the module node's biology with organ-specific substitution. Verified the AATD `Hepatic Protein Aggregation` node against the module node in PR #2772:

| Aspect | Module node | AATD node | Consistent? |
|---|---|---|---|
| Cell type | `hepatocyte` (CL:0000182) | `hepatocyte` (CL:0000182) | ✅ exact |
| Evidence | PMID:28752441, PMID:39440224 | PMID:22500781, **PMID:28752441**, **PMID:39440224** | ✅ shared anchors |
| Mechanism | misfolding → ~85% ER retention → proteotoxic burden | Z-AAT E342K → ~85% ER retention → proteotoxic stress | ✅ same |
| Downstream | generic `ER Stress and Unfolded Protein Response` | organ-specific `Hepatocyte Injury and Stellate Cell Activation` + `Protease-Antiprotease Imbalance in Lung` | ✅ expected organ-specific substitution |

The AATD node content is **unchanged** — this is annotation-only, consistent with the "Not DRY / conformance is consistency-checking, not inheritance" model in CLAUDE.md.

## Validation

- `just validate kb/disorders/Alpha_1_Antitrypsin_Deficiency.yaml` → schema ✅ / terms ✅ / references ✅ (0 reference checks; no new evidence added)
- `uv run pytest tests/test_data.py -k "Alpha_1_Antitrypsin or conforms"` → 7 passed
- Incidental validator-driven cache-normalization of 4 unrelated `clinicaltrials_NCT*.md` files was **reverted** (not staged) per the CLAUDE.md no-hand-edit-cache + targeted-add guardrails.

## What this PR intentionally does NOT do

- No new evidence / PMID fetches / cache files.
- No content edits to the AATD node or any other entry.
- Does **not** add the HFSD entry — still blocked on `MONDO:7770747` OAK resolution; should be a separate PR once the term resolves and #2772 has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)