### PR TITLE
Enhance Susac syndrome curation

### DIFF
--- a/kb/disorders/Susac_Syndrome.yaml
+++ b/kb/disorders/Susac_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Susac Syndrome
 creation_date: "2026-05-07T02:04:03Z"
-updated_date: "2026-05-07T02:04:03Z"
+updated_date: "2026-05-16T15:18:07Z"
 description: >-
   Susac syndrome is a rare acquired autoimmune microangiopathy of the brain,
   retina, and inner ear. The core disease mechanism is immune-mediated injury
@@ -13,10 +13,54 @@ disease_term:
   term:
     id: MONDO:0019390
     label: Susac syndrome
+mappings:
+  mondo_mappings:
+  - term:
+      id: MONDO:0019390
+      label: Susac syndrome
+    mapping_predicate: skos:exactMatch
+    mapping_source: Orphanet ORPHA:838
+    mapping_justification: >-
+      Orphanet ORPHA:838 lists MONDO:0019390 as an exact cross-reference for
+      Susac syndrome.
+external_assertions:
+- name: Orphanet Susac syndrome disease record
+  source: Orphanet
+  assertion_type: structured_disease_record
+  external_id: ORPHA:838
+  url: http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=838
+  description: >-
+    Orphanet's ORPHA:838 record provides the Susac syndrome definition,
+    retinocochleocerebral vasculopathy synonym, all-ages onset, HPO phenotype
+    table, and exact MONDO mapping used in this entry.
+  evidence:
+  - reference: ORPHA:838
+    reference_title: Susac syndrome
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "MONDO:0019390 | Exact"
+    explanation: Orphanet maps ORPHA:838 exactly to the MONDO term used by this entry.
 parents:
 - Autoimmune Disorder
 - Neurological Disorder
 - Eye disorder
+definitions:
+- name: Orphanet Susac syndrome definition
+  definition_type: OTHER
+  description: >-
+    Rare autoimmune-mediated microvascular occlusive disease involving the
+    brain, retina, and inner ear, clinically characterized by CNS dysfunction,
+    branch retinal artery occlusions, and sensorineural hearing loss.
+  evidence:
+  - reference: ORPHA:838
+    reference_title: Susac syndrome
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      A rare systemic or rheumatologic disease characterized by the triad of central nervous system (CNS) dysfunction, branch retinal artery occlusions (BRAOs) and sensorineural hearing loss (SNHL) due to autoimmune-mediated occlusions of microvessels in the brain, retina, and inner ear.
+    explanation: >-
+      Orphanet defines Susac syndrome by the CNS, retinal, and inner-ear triad
+      caused by autoimmune-mediated microvascular occlusion.
 prevalence:
 - population: Adults in Austria
   percentage: 0.148 per 100,000 five-year period prevalence; 0.024 per 100,000 annual incidence
@@ -69,6 +113,22 @@ progression:
     explanation: >-
       The multicenter follow-up cohort documents persistent functional impact
       in a substantial subset.
+- phase: Systematic-review outcome profile
+  notes: >-
+    A 2025 systematic review of 435 published patients found heterogeneous
+    recovery across neurologic, ophthalmologic, and audiovestibular domains,
+    with relapse in a minority and uncommon mortality during available
+    follow-up.
+  evidence:
+  - reference: PMID:40715894
+    reference_title: "Susac Syndrome: A Systematic Review and Survival Analysis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In a subgroup of 123 patients with available follow-up data (median duration: 12 months), 82.1% (n = 101) remained stable with controlled disease, 12.2% (n = 15) experienced a relapse, and 5.7% (n = 7) died.
+    explanation: >-
+      The systematic review provides quantitative follow-up outcomes supporting
+      relapse and mortality context.
 pathophysiology:
 - name: Immune-mediated microvascular endotheliopathy
   description: >-
@@ -107,10 +167,40 @@ pathophysiology:
   downstream:
   - target: CD8 T-cell endothelial injury
     description: Cytotoxic T-cell adhesion and effector polarization injure microvascular endothelium.
+    evidence:
+    - reference: PMID:31852955
+      reference_title: "CD8(+) T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our study identifies CD8+ T-cell-mediated endotheliopathy as a key disease mechanism in SuS and highlights therapeutic opportunities.
+      explanation: >-
+        This directly supports CD8 T-cell endothelial injury as a downstream
+        mechanism of the disease-level microangiopathy.
   - target: Retinal arteriolar occlusion
     description: Occlusive microangiopathy affects retinal branch arterioles.
+    evidence:
+    - reference: ORPHA:838
+      reference_title: Susac syndrome
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare systemic or rheumatologic disease characterized by the triad of central nervous system (CNS) dysfunction, branch retinal artery occlusions (BRAOs) and sensorineural hearing loss (SNHL) due to autoimmune-mediated occlusions of microvessels in the brain, retina, and inner ear.
+      explanation: >-
+        Orphanet links autoimmune microvascular occlusion to branch retinal
+        artery occlusions.
   - target: Central nervous system ischemic injury
     description: Occlusive microangiopathy produces multifocal brain ischemic lesions.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        subacute encephalopathy with unusual headache and pseudo-psychiatric features associated with multifocal ischemic white matter, grey matter nuclei and specifically corpus callosum lesions along with leptomeningeal enhancement on brain MRI
+      explanation: >-
+        The review links Susac CNS manifestations to multifocal ischemic brain
+        lesions.
   evidence:
   - reference: PMID:37608221
     reference_title: "Susac syndrome: neurological update (clinical features, long-term observational follow-up and management of sixteen patients)."
@@ -158,6 +248,16 @@ pathophysiology:
   downstream:
   - target: Central nervous system ischemic injury
     description: Endothelial injury and microhemorrhages contribute to brain tissue damage.
+    evidence:
+    - reference: PMID:31852955
+      reference_title: "CD8(+) T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our study identifies CD8+ T-cell-mediated endotheliopathy as a key disease mechanism in SuS and highlights therapeutic opportunities.
+      explanation: >-
+        The mechanistic study supports CD8 T-cell endotheliopathy as a proximal
+        injury mechanism feeding CNS tissue injury.
   evidence:
   - reference: PMID:31852955
     reference_title: "CD8(+) T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
@@ -209,6 +309,16 @@ pathophysiology:
   downstream:
   - target: Immune-mediated microvascular endotheliopathy
     description: Humoral autoimmunity may contribute to endothelial injury in a subset of patients.
+    evidence:
+    - reference: PMID:24606999
+      reference_title: "Clinical, paraclinical and serological findings in Susac syndrome: an international multicenter study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In all seropositive cases, AECA belonged to the complement-activating IgG1 subclass.
+      explanation: >-
+        Complement-activating anti-endothelial antibodies support a humoral
+        route into immune-mediated endotheliopathy in seropositive patients.
   evidence:
   - reference: PMID:24606999
     reference_title: "Clinical, paraclinical and serological findings in Susac syndrome: an international multicenter study."
