### PR TITLE
Redesign Dismech docs and link to them from main page

### DIFF
--- a/details/index.html
+++ b/details/index.html
@@ -3,801 +3,1903 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>dismech - Project Details</title>
+    <title>dismech - Detailed Documentation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <style>
-        :root {
-            --primary: #0f766e;
-            --primary-light: #14b8a6;
-            --primary-dark: #0d5c56;
-            --accent: #6366f1;
-            --bg: #f0fdfa;
-            --surface: #ffffff;
-            --text: #134e4a;
-            --text-light: #5f7a78;
-            --border: #ccfbf1;
-        }
-
-        * {
+        *, *::before, *::after {
             box-sizing: border-box;
             margin: 0;
             padding: 0;
         }
 
+        :root {
+            --teal: #00838f;
+            --teal-mid: #008c99;
+            --teal-light: #a6ecf2;
+            --teal-50: #e8f6f8;
+            --gray-50: #f9fafb;
+            --gray-100: #f3f4f6;
+            --gray-200: #e5e7eb;
+            --gray-300: #d1d5db;
+            --gray-500: #6b7280;
+            --gray-600: #4b5563;
+            --gray-700: #374151;
+            --gray-800: #1f2937;
+            --gray-900: #111827;
+            --font: 'Lora', Georgia, 'Times New Roman', serif;
+            --mono: ui-monospace, "SF Mono", "Cascadia Code", monospace;
+            --max-width: 960px;
+        }
+
         body {
-            font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
-            background: var(--bg);
-            color: var(--text);
+            font-family: var(--font);
+            color: var(--gray-800);
             line-height: 1.7;
+            background:
+                radial-gradient(circle at top right, rgba(166, 236, 242, 0.4), transparent 24%),
+                linear-gradient(180deg, #fff 0%, #f9fafb 100%);
+        }
+
+        a {
+            color: var(--teal);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        nav {
+            position: sticky;
+            top: 0;
+            background: rgba(255, 255, 255, 0.96);
+            backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--gray-200);
+            z-index: 100;
+            padding: 0.75rem 1.5rem;
+        }
+
+        .nav-inner {
+            max-width: var(--max-width);
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .nav-logo {
+            font-weight: 700;
+            font-size: 1.1rem;
+            color: var(--teal);
+            letter-spacing: -0.02em;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 1.25rem;
+            align-items: center;
+            font-size: 0.875rem;
+            flex-wrap: wrap;
+        }
+
+        .nav-links a {
+            color: var(--gray-600);
+        }
+
+        .nav-links a:hover,
+        .nav-links a.active {
+            color: var(--teal);
+            text-decoration: none;
+        }
+
+        .gh-icon {
+            width: 18px;
+            height: 18px;
+            vertical-align: middle;
+        }
+
+        .hero-bg {
+            background: var(--teal-50);
+            border-bottom: 1px solid var(--gray-200);
         }
 
         .hero {
-            background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 60%, var(--accent) 100%);
-            color: #fff;
-            padding: 56px 24px 64px;
-            text-align: center;
+            max-width: var(--max-width);
+            margin: 0 auto;
+            padding: 5.5rem 1.5rem 3.5rem;
+            display: grid;
+            grid-template-columns: minmax(0, 1.4fr) minmax(260px, 0.9fr);
+            gap: 1.5rem;
+            align-items: end;
         }
 
         .hero h1 {
             font-size: 2.4rem;
-            margin-bottom: 10px;
+            font-weight: 700;
+            color: var(--teal);
+            line-height: 1.12;
+            margin-bottom: 0.75rem;
+            letter-spacing: -0.02em;
         }
 
-        .hero p {
-            font-size: 1.05rem;
-            opacity: 0.92;
-            max-width: 820px;
-            margin: 0 auto 24px;
+        .hero-tagline {
+            font-size: 1.2rem;
+            font-style: italic;
+            color: var(--gray-700);
+            margin-bottom: 0.75rem;
+        }
+
+        .hero-sub {
+            font-size: 1rem;
+            color: var(--gray-600);
+            max-width: 600px;
+            margin-bottom: 1.5rem;
         }
 
         .hero-actions {
             display: flex;
-            justify-content: center;
-            gap: 12px;
+            gap: 0.75rem;
             flex-wrap: wrap;
         }
 
         .btn {
             display: inline-block;
-            text-decoration: none;
-            padding: 12px 18px;
-            border-radius: 10px;
-            font-weight: 600;
-            font-size: 0.96rem;
-            transition: all 0.2s ease;
+            padding: 0.65rem 1.5rem;
+            border-radius: 6px;
+            font-size: 0.9rem;
+            font-weight: 500;
+            font-family: var(--font);
+            transition: background 0.15s, border-color 0.15s;
         }
 
         .btn-primary {
-            background: #fff;
-            color: var(--primary-dark);
+            background: var(--teal);
+            color: #fff;
         }
 
         .btn-primary:hover {
-            transform: translateY(-1px);
+            background: var(--teal-mid);
+            text-decoration: none;
         }
 
         .btn-secondary {
-            color: #fff;
-            border: 1px solid rgba(255, 255, 255, 0.45);
-            background: rgba(255, 255, 255, 0.13);
+            background: #fff;
+            color: var(--gray-700);
+            border: 1px solid var(--gray-200);
         }
 
-        .container {
-            max-width: 1000px;
+        .btn-secondary:hover {
+            background: var(--gray-100);
+            text-decoration: none;
+        }
+
+        .hero-card {
+            background: rgba(255, 255, 255, 0.8);
+            border: 1px solid var(--gray-200);
+            border-radius: 12px;
+            padding: 1.1rem 1.2rem;
+        }
+
+        .hero-card h2 {
+            font-size: 0.95rem;
+            color: var(--gray-900);
+            margin-bottom: 0.65rem;
+        }
+
+        .hero-card ul {
+            padding-left: 1rem;
+            color: var(--gray-600);
+            font-size: 0.88rem;
+        }
+
+        .hero-card li + li {
+            margin-top: 0.45rem;
+        }
+
+        .main {
+            max-width: var(--max-width);
             margin: 0 auto;
-            padding: 36px 20px 56px;
+            padding: 2rem 1.5rem 4rem;
+        }
+
+        .quick-nav {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .quick-nav a {
+            padding: 0.85rem 0.95rem;
+            border: 1px solid var(--gray-200);
+            border-radius: 8px;
+            background: #fff;
+            font-size: 0.88rem;
+            color: var(--gray-700);
+            text-align: center;
+        }
+
+        .quick-nav a:hover {
+            border-color: var(--teal-light);
+            color: var(--teal);
+            text-decoration: none;
         }
 
         .section {
-            background: var(--surface);
-            border: 1px solid var(--border);
-            border-radius: 14px;
-            padding: 24px;
-            margin-bottom: 18px;
+            background: #fff;
+            border: 1px solid var(--gray-200);
+            border-radius: 12px;
+            padding: 1.6rem;
+            margin-bottom: 1.25rem;
+            box-shadow: 0 6px 30px rgba(17, 24, 39, 0.03);
         }
 
         .section h2 {
-            font-size: 1.35rem;
-            margin-bottom: 10px;
+            font-size: 1.45rem;
+            color: var(--gray-900);
+            margin-bottom: 0.8rem;
         }
 
         .section h3 {
             font-size: 1.05rem;
-            margin-top: 14px;
-            margin-bottom: 8px;
+            color: var(--gray-900);
+            margin: 1.3rem 0 0.7rem;
         }
 
-        .section p {
-            color: var(--text-light);
-        }
-
-        .section p + p {
-            margin-top: 10px;
-        }
-
-        .small {
-            font-size: 0.9rem;
-        }
-
-        .muted {
-            color: var(--text-light);
-        }
-
-        ul, ol {
-            padding-left: 20px;
-            color: var(--text-light);
-        }
-
-        li + li {
-            margin-top: 6px;
-        }
-
-        code, pre {
-            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-            font-size: 0.9rem;
-        }
-
-        pre {
-            margin-top: 10px;
-            background: #062723;
-            color: #d8faf6;
-            padding: 14px;
-            border-radius: 10px;
-            overflow-x: auto;
-        }
-
-        a {
-            color: var(--primary-dark);
-        }
-
-        .toc {
-            display: grid;
-            gap: 8px;
-            margin-top: 10px;
-        }
-
-        .toc a {
-            text-decoration: none;
-            color: var(--primary-dark);
-            font-weight: 600;
-        }
-
-        .toc a:hover {
-            text-decoration: underline;
-        }
-
-        .kpi-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 12px;
-            margin-top: 14px;
-        }
-
-        .kpi {
-            background: #ecfdf5;
-            border: 1px solid #99f6e4;
-            border-radius: 10px;
-            padding: 12px;
-        }
-
-        .kpi .label {
-            display: block;
-            font-size: 0.8rem;
-            color: var(--text-light);
-            text-transform: uppercase;
-            letter-spacing: 0.04em;
-        }
-
-        .kpi .value {
-            display: block;
-            margin-top: 4px;
-            font-size: 1.15rem;
-            font-weight: 700;
-            color: var(--text);
-        }
-
-        .detail-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 10px;
+        .section p,
+        .section li,
+        .section td,
+        .section th {
+            color: var(--gray-600);
             font-size: 0.95rem;
         }
 
-        .detail-table th,
-        .detail-table td {
-            border: 1px solid var(--border);
-            padding: 10px;
+        .section p + p {
+            margin-top: 0.8rem;
+        }
+
+        .pill-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .pill {
+            display: inline-block;
+            padding: 0.32rem 0.75rem;
+            background: var(--teal-50);
+            border: 1px solid var(--teal-light);
+            border-radius: 999px;
+            font-size: 0.8rem;
+            color: var(--teal);
+            font-weight: 500;
+        }
+
+        .section-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+            align-items: start;
+        }
+
+        .guide-group {
+            border: 1px solid var(--gray-200);
+            border-radius: 10px;
+            padding: 1rem;
+            background: linear-gradient(180deg, #fff 0%, #f9fafb 100%);
+        }
+
+        .guide-group.span-2 {
+            grid-column: 1 / -1;
+        }
+
+        .guide-group h3 {
+            margin-top: 0;
+            margin-bottom: 0.45rem;
+            font-size: 1rem;
+        }
+
+        .guide-group p {
+            font-size: 0.88rem;
+            color: var(--gray-500);
+            margin-bottom: 0.85rem;
+        }
+
+        .guide-list {
+            display: grid;
+            gap: 0.75rem;
+        }
+
+        .guide-item {
+            padding-left: 0.85rem;
+            padding-top: 0.1rem;
+            border-left: 3px solid var(--teal-light);
+        }
+
+        .guide-item-head {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            margin-bottom: 0.2rem;
+        }
+
+        .guide-item strong {
+            display: inline-block;
+            color: var(--gray-900);
+            font-size: 0.9rem;
+            margin-bottom: 0;
+        }
+
+        .guide-item-text {
+            color: var(--gray-600);
+            font-size: 0.92rem;
+        }
+
+        .guide-icon {
+            width: 28px;
+            height: 28px;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.88rem;
+            flex: 0 0 28px;
+        }
+
+        .callout {
+            margin-top: 1rem;
+            padding: 0.95rem 1rem;
+            border: 1px solid var(--teal-light);
+            border-radius: 10px;
+            background: var(--teal-50);
+            color: var(--gray-700);
+            font-size: 0.92rem;
+        }
+
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 0.9rem;
+            margin-top: 1rem;
+        }
+
+        .feature-card {
+            border: 1px solid var(--gray-200);
+            border-radius: 10px;
+            padding: 1rem;
+            background: #fff;
+        }
+
+        .feature-card h3 {
+            margin: 0 0 0.4rem;
+            font-size: 0.95rem;
+        }
+
+        .diagram {
+            margin-top: 1rem;
+            padding: 1.1rem;
+            border: 1px solid var(--gray-200);
+            border-radius: 12px;
+            background: linear-gradient(180deg, #fff 0%, #f9fafb 100%);
+        }
+
+        .diagram-title {
+            font-size: 0.95rem;
+            color: var(--gray-900);
+            margin-bottom: 0.85rem;
+        }
+
+        .flow {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 0;
+            margin-bottom: 0.85rem;
+        }
+
+        .flow-node {
+            padding: 0.5rem 0.9rem;
+            background: var(--teal-50);
+            border: 1px solid var(--teal-light);
+            border-radius: 8px;
+            font-size: 0.84rem;
+            color: var(--gray-800);
+            white-space: nowrap;
+        }
+
+        .flow-node.secondary {
+            background: var(--gray-50);
+            border-color: var(--gray-200);
+        }
+
+        .flow-arrow {
+            padding: 0 0.45rem;
+            color: var(--gray-300);
+            font-size: 1.1rem;
+        }
+
+        .diagram-meta {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 0.8rem;
+            margin-top: 1rem;
+        }
+
+        .diagram-meta-item {
+            border: 1px solid var(--gray-200);
+            border-radius: 8px;
+            padding: 0.8rem;
+            background: #fff;
+        }
+
+        .diagram-meta-item strong {
+            display: block;
+            color: var(--gray-900);
+            font-size: 0.84rem;
+            margin-bottom: 0.2rem;
+        }
+
+        .pathograph-container {
+            margin: 1rem 0 0;
+            padding: 0;
+            background: #fff;
+            border-radius: 12px;
+            border: 1px solid var(--gray-200);
+            overflow: hidden;
+            position: relative;
+        }
+
+        .pathograph-container svg {
+            display: block;
+            width: 100%;
+            cursor: grab;
+        }
+
+        .pathograph-container svg:active {
+            cursor: grabbing;
+        }
+
+        .pathograph-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            padding: 0.8rem 1rem;
+            background: var(--gray-50);
+            border-bottom: 1px solid var(--gray-200);
+            font-size: 0.78rem;
+            color: var(--gray-500);
+        }
+
+        .pathograph-legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            cursor: pointer;
+            user-select: none;
+        }
+
+        .pathograph-legend-item.dimmed {
+            opacity: 0.35;
+        }
+
+        .pathograph-legend-item input {
+            accent-color: var(--teal);
+            margin: 0;
+        }
+
+        .pathograph-legend-swatch {
+            width: 14px;
+            height: 14px;
+            border-radius: 3px;
+            border: 1px solid rgba(0, 0, 0, 0.15);
+            flex-shrink: 0;
+        }
+
+        .graph-note {
+            margin: 0.9rem 0 0;
+            font-size: 0.84rem;
+            color: var(--gray-500);
+        }
+
+        .pathograph-tooltip {
+            position: absolute;
+            pointer-events: none;
+            background: rgba(17, 24, 39, 0.94);
+            color: #f9fafb;
+            padding: 0.55rem 0.75rem;
+            border-radius: 8px;
+            font-size: 0.78rem;
+            line-height: 1.45;
+            max-width: 320px;
+            z-index: 100;
+            opacity: 0;
+            transition: opacity 0.15s;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        }
+
+        .pathograph-tooltip .tt-title {
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+            color: #e5e7eb;
+        }
+
+        .pathograph-tooltip .tt-type {
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            opacity: 0.7;
+            margin-bottom: 0.35rem;
+        }
+
+        .pathograph-tooltip .tt-desc {
+            margin-bottom: 0.4rem;
+            color: #d1d5db;
+        }
+
+        .pathograph-tooltip .tt-meta {
+            font-size: 0.72rem;
+            color: #9ca3af;
+        }
+
+        .pathograph-tooltip .tt-meta span {
+            display: block;
+            margin: 2px 0;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 0.85rem;
+        }
+
+        th,
+        td {
+            border: 1px solid var(--gray-200);
+            padding: 0.85rem;
             vertical-align: top;
             text-align: left;
         }
 
-        .detail-table th {
-            background: #f0fdfa;
-            color: var(--text);
-        }
-
-        .callout {
-            margin-top: 12px;
-            padding: 12px 14px;
-            border-radius: 10px;
-            border: 1px solid #a7f3d0;
-            background: #ecfdf5;
-            color: var(--text);
-            font-size: 0.95rem;
-        }
-
-        .schema-cta {
-            border: 1px solid #99f6e4;
-            background: linear-gradient(135deg, #ecfeff 0%, #f0fdfa 100%);
-            border-radius: 14px;
-            padding: 18px;
-            margin-top: 14px;
-            text-align: center;
-        }
-
-        .schema-cta h3 {
-            margin: 0 0 8px;
-            color: var(--text);
-            font-size: 1.15rem;
-        }
-
-        .schema-cta p {
-            margin: 0 0 12px;
-            color: var(--text-light);
-        }
-
-        .schema-cta a {
-            display: inline-block;
-            background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-            color: #fff;
-            text-decoration: none;
-            font-weight: 700;
-            padding: 12px 18px;
-            border-radius: 10px;
-            box-shadow: 0 10px 24px rgba(15, 118, 110, 0.2);
-        }
-
-        .schema-cta a:hover {
-            transform: translateY(-1px);
-        }
-
-        .toc-grid {
-            margin-top: 12px;
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-            gap: 8px;
-        }
-
-        .toc-grid a {
-            text-decoration: none;
-            border: 1px solid var(--border);
-            border-radius: 9px;
-            padding: 8px 10px;
-            background: #f8fffd;
-            color: var(--primary-dark);
+        th {
+            background: var(--gray-50);
+            color: var(--gray-900);
             font-weight: 600;
-            font-size: 0.93rem;
         }
 
-        .toc-grid a:hover {
-            background: #ecfdf5;
+        code,
+        pre {
+            font-family: var(--mono);
+            font-size: 0.88rem;
         }
 
-        .repo-grid {
-            margin-top: 10px;
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-            gap: 10px;
-        }
-
-        .repo-card {
-            border: 1px solid var(--border);
+        pre {
+            margin-top: 0.8rem;
+            padding: 1rem;
             border-radius: 10px;
-            background: #f8fffd;
-            padding: 11px 12px;
+            background: #111827;
+            color: #f9fafb;
+            overflow-x: auto;
         }
 
-        .repo-card h3 {
-            margin-top: 0;
-            margin-bottom: 4px;
-            font-size: 0.98rem;
-        }
-
-        .repo-card code {
-            display: inline-block;
-            margin-bottom: 4px;
-        }
-
-        .flow-list {
-            margin-top: 10px;
-        }
-
-        .flow-list li {
-            margin-bottom: 8px;
-        }
-
-        .source-map td:first-child {
-            white-space: nowrap;
-            width: 1%;
-            font-weight: 600;
-            color: var(--text);
-        }
-
-        .disease-guide-grid {
-            margin-top: 12px;
+        .toc {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-            gap: 10px;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.75rem;
+            margin-top: 1rem;
         }
 
-        .disease-guide-card {
-            border: 1px solid var(--border);
+        .toc a {
+            display: block;
+            padding: 0.85rem 0.95rem;
+            border: 1px solid var(--gray-200);
+            border-radius: 8px;
+            background: #fff;
+            font-size: 0.9rem;
+            color: var(--gray-700);
+        }
+
+        .toc a:hover {
+            border-color: var(--teal-light);
+            color: var(--teal);
+            text-decoration: none;
+        }
+
+        .resource-list {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.75rem;
+            margin-top: 1rem;
+        }
+
+        .resource-card {
+            border: 1px solid var(--gray-200);
             border-radius: 10px;
-            background: #f8fffd;
-            padding: 11px 12px;
-            display: flex;
-            gap: 10px;
-            align-items: flex-start;
+            padding: 0.95rem;
+            background: #fff;
         }
 
-        .disease-guide-icon {
-            width: 30px;
-            height: 30px;
-            border-radius: 999px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
+        .resource-card strong {
+            display: block;
+            color: var(--gray-900);
+            margin-bottom: 0.25rem;
             font-size: 0.9rem;
-            flex: 0 0 30px;
         }
 
-        .disease-guide-title {
-            font-weight: 700;
-            font-size: 0.96rem;
-            color: var(--text);
-            margin-bottom: 2px;
-        }
-
-        .disease-guide-card p {
-            margin: 0;
-            font-size: 0.9rem;
-            line-height: 1.45;
-        }
-
-        .section-title-with-icon {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .section-title-icon {
-            width: 30px;
-            height: 30px;
-            border-radius: 999px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 0.9rem;
-            flex: 0 0 30px;
-        }
-
-        .footer {
+        footer {
+            border-top: 1px solid var(--gray-200);
+            padding: 2rem 1.5rem;
             text-align: center;
-            padding: 26px 20px 34px;
-            color: var(--text-light);
-            font-size: 0.92rem;
+            font-size: 0.8rem;
+            color: var(--gray-500);
+        }
+
+        footer a {
+            color: var(--gray-500);
+        }
+
+        footer a:hover {
+            color: var(--teal);
+        }
+
+        @media (max-width: 900px) {
+            .hero,
+            .section-grid,
+            .feature-grid,
+            .resource-list,
+            .diagram-meta,
+            .toc {
+                grid-template-columns: 1fr;
+            }
+
+            .quick-nav {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 768px) {
+            .hero h1 {
+                font-size: 2rem;
+            }
+
+            .nav-links {
+                gap: 0.9rem;
+            }
+
+            .flow {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .flow-arrow {
+                transform: rotate(90deg);
+                padding: 0.2rem 0;
+            }
         }
     </style>
+    <script src="https://d3js.org/d3.v7.min.js" integrity="sha384-CjloA8y00+1SDAUkjs099PVfnY2KmDC2BZnws9kh8D/lX1s46w6EPhpXdqMfjK6i" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js" integrity="sha384-2IH3T69EIKYC4c+RXZifZRvaH5SRUdacJW7j6HtE5rQbvLhKKdawxq6vpIzJ7j9M" crossorigin="anonymous"></script>
+    <script>
+        var DOC_PATHOGRAPH_NODE_SHAPES = {
+            pathophysiology: "roundrect",
+            phenotype: "ellipse",
+            environmental: "diamond",
+            genetic: "hexagon",
+            treatment: "rect",
+            biochemical: "circle",
+            experimental_model: "roundrect",
+            computational_model: "roundrect",
+            unknown: "roundrect"
+        };
+
+        var DOC_PATHOGRAPH_NODE_LABELS = {
+            pathophysiology: "Pathophysiology",
+            phenotype: "Phenotype",
+            environmental: "Environmental factor",
+            genetic: "Genetic factor",
+            treatment: "Treatment",
+            biochemical: "Biochemical marker",
+            experimental_model: "Experimental model",
+            computational_model: "Computational model",
+            unknown: "Uncategorized"
+        };
+
+        var DOC_PATHOGRAPH_NODE_STROKES = {
+            pathophysiology: "#93c5fd",
+            phenotype: "#fcd34d",
+            environmental: "#86efac",
+            genetic: "#c4b5fd",
+            treatment: "#f9a8d4",
+            biochemical: "#a5b4fc",
+            experimental_model: "#14b8a6",
+            computational_model: "#65a30d",
+            unknown: "#d1d5db"
+        };
+
+        var DOC_PATHOGRAPH_NODE_ICONS = {
+            pathophysiology: "⚙",
+            phenotype: "◉",
+            environmental: "◇",
+            genetic: "🧬",
+            treatment: "💊",
+            biochemical: "⚗",
+            experimental_model: "🧫",
+            computational_model: "🧮",
+            unknown: "?"
+        };
+
+        var DOC_PATHOGRAPH_EXPERIMENTAL_MODEL_ICONS = {
+            CELL_LINE: "🧫",
+            PRIMARY_CELL_CULTURE: "🧫",
+            IPSC_DERIVED_MODEL: "🧫",
+            ORGANOID: "◍",
+            ORGAN_ON_CHIP: "▣",
+            CO_CULTURE: "⇄"
+        };
+
+        function docsHumanizeEnum(value) {
+            return value ? String(value).replace(/_/g, " ") : "";
+        }
+
+        function docsGetModelTypeIcon(modelType) {
+            return DOC_PATHOGRAPH_EXPERIMENTAL_MODEL_ICONS[modelType] || DOC_PATHOGRAPH_NODE_ICONS.experimental_model;
+        }
+
+        function docsGetNodeIcon(nodeData) {
+            if (nodeData && nodeData.node_type === "experimental_model") {
+                return docsGetModelTypeIcon(nodeData.meta && nodeData.meta.model_type);
+            }
+            return DOC_PATHOGRAPH_NODE_ICONS[(nodeData || {}).node_type] || "";
+        }
+
+        function docsIsReadoutEdge(edgeData) {
+            return edgeData && edgeData.predicate === "readout";
+        }
+
+        function docsEdgeStroke(edgeData) {
+            if (docsIsReadoutEdge(edgeData)) return "#4f46e5";
+            return "#9ca3af";
+        }
+
+        function docsEdgeDashArray(edgeData) {
+            if (docsIsReadoutEdge(edgeData)) return "3 4";
+            return "none";
+        }
+
+        function docsEdgeMarker(edgeData) {
+            if (docsIsReadoutEdge(edgeData)) return "url(#docs-pg-arrow-readout)";
+            return "url(#docs-pg-arrow)";
+        }
+
+        function docsEdgeTitle(edgeData) {
+            var parts = [edgeData.source + " -> " + edgeData.target];
+            if (edgeData.predicate) parts.push(docsHumanizeEnum(edgeData.predicate));
+            if (edgeData.relationship) parts.push(docsHumanizeEnum(edgeData.relationship));
+            if (edgeData.description) parts.push(edgeData.description);
+            return parts.join("\n");
+        }
+
+        function docsEscapeHtml(str) {
+            var div = document.createElement("div");
+            div.appendChild(document.createTextNode(str || ""));
+            return div.innerHTML;
+        }
+
+        function renderDocsPathograph(containerId, data) {
+            var container = document.getElementById(containerId);
+            var svgEl = document.getElementById(containerId + "-svg");
+            var tooltipEl = document.getElementById(containerId + "-tooltip");
+            var legendEl = document.getElementById(containerId + "-legend");
+            if (!container || !svgEl || !tooltipEl || !legendEl || !data || !data.nodes || !data.nodes.length) return;
+
+            legendEl.innerHTML = "";
+            var svg = d3.select(svgEl);
+            svg.selectAll("*").remove();
+
+            var g = new dagre.graphlib.Graph();
+            g.setGraph({ rankdir: "LR", nodesep: 40, ranksep: 80, marginx: 30, marginy: 30 });
+            g.setDefaultEdgeLabel(function() { return {}; });
+
+            var nodeMap = {};
+            data.nodes.forEach(function(node) {
+                nodeMap[node.id] = node;
+                var labelLen = node.id.length;
+                var width = Math.max(120, Math.min(240, labelLen * 8 + 34));
+                g.setNode(node.id, { width: width, height: 44, label: node.id });
+            });
+
+            data.edges.forEach(function(edge) {
+                g.setEdge(edge.source, edge.target);
+            });
+            dagre.layout(g);
+
+            var graphInfo = g.graph();
+            var totalWidth = graphInfo.width + 60;
+            var totalHeight = graphInfo.height + 60;
+
+            svg
+                .attr("viewBox", "0 0 " + totalWidth + " " + totalHeight)
+                .attr("preserveAspectRatio", "xMidYMid meet")
+                .style("min-height", Math.min(totalHeight, 620) + "px");
+
+            var rootGroup = svg.append("g").attr("class", "pathograph-root");
+
+            svg.call(
+                d3.zoom().scaleExtent([0.3, 3]).on("zoom", function(event) {
+                    rootGroup.attr("transform", event.transform);
+                })
+            );
+
+            var defs = svg.append("defs");
+            defs.append("marker")
+                .attr("id", "docs-pg-arrow")
+                .attr("viewBox", "0 0 10 6")
+                .attr("refX", 10)
+                .attr("refY", 3)
+                .attr("markerWidth", 8)
+                .attr("markerHeight", 6)
+                .attr("orient", "auto")
+                .append("path")
+                .attr("d", "M0,0 L10,3 L0,6 Z")
+                .attr("fill", "#9ca3af");
+
+            defs.append("marker")
+                .attr("id", "docs-pg-arrow-readout")
+                .attr("viewBox", "0 0 10 6")
+                .attr("refX", 10)
+                .attr("refY", 3)
+                .attr("markerWidth", 8)
+                .attr("markerHeight", 6)
+                .attr("orient", "auto")
+                .append("path")
+                .attr("d", "M0,0 L10,3 L0,6 Z")
+                .attr("fill", "#4f46e5");
+
+            var edgesGroup = rootGroup.append("g").attr("class", "pg-edges");
+            data.edges.forEach(function(edge) {
+                var dagreEdge = g.edge(edge.source, edge.target);
+                if (!dagreEdge || !dagreEdge.points) return;
+                var line = d3.line()
+                    .x(function(point) { return point.x; })
+                    .y(function(point) { return point.y; })
+                    .curve(d3.curveBasis);
+
+                edgesGroup.append("path")
+                    .attr("d", line(dagreEdge.points))
+                    .attr("fill", "none")
+                    .attr("stroke", docsEdgeStroke(edge))
+                    .attr("stroke-width", 1.8)
+                    .attr("stroke-dasharray", docsEdgeDashArray(edge))
+                    .attr("marker-end", docsEdgeMarker(edge))
+                    .attr("data-source", edge.source)
+                    .attr("data-target", edge.target)
+                    .append("title")
+                    .text(docsEdgeTitle(edge));
+            });
+
+            function drawNodeShape(selection, nodeData, width, height) {
+                var shape = DOC_PATHOGRAPH_NODE_SHAPES[nodeData.node_type] || "roundrect";
+                var stroke = DOC_PATHOGRAPH_NODE_STROKES[nodeData.node_type] || "#d1d5db";
+
+                if (shape === "ellipse") {
+                    selection.append("ellipse")
+                        .attr("rx", width / 2)
+                        .attr("ry", height / 2)
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                } else if (shape === "diamond") {
+                    var dx = width / 2;
+                    var dy = height / 2;
+                    selection.append("polygon")
+                        .attr("points", "0," + (-dy) + " " + dx + ",0 0," + dy + " " + (-dx) + ",0")
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                } else if (shape === "hexagon") {
+                    var hx = width / 2;
+                    var hy = height / 2;
+                    var inset = width * 0.2;
+                    selection.append("polygon")
+                        .attr("points",
+                            (-hx + inset) + "," + (-hy) + " " +
+                            (hx - inset) + "," + (-hy) + " " +
+                            hx + ",0 " +
+                            (hx - inset) + "," + hy + " " +
+                            (-hx + inset) + "," + hy + " " +
+                            (-hx) + ",0"
+                        )
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                } else if (shape === "circle") {
+                    selection.append("circle")
+                        .attr("r", Math.min(width, height) / 2)
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                } else if (shape === "rect") {
+                    selection.append("rect")
+                        .attr("x", -width / 2)
+                        .attr("y", -height / 2)
+                        .attr("width", width)
+                        .attr("height", height)
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                } else {
+                    selection.append("rect")
+                        .attr("x", -width / 2)
+                        .attr("y", -height / 2)
+                        .attr("width", width)
+                        .attr("height", height)
+                        .attr("rx", 8)
+                        .attr("ry", 8)
+                        .attr("fill", nodeData.color)
+                        .attr("stroke", stroke)
+                        .attr("stroke-width", 1.5);
+                }
+            }
+
+            var nodesGroup = rootGroup.append("g").attr("class", "pg-nodes");
+            data.nodes.forEach(function(node) {
+                var dagreNode = g.node(node.id);
+                if (!dagreNode) return;
+                var nodeGroup = nodesGroup.append("g")
+                    .attr("transform", "translate(" + dagreNode.x + "," + dagreNode.y + ")")
+                    .attr("data-node-type", node.node_type)
+                    .attr("data-node-id", node.id)
+                    .style("cursor", "pointer");
+
+                drawNodeShape(nodeGroup, node, dagreNode.width, dagreNode.height);
+
+                var nodeIcon = docsGetNodeIcon(node);
+                if (nodeIcon) {
+                    var iconGroup = nodeGroup.append("g")
+                        .attr("transform", "translate(" + (-dagreNode.width / 2 + 12) + "," + (-dagreNode.height / 2 + 10) + ")")
+                        .style("pointer-events", "none");
+                    iconGroup.append("circle")
+                        .attr("r", 9)
+                        .attr("fill", "rgba(255,255,255,0.95)")
+                        .attr("stroke", DOC_PATHOGRAPH_NODE_STROKES[node.node_type] || "#d1d5db")
+                        .attr("stroke-width", 1.2);
+                    iconGroup.append("text")
+                        .attr("text-anchor", "middle")
+                        .attr("dominant-baseline", "central")
+                        .attr("font-size", "10px")
+                        .attr("font-family", '"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", system-ui, sans-serif')
+                        .text(nodeIcon);
+                }
+
+                var label = node.id;
+                var maxChars = Math.floor(dagreNode.width / 7);
+                if (label.length > maxChars) label = label.substring(0, maxChars - 1) + "…";
+                nodeGroup.append("text")
+                    .attr("text-anchor", "middle")
+                    .attr("dominant-baseline", "central")
+                    .attr("font-size", "11px")
+                    .attr("font-family", "system-ui, -apple-system, sans-serif")
+                    .attr("fill", "#1f2937")
+                    .text(label);
+
+                nodeGroup.on("mouseenter", function(event) {
+                    highlightNode(node.id, true);
+                    showTooltip(event, node);
+                }).on("mouseleave", function() {
+                    highlightNode(node.id, false);
+                    hideTooltip();
+                }).on("click", function(event) {
+                    event.stopPropagation();
+                    highlightNode(node.id, true);
+                    showTooltip(event, node);
+                });
+            });
+
+            svg.on("click", function() {
+                clearHighlight();
+                hideTooltip();
+            });
+
+            function highlightNode(nodeId, on) {
+                if (!on) {
+                    clearHighlight();
+                    return;
+                }
+                var connectedNodes = new Set([nodeId]);
+                data.edges.forEach(function(edge) {
+                    if (edge.source === nodeId) connectedNodes.add(edge.target);
+                    if (edge.target === nodeId) connectedNodes.add(edge.source);
+                });
+                nodesGroup.selectAll("g").each(function() {
+                    var element = d3.select(this);
+                    var nodeIdValue = element.attr("data-node-id");
+                    element.style("opacity", connectedNodes.has(nodeIdValue) ? 1 : 0.2);
+                });
+                edgesGroup.selectAll("path").each(function() {
+                    var element = d3.select(this);
+                    var source = element.attr("data-source");
+                    var target = element.attr("data-target");
+                    element.style("opacity", source === nodeId || target === nodeId ? 1 : 0.1);
+                });
+            }
+
+            function clearHighlight() {
+                nodesGroup.selectAll("g").style("opacity", 1);
+                edgesGroup.selectAll("path").style("opacity", 1);
+            }
+
+            function showTooltip(event, node) {
+                var html = [];
+                var nodeIcon = docsGetNodeIcon(node);
+                html.push('<div class="tt-title">' + (nodeIcon ? docsEscapeHtml(nodeIcon) + ' ' : '') + docsEscapeHtml(node.id) + '</div>');
+                html.push('<div class="tt-type">' + docsEscapeHtml(DOC_PATHOGRAPH_NODE_LABELS[node.node_type] || node.node_type) + '</div>');
+                if (node.description) {
+                    html.push('<div class="tt-desc">' + docsEscapeHtml(node.description) + '</div>');
+                }
+                var meta = node.meta || {};
+                var metaParts = [];
+                if (meta.genes && meta.genes.length) metaParts.push('<span>Genes: ' + docsEscapeHtml(meta.genes.join(', ')) + '</span>');
+                if (meta.cell_types && meta.cell_types.length) metaParts.push('<span>Cells: ' + docsEscapeHtml(meta.cell_types.join(', ')) + '</span>');
+                if (meta.biological_processes && meta.biological_processes.length) metaParts.push('<span>Processes: ' + docsEscapeHtml(meta.biological_processes.join(', ')) + '</span>');
+                if (meta.locations && meta.locations.length) metaParts.push('<span>Location: ' + docsEscapeHtml(meta.locations.join(', ')) + '</span>');
+                if (meta.therapeutic_agents && meta.therapeutic_agents.length) metaParts.push('<span>Agents: ' + docsEscapeHtml(meta.therapeutic_agents.join(', ')) + '</span>');
+                if (meta.model_type) metaParts.push('<span>Model type: ' + docsEscapeHtml(docsHumanizeEnum(meta.model_type)) + '</span>');
+                if (meta.model_software) metaParts.push('<span>Software: ' + docsEscapeHtml(meta.model_software) + '</span>');
+                if (meta.readout_of) metaParts.push('<span>Readout of: ' + docsEscapeHtml(meta.readout_of) + '</span>');
+                if (meta.evidence_count) metaParts.push('<span>Evidence: ' + docsEscapeHtml(String(meta.evidence_count)) + ' items</span>');
+                if (meta.publication) metaParts.push('<span>Publication: ' + docsEscapeHtml(meta.publication) + '</span>');
+                if (metaParts.length) {
+                    html.push('<div class="tt-meta">' + metaParts.join('') + '</div>');
+                }
+
+                tooltipEl.innerHTML = html.join('');
+                tooltipEl.style.opacity = '1';
+
+                var rect = container.getBoundingClientRect();
+                var x = event.clientX - rect.left + 14;
+                var y = event.clientY - rect.top + 14;
+                if (x + 330 > rect.width) x = x - 340;
+                if (y + 180 > rect.height) y = Math.max(4, y - 180);
+                tooltipEl.style.left = x + 'px';
+                tooltipEl.style.top = y + 'px';
+            }
+
+            function hideTooltip() {
+                tooltipEl.style.opacity = '0';
+            }
+
+            var typesInGraph = {};
+            data.nodes.forEach(function(node) {
+                typesInGraph[node.node_type] = node.color;
+            });
+            var activeTypes = new Set(Object.keys(typesInGraph));
+
+            Object.keys(typesInGraph).forEach(function(type) {
+                var item = document.createElement('label');
+                item.className = 'pathograph-legend-item';
+                item.setAttribute('data-type', type);
+
+                var checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.checked = true;
+                checkbox.setAttribute('aria-label', 'Toggle ' + (DOC_PATHOGRAPH_NODE_LABELS[type] || type));
+                item.appendChild(checkbox);
+
+                var swatch = document.createElement('div');
+                swatch.className = 'pathograph-legend-swatch';
+                swatch.style.background = typesInGraph[type];
+                swatch.style.borderColor = DOC_PATHOGRAPH_NODE_STROKES[type] || '#d1d5db';
+                item.appendChild(swatch);
+
+                var label = document.createElement('span');
+                var icon = DOC_PATHOGRAPH_NODE_ICONS[type] || '';
+                label.textContent = (icon ? icon + ' ' : '') + (DOC_PATHOGRAPH_NODE_LABELS[type] || type);
+                item.appendChild(label);
+
+                checkbox.addEventListener('change', function() {
+                    if (checkbox.checked) {
+                        activeTypes.add(type);
+                        item.classList.remove('dimmed');
+                    } else {
+                        activeTypes.delete(type);
+                        item.classList.add('dimmed');
+                    }
+                    filterByType();
+                });
+
+                legendEl.appendChild(item);
+            });
+
+            function filterByType() {
+                nodesGroup.selectAll('g').each(function() {
+                    var element = d3.select(this);
+                    var type = element.attr('data-node-type');
+                    element.style('display', activeTypes.has(type) ? null : 'none');
+                });
+                edgesGroup.selectAll('path').each(function() {
+                    var element = d3.select(this);
+                    var sourceNode = nodeMap[element.attr('data-source')];
+                    var targetNode = nodeMap[element.attr('data-target')];
+                    var sourceVisible = sourceNode && activeTypes.has(sourceNode.node_type);
+                    var targetVisible = targetNode && activeTypes.has(targetNode.node_type);
+                    element.style('display', sourceVisible && targetVisible ? null : 'none');
+                });
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            var docsPathographData = {
+                nodes: [
+                    {
+                        id: 'Inherited signaling variant',
+                        node_type: 'genetic',
+                        color: '#ede9fe',
+                        description: 'A synthetic inherited variant used to show how genetic drivers appear as their own pathograph node type.',
+                        meta: {
+                            genes: ['GENE1'],
+                            evidence_count: 2,
+                            publication: 'PMID:00000001'
+                        }
+                    },
+                    {
+                        id: 'Air pollutant exposure',
+                        node_type: 'environmental',
+                        color: '#dcfce7',
+                        description: 'Environmental factors can be linked directly into the causal graph when they influence onset or severity.',
+                        meta: {
+                            locations: ['airway epithelium'],
+                            evidence_count: 1
+                        }
+                    },
+                    {
+                        id: 'Barrier repair failure',
+                        node_type: 'pathophysiology',
+                        color: '#dbeafe',
+                        description: 'A mechanistic node representing impaired tissue repair after injury.',
+                        meta: {
+                            genes: ['GENE1'],
+                            cell_types: ['epithelial cell'],
+                            biological_processes: ['wound healing', 'stress response'],
+                            locations: ['bronchial epithelium'],
+                            evidence_count: 4
+                        }
+                    },
+                    {
+                        id: 'Chronic cytokine signal',
+                        node_type: 'pathophysiology',
+                        color: '#dbeafe',
+                        description: 'Mechanistic nodes can chain together to show multi-step progression rather than a single collapsed summary.',
+                        meta: {
+                            cell_types: ['macrophage', 'fibroblast'],
+                            biological_processes: ['cytokine-mediated signaling pathway'],
+                            evidence_count: 3
+                        }
+                    },
+                    {
+                        id: 'Inflammation marker panel',
+                        node_type: 'biochemical',
+                        color: '#e0e7ff',
+                        description: 'Biochemical nodes often act as readouts for a mechanism rather than as a direct causal step.',
+                        meta: {
+                            readout_of: 'Chronic cytokine signal',
+                            evidence_count: 2
+                        }
+                    },
+                    {
+                        id: 'Breathlessness flares',
+                        node_type: 'phenotype',
+                        color: '#fef3c7',
+                        description: 'Phenotype nodes capture downstream manifestations that result from the mechanism chain.',
+                        meta: {
+                            evidence_count: 3
+                        }
+                    },
+                    {
+                        id: 'Targeted kinase inhibitor',
+                        node_type: 'treatment',
+                        color: '#fce7f3',
+                        description: 'Treatments can connect back to the mechanism they are intended to modulate.',
+                        meta: {
+                            therapeutic_agents: ['example kinase inhibitor'],
+                            evidence_count: 2
+                        }
+                    },
+                    {
+                        id: 'Airway organoid assay',
+                        node_type: 'experimental_model',
+                        color: '#ccfbf1',
+                        description: 'Experimental model nodes show where a mechanism is studied in a disease-relevant system.',
+                        meta: {
+                            model_type: 'ORGANOID',
+                            evidence_count: 1
+                        }
+                    },
+                    {
+                        id: 'Multiscale progression model',
+                        node_type: 'computational_model',
+                        color: '#ecfccb',
+                        description: 'Computational model nodes capture simulations or in silico systems linked to mechanisms or outcomes.',
+                        meta: {
+                            model_software: 'SyntheticSim',
+                            evidence_count: 1
+                        }
+                    }
+                ],
+                edges: [
+                    {
+                        source: 'Inherited signaling variant',
+                        target: 'Barrier repair failure',
+                        predicate: 'activates',
+                        description: 'Genetic predisposition increases vulnerability of the repair pathway.'
+                    },
+                    {
+                        source: 'Air pollutant exposure',
+                        target: 'Barrier repair failure',
+                        predicate: 'aggravates',
+                        description: 'Exposure worsens the upstream injury-repair balance.'
+                    },
+                    {
+                        source: 'Barrier repair failure',
+                        target: 'Chronic cytokine signal',
+                        predicate: 'causes',
+                        description: 'Failed repair drives persistent inflammatory signaling.'
+                    },
+                    {
+                        source: 'Chronic cytokine signal',
+                        target: 'Breathlessness flares',
+                        predicate: 'causes',
+                        description: 'Mechanism node leads to a patient-facing phenotype.'
+                    },
+                    {
+                        source: 'Inflammation marker panel',
+                        target: 'Chronic cytokine signal',
+                        predicate: 'readout',
+                        description: 'Biomarker node is shown as a readout edge in the live pathograph style.'
+                    },
+                    {
+                        source: 'Targeted kinase inhibitor',
+                        target: 'Chronic cytokine signal',
+                        predicate: 'attenuates',
+                        description: 'Treatment target points back to the mechanism it is meant to modulate.'
+                    },
+                    {
+                        source: 'Airway organoid assay',
+                        target: 'Barrier repair failure',
+                        predicate: 'models',
+                        description: 'Experimental system attached to the mechanism it studies.'
+                    },
+                    {
+                        source: 'Multiscale progression model',
+                        target: 'Breathlessness flares',
+                        predicate: 'models',
+                        description: 'Computational model linked to the phenotype trajectory it predicts.'
+                    }
+                ]
+            };
+
+            renderDocsPathograph('docs-pathograph', docsPathographData);
+        });
+    </script>
 </head>
 <body>
-    <header class="hero">
-        <h1>Dismech Project Details</h1>
-        <div class="hero-actions">
-            <a class="btn btn-primary" href="../app/index.html">Browse Disorders</a>
-            <a class="btn btn-secondary" href="../index.html">Back to Home</a>
-            <a class="btn btn-secondary" href="https://docs.google.com/presentation/d/1XrbLle8gVQQcoT8IzpIfll4VnUl_68mQVTa6cIzN2vs/edit?usp=sharing" target="_blank" rel="noopener noreferrer">Presentation Slides</a>
-        </div>
-    </header>
-
-    <main class="container">
-        <section class="section" id="orientation">
-            <h2>Quick Navigation</h2>
-            <div class="toc-grid">
-                <a href="#science-curation">What is Dismech?</a>
-                <a href="#technical-implementation">Technical Implementation</a>
+    <nav>
+        <div class="nav-inner">
+            <a class="nav-logo" href="../index.html">dismech</a>
+            <div class="nav-links">
+                <a href="../app/index.html">Browse</a>
+                <a href="./" class="active">Docs</a>
+                <a href="../pages/modules/index.html">Modules</a>
+                <a href="../pages/comorbidities/">Trajectories</a>
+                <a href="../pages/classifications/">Classifications</a>
+                <a href="https://github.com/monarch-initiative/dismech/tree/main/research">Research</a>
+                <a href="../elements/">Schema</a>
+                <a href="https://github.com/monarch-initiative/dismech" aria-label="GitHub">
+                    <svg class="gh-icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                </a>
             </div>
-            <div class="schema-cta">
-                <h3>Schema Docs</h3>
-                <p>Browse the full autogenerated schema reference and class/slot documentation.</p>
-                <a href="https://dismech.monarchinitiative.org/elements/">Open Schema Documentation</a>
+        </div>
+    </nav>
+
+    <div class="hero-bg">
+        <section class="hero">
+            <div>
+                <h1>Guide to using the Dismech knowledge base</h1>
+                <p class="hero-tagline">How to read disease pages, follow evidence, and trace linked resources</p>
+                <p class="hero-sub">This page explains what appears on disorder pages, where linked terms and identifiers come from, and how to follow each page back to its curated source record.</p>
+                <div class="hero-actions">
+                    <a href="../app/index.html" class="btn btn-primary">Browse disorders</a>
+                    <a href="../elements/" class="btn btn-secondary">Open schema docs</a>
+                    <a href="../index.html" class="btn btn-secondary">Back to home</a>
+                </div>
+            </div>
+            <aside class="hero-card">
+                <h2>What this page covers</h2>
+                <ul>
+                    <li>What each disease-page section is for</li>
+                    <li>A compact pathograph example showing how causal steps are connected</li>
+                    <li>The main external resources, ontologies, and evidence sources used across the site</li>
+                </ul>
+            </aside>
+        </section>
+    </div>
+
+    <main class="main">
+        <div class="quick-nav">
+            <a href="#overview">Overview</a>
+            <a href="#page-guide">Page Guide</a>
+            <a href="#pathograph-example">Pathograph Example</a>
+            <a href="#curation-model">How Pages Are Made</a>
+            <a href="#linked-resources">External Resources</a>
+            <a href="#implementation">Behind the Scenes</a>
+        </div>
+
+        <section class="section" id="overview">
+            <h2>Overview</h2>
+            <p>Dismech turns curated disease records into browsable disorder pages. Each page is assembled from structured data defined with <a href="https://linkml.io/linkml/" target="_blank" rel="noopener noreferrer">Linked Data Modeling Language (LinkML)</a>, so sections appear only when that disease has curated information for them.</p>
+            <p>The current disorder pages cover disease identity, mechanisms, phenotypes, genetics, treatments, model systems, datasets, references, and supporting structure such as pathographs and differential diagnoses.</p>
+            <div class="pill-row">
+                <span class="pill">Schema-driven pages</span>
+                <span class="pill">Linked ontology terms</span>
+                <span class="pill">Quoted evidence</span>
+                <span class="pill">Browsable source records</span>
+            </div>
+            <div class="callout">The guide below reflects the current disorder-page layout and the underlying <a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer">Dismech schema</a>.</div>
+        </section>
+
+        <section class="section" id="page-guide">
+            <h2>Disease Page Section Guide</h2>
+            <p>The sections below reflect the headings that the current disorder template can render. Some are foundational identity sections, others are optional translational or evidence-heavy sections that only appear when curated.</p>
+            <div class="callout">Colors in the section guide reflect those used in disorder pages.</div>
+
+            <div class="section-grid">
+                <div class="guide-group">
+                    <h3>Identity and structure</h3>
+                    <p>These sections establish what the disease is, how it is classified, and how formal criteria or subtype structure are represented.</p>
+                    <div class="guide-list">
+                        <div class="guide-item" style="border-left-color: #d97706;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fef3c7; color: #d97706;">🏷</span>
+                                <strong>Classifications</strong>
+                            </div>
+                            <div class="guide-item-text">External or internal classification systems such as mechanistic categories or chapter-level groupings.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #0369a1;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #e0f2fe; color: #0369a1;">🔗</span>
+                                <strong>Mappings</strong>
+                            </div>
+                            <div class="guide-item-text">Cross-references to the <a href="https://mondo.monarchinitiative.org/" target="_blank" rel="noopener noreferrer">Monarch Disease Ontology (MONDO)</a>, the <a href="https://ncithesaurus.nci.nih.gov/ncitbrowser/" target="_blank" rel="noopener noreferrer">NCI Thesaurus (NCIT)</a>, the <a href="https://www.who.int/standards/classifications/classification-of-diseases" target="_blank" rel="noopener noreferrer">International Classification of Diseases (ICD)</a>, and related identifier systems.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #0e7490;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #cffafe; color: #0e7490;">📘</span>
+                                <strong>Definitions</strong>
+                            </div>
+                            <div class="guide-item-text">Formal definitions or criteria sets with inclusion, exclusion, laboratory, imaging, and scope metadata.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #92400e;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fef3c7; color: #92400e;">👪</span>
+                                <strong>Inheritance</strong>
+                            </div>
+                            <div class="guide-item-text">Inheritance patterns at disease or subtype level with ontology-backed inheritance descriptors.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #4f46e5;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #eef2ff; color: #4f46e5;">◆</span>
+                                <strong>Subtypes</strong>
+                            </div>
+                            <div class="guide-item-text">Named subtype structure, optional display names, mappings, frequencies, subtype genes, and subtype-specific inheritance.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #6d28d9;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ede9fe; color: #6d28d9;">C</span>
+                                <strong>Comorbidities</strong>
+                            </div>
+                            <div class="guide-item-text">Links into curated disease-trajectory and association pages when those associations exist.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="guide-group">
+                    <h3>Mechanisms and manifestations</h3>
+                    <p>These sections describe the biological story of the disease, from mechanistic events to phenotypic consequences and diagnostic distinctions.</p>
+                    <div class="guide-list">
+                        <div class="guide-item" style="border-left-color: #d97706;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fef3c7; color: #d97706;">⚙</span>
+                                <strong>Pathophysiology</strong>
+                            </div>
+                            <div class="guide-item-text">Named mechanistic nodes with genes, cell types, biological processes, cellular components, locations, evidence, and downstream edges.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #c2410c;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ffedd5; color: #c2410c;">✶</span>
+                                <strong>Histopathology</strong>
+                            </div>
+                            <div class="guide-item-text">Tissue-level microscopic findings that are distinct from general phenotype assertions.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #4f46e5;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #e0e7ff; color: #4f46e5;">⬡</span>
+                                <strong>Pathograph</strong>
+                            </div>
+                            <div class="guide-item-text">Interactive causal graph synthesized from pathophysiology, phenotypes, genes, treatments, models, and linked edges.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #16a34a;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #f0fdf4; color: #16a34a;">●</span>
+                                <strong>Phenotypes</strong>
+                            </div>
+                            <div class="guide-item-text">Clinical or cellular manifestations with <a href="https://hpo.jax.org/" target="_blank" rel="noopener noreferrer">Human Phenotype Ontology (HPO)</a> terms, frequency, severity, onset, and context-specific evidence when available.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #2563eb;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #dbeafe; color: #2563eb;">🧬</span>
+                                <strong>Genetic Associations</strong>
+                            </div>
+                            <div class="guide-item-text">Genes, variants, inheritance context, and mechanism-linked disease genetics.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #0d9488;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ccfbf1; color: #0d9488;">🌍</span>
+                                <strong>Environmental Factors</strong>
+                            </div>
+                            <div class="guide-item-text">Exposures and contextual factors that influence onset, progression, or severity.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #d97706;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fef3c7; color: #d97706;">🔬</span>
+                                <strong>Biochemical Markers</strong>
+                            </div>
+                            <div class="guide-item-text">Biomarkers plus optional pathograph readout links that say what mechanism or endpoint a marker reports on.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #dc2626;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fef2f2; color: #dc2626;">🔀</span>
+                                <strong>Differential Diagnoses</strong>
+                            </div>
+                            <div class="guide-item-text">Overlapping diseases together with distinguishing features and supporting evidence.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="guide-group">
+                    <h3>Interventions and evidence surfaces</h3>
+                    <p>These sections cover therapeutic strategy, translational resources, and the experimental or computational systems used to study disease mechanisms.</p>
+                    <div class="guide-list">
+                        <div class="guide-item" style="border-left-color: #7c3aed;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ede9fe; color: #7c3aed;">💊</span>
+                                <strong>Treatments</strong>
+                            </div>
+                            <div class="guide-item-text">Therapeutic actions, mechanism targets, target phenotypes, therapeutic agents, and supporting evidence.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #0284c7;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #e0f2fe; color: #0284c7;">📊</span>
+                                <strong>Related Datasets</strong>
+                            </div>
+                            <div class="guide-item-text">Dataset records pointing to public omics, phenotype, or perturbation resources relevant to the disease.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #a855f7;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #f5f3ff; color: #a855f7;">🔬</span>
+                                <strong>Clinical Trials</strong>
+                            </div>
+                            <div class="guide-item-text">Trial phase, status, description, target phenotypes, and evidence snippets linked to <a href="https://clinicaltrials.gov/" target="_blank" rel="noopener noreferrer">ClinicalTrials.gov</a>.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #f59e0b;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #fffbeb; color: #f59e0b;">🧫</span>
+                                <strong>Experimental Models</strong>
+                            </div>
+                            <div class="guide-item-text">Non-animal disease-relevant systems linked back to specific pathophysiology nodes.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #22c55e;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #f0fdf4; color: #22c55e;">🧮</span>
+                                <strong>Computational Models</strong>
+                            </div>
+                            <div class="guide-item-text">In silico models, perturbations, variables, and modeled mechanisms.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="guide-group">
+                    <h3>Interface behaviors</h3>
+                    <p>These are page-level affordances that help readers navigate and interrogate a curated disease record.</p>
+                    <div class="guide-list">
+                        <div class="guide-item" style="border-left-color: #475569;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #f1f5f9; color: #475569;">#</span>
+                                <strong>Stats bar</strong>
+                            </div>
+                            <div class="guide-item-text">Quick counts for major populated sections, including pathograph node count when present.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #059669;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ecfdf5; color: #059669;">🧠</span>
+                                <strong>OpenScientist panel</strong>
+                            </div>
+                            <div class="guide-item-text">Page-level research assistant entry point for question-driven deep research on the current disease.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #0e7490;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #ecfeff; color: #0e7490;">↔</span>
+                                <strong>Cross-links</strong>
+                            </div>
+                            <div class="guide-item-text">Pathophysiology entries can link to downstream nodes, treatment targets, biomarkers, and model systems.</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="guide-group span-2">
+                    <h3>Metadata and provenance</h3>
+                    <p>These sections surface generated artifacts and the audit trail around the underlying disease record.</p>
+                    <div class="guide-list">
+                        <div class="guide-item" style="border-left-color: #a855f7;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #faf5ff; color: #a855f7;">📄</span>
+                                <strong>Reports</strong>
+                            </div>
+                            <div class="guide-item-text">Embedded higher-level generated analyses surfaced with the disease page when available.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #475569;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #f1f5f9; color: #475569;">{ }</span>
+                                <strong>Source YAML</strong>
+                            </div>
+                            <div class="guide-item-text">The underlying curated record, stored in <a href="https://yaml.org/" target="_blank" rel="noopener noreferrer">YAML</a>, used to generate the page for review and audit.</div>
+                        </div>
+                        <div class="guide-item" style="border-left-color: #4f46e5;">
+                            <div class="guide-item-head">
+                                <span class="guide-icon" style="background: #eef2ff; color: #4f46e5;">📚</span>
+                                <strong>References and Deep Research</strong>
+                            </div>
+                            <div class="guide-item-text">Curated publication references plus linked synthesized research outputs.</div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
 
-        <section class="section" id="science-curation">
-            <h2 class="section-title-with-icon">
-                <span class="section-title-icon" style="background: #ccfbf1; color: #0d9488;">🧭</span>
-                <span>What is Dismech?</span>
-            </h2>
-            <p>
-                Dismech curates disease knowledge in a structured format: mechanistic assertions, clinical features, genetics,
-                interventions, and supporting evidence mapped to ontology terms.
-            </p>
-            <p>
-                On each Disease page, sections appear when curated data exists for that topic. The guide below summarizes what each
-                section is intended to capture.
-            </p>
+        <section class="section" id="pathograph-example">
+            <h2>Pathograph Example</h2>
+            <p>A pathograph is the disease page’s causal graph view. Instead of summarizing a mechanism as prose, it lays out linked nodes for mechanisms, phenotypes, genetics, treatments, biomarkers, environmental factors, and model systems.</p>
+            <p>This example uses synthetic data, but it is rendered in the same interactive style as a real disease page so you can see how the different node categories appear together.</p>
 
-            <h3>Disease Page Section Guide</h3>
-            <div class="disease-guide-grid">
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #fef3c7; color: #d97706;">⚙</div>
-                    <div>
-                        <div class="disease-guide-title">Pathophysiology</div>
-                        <p>Granular causal events linking molecular and cellular mechanisms to downstream disease outcomes.</p>
-                    </div>
+            <div class="graph-note">Use the checkboxes to hide or show graph categories. Hover nodes for metadata, and drag the graph to inspect the layout.</div>
+            <div class="pathograph-container" id="docs-pathograph">
+                <div class="pathograph-legend" id="docs-pathograph-legend"></div>
+                <svg id="docs-pathograph-svg" role="img">
+                    <title>Pathograph example showing synthetic mechanisms, phenotypes, treatments, biomarkers, and model nodes</title>
+                    <desc>Interactive directed graph showing how different node types in a Dismech pathograph can connect through causal and readout relationships.</desc>
+                </svg>
+                <div class="pathograph-tooltip" id="docs-pathograph-tooltip"></div>
+            </div>
+
+            <div class="diagram-meta">
+                <div class="diagram-meta-item">
+                    <strong>Causal overview</strong>
+                    A pathograph helps readers move quickly from upstream drivers to downstream outcomes, making it easier to understand the overall disease story at a glance.
                 </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #dcfce7; color: #16a34a;">●</div>
-                    <div>
-                        <div class="disease-guide-title">Phenotypes</div>
-                        <p>Clinical manifestations, frequencies, and context with phenotype ontology annotation.</p>
-                    </div>
+                <div class="diagram-meta-item">
+                    <strong>Context in one place</strong>
+                    By placing mechanisms, phenotypes, treatments, biomarkers, and models in one connected view, the graph shows how pieces of evidence relate rather than listing them as isolated facts.
                 </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #dbeafe; color: #2563eb;">🧬</div>
-                    <div>
-                        <div class="disease-guide-title">Genetic Associations</div>
-                        <p>Genes and variants linked to disease risk, presentation, inheritance, or subtype structure.</p>
-                    </div>
+                <div class="diagram-meta-item">
+                    <strong>Linked interpretation</strong>
+                    Mechanisms, biomarker readouts, treatments, and model systems can all point into the same graph, helping the page stay biologically coherent.
                 </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #ede9fe; color: #7c3aed;">💊</div>
-                    <div>
-                        <div class="disease-guide-title">Treatments</div>
-                        <p>Therapies, intended effects, mechanism targets, and phenotype targets when available.</p>
-                    </div>
+            </div>
+        </section>
+
+        <section class="section" id="curation-model">
+            <h2>How Pages Are Made</h2>
+            <p>Each disease page starts as a curated source record written in <a href="https://yaml.org/" target="_blank" rel="noopener noreferrer">YAML</a>. That record is checked against the <a href="https://linkml.io/linkml/" target="_blank" rel="noopener noreferrer">Linked Data Modeling Language (LinkML)</a> schema, then rendered into the public page and related browser data.</p>
+
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <h3>Structured disease records</h3>
+                    <p>Curated disease entries live in <a href="https://github.com/monarch-initiative/dismech/tree/main/kb/disorders" target="_blank" rel="noopener noreferrer">kb/disorders</a>.</p>
                 </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #ccfbf1; color: #0d9488;">🌍</div>
-                    <div>
-                        <div class="disease-guide-title">Environmental Factors</div>
-                        <p>Exposures and contextual factors that influence onset, progression, or severity.</p>
-                    </div>
+                <div class="feature-card">
+                    <h3>Shared data model</h3>
+                    <p>The rules for what can appear on a page are defined in <a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer">src/dismech/schema/dismech.yaml</a>.</p>
                 </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #fef3c7; color: #d97706;">🔬</div>
-                    <div>
-                        <div class="disease-guide-title">Biochemical Markers</div>
-                        <p>Laboratory and molecular markers, including expected presence/absence and context.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #fef2f2; color: #dc2626;">🔀</div>
-                    <div>
-                        <div class="disease-guide-title">Differential Diagnoses</div>
-                        <p>Conditions with overlapping presentation and curated distinguishing features.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #f5f3ff; color: #a855f7;">🔬</div>
-                    <div>
-                        <div class="disease-guide-title">Clinical Trials</div>
-                        <p>Relevant trials with phase, status, and intervention/target phenotype context.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #ffedd5; color: #c2410c;">✶</div>
-                    <div>
-                        <div class="disease-guide-title">Histopathology</div>
-                        <p>Tissue-level findings and characteristic microscopic patterns when curated.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #e0f2fe; color: #0284c7;">📊</div>
-                    <div>
-                        <div class="disease-guide-title">Related Datasets</div>
-                        <p>Data resources supporting mechanistic or translational analyses.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #e0e7ff; color: #4f46e5;">⬡</div>
-                    <div>
-                        <div class="disease-guide-title">Causal Graph</div>
-                        <p>Visual summary of curated upstream/downstream links connecting mechanistic events and outcomes.</p>
-                    </div>
-                </div>
-                <div class="disease-guide-card">
-                    <div class="disease-guide-icon" style="background: #f1f5f9; color: #475569;">{ }</div>
-                    <div>
-                        <div class="disease-guide-title">Source YAML</div>
-                        <p>Raw, structured record used to generate the page, useful for auditing and curation review.</p>
-                    </div>
+                <div class="feature-card">
+                    <h3>Checked quotations</h3>
+                    <p>Evidence snippets are checked against fetched source text cached in <a href="https://github.com/monarch-initiative/dismech/tree/main/references_cache" target="_blank" rel="noopener noreferrer">references_cache</a>.</p>
                 </div>
             </div>
 
-            <h3>Data Curation Model</h3>
-            <table class="detail-table">
+            <h3>Validation workflow</h3>
+            <table>
                 <thead>
                     <tr>
-                        <th>Curated Asset</th>
-                        <th>Purpose</th>
-                        <th>Location (GitHub)</th>
+                        <th>Check</th>
+                        <th>What it protects</th>
+                        <th>Typical command</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td>Disease records</td>
-                        <td>Primary YAML source of truth for pathophysiology, phenotypes, genetics, treatments, and evidence.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/kb/disorders" target="_blank" rel="noopener noreferrer"><code>kb/disorders/</code></a></td>
+                        <td>Schema validation</td>
+                        <td>Ensures the YAML record conforms to the disease model and required structure.</td>
+                        <td><code>just validate kb/disorders/Some_Disease.yaml</code></td>
                     </tr>
                     <tr>
-                        <td>Comorbidity records</td>
-                        <td>Structured associations between conditions with mechanistic and evidence context.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/kb/comorbidities" target="_blank" rel="noopener noreferrer"><code>kb/comorbidities/</code></a></td>
+                        <td>Reference validation</td>
+                        <td>Checks quoted snippets against cached <a href="https://pubmed.ncbi.nlm.nih.gov/" target="_blank" rel="noopener noreferrer">PubMed</a>, trial, or structured-source content.</td>
+                        <td><code>just validate-references kb/disorders/Some_Disease.yaml</code></td>
                     </tr>
                     <tr>
-                        <td>Disease model schema</td>
-                        <td>Defines required structure, allowed terms, and evidence object model.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer"><code>src/dismech/schema/dismech.yaml</code></a></td>
-                    </tr>
-                    <tr>
-                        <td>Evidence cache</td>
-                        <td>Local reference cache used for repeatable citation/snippet validation.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/references_cache" target="_blank" rel="noopener noreferrer"><code>references_cache/</code></a></td>
+                        <td>Project QC</td>
+                        <td>Runs the broader project quality stack including cache checks and validation layers.</td>
+                        <td><code>just qc</code></td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>Evidence and Provenance Workflow</h3>
-            <ul>
-                <li>Assertions use explicit support status (<code>SUPPORT</code>, <code>PARTIAL</code>, <code>REFUTE</code>, etc.) and evidence source categories.</li>
-                <li>Reference snippets are validated against source text to reduce hallucinated evidence.</li>
-                <li>Curation quality is monitored through schema checks, ontology checks, and reference checks.</li>
-            </ul>
-<pre><code># Validate one disease file end-to-end
+            <pre><code># Validate one disease record
 just validate kb/disorders/Some_Disease.yaml
 
-# Validate reference snippets against source content
+# Check evidence snippets
 just validate-references kb/disorders/Some_Disease.yaml
 
-# Run cross-project quality checks
-just qc
-just compliance-all
-just compliance-weighted</code></pre>
-            <p>
-                Related guidance on hallucination-resistant evidence:
-                <a href="https://ai4curation.io/aidocs/how-tos/make-ids-hallucination-resistant/" target="_blank" rel="noopener noreferrer">AI4Curation: Make IDs Hallucination-Resistant</a>.
-            </p>
-
-            <h3>Contributor Path</h3>
-            <p>
-                Contribute by curating YAML records, running validations, and submitting pull requests with evidence-backed updates.
-                Start here:
-                <a href="https://github.com/monarch-initiative/dismech/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer"><code>CONTRIBUTING.md</code></a>.
-            </p>
-            <p>
-                Open issues and curation priorities:
-                <a href="https://github.com/monarch-initiative/dismech/issues" target="_blank" rel="noopener noreferrer">GitHub Issues</a>.
-            </p>
+# Run the broader quality-control stack
+just qc</code></pre>
         </section>
 
-        <section class="section" id="technical-implementation">
-            <h2 class="section-title-with-icon">
-                <span class="section-title-icon" style="background: #dbeafe; color: #2563eb;">🛠</span>
-                <span>Technical Implementation</span>
-            </h2>
-            <p>
-                Dismech combines deterministic validation/build infrastructure with agentic research and curation workflows.
-                This section maps architecture components to concrete repository files and external tooling.
-            </p>
-            <p>
-                Rendered schema documentation is available at
-                <a href="https://dismech.monarchinitiative.org/elements/">https://dismech.monarchinitiative.org/elements/</a>.
-            </p>
+        <section class="section" id="linked-resources">
+            <h2>External Resources Dismech Uses</h2>
+            <p>Dismech pages do not stand alone. They link out to disease, phenotype, gene, treatment, anatomy, chemistry, trial, and literature resources so you can move from a page summary to the original terminology and evidence source.</p>
+            <p>The table below covers the main resources that appear in mappings, linked terms, references, and evidence-backed sections across the site.</p>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th>Resource</th>
+                        <th>What you will see on Dismech pages</th>
+                        <th>Documentation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><a href="https://mondo.monarchinitiative.org/" target="_blank" rel="noopener noreferrer">Monarch Disease Ontology (MONDO)</a></td>
+                        <td>Disease identifiers and mappings used to anchor a disorder to a shared disease vocabulary.</td>
+                        <td><a href="https://mondo.monarchinitiative.org/" target="_blank" rel="noopener noreferrer">MONDO docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://hpo.jax.org/" target="_blank" rel="noopener noreferrer">Human Phenotype Ontology (HPO)</a></td>
+                        <td>Phenotype terms for signs, symptoms, laboratory abnormalities, and cellular findings.</td>
+                        <td><a href="https://hpo.jax.org/" target="_blank" rel="noopener noreferrer">HPO docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://geneontology.org/" target="_blank" rel="noopener noreferrer">Gene Ontology (GO)</a></td>
+                        <td>Biological processes, cellular components, and related mechanistic annotations.</td>
+                        <td><a href="https://geneontology.org/docs/ontology-documentation/" target="_blank" rel="noopener noreferrer">GO documentation</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://obophenotype.github.io/cell-ontology/" target="_blank" rel="noopener noreferrer">Cell Ontology (CL)</a></td>
+                        <td>Cell-type terms used in pathophysiology, models, and other mechanism-linked sections.</td>
+                        <td><a href="https://obophenotype.github.io/cell-ontology/" target="_blank" rel="noopener noreferrer">CL docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://obophenotype.github.io/uberon/" target="_blank" rel="noopener noreferrer">Uber-anatomy Ontology (Uberon)</a></td>
+                        <td>Anatomy and tissue terms that help place mechanisms and findings in the body.</td>
+                        <td><a href="https://obophenotype.github.io/uberon/" target="_blank" rel="noopener noreferrer">Uberon docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.ebi.ac.uk/chebi/" target="_blank" rel="noopener noreferrer">Chemical Entities of Biological Interest (ChEBI)</a></td>
+                        <td>Specific drug or chemical identifiers used for treatments, biomarkers, and molecular context.</td>
+                        <td><a href="https://www.ebi.ac.uk/chebi/" target="_blank" rel="noopener noreferrer">ChEBI docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://obofoundry.org/ontology/maxo.html" target="_blank" rel="noopener noreferrer">Medical Action Ontology (MAXO)</a></td>
+                        <td>Treatment-action terms such as pharmacotherapy, surgery, rehabilitation, and supportive care.</td>
+                        <td><a href="https://obofoundry.org/ontology/maxo.html" target="_blank" rel="noopener noreferrer">MAXO docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://ncithesaurus.nci.nih.gov/ncitbrowser/" target="_blank" rel="noopener noreferrer">NCI Thesaurus (NCIT)</a></td>
+                        <td>Additional disease, treatment, and drug-class terms, especially where cancer or intervention detail is helpful.</td>
+                        <td><a href="https://ncithesaurus.nci.nih.gov/ncitbrowser/" target="_blank" rel="noopener noreferrer">NCIT browser</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.genenames.org/" target="_blank" rel="noopener noreferrer">Human Gene Nomenclature Committee (HGNC)</a></td>
+                        <td>Stable human gene identifiers used in genetic associations and mechanistic annotations.</td>
+                        <td><a href="https://www.genenames.org/" target="_blank" rel="noopener noreferrer">HGNC docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.who.int/standards/classifications/classification-of-diseases" target="_blank" rel="noopener noreferrer">International Classification of Diseases (ICD)</a></td>
+                        <td>Clinical coding mappings used to connect Dismech records to common diagnostic code systems.</td>
+                        <td><a href="https://www.who.int/standards/classifications/classification-of-diseases" target="_blank" rel="noopener noreferrer">ICD docs</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://pubmed.ncbi.nlm.nih.gov/" target="_blank" rel="noopener noreferrer">PubMed</a> and PubMed identifiers (PMIDs)</td>
+                        <td>Literature references and quoted evidence snippets used to support claims on disease pages.</td>
+                        <td><a href="https://pubmed.ncbi.nlm.nih.gov/" target="_blank" rel="noopener noreferrer">PubMed</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://clinicaltrials.gov/" target="_blank" rel="noopener noreferrer">ClinicalTrials.gov</a> and NCT identifiers</td>
+                        <td>Clinical trial records linked from treatment and translational sections when trial data is curated.</td>
+                        <td><a href="https://clinicaltrials.gov/" target="_blank" rel="noopener noreferrer">ClinicalTrials.gov</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://www.orpha.net/" target="_blank" rel="noopener noreferrer">Orphanet</a> and ORPHA identifiers</td>
+                        <td>Rare-disease definitions, epidemiology, phenotypes, and cross-references incorporated through structured sources.</td>
+                        <td><a href="https://www.orpha.net/" target="_blank" rel="noopener noreferrer">Orphanet</a></td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://clinicalgenome.org/" target="_blank" rel="noopener noreferrer">Clinical Genome Resource (ClinGen)</a></td>
+                        <td>Structured evidence from ClinGen Gene-Disease Validity (CGGV) and ClinGen Dosage Sensitivity (CGDS) records.</td>
+                        <td><a href="https://search.clinicalgenome.org/kb/gene-validity" target="_blank" rel="noopener noreferrer">ClinGen gene validity</a> and <a href="https://search.clinicalgenome.org/kb/gene-dosage" target="_blank" rel="noopener noreferrer">ClinGen dosage</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="section" id="implementation">
+            <h2>Behind the Scenes</h2>
+            <p>If you want the project mechanics, these are the main tools and workflows that keep pages validated, linked, and up to date. Automated helpers can assist with drafting, but published pages still come from repository files, validation commands, and normal pull request review.</p>
 
             <h3>Core Tools Used in This Project</h3>
-            <table class="detail-table">
+            <table>
                 <thead>
                     <tr>
                         <th>Tool</th>
-                        <th>Brief Explanation</th>
-                        <th>How It Is Used Here</th>
+                        <th>Brief explanation</th>
+                        <th>How it is used here</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener noreferrer">Claude and Claude Code</a></td>
                         <td>LLM assistant tooling used for guided curation, review responses, and targeted repository edits.</td>
-                        <td>
-                            Integrated via GitHub workflows such as
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude.yml" target="_blank" rel="noopener noreferrer"><code>claude.yml</code></a>
-                            and
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude-code-review.yml" target="_blank" rel="noopener noreferrer"><code>claude-code-review.yml</code></a>.
-                        </td>
+                        <td>Integrated via GitHub workflows such as <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude.yml" target="_blank" rel="noopener noreferrer">claude.yml</a> and <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/claude-code-review.yml" target="_blank" rel="noopener noreferrer">claude-code-review.yml</a>.</td>
                     </tr>
                     <tr>
                         <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/dragon-ai.yml" target="_blank" rel="noopener noreferrer">DRAGON-AI</a></td>
                         <td>An ontology-aware agent workflow used for repository interactions and follow-up edits triggered from collaboration events.</td>
-                        <td>
-                            Configured in
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/dragon-ai.yml" target="_blank" rel="noopener noreferrer"><code>.github/workflows/dragon-ai.yml</code></a>
-                            for mention-driven issue/PR/review processing.
-                        </td>
+                        <td>Configured in <a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/dragon-ai.yml" target="_blank" rel="noopener noreferrer">.github/workflows/dragon-ai.yml</a> for mention-driven issue, PR, and review processing.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Agents (Edison, OpenAI, Perplexity)</a></td>
+                        <td><a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Agents</a></td>
                         <td>Provider-based research agents used to populate initial evidence candidates before structured curation and validation.</td>
-                        <td>
-                            Run through
-                            <a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Client</a>
-                            and project commands in
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer"><code>project.justfile</code></a>
-                            (for example, <code>just research-disorder perplexity ...</code> or <code>just research-disorder openai ...</code>).
-                        </td>
+                        <td>Run through <a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Client</a> and repository commands in <a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer">project.justfile</a>.</td>
                     </tr>
                     <tr>
                         <td><a href="https://github.com/features/actions" target="_blank" rel="noopener noreferrer">GitHub Actions</a></td>
                         <td>Automation platform for CI checks, scheduled compliance runs, page generation, deploys, and release exports.</td>
-                        <td>
-                            Workflow definitions are maintained in
-                            <a href="https://github.com/monarch-initiative/dismech/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer"><code>.github/workflows/</code></a>,
-                            including build/test, generation, weekly compliance, and agent workflows.
-                        </td>
+                        <td>Workflow definitions are maintained in <a href="https://github.com/monarch-initiative/dismech/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer">.github/workflows</a>, including build/test, generation, weekly compliance, and agent workflows.</td>
                     </tr>
                     <tr>
                         <td><a href="https://github.com/casey/just" target="_blank" rel="noopener noreferrer">Just and Justfiles</a></td>
                         <td>A command runner for repeatable project tasks, similar to lightweight build recipes.</td>
-                        <td>
-                            Project commands for validation, page generation, QC dashboards, research, and exports are defined in
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer"><code>project.justfile</code></a>
-                            and imported via
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/justfile" target="_blank" rel="noopener noreferrer"><code>justfile</code></a>.
-                        </td>
+                        <td>Project commands for validation, page generation, QC dashboards, research, and exports are defined in <a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer">project.justfile</a> and imported via <a href="https://github.com/monarch-initiative/dismech/blob/main/justfile" target="_blank" rel="noopener noreferrer">justfile</a>.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://incatools.github.io/ontology-access-kit/" target="_blank" rel="noopener noreferrer">OAK (Ontology Access Kit)</a></td>
-                        <td>A unified API/toolkit for ontology lookup, traversal, and term validation across ontology sources.</td>
-                        <td>
-                            OAK adapters are configured in
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/conf/oak_config.yaml" target="_blank" rel="noopener noreferrer"><code>conf/oak_config.yaml</code></a>
-                            and used by LinkML term-validation steps to check IDs/labels in curated records.
-                        </td>
+                        <td><a href="https://incatools.github.io/ontology-access-kit/" target="_blank" rel="noopener noreferrer">OAK</a></td>
+                        <td>A unified API and toolkit for ontology lookup, traversal, and term validation across ontology sources.</td>
+                        <td>Adapters are configured in <a href="https://github.com/monarch-initiative/dismech/blob/main/conf/oak_config.yaml" target="_blank" rel="noopener noreferrer">conf/oak_config.yaml</a> and used by LinkML term-validation steps.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://linkml.io/linkml/" target="_blank" rel="noopener noreferrer">LinkML Language and Tooling</a></td>
-                        <td>A data modeling language and ecosystem for defining schemas, generating artifacts, and validating data.</td>
-                        <td>
-                            The core model is defined in
-                            <a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer"><code>src/dismech/schema/dismech.yaml</code></a>;
-                            Dismech uses LinkML validators (schema, term, and reference validation) and related tooling in the QC pipeline.
-                        </td>
+                        <td><a href="https://linkml.io/linkml/" target="_blank" rel="noopener noreferrer">LinkML</a></td>
+                        <td>A data modeling language and tooling ecosystem for defining schemas, generating artifacts, and validating data.</td>
+                        <td>The core model is defined in <a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer">src/dismech/schema/dismech.yaml</a>; Dismech uses schema, term, and reference validation in the QC pipeline.</td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>Architecture: Foundational and Agentic Components</h3>
-            <table class="detail-table">
+            <h3>Main project layers</h3>
+            <table>
                 <thead>
                     <tr>
                         <th>Layer</th>
-                        <th>What It Does</th>
-                        <th>Implementation Link</th>
+                        <th>What it does</th>
+                        <th>Implementation link</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td>Data model</td>
-                        <td>Disease classes, slots, enums, descriptor bindings, evidence model.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer"><code>src/dismech/schema/dismech.yaml</code></a></td>
+                        <td>Disease classes, slots, enums, descriptor bindings, and evidence model.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/schema/dismech.yaml" target="_blank" rel="noopener noreferrer">src/dismech/schema/dismech.yaml</a></td>
                     </tr>
                     <tr>
                         <td>Knowledge content</td>
                         <td>Curated disease and comorbidity records in YAML.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/kb" target="_blank" rel="noopener noreferrer"><code>kb/</code></a></td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/kb" target="_blank" rel="noopener noreferrer">kb</a></td>
                     </tr>
                     <tr>
                         <td>Ontology adapters</td>
                         <td>OAK-backed ontology resolution and term validation configuration.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/conf/oak_config.yaml" target="_blank" rel="noopener noreferrer"><code>conf/oak_config.yaml</code></a></td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/conf/oak_config.yaml" target="_blank" rel="noopener noreferrer">conf/oak_config.yaml</a></td>
                     </tr>
                     <tr>
                         <td>Rendering pipeline</td>
-                        <td>Generates disorder/comorbidity/classification pages and causal graph views.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/render.py" target="_blank" rel="noopener noreferrer"><code>src/dismech/render.py</code></a></td>
+                        <td>Generates disorder, comorbidity, and classification pages plus causal graph views.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/src/dismech/render.py" target="_blank" rel="noopener noreferrer">src/dismech/render.py</a></td>
                     </tr>
                     <tr>
                         <td>Browser UI</td>
-                        <td>Faceted search app, schema-driven field config, generated records.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/app" target="_blank" rel="noopener noreferrer"><code>app/</code></a></td>
+                        <td>Faceted search app, schema-driven field config, and generated records.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/app" target="_blank" rel="noopener noreferrer">app</a></td>
                     </tr>
                     <tr>
                         <td>Commands and recipes</td>
                         <td>Validation, generation, research, and export task entry points.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer"><code>project.justfile</code></a></td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/project.justfile" target="_blank" rel="noopener noreferrer">project.justfile</a></td>
                     </tr>
                     <tr>
                         <td>Automation workflows</td>
-                        <td>CI, page generation, compliance loops, docs deploy, release exports.</td>
-                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer"><code>.github/workflows/</code></a></td>
+                        <td>Continuous integration, page generation, compliance loops, docs deploy, and release exports.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/tree/main/.github/workflows" target="_blank" rel="noopener noreferrer">.github/workflows</a></td>
                     </tr>
                     <tr>
                         <td>Agentic research integration</td>
-                        <td>Provider-based deep research report generation used in curation loops.</td>
+                        <td>Provider-based deep-research report generation used in curation loops.</td>
                         <td><a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Client</a></td>
                     </tr>
                 </tbody>
             </table>
 
-            <h3>Build and Validation Commands</h3>
-<pre><code># Validate all disorders (schema + terms + references + deep-research QC)
-just qc
-
-# Generate pages and browser data
-just gen-pages
-just gen-browser-data
-just gen-all
-
-# Generate compliance dashboard
-just gen-dashboard
-
-# Export KGX
-just export-kgx</code></pre>
-
             <h3>Automation Workflows</h3>
-            <p>
-                The workflow layer is more than standard CI. It combines deterministic quality gates with recurring
-                agent-assisted maintenance loops, then routes results back through normal PR review.
-            </p>
-            <table class="detail-table">
+            <p>These workflows keep the site current and checked. They combine standard continuous integration with recurring maintenance jobs, then route the results back through normal pull request review.</p>
+            <table>
                 <thead>
                     <tr>
                         <th>Workflow</th>
-                        <th>Trigger and Scope</th>
-                        <th>Automated Actions</th>
-                        <th>Human Touchpoint</th>
+                        <th>Trigger and scope</th>
+                        <th>Automated actions</th>
+                        <th>Human touchpoint</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/main.yaml" target="_blank" rel="noopener noreferrer"><code>main.yaml</code></a></td>
-                        <td>Push to <code>main</code> and all PRs; path-filtered to changed source, disorder YAML, and comorbidity YAML.</td>
-                        <td>Runs linting, validates only changed disorder/comorbidity files with project recipes, and runs tests when source code changes.</td>
-                        <td>Reviewers inspect failing/passing checks and request edits before merge.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/main.yaml" target="_blank" rel="noopener noreferrer">main.yaml</a></td>
+                        <td>Push to main and all pull requests; path-filtered to changed source, disorder YAML, and comorbidity YAML.</td>
+                        <td>Runs linting, validates only changed disorder and comorbidity files, and runs tests when source code changes.</td>
+                        <td>Reviewers inspect failing and passing checks and request edits before merge.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/generate-pages.yaml" target="_blank" rel="noopener noreferrer"><code>generate-pages.yaml</code></a></td>
-                        <td>Push to <code>main</code> when KB/templates/render/export/QC config changes, plus manual dispatch.</td>
-                        <td>Regenerates disorder/comorbidity pages, browser data, and dashboard; commits outputs and opens an automated PR when diffs exist.</td>
-                        <td>Maintainers review generated-content PRs and spot-check render/dashboard correctness.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/generate-pages.yaml" target="_blank" rel="noopener noreferrer">generate-pages.yaml</a></td>
+                        <td>Push to main when KB, templates, render, export, or QC config changes, plus manual dispatch.</td>
+                        <td>Regenerates pages, browser data, and dashboard output; commits outputs and opens an automated pull request when diffs exist.</td>
+                        <td>Maintainers review generated-content pull requests and spot-check render and dashboard correctness.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/weekly-compliance.yaml" target="_blank" rel="noopener noreferrer"><code>weekly-compliance.yaml</code></a></td>
-                        <td>Weekly cron plus manual dispatch with inputs (<code>num_files</code>, <code>areas_for_improvement</code>, model).</td>
-                        <td>Runs agentic compliance-improvement passes using compliance metrics and validation loops, then prepares per-file fix PRs.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/weekly-compliance.yaml" target="_blank" rel="noopener noreferrer">weekly-compliance.yaml</a></td>
+                        <td>Weekly cron plus manual dispatch with inputs like num_files, areas_for_improvement, and model choice.</td>
+                        <td>Runs automated compliance-improvement passes using compliance metrics and validation loops, then prepares per-file fix pull requests.</td>
                         <td>Humans choose focus areas, review generated fixes, and merge or request correction.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/post-review-agent.yml" target="_blank" rel="noopener noreferrer"><code>post-review-agent.yml</code></a></td>
-                        <td>Daily cron plus manual dispatch (<code>days_back</code>, <code>dry_run</code>, optional PR number, model choice).</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/post-review-agent.yml" target="_blank" rel="noopener noreferrer">post-review-agent.yml</a></td>
+                        <td>Daily cron plus manual dispatch with days_back, dry_run, optional pull request number, and model choice.</td>
                         <td>Scans unresolved editorial review comments and chooses one action: suggested patch, thread reply, or new issue for broader work.</td>
-                        <td>PR authors accept/reject suggested changes and continue discussion in review threads.</td>
+                        <td>Pull request authors accept or reject suggested changes and continue discussion in review threads.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/dragon-ai.yml" target="_blank" rel="noopener noreferrer"><code>dragon-ai.yml</code></a></td>
-                        <td>Issue/PR/comment events; runs only on qualifying mentions from allowlisted controllers.</td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/dragon-ai.yml" target="_blank" rel="noopener noreferrer">dragon-ai.yml</a></td>
+                        <td>Issue, pull request, and comment events; runs only on qualifying mentions from allowlisted controllers.</td>
                         <td>Parses mention intent, builds a structured prompt, and runs headless agent execution tied to GitHub context.</td>
-                        <td>Controllers direct tasks in threads; maintainers review resulting changes/PRs.</td>
+                        <td>Controllers direct tasks in threads; maintainers review resulting changes and pull requests.</td>
                     </tr>
                     <tr>
-                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/kgx-release.yaml" target="_blank" rel="noopener noreferrer"><code>kgx-release.yaml</code></a></td>
+                        <td><a href="https://github.com/monarch-initiative/dismech/blob/main/.github/workflows/kgx-release.yaml" target="_blank" rel="noopener noreferrer">kgx-release.yaml</a></td>
                         <td>Release-oriented export flow.</td>
-                        <td>Builds KGX export artifacts and attaches versioned outputs to releases.</td>
-                        <td>Release maintainers verify export quality and publish release notes/artifacts.</td>
+                        <td>Builds <a href="https://github.com/biolink/kgx" target="_blank" rel="noopener noreferrer">Knowledge Graph Exchange (KGX)</a> export artifacts and attaches versioned outputs to releases.</td>
+                        <td>Release maintainers verify export quality and publish release notes and artifacts.</td>
                     </tr>
                 </tbody>
             </table>
-            <div class="callout">
-                Distinctive pattern: validation and generation are continuous, but every meaningful content change still passes through transparent GitHub PR review with explicit provenance and evidence checks.
-            </div>
+            <div class="callout">Validation and generation run continuously, but every meaningful content change still goes through transparent GitHub pull request review with explicit provenance and evidence checks.</div>
 
             <h3>Related Tooling and Integrations</h3>
             <div class="toc">
@@ -810,11 +1912,33 @@ just export-kgx</code></pre>
                 <a href="https://github.com/linkml/linkml-browser" target="_blank" rel="noopener noreferrer">LinkML Browser</a>
                 <a href="https://github.com/monarch-initiative/deep-research-client" target="_blank" rel="noopener noreferrer">Deep Research Client</a>
             </div>
+
+            <h3>Key references and entry points</h3>
+            <div class="resource-list">
+                <div class="resource-card">
+                    <strong>Schema docs</strong>
+                    <p>The autogenerated schema reference is available at <a href="https://dismech.monarchinitiative.org/elements/" target="_blank" rel="noopener noreferrer">dismech.monarchinitiative.org/elements</a>.</p>
+                </div>
+                <div class="resource-card">
+                    <strong>Contribution guide</strong>
+                    <p>Project contribution workflow lives in <a href="https://github.com/monarch-initiative/dismech/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">CONTRIBUTING.md</a>.</p>
+                </div>
+                <div class="resource-card">
+                    <strong>Ontology validation</strong>
+                    <p>Ontology adapters and term-validation configuration are maintained in <a href="https://github.com/monarch-initiative/dismech/blob/main/conf/oak_config.yaml" target="_blank" rel="noopener noreferrer">conf/oak_config.yaml</a>.</p>
+                </div>
+                <div class="resource-card">
+                    <strong>Research integration</strong>
+                    <p>Deep-research reports complement curation, but they do not replace schema, term, or reference validation.</p>
+                </div>
+            </div>
         </section>
     </main>
 
-    <footer class="footer">
-        Part of the <a href="https://monarchinitiative.org" target="_blank" rel="noopener noreferrer">Monarch Initiative</a>.
+    <footer>
+        <a href="https://monarchinitiative.org">Monarch Initiative</a> &middot;
+        <a href="https://github.com/monarch-initiative/dismech">GitHub</a> &middot;
+        CC-BY 4.0
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -348,6 +348,67 @@
       margin-bottom: 1rem;
     }
 
+    .details-teaser {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 1.5rem 4rem;
+    }
+
+    .details-teaser-card {
+      display: grid;
+      grid-template-columns: minmax(0, 1.3fr) minmax(260px, 0.9fr);
+      gap: 1.5rem;
+      padding: 1.75rem;
+      border: 1px solid var(--gray-200);
+      border-radius: 12px;
+      background:
+        radial-gradient(circle at top right, rgba(166, 236, 242, 0.55), transparent 32%),
+        linear-gradient(180deg, #ffffff 0%, #f9fafb 100%);
+    }
+
+    .details-teaser-copy h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: var(--gray-900);
+      margin-bottom: 0.75rem;
+    }
+
+    .details-teaser-copy p {
+      color: var(--gray-600);
+      font-size: 0.95rem;
+      margin-bottom: 0.85rem;
+    }
+
+    .details-teaser-points {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 1.1rem 0 1.35rem;
+    }
+
+    .details-teaser-aside {
+      border-left: 1px solid var(--gray-200);
+      padding-left: 1.5rem;
+      align-self: stretch;
+    }
+
+    .details-teaser-aside h3 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--gray-900);
+      margin-bottom: 0.75rem;
+    }
+
+    .details-teaser-aside ul {
+      padding-left: 1rem;
+      color: var(--gray-600);
+      font-size: 0.88rem;
+    }
+
+    .details-teaser-aside li + li {
+      margin-top: 0.55rem;
+    }
+
     /* Grid */
     .grid-section {
       max-width: var(--max-width);
@@ -422,6 +483,17 @@
         grid-template-columns: 1fr;
       }
 
+      .details-teaser-card {
+        grid-template-columns: 1fr;
+      }
+
+      .details-teaser-aside {
+        border-left: 0;
+        border-top: 1px solid var(--gray-200);
+        padding-left: 0;
+        padding-top: 1.25rem;
+      }
+
       .nav-links {
         gap: 1rem;
       }
@@ -446,6 +518,7 @@
       <span class="nav-logo">dismech</span>
       <div class="nav-links">
         <a href="app/index.html">Browse</a>
+        <a href="details/">Docs</a>
         <a href="pages/modules/index.html">Modules</a>
         <a href="pages/comorbidities/">Trajectories</a>
         <a href="pages/classifications/">Classifications</a>
@@ -582,6 +655,29 @@
 
     <div class="cta-center">
       <a href="pages/disorders/Fanconi_Anemia.html" class="btn btn-primary">View the full Fanconi Anemia page &rarr;</a>
+    </div>
+  </section>
+
+  <section class="details-teaser">
+    <div class="details-teaser-card">
+      <div class="details-teaser-copy">
+        <h2>Understand how a disease page is built</h2>
+        <p>The detailed docs walk through the Dismech page structure, the schema-backed sections behind each disorder page, and how pathographs connect mechanisms to phenotypes, treatments, and models.</p>
+        <div class="details-teaser-points">
+          <span class="badge">Section guide</span>
+          <span class="badge">Pathograph overview</span>
+          <span class="badge">Schema links</span>
+        </div>
+        <a href="details/" class="btn btn-primary">Open the detailed docs &rarr;</a>
+      </div>
+      <aside class="details-teaser-aside">
+        <h3>Inside the docs</h3>
+        <ul>
+          <li>What each disease-page section means in the current renderer</li>
+          <li>How evidence, ontology mappings, and references fit together</li>
+          <li>A pathograph example showing how Dismech encodes causal chains</li>
+        </ul>
+      </aside>
     </div>
   </section>
 


### PR DESCRIPTION
* Redesigns the Dismech documentation page, including a rendered Pathograph example, a list of related data sources/vocabularies, and an updated section guide.
* adds a new "details" documentation teaser section to the homepage, including both layout and responsive styles, and updates the navigation to link to the new docs.
* Updates the top navigation bar to include a "Docs" link pointing to the new documentation section.

