### PR TITLE
Add anatomic subtype evidence to Leiomyosarcoma (#1117)

### DIFF
--- a/kb/disorders/Leiomyosarcoma.yaml
+++ b/kb/disorders/Leiomyosarcoma.yaml
@@ -1,6 +1,6 @@
 name: Leiomyosarcoma
 creation_date: '2026-04-12T05:10:52Z'
-updated_date: '2026-04-27T18:00:00Z'
+updated_date: '2026-05-16T00:00:00Z'
 description: >-
   Leiomyosarcoma is an aggressive soft tissue sarcoma arising from smooth muscle
   cells or mesenchymal precursors with smooth-muscle differentiation. It most
@@ -21,16 +21,37 @@ has_subtypes:
     Leiomyosarcoma arising from the myometrium. Uterine tumors represent a major
     anatomic subset and often present with distinct gynecologic imaging and
     operative considerations.
+  evidence:
+  - reference: PMID:31869131
+    reference_title: Leiomyosarcoma.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "leiomyosarcoma primarily occurs in the retroperitoneum, uterus, and extremities, in descending order of frequency."
+    explanation: This identifies the uterus as one of the principal anatomic sites of leiomyosarcoma, supporting uterine leiomyosarcoma as a major anatomic subtype.
 - name: Retroperitoneal Leiomyosarcoma
   description: >-
     Deep abdominopelvic tumors arising in the retroperitoneum or pelvis. These
     lesions are often large at diagnosis and have a high risk of metastatic
     progression.
+  evidence:
+  - reference: PMID:35715148
+    reference_title: "Leiomyosarcoma: Current Clinical Management and Future Horizons."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Leiomyosarcomas are soft tissue tumors that are derived from smooth muscle mainly in the pelvis and retroperitoneum."
+    explanation: This supports the pelvis and retroperitoneum as the predominant sites of leiomyosarcoma, anchoring retroperitoneal leiomyosarcoma as a major anatomic subtype.
 - name: Extremity or Truncal Leiomyosarcoma
   description: >-
     Extrauterine soft tissue tumors arising in the extremities or trunk wall.
     These tumors share the genetically complex biology of leiomyosarcoma while
     differing in surgical approach and local recurrence patterns.
+  evidence:
+  - reference: PMID:31869131
+    reference_title: Leiomyosarcoma.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "leiomyosarcoma primarily occurs in the retroperitoneum, uterus, and extremities, in descending order of frequency."
+    explanation: This identifies the extremities as a principal anatomic site of leiomyosarcoma, supporting extremity or truncal leiomyosarcoma as a recognized anatomic subtype.
 pathophysiology:
 - name: Smooth Muscle Lineage Malignant Transformation
   description: >-


### PR DESCRIPTION
## Summary

Bounded compliance augmentation for the existing `Leiomyosarcoma.yaml` entry (issue #1117 is a stale umbrella issue; the entry was created in #1123 and incrementally augmented since).

- Adds `evidence` to all three `has_subtypes` entries (Uterine, Retroperitoneal, Extremity/Truncal), which previously had no evidence (compliance `has_subtypes[*].evidence` 0% → 100%).
- Reuses **already-cached, already-CI-validated** snippets:
  - `PMID:31869131` snippet `"leiomyosarcoma primarily occurs in the retroperitoneum, uterus, and extremities, in descending order of frequency."` — byte-identical to the snippet already used in `pathophysiology[0].evidence` of this same file.
  - `PMID:35715148` snippet `"Leiomyosarcomas are soft tissue tumors that are derived from smooth muscle mainly in the pelvis and retroperitoneum."` — byte-identical to the snippet already used in `phenotypes[0].evidence` of this same file.
- Bumps `updated_date` to reflect the content change.

No new reference cache files were created (both PMIDs already cached). Zero hallucination/mismatch risk by construction — snippets are reused verbatim from existing passing evidence.

## Scope intentionally NOT included

- Causal-edge (`downstream`) evidence, `classifications` evidence, and `datasets` remain as separate compliance gaps — left for follow-up to keep this change bounded and low-risk.
- The pre-existing `subtypes missing subtype_term` warning is unchanged and out of scope here.

## Validation

- `just validate kb/disorders/Leiomyosarcoma.yaml` → passed
- `just validate-references kb/disorders/Leiomyosarcoma.yaml` → passed
- `just validate-terms kb/disorders/Leiomyosarcoma.yaml` → passed
- `uv run pytest tests/test_data.py` (Leiomyosarcoma + subtype FK) → 1107 passed

Closes none — leaving #1117 open as the ongoing umbrella issue; commenting there with assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)