@@ -259,10 +369,40 @@ pathophysiology:
   downstream:
   - target: Encephalopathy
     description: Cerebral lesions produce encephalopathy and neurocognitive symptoms.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        subacute encephalopathy with unusual headache and pseudo-psychiatric features associated with multifocal ischemic white matter, grey matter nuclei and specifically corpus callosum lesions along with leptomeningeal enhancement on brain MRI
+      explanation: >-
+        The review ties encephalopathy to multifocal ischemic brain lesions in
+        Susac syndrome.
   - target: Cognitive impairment
     description: Cerebral involvement commonly affects executive function and recall.
+    evidence:
+    - reference: PMID:38954275
+      reference_title: "The neurocognitive and neuropsychiatric manifestations of Susac syndrome: a brief review of the literature and future directions."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Existing literature indicates that cognitive deficits range in severity from subtle to profound.
+      explanation: >-
+        This review directly supports cognitive impairment as a downstream CNS
+        manifestation.
   - target: Neuropsychiatric manifestations
     description: Cerebral involvement can include psychiatric or behavioral manifestations.
+    evidence:
+    - reference: PMID:38954275
+      reference_title: "The neurocognitive and neuropsychiatric manifestations of Susac syndrome: a brief review of the literature and future directions."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Psychiatric manifestations may be absent or may include anxiety, mood disorders or psychosis.
+      explanation: >-
+        The review supports neuropsychiatric symptoms as a less frequent
+        downstream CNS manifestation.
   evidence:
   - reference: PMID:35413469
     reference_title: "Susac syndrome: A scoping review."
@@ -291,8 +431,28 @@ pathophysiology:
   downstream:
   - target: Branch Retinal Artery Occlusion
     description: Branch retinal artery occlusions are the defining retinal manifestation.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        ophthalmological involvement that may be pauci-symptomatic, with bilateral occlusions of the branches of the central artery of the retina at fundoscopy and arterial wall hyperfluorescence on fluorescein angiography
+      explanation: >-
+        The review directly supports branch retinal arterial occlusion as the
+        defining retinal lesion.
   - target: Scotoma
     description: Retinal ischemia can produce localized visual field loss.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        ophthalmological involvement that may be pauci-symptomatic, with bilateral occlusions of the branches of the central artery of the retina at fundoscopy and arterial wall hyperfluorescence on fluorescein angiography
+      explanation: >-
+        Branch retinal artery occlusion supports localized ischemic visual
+        field defects such as scotoma.
   evidence:
   - reference: PMID:35413469
     reference_title: "Susac syndrome: A scoping review."
@@ -320,8 +480,28 @@ pathophysiology:
   downstream:
   - target: Sensorineural Hearing Impairment
     description: Cochlear ischemic injury leads to sensorineural hearing impairment.
+    evidence:
+    - reference: PMID:39379650
+      reference_title: "Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Fifteen patients had objectified predominant low- to midfrequency sensorineural hearing loss and 8 out of 18 patients showed abnormalities on vestibular testing, most frequently vestibular evoked myogenic potential-abnormalities, indicating otolith dysfunction.
+      explanation: >-
+        The 2025 cohort supports sensorineural hearing loss as an objectively
+        measured cochleovestibular downstream manifestation.
   - target: Vertigo
     description: Vestibular involvement can produce vertigo or imbalance.
+    evidence:
+    - reference: PMID:39379650
+      reference_title: "Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        All 21 patients experienced some form of audiovestibular complaints during the disease course, with vertigo and instability being most frequently reported, followed by hearing loss, tinnitus and aural fullness.
+      explanation: >-
+        The 2025 cohort directly supports vertigo and instability as common
+        vestibular downstream manifestations.
   evidence:
   - reference: PMID:35413469
     reference_title: "Susac syndrome: A scoping review."
@@ -616,6 +796,16 @@ treatments:
   - target: Immune-mediated microvascular endotheliopathy
     treatment_effect: MODULATES
     description: Corticosteroids aim to suppress active immune-mediated vascular inflammation.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        First-line treatment mostly consists of high dose corticosteroids.
+      explanation: >-
+        High-dose corticosteroid use supports immune modulation of active
+        microvascular inflammation.
   evidence:
   - reference: PMID:35413469
     reference_title: "Susac syndrome: A scoping review."
@@ -639,6 +829,16 @@ treatments:
   - target: Humoral microvascular autoimmunity
     treatment_effect: MODULATES
     description: IVIG may modulate humoral and cellular immune injury.
+    evidence:
+    - reference: PMID:26715396
+      reference_title: "Treatment of Susac Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Additional agents, including intravenous immunoglobulins, intravenous cyclophosphamide, or rituximab are often necessary to induce a sustained remission.
+      explanation: >-
+        The treatment review supports IVIG as an immune-modulating adjunct for
+        sustained remission.
   evidence:
   - reference: PMID:26715396
     reference_title: "Treatment of Susac Syndrome."
@@ -680,9 +880,29 @@ treatments:
   - target: CD8 T-cell endothelial injury
     treatment_effect: MODULATES
     description: Immunosuppressive therapy aims to reduce active immune effector injury.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In refractory patients or in case of relapse, immunomodulatory molecules such as intravenous immunoglobulins or immunosuppressive drugs such as mycophenolate mofetil, cyclophosphamide or rituximab should be started.
+      explanation: >-
+        Escalation to broad immunomodulatory and immunosuppressive treatment
+        supports modulation of active cellular immune effector injury.
   - target: Humoral microvascular autoimmunity
     treatment_effect: MODULATES
     description: B-cell-directed or broader immunosuppression may reduce humoral contributions.
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In refractory patients or in case of relapse, immunomodulatory molecules such as intravenous immunoglobulins or immunosuppressive drugs such as mycophenolate mofetil, cyclophosphamide or rituximab should be started.
+      explanation: >-
+        Rituximab and broader immunosuppression support modulation of humoral
+        autoimmune contributors in relapsing or refractory disease.
   evidence:
   - reference: PMID:35413469
     reference_title: "Susac syndrome: A scoping review."
@@ -715,6 +935,16 @@ treatments:
     description: >-
       Natalizumab blocks alpha-4-integrin-mediated leukocyte adhesion, aiming
       to interrupt CD8 T-cell adhesion to microvascular endothelium.
+    evidence:
+    - reference: PMID:31852955
+      reference_title: "CD8+ T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        disease severity decreases in four SuS patients treated with natalizumab along with other therapy.
+      explanation: >-
+        Natalizumab support is partial because the report involved only four
+        patients and concomitant therapy.
   evidence:
   - reference: PMID:31852955
     reference_title: "CD8+ T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
@@ -747,6 +977,16 @@ treatments:
     description: >-
       Aspirin is used adjunctively to address the occlusive microvascular
       component, while efficacy evidence remains limited.
+    evidence:
+    - reference: PMID:26715396
+      reference_title: "Treatment of Susac Syndrome."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Aspirin may be used as an adjunctive agent, although evidence showing efficacy is scant.
+      explanation: >-
+        Aspirin is an adjunctive antiplatelet approach to the occlusive
+        microvascular component, but efficacy evidence is limited.
   evidence:
   - reference: PMID:26715396
     reference_title: "Treatment of Susac Syndrome."
@@ -757,6 +997,88 @@ treatments:
     explanation: >-
       The treatment review supports aspirin use only as an adjunct with limited
       efficacy evidence.
+clinical_trials:
+- name: NCT06881368
+  phase: NOT_APPLICABLE
+  status: NOT_RECRUITING
+  description: >-
+    CARESS prospective cohort for phenotypic and etiological characterization
+    of adult Susac syndrome, designed to collect defined cases with at least
+    two triad signs after exclusion of key mimics.
+  target_phenotypes:
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  - preferred_term: Branch retinal artery occlusion
+    term:
+      id: HP:0020161
+      label: Branch retinal artery occlusion
+  - preferred_term: Sensorineural hearing impairment
+    term:
+      id: HP:0000407
+      label: Sensorineural hearing impairment
+  evidence:
+  - reference: clinicaltrials:NCT06881368
+    reference_title: Phenotypic and Etiological Characterization of Susac Syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      SUSAC's Syndrome (SS) is characterized by the clinical triad of encephalopathy, hearing loss, and retinal artery branch occlusions.
+    explanation: >-
+      The trial record supports a current prospective cohort focused on the
+      Susac clinical triad.
+- name: NCT01481662
+  phase: NOT_APPLICABLE
+  status: UNKNOWN
+  description: >-
+    French retrospective and prospective cohort designed to characterize
+    epidemiological, clinical, etiological, diagnostic, imaging, treatment, and
+    biomarker features of Susac syndrome.
+  target_phenotypes:
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  - preferred_term: Branch retinal artery occlusion
+    term:
+      id: HP:0020161
+      label: Branch retinal artery occlusion
+  - preferred_term: Sensorineural hearing impairment
+    term:
+      id: HP:0000407
+      label: Sensorineural hearing impairment
+  evidence:
+  - reference: clinicaltrials:NCT01481662
+    reference_title: "Epidemiological, Clinical and Etiological Features of SUSAC's Syndrome (RETINOCOCHLEOCEREBRAL Vasculopathy)"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The exhaustive and systematic analysis of each case will help to better define different aspects of the disease such as the incidence and prevalence, the clinical presentation, the diagnostic modalities and the impact of treatments.
+    explanation: >-
+      The trial record supports systematic cohort collection across
+      epidemiology, clinical presentation, diagnosis, and treatment impact.
+- name: NCT01273792
+  phase: NOT_APPLICABLE
+  status: UNKNOWN
+  description: >-
+    Biomarker study aiming to identify relevant biomarkers and clarify Susac
+    syndrome pathogenesis.
+  target_phenotypes:
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  evidence:
+  - reference: clinicaltrials:NCT01273792
+    reference_title: Investigation of Relevant Biomarkers in Patients With Susac Syndrome
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The aim of this investigation is to identify relevant biomarkers and to elucidate the pathogenesis of Susac syndrome
+    explanation: >-
+      The trial record supports biomarker/pathogenesis investigation as a
+      Susac-specific clinical study.
 references:
 - reference: DOI:10.1007/s00415-023-11891-z
   title: "Susac syndrome: neurological update (clinical features, long-term observational follow-up and management of sixteen patients)."
@@ -765,6 +1087,16 @@ references:
   findings:
   - statement: Long-term clinical series supporting the triad, MRI findings, clinical course, and treatment algorithm.
     supporting_text: "Susac syndrome: neurological update (clinical features, long-term observational follow-up and management of sixteen patients)."
+    evidence:
+    - reference: PMID:37608221
+      reference_title: "Susac syndrome: neurological update (clinical features, long-term observational follow-up and management of sixteen patients)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Susac syndrome is a likely autoimmune microangiopathy affecting the brain, retina and inner ear.
+      explanation: >-
+        Deep research cited this clinical series for Susac triad and mechanism
+        context.
 - reference: DOI:10.1016/j.autrev.2022.103097
   title: "Susac syndrome: A scoping review."
   found_in:
@@ -772,6 +1104,16 @@ references:
   findings:
   - statement: Scoping review supporting inflammatory microangiopathy, diagnostic domains, relapsing course, and immunosuppressive treatment.
     supporting_text: "Susac syndrome: A scoping review."
+    evidence:
+    - reference: PMID:35413469
+      reference_title: "Susac syndrome: A scoping review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Susac syndrome is a rare disease characterized by an inflammatory microangiopathy limited to the brain, eye, and ear vessels.
+      explanation: >-
+        Deep research cited this review for inflammatory microangiopathy and
+        diagnostic domain context.
 - reference: DOI:10.1186/1742-2094-11-46
   title: "Clinical, paraclinical and serological findings in Susac syndrome: an international multicenter study."
   found_in:
@@ -779,6 +1121,16 @@ references:
   findings:
   - statement: Multicenter study supporting anti-endothelial cell antibodies and complement-capable humoral autoimmunity in a subset.
     supporting_text: "Clinical, paraclinical and serological findings in Susac syndrome: an international multicenter study."
+    evidence:
+    - reference: PMID:24606999
+      reference_title: "Clinical, paraclinical and serological findings in Susac syndrome: an international multicenter study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In all seropositive cases, AECA belonged to the complement-activating IgG1 subclass.
+      explanation: >-
+        Deep research cited this multicenter study for humoral autoimmunity in
+        Susac syndrome.
 - reference: DOI:10.1186/s13256-023-03838-9
   title: "Use of disease assessment tools to increase the value of case reports on Susac syndrome: two case reports."
   found_in:
@@ -786,6 +1138,16 @@ references:
   findings:
   - statement: Case-report source supporting structured disease assessment and monitoring context.
     supporting_text: "Use of disease assessment tools to increase the value of case reports on Susac syndrome: two case reports."
+    evidence:
+    - reference: DOI:10.1186/s13256-023-03838-9
+      reference_title: "Use of disease assessment tools to increase the value of case reports on Susac syndrome: two case reports"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        There is a need for disease assessment tools that can help clinicians and patients to more easily, accurately, and uniformly track the clinical course and outcome of Susac syndrome.
+      explanation: >-
+        Deep research cited this report for structured assessment and monitoring
+        context.
 - reference: DOI:10.1212/nxi.0000000000200357
   title: "Clinical Characterization and Prognostic Risk Factors of Susac Syndrome: A Retrospective Multicenter Study."
   found_in:
@@ -793,6 +1155,16 @@ references:
   findings:
   - statement: Multicenter cohort supporting phenotype triad, exacerbation timing, prognosis, and functional outcomes.
     supporting_text: "Clinical Characterization and Prognostic Risk Factors of Susac Syndrome: A Retrospective Multicenter Study."
+    evidence:
+    - reference: PMID:39693597
+      reference_title: "Clinical Characterization and Prognostic Risk Factors of Susac Syndrome: A Retrospective Multicenter Study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Susac syndrome (SuS) is a rare disorder characterized by encephalopathy, branch retinal artery occlusion, and sensorineural hearing loss, often accompanied by vertigo.
+      explanation: >-
+        Deep research cited this multicenter cohort for triad and prognosis
+        context.
 - reference: DOI:10.1038/s41467-019-13593-5
   title: "CD8+ T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
   found_in:
@@ -800,6 +1172,16 @@ references:
   findings:
   - statement: Mechanistic study supporting CD8 T-cell-mediated endothelial injury and targetability of T-cell adhesion.
     supporting_text: "CD8+ T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
+    evidence:
+    - reference: PMID:31852955
+      reference_title: "CD8(+) T cell-mediated endotheliopathy is a targetable mechanism of neuro-inflammation in Susac syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Our study identifies CD8+ T-cell-mediated endotheliopathy as a key disease mechanism in SuS and highlights therapeutic opportunities.
+      explanation: >-
+        Deep research cited this mechanistic study for targetable CD8
+        endotheliopathy.
 - reference: DOI:10.1080/00207454.2016.1254631
   title: "Susac's syndrome: clinical course and epidemiology in a Central European population."
   found_in:
@@ -807,6 +1189,16 @@ references:
   findings:
   - statement: Population-based Austrian study supporting prevalence and incidence estimates.
     supporting_text: "Susac's syndrome: clinical course and epidemiology in a Central European population."
+    evidence:
+    - reference: PMID:27788613
+      reference_title: "Susac's syndrome: clinical course and epidemiology in a Central European population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Minimum five-year period prevalence of the disease is 0.148/100,000 (95% confidence interval (CI) 0.071-0.272), annual incidence is 0.024/100,000 (95% CI 0.010-0.047).
+      explanation: >-
+        Deep research cited this population-based study for incidence and
+        prevalence estimates.
 - reference: DOI:10.1186/s12883-020-01892-0
   title: "Increased incidence of Susac syndrome: a case series study."
   found_in:
@@ -814,6 +1206,16 @@ references:
   findings:
   - statement: Case series supporting multimodal diagnostic procedures and possible post-infectious observations.
     supporting_text: "Increased incidence of Susac syndrome: a case series study."
+    evidence:
+    - reference: PMID:32878610
+      reference_title: "Increased incidence of Susac syndrome: a case series study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Infectious serological findings may imply a post infectious mechanism.
+      explanation: >-
+        Deep research cited this case series for possible post-infectious
+        observations and diagnostic context.
 - reference: DOI:10.1007/s10072-024-07672-9
   title: "The neurocognitive and neuropsychiatric manifestations of Susac syndrome: a brief review of the literature and future directions."
   found_in:
@@ -821,6 +1223,16 @@ references:
   findings:
   - statement: Review supporting neurocognitive and neuropsychiatric manifestations.
     supporting_text: "The neurocognitive and neuropsychiatric manifestations of Susac syndrome: a brief review of the literature and future directions."
+    evidence:
+    - reference: PMID:38954275
+      reference_title: "The neurocognitive and neuropsychiatric manifestations of Susac syndrome: a brief review of the literature and future directions."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Existing literature indicates that cognitive deficits range in severity from subtle to profound.
+      explanation: >-
+        Deep research cited this review for neurocognitive and
+        neuropsychiatric manifestations.
 - reference: DOI:10.3389/fneur.2024.1339438
   title: "Case report: Susac syndrome-two ends of the spectrum, single center case reports and review of the literature."
   found_in:
@@ -828,6 +1240,16 @@ references:
   findings:
   - statement: Review and case-report source supporting diagnostic challenge, black-blood MRI utility, and treatability with timely intervention.
     supporting_text: "Case report: Susac syndrome-two ends of the spectrum, single center case reports and review of the literature."
+    evidence:
+    - reference: DOI:10.3389/fneur.2024.1339438
+      reference_title: "Case report: Susac syndrome-two ends of the spectrum, single center case reports and review of the literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Diagnosing Susac syndrome may be extremely challenging not only due to its rarity, but also due to the variability of its clinical presentation.
+      explanation: >-
+        Deep research cited this case-report review for diagnostic challenge and
+        timely-treatment context.
 - reference: DOI:10.1007/s11940-015-0386-x
   title: Treatment of Susac Syndrome.
   found_in:
@@ -835,4 +1257,90 @@ references:
   findings:
   - statement: Treatment review supporting expert-guided early aggressive immunomodulatory therapy and monitoring.
     supporting_text: Treatment of Susac Syndrome.
+    evidence:
+    - reference: PMID:26715396
+      reference_title: "Treatment of Susac Syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Additional agents, including intravenous immunoglobulins, intravenous cyclophosphamide, or rituximab are often necessary to induce a sustained remission.
+      explanation: >-
+        Deep research cited this treatment review for aggressive
+        immunomodulatory therapy and monitoring.
+- reference: ORPHA:838
+  title: Susac syndrome
+  findings:
+  - statement: >-
+      Orphanet defines Susac syndrome, lists retinocochleocerebral
+      vasculopathy as a synonym, maps the disease exactly to MONDO:0019390, and
+      provides HPO frequencies for headache, corpus-callosum abnormality,
+      sensorineural hearing impairment, visual loss, confusion, and cognitive
+      impairment.
+    supporting_text: >-
+      A rare systemic or rheumatologic disease characterized by the triad of central nervous system (CNS) dysfunction, branch retinal artery occlusions (BRAOs) and sensorineural hearing loss (SNHL) due to autoimmune-mediated occlusions of microvessels in the brain, retina, and inner ear.
+    evidence:
+    - reference: ORPHA:838
+      reference_title: Susac syndrome
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare systemic or rheumatologic disease characterized by the triad of central nervous system (CNS) dysfunction, branch retinal artery occlusions (BRAOs) and sensorineural hearing loss (SNHL) due to autoimmune-mediated occlusions of microvessels in the brain, retina, and inner ear.
+      explanation: >-
+        Orphanet provides disease definition, cross-reference, and phenotype
+        context for Susac syndrome.
+- reference: PMID:40715894
+  title: "Susac Syndrome: A Systematic Review and Survival Analysis."
+  findings:
+  - statement: >-
+      2025 systematic review of 435 published patients supporting quantitative
+      phenotype frequencies, incomplete triad at onset, relapse, mortality, and
+      domain-specific recovery outcomes.
+    supporting_text: >-
+      A total of 435 patients (males: 32.6%, n = 142), derived from 176 studies, were included in the analysis.
+    evidence:
+    - reference: PMID:40715894
+      reference_title: "Susac Syndrome: A Systematic Review and Survival Analysis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        A total of 435 patients (males: 32.6%, n = 142), derived from 176 studies, were included in the analysis.
+      explanation: >-
+        This systematic review provides the largest current published-patient
+        outcome synthesis identified during the Susac enhancement audit.
+- reference: PMID:39379650
+  title: "Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study."
+  findings:
+  - statement: >-
+      2025 cohort supporting detailed audiovestibular phenotyping, low- to
+      mid-frequency sensorineural hearing loss, vestibular-test abnormalities,
+      and otolith dysfunction.
+    supporting_text: >-
+      Fifteen patients had objectified predominant low- to midfrequency sensorineural hearing loss and 8 out of 18 patients showed abnormalities on vestibular testing, most frequently vestibular evoked myogenic potential-abnormalities, indicating otolith dysfunction.
+    evidence:
+    - reference: PMID:39379650
+      reference_title: "Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Fifteen patients had objectified predominant low- to midfrequency sensorineural hearing loss and 8 out of 18 patients showed abnormalities on vestibular testing, most frequently vestibular evoked myogenic potential-abnormalities, indicating otolith dysfunction.
+      explanation: >-
+        This cohort provides contemporary audiovestibular phenotype evidence.
+- reference: DOI:10.1007/s10072-025-08451-w
+  title: Susac syndrome - different treatment approaches for one disease (analysis of case series)
+  findings:
+  - statement: >-
+      2025 case-series analysis supporting heterogeneous treatment response and
+      the need for individualized long-term immunosuppression strategies.
+    supporting_text: >-
+      The described cases highlight differences in the course of the disease and response to immunosuppressive therapy.
+    evidence:
+    - reference: DOI:10.1007/s10072-025-08451-w
+      reference_title: Susac syndrome - different treatment approaches for one disease (analysis of case series)
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The described cases highlight differences in the course of the disease and response to immunosuppressive therapy.
+      explanation: >-
+        This 2025 case series supports heterogeneous treatment response and
+        individualized treatment planning.
 datasets:

--- a/references_cache/DOI_10.1007_s10072-025-08451-w.md
+++ b/references_cache/DOI_10.1007_s10072-025-08451-w.md
@@ -1,0 +1,37 @@
+---
+reference_id: "DOI:10.1007/s10072-025-08451-w"
+title: Susac syndrome – different treatment approaches for one disease (analysis of case series)
+authors:
+- Bogna Grygiel-Górniak
+- Maria Magdalena Joks
+- Łukasz Mazurkiewicz
+- Włodzimierz Samborski
+journal: Neurological Sciences
+year: '2025'
+doi: 10.1007/s10072-025-08451-w
+content_type: abstract_only
+---
+
+# Susac syndrome – different treatment approaches for one disease (analysis of case series)
+**Authors:** Bogna Grygiel-Górniak, Maria Magdalena Joks, Łukasz Mazurkiewicz, Włodzimierz Samborski
+**Journal:** Neurological Sciences (2025)
+**DOI:** [10.1007/s10072-025-08451-w](https://doi.org/10.1007/s10072-025-08451-w)
+
+## Content
+
+Abstract
+
+Background
+Susac syndrome is a rare, autoimmune, occlusive endotheliopathy that affects blood vessels in the central nervous system (CNS), retina, and inner ear. At initial medical evaluation, the classic triad of symptoms is present in less than one-third of patients, making diagnosis challenging.
+
+
+Methods
+A brief review and retrospective analysis of the course, disease activity, exacerbations, and treatment of four patients with Susac syndrome.
+
+
+Results
+The mean age of the patients was 25.8 years, and the average disease duration was 183.5 months +/- 90.65. The clinical triad was observed at the onset of the disease in only one patient. The first patient with predominant CNS symptoms was treated with prednisone, methotrexate, and sulfasalazine (IVIG and GCS i.v. were used during exacerbations). The next patient with exacerbation of ENT symptoms was treated with oral methylprednisolone (MP) and mycophenolate mofetil. The third patient had no clear predominance of any symptoms and responded well to azathioprine. The last patient presented mainly ophthalmological symptoms and was initially treated with cyclophosphamide (total dose 6200 mg) and IVIG. Later, azathioprine and mycophenolate mofetil were introduced.
+
+
+Conclusions
+The described cases highlight differences in the course of the disease and response to immunosuppressive therapy. Patients initially responded very well to high doses of GCS and IVIG. However, in addition to long-term remissions, relapses also developed. Therefore, individual treatment based on the principles of personalized medicine is necessary.

--- a/references_cache/DOI_10.1186_s13256-023-03838-9.md
+++ b/references_cache/DOI_10.1186_s13256-023-03838-9.md
@@ -1,0 +1,31 @@
+---
+reference_id: "DOI:10.1186/s13256-023-03838-9"
+title: "Use of disease assessment tools to increase the value of case reports on Susac syndrome: two case reports"
+authors:
+- Danielle R. Bullock
+- Robert T. Spencer
+- Richard K. Vehe
+- Sunil Srivastava
+- Robert M. Rennebohm
+journal: Journal of Medical Case Reports
+year: '2023'
+doi: 10.1186/s13256-023-03838-9
+content_type: abstract_only
+---
+
+# Use of disease assessment tools to increase the value of case reports on Susac syndrome: two case reports
+**Authors:** Danielle R. Bullock, Robert T. Spencer, Richard K. Vehe, Sunil Srivastava, Robert M. Rennebohm
+**Journal:** Journal of Medical Case Reports (2023)
+**DOI:** [10.1186/s13256-023-03838-9](https://doi.org/10.1186/s13256-023-03838-9)
+
+## Content
+
+Abstract
+Background
+Susac syndrome is an immune-mediated, ischemia-producing, occlusive microvascular endotheliopathy that threatens the brain, retina, and inner ear. There is a need for disease assessment tools that can help clinicians and patients to more easily, accurately, and uniformly track the clinical course and outcome of Susac syndrome. Ideally, such tools should simultaneously facilitate the clinical care and study of Susac syndrome and improve the value of future case reports. To meet this need, two novel clinical assessment tools were developed: the Susac Symptoms Form and the Susac Disease Damage Score. The former is a comprehensive self-report form that is completed by patients/families to serially document the clinical status of a patient. The latter documents the extent of damage perceived by individual patients/families and their physicians. Both forms were initially trialed with two particularly representative and instructive patients. The results of this trial are shared in this report.
+
+Case presentation
+Patient 1 is a 21-year-old Caucasian female who presented with an acute onset of headache, paresthesias, cognitive dysfunction, and emotional lability. Patient 2 is a 14-year-old Caucasian female who presented with an acute onset of headache, cognitive dysfunction, urinary incontinence, ataxia, and personality change. Both patients fulfilled criteria for a definite diagnosis of Susac syndrome: both eventually developed brain, retinal, and inner ear involvement, and both had typical “snowball lesions” on magnetic resonance imaging. The Susac Symptoms Form documented initial improvement in both patients, was sufficiently sensitive in detecting a subsequent relapse in the second patient, and succinctly documented the long-term clinical course in both patients. The Disease Damage Score documented minimal disease damage in the first patient and more significant damage in the second.
+
+Conclusions
+The Susac Symptoms Form and the Disease Damage Score are useful disease assessment tools, both for clinical care and research purposes. Their use could enhance the value of future case reports on Susac syndrome and could improve opportunities to learn from a series of such reports.

--- a/references_cache/DOI_10.3389_fneur.2024.1339438.md
+++ b/references_cache/DOI_10.3389_fneur.2024.1339438.md
@@ -1,0 +1,33 @@
+---
+reference_id: "DOI:10.3389/fneur.2024.1339438"
+title: "Case report: Susac syndrome—two ends of the spectrum, single center case reports and review of the literature"
+authors:
+- Martina Cviková
+- Jakub Štefela
+- Vít Všianský
+- Michal Dufek
+- Irena Doležalová
+- Jan Vinklárek
+- Roman Herzig
+- Markéta Zemanová
+- Vladimír Červeňák
+- Jaroslav Brichta
+- Veronika Bárková
+- David Kouřil
+- Petr Aulický
+- Pavel Filip
+- Viktor Weiss
+journal: Frontiers in Neurology
+year: '2024'
+doi: 10.3389/fneur.2024.1339438
+content_type: abstract_only
+---
+
+# Case report: Susac syndrome—two ends of the spectrum, single center case reports and review of the literature
+**Authors:** Martina Cviková, Jakub Štefela, Vít Všianský, Michal Dufek, Irena Doležalová, Jan Vinklárek, Roman Herzig, Markéta Zemanová, Vladimír Červeňák, Jaroslav Brichta, Veronika Bárková, David Kouřil, Petr Aulický, Pavel Filip, Viktor Weiss
+**Journal:** Frontiers in Neurology (2024)
+**DOI:** [10.3389/fneur.2024.1339438](https://doi.org/10.3389/fneur.2024.1339438)
+
+## Content
+
+Susac syndrome is a rare and enigmatic complex neurological disorder primarily affecting small blood vessels in the brain, retina, and inner ear. Diagnosing Susac syndrome may be extremely challenging not only due to its rarity, but also due to the variability of its clinical presentation. This paper describes two vastly different cases—one with mild symptoms and good response to therapy, the other with severe, complicated course, relapses and long-term sequelae despite multiple therapeutic interventions. Building upon the available guidelines, we highlight the utility of black blood MRI in this disease and provide a comprehensive review of available clinical experience in clinical presentation, diagnosis and therapy of this disease. Despite its rarity, the awareness of Susac syndrome may be of uttermost importance since it ultimately is a treatable condition. If diagnosed in a timely manner, early intervention can substantially improve the outcomes of our patients.

--- a/references_cache/ORPHA_838.md
+++ b/references_cache/ORPHA_838.md
@@ -1,0 +1,79 @@
+---
+reference_id: "ORPHA:838"
+title: "Susac syndrome"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:838  Susac syndrome
+
+**ORPHA:838** — Susac syndrome (Disease, Disorder)
+
+## Synonyms
+
+- Retinocochleocerebral vasculopathy
+
+## Definition
+
+A rare systemic or rheumatologic disease characterized by the triad of central nervous system (CNS) dysfunction, branch retinal artery occlusions (BRAOs) and sensorineural hearing loss (SNHL) due to autoimmune-mediated occlusions of microvessels in the brain, retina, and inner ear.
+
+## Inheritance
+
+- Unknown
+
+## Natural history
+
+- Age of onset: All ages
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| - | Worldwide | Cases/families | PMID:23628737 |
+| Unknown | Worldwide | Point prevalence | ORPHANET |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000360 | Tinnitus | Occasional (29-5%) |
+| HP:0000407 | Sensorineural hearing impairment | Frequent (79-30%) |
+| HP:0000496 | Abnormality of eye movement | Occasional (29-5%) |
+| HP:0000572 | Visual loss | Frequent (79-30%) |
+| HP:0000651 | Diplopia | Occasional (29-5%) |
+| HP:0000708 | Atypical behavior | Occasional (29-5%) |
+| HP:0000709 | Psychosis | Occasional (29-5%) |
+| HP:0000741 | Apathy | Occasional (29-5%) |
+| HP:0000751 | Personality changes | Occasional (29-5%) |
+| HP:0001254 | Lethargy | Occasional (29-5%) |
+| HP:0001260 | Dysarthria | Occasional (29-5%) |
+| HP:0001273 | Abnormal corpus callosum morphology | Frequent (79-30%) |
+| HP:0001289 | Confusion | Frequent (79-30%) |
+| HP:0001290 | Generalized hypotonia | Frequent (79-30%) |
+| HP:0001324 | Muscle weakness | Occasional (29-5%) |
+| HP:0002017 | Nausea and vomiting | Occasional (29-5%) |
+| HP:0002066 | Gait ataxia | Occasional (29-5%) |
+| HP:0002315 | Headache | Very frequent (99-80%) |
+| HP:0002321 | Vertigo | Occasional (29-5%) |
+| HP:0002493 | Upper motor neuron dysfunction | Occasional (29-5%) |
+| HP:0003474 | Somatic sensory dysfunction | Occasional (29-5%) |
+| HP:0100543 | Cognitive impairment | Frequent (79-30%) |
+| HP:0100851 | Abnormal emotion/affect behavior | Occasional (29-5%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| GARD:7713 | Exact |
+| ICD-10:I67.7 | Narrower |
+| ICD-11:8A45.2Y | Narrower |
+| MONDO:0019390 | Exact |
+| MeSH:D055955 | Exact |
+| MedDRA:10071573 | Exact |
+| UMLS:C2717757 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=838)

--- a/references_cache/PMID_39379650.md
+++ b/references_cache/PMID_39379650.md
@@ -1,0 +1,107 @@
+---
+reference_id: "PMID:39379650"
+title: "Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study."
+authors:
+- Roelens A
+- Vandekerckhove M
+- Maes L
+- Dekeyser C
+- Hemelsoet D
+- Van Driessche V
+- Miatton M
+- Van Hijfte L
+- De Zaeytijd J
+- Van Vrekhem T
+- Laureys G
+- Van Hoecke H
+journal: Eur Arch Otorhinolaryngol
+year: '2025'
+doi: 10.1007/s00405-024-09011-2
+keywords:
+- Humans
+- "Susac Syndrome/complications, physiopathology, diagnosis"
+- Female
+- Male
+- Adult
+- "Hearing Loss, Sensorineural/etiology, physiopathology, diagnosis"
+- Phenotype
+- Adolescent
+- Middle Aged
+- Young Adult
+- Vestibular Evoked Myogenic Potentials
+- Child
+- Cohort Studies
+- Vestibular Function Tests
+- Retrospective Studies
+content_type: abstract_only
+---
+
+# Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study.
+**Authors:** Roelens A, Vandekerckhove M, Maes L, Dekeyser C, Hemelsoet D, Van Driessche V, Miatton M, Van Hijfte L, De Zaeytijd J, Van Vrekhem T, Laureys G, Van Hoecke H
+**Journal:** Eur Arch Otorhinolaryngol (2025)
+**DOI:** [10.1007/s00405-024-09011-2](https://doi.org/10.1007/s00405-024-09011-2)
+
+## Content
+
+1. Eur Arch Otorhinolaryngol. 2025 Mar;282(3):1189-1200. doi:
+10.1007/s00405-024-09011-2. Epub 2024 Oct 8.
+
+Phenotyping vestibulocochlear manifestations in Susac syndrome: a cohort study.
+
+Roelens A(#)(1), Vandekerckhove M(#)(2), Maes L(3), Dekeyser C(4), Hemelsoet
+D(4), Van Driessche V(5), Miatton M(3), Van Hijfte L(3), De Zaeytijd J(6), Van
+Vrekhem T(3), Laureys G(4), Van Hoecke H(2).
+
+Author information:
+(1)Department of Otorhinolaryngology, Department of Head and Skin, Ghent
+University Hospital, Ghent, Belgium. astrid.roelens@ugent.be.
+(2)Department of Otorhinolaryngology, Department of Head and Skin, Ghent
+University Hospital, Ghent, Belgium.
+(3)Department of Rehabilitation Sciences, Ghent University Hospital, Ghent,
+Belgium.
+(4)Department of Neurology, Department of Head and Skin, Ghent University
+Hospital, Ghent, Belgium.
+(5)Department of Radiology, Ghent University Hospital, Ghent, Belgium.
+(6)Department of Ophthalmology, Department of Head and Skin, Ghent University
+Hospital, Ghent, Belgium.
+(#)Contributed equally
+
+PURPOSE: To characterize vestibulocochlear involvement in patients with Susac
+syndrome (SuS), a rare immune-mediated endotheliopathy of cerebral, retinal and
+inner ear microvasculature causing a triad of encephalopathy, branch retinal
+artery occlusions and sensorineural hearing loss.
+METHODS: The electronic patient files of 21 patients with SuS are reviewed for
+data on demography, clinical presentation, disease course and audiovestibular
+testing.
+RESULTS: All 21 patients experienced some form of audiovestibular complaints
+during the disease course, with vertigo and instability being most frequently
+reported, followed by hearing loss, tinnitus and aural fullness. These
+audiovestibular symptoms did not always coincide. Fifteen patients had
+objectified predominant low- to midfrequency sensorineural hearing loss and 8
+out of 18 patients showed abnormalities on vestibular testing, most frequently
+vestibular evoked myogenic potential-abnormalities, indicating otolith
+dysfunction. Treatment protocols consisted of uniformly extensive
+immunosuppressive therapy and hearing loss remained mostly mild.
+CONCLUSION: Audiovestibular involvement is very common in patients with SuS.
+Characteristic findings include a "reverse-slope" configuration on audiological
+testing and otolith dysfunction on vestibular testing. Aggressive
+immunosuppression may prevent severe audiovestibular dysfunction. Symptoms as
+aural fullness and otolith dysfunction may indicate an underlying hydrops.
+Further investigations are necessary to elucidate the histopathological
+mechanisms underlying these preferentially involved cochleovestibular areas.
+Early recognition and treatment of SuS are important to stabilize or decrease
+disease activity and might also have beneficial effects on inner ear outcome.
+THE SUBMITTED MANUSCRIPT REPORTS DATA DERIVED FROM CLINICAL OBSERVATIONS IN
+HUMANS: Consent for the research was provided by the Ethics Committee of Ghent
+University hospital (application number 2019/1443, registration date 31/12/2021,
+principal investigator Guy Laureys).
+
+© 2024. The Author(s), under exclusive licence to Springer-Verlag GmbH Germany,
+part of Springer Nature.
+
+DOI: 10.1007/s00405-024-09011-2
+PMID: 39379650 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. No funding was received for
+conducting this study. The authors have no interests to declare that are
+relevant to the content of this article.

--- a/references_cache/PMID_40715894.md
+++ b/references_cache/PMID_40715894.md
@@ -1,0 +1,99 @@
+---
+reference_id: "PMID:40715894"
+title: "Susac Syndrome: A Systematic Review and Survival Analysis."
+authors:
+- Pace GM
+- Canali L
+- Villari D
+- Spriano G
+- Mercante G
+- Mosnier I
+- Bernardeschi D
+- Colombo G
+- Di Bari M
+journal: Clin Rev Allergy Immunol
+year: '2025'
+doi: 10.1007/s12016-025-09087-6
+keywords:
+- Humans
+- "Susac Syndrome/mortality, diagnosis, epidemiology, therapy"
+- Adult
+- Male
+- Female
+- Survival Analysis
+- Young Adult
+- Adolescent
+- Middle Aged
+- Child
+- Aged
+- Prognosis
+content_type: abstract_only
+---
+
+# Susac Syndrome: A Systematic Review and Survival Analysis.
+**Authors:** Pace GM, Canali L, Villari D, Spriano G, Mercante G, Mosnier I, Bernardeschi D, Colombo G, Di Bari M
+**Journal:** Clin Rev Allergy Immunol (2025)
+**DOI:** [10.1007/s12016-025-09087-6](https://doi.org/10.1007/s12016-025-09087-6)
+
+## Content
+
+1. Clin Rev Allergy Immunol. 2025 Jul 26;68(1):73. doi:
+10.1007/s12016-025-09087-6.
+
+Susac Syndrome: A Systematic Review and Survival Analysis.
+
+Pace GM(1)(2), Canali L(3)(4)(5), Villari D(1)(2), Spriano G(1)(2), Mercante
+G(1)(2), Mosnier I(6)(7), Bernardeschi D(6), Colombo G(8), Di Bari M(8).
+
+Author information:
+(1)Department of Biomedical Sciences, Humanitas University, Pieve Emanuele,
+Milan, Italy.
+(2)Otorhinolaryngology Unit, IRCCS Humanitas Clinical and Research Center,
+Rozzano, Milan, Italy.
+(3)Department of Biomedical Sciences, Humanitas University, Pieve Emanuele,
+Milan, Italy. lucacanali96@gmail.com.
+(4)Otorhinolaryngology Unit, IRCCS Humanitas Clinical and Research Center,
+Rozzano, Milan, Italy. lucacanali96@gmail.com.
+(5)Service d'Oto-Rhino-Laryngologie, Hôpital Pitié-Salpêtrière, AP-HP, Sorbonne
+Université, Paris, France. lucacanali96@gmail.com.
+(6)Service d'Oto-Rhino-Laryngologie, Hôpital Pitié-Salpêtrière, AP-HP, Sorbonne
+Université, Paris, France.
+(7)Unité Fonctionnelle Implants Auditifs, ORL, GH Pitié-Salpêtrière, AP-HP
+Sorbonne Université, Paris, France.
+(8)Otorhinolaryngology, Head and Neck Department, Ospedale Nuovo di Legnano,
+ASST Ovest Milanese, Legnano, MI, Italy.
+
+The aim of this study is to analyze data from all cases of Susac syndrome that
+have been published in the literature. This study was conducted in conformity
+with the PRISMA statement. A systematic review and survival analysis was
+performed for overall survival (OS) and progression-free survival (PFS). A total
+of 435 patients (males: 32.6%, n = 142), derived from 176 studies, were included
+in the analysis. The median age at diagnosis was 35 years (n = 433/435; range
+7-69). Neurological symptoms were the most frequent (87.4%, n = 380/435). Among
+audio-vestibular symptoms (84.3%, n = 365/433), hearing loss was the most common
+manifestation (87.9%, n = 327/372). Branch retinal artery occlusions (BRAOs)
+were observed in 91.6% of patients (n = 261/285), while ophthalmological
+symptoms were reported in 78.9% (n = 288/365). The complete triad at onset was
+present in only 20.1% (n = 61/304) of cases. Complete recovery without sequelae
+was achieved in 59.5% (n = 44/74) of patients which reported neurological
+involvement, 39.7% (n = 27/68) of those with ophthalmological symptoms, and
+17.7% (n = 11/62) of those with audio-vestibular symptoms. Partial recovery was
+observed in 36.5% (n = 27/74), 50.0% (n = 34/68), and 38.7% (n = 24/62) of
+patients, respectively. In a subgroup of 123 patients with available follow-up
+data (median duration: 12 months), 82.1% (n = 101) remained stable with
+controlled disease, 12.2% (n = 15) experienced a relapse, and 5.7% (n = 7) died.
+OS at 1 and 3 years was 94% (95% CI 88-97%). PFS was 89% at 1 year (95% CI:
+80-94%) and 83% at 3 years (95% CI: 69-91%). Susac syndrome presents a
+significant clinical challenge. While presentations and outcomes are very
+heterogeneous, mortality is uncommon. The potential for relapse and long-term
+sequelae highlights the need for greater awareness and deeper understanding of
+the disease.
+
+© 2025. The Author(s), under exclusive licence to Springer Science+Business
+Media, LLC, part of Springer Nature.
+
+DOI: 10.1007/s12016-025-09087-6
+PMID: 40715894 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Competing interests: The authors
+declare no competing interests.

--- a/references_cache/clinicaltrials_NCT01273792.md
+++ b/references_cache/clinicaltrials_NCT01273792.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT01273792
+title: Investigation of Relevant Biomarkers in Patients With Susac Syndrome
+content_type: summary
+---
+
+# Investigation of Relevant Biomarkers in Patients With Susac Syndrome
+
+## Content
+
+Susac Syndrome is a rare disease and the establishment of the diagnosis is often difficult. The aim of this investigation is to identify relevant biomarkers and to elucidate the pathogenesis of Susac syndrome

--- a/references_cache/clinicaltrials_NCT01481662.md
+++ b/references_cache/clinicaltrials_NCT01481662.md
@@ -1,0 +1,13 @@
+---
+reference_id: clinicaltrials:NCT01481662
+title: "Epidemiological, Clinical and Etiological Features of SUSAC's Syndrome (RETINOCOCHLEOCEREBRAL Vasculopathy)"
+content_type: summary
+---
+
+# Epidemiological, Clinical and Etiological Features of SUSAC's Syndrome (RETINOCOCHLEOCEREBRAL Vasculopathy)
+
+## Content
+
+SUSAC's Syndrome (SS) is characterized by the clinical triad of encephalopathy, hearing loss, and retinal artery branch occlusions. Since the first description of SS in 1979, hundreds of patients with SS, mostly young women, have been reported. However, comprehensive epidemiological, clinical and etiological features of SS have never been specifically addressed so far.
+
+The objective of this study is to characterize the epidemiological, clinical, and etiological features of SUSAC's Syndrome. In this aim, the investigators will constitute a national clinical-based cohort including all SS cases retrospectively reported in France since the last 20 years and all new cases prospectively observed. French Society of Neurology, Ophthalmology and Internal Medicine will be asked to collaborate. Every case will be reviewed by an expert comity of internists, neurologists and neuroradiologists to validate the diagnosis. The exhaustive and systematic analysis of each case will help to better define different aspects of the disease such as the incidence and prevalence, the clinical presentation, the diagnostic modalities and the impact of treatments. Diffusion tensor magnetic resonance imaging of the brain will be obtained to more carefully study the cerebral microvasculopathy of the disease. Serum, cerebrospinal fluid, and DNA samples from each patient will also be collected to study potential autoimmune, thrombotic and infectious markers.

--- a/references_cache/clinicaltrials_NCT06881368.md
+++ b/references_cache/clinicaltrials_NCT06881368.md
@@ -1,0 +1,11 @@
+---
+reference_id: clinicaltrials:NCT06881368
+title: Phenotypic and Etiological Characterization of Susac Syndrome
+content_type: summary
+---
+
+# Phenotypic and Etiological Characterization of Susac Syndrome
+
+## Content
+
+SUSAC's Syndrome (SS) is characterized by the clinical triad of encephalopathy, hearing loss, and retinal artery branch occlusions. Since the first description of SS in 1979, hundreds of patients with SS, mostly young women, have been reported. However, comprehensive epidemiological, clinical and etiological features of SS have never been specifically addressed so far.


### PR DESCRIPTION
## Summary

- Enhance the existing `kb/disorders/Susac_Syndrome.yaml` entry with Orphanet ORPHA:838 definition, exact MONDO mapping, and external assertion context.
- Add 2025 systematic-review outcome evidence, 2025 audiovestibular cohort evidence, 2025 treatment-response case-series evidence, and current/legacy ClinicalTrials.gov Susac cohort and biomarker studies.
- Fill missing evidence coverage for downstream pathophysiology edges, treatment target mechanisms, and top-level reference findings.
- Add generated Orphanet, PubMed, DOI, and ClinicalTrials.gov reference caches.

## Source/database notes

- Orphanet cache was generated with `just structured-rebuild-orphanet --id 838` after Orphadata refresh.
- Reference caches were generated with `just fetch-reference`; generated cache formatting was left in repo-generated form.
- Existing Falcon deep research remains present. I attempted `just research-disorder openscientist Susac_Syndrome`; it ran for 1800 seconds with no output or citation artifact and was terminated at the repo batch tooling's default per-attempt timeout.

## Validation

- `pre-commit run yamlfix --files kb/disorders/Susac_Syndrome.yaml`
- `just validate kb/disorders/Susac_Syndrome.yaml`
- `just check-reference-cache-frontmatter`
- `just compliance kb/disorders/Susac_Syndrome.yaml` -> 99.5% global, 100.0% weighted
- `just qc-deep-research --only Susac_Syndrome --fail-on-missing-reference --fail-on-unresolved-cache --fail-on-holder-bucket` -> 0 missing refs, 0 unresolved cache refs, 0 holder-bucket refs; second-provider count remains 0/1 because OpenScientist timed out without producing artifacts
- `git diff --check -- . ':(exclude)references_cache/*.md'`