### PR TITLE
feat(skills): mandatory GeneReviews baseline step for curation and review

### DIFF
--- a/.claude/skills/dismech-pr-review/SKILL.md
+++ b/.claude/skills/dismech-pr-review/SKILL.md
@@ -238,6 +238,45 @@ defence against schema-valid but content-incomplete entries.
 - Align with clingen where possible
 - Lumping and splitting can be hard and ambiguous - it is OK to summon a human to help you resolve, and hold off on approving until the human approves
 
+15. GeneReviews Baseline Completeness
+
+For new entries and major augmentations, verify that GeneReviews was used as a
+mandatory baseline where applicable.
+
+**Step 1 — Is a GeneReviews article tagged?**
+
+Check the top-level `references:` block for an entry with `tags: [GeneReviews]`.
+
+```yaml
+references:
+  - reference: PMID:XXXXXXXX
+    tags:
+      - GeneReviews
+```
+
+If no such tag exists, search PubMed:
+```bash
+curl -sG "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi" \
+  --data-urlencode "db=pubmed" --data-urlencode "retmode=json" \
+  --data-urlencode "term=<DISEASE NAME>[TI] GeneReviews[TI]"
+```
+
+- If a GeneReviews article **exists** and is **not tagged** in a new Mendelian entry,
+  that is a **blocking omission** — flag it as `REQUEST_CHANGES`.
+- If no GeneReviews article exists, no action needed.
+
+**Step 2 — If GeneReviews is tagged, check coverage**
+
+Read the cached abstract at `references_cache/PMID_<ID>.md` and verify:
+- Every phenotype listed in the *Clinical Characteristics* section of the
+  abstract is either present in the YAML `phenotypes:` block or the omission
+  is clearly intentional (documented scope narrowing).
+- Any *Agents/Circumstances to Avoid* mentioned in the abstract are reflected
+  in the relevant treatment entry.
+
+Absence of a GeneReviews-documented phenotype that affects >10% of patients
+is **blocking** under the same threshold as the Content-Completeness Checklist.
+
 ## Review Decision: Formal GitHub Review
 
 After completing the review, you MUST submit a formal GitHub review (not just a comment).
@@ -249,6 +288,7 @@ Submit `--approve` when **all** of the following hold:
 - No major ontology placement errors (e.g., GO molecular function term in `biological_processes`)
 - All pathophysiology entries are atomic (not chained multi-step sentences)
 - When matching deep-research artifacts exist, the **Content-Completeness Checklist** was completed and no blocking omissions remain across any dimension (phenotypes, subtypes, pathophysiology, treatments, genetics, biomarkers, references)
+- GeneReviews baseline check completed (item 15): if a GeneReviews article exists, it is tagged and its Clinical Characteristics are covered
 - At most minor wording / completeness issues
 - (CI handles schema/term/reference validation — do not duplicate that work)
 
@@ -260,6 +300,8 @@ Submit `--request-changes` when **any one** of the following is true:
 - Pathophysiology entries bundled into chains rather than single atomic events
 - Claim–evidence mismatch (evidence snippet does not support the stated claim)
 - A central research-backed mechanism, phenotype, diagnostic, treatment, biomarker, or subtype was omitted even though the supporting evidence is clear, quotable, and in scope for this YAML
+- A GeneReviews article exists for a new Mendelian entry but is not tagged (`tags: [GeneReviews]`) in the top-level `references:` block
+- A GeneReviews-documented phenotype affecting >10% of patients is absent from the YAML with no documented scoping rationale
 
 ### COMMENT + reassign to @cmungall
 Submit `--comment` and reassign the PR/issue to `@cmungall` when:

--- a/.claude/skills/initiate-new-disorder-creation/SKILL.md
+++ b/.claude/skills/initiate-new-disorder-creation/SKILL.md
@@ -171,6 +171,83 @@ For example:
 
 You MUST read this before progressing.
 
+### Step 3b: GeneReviews Baseline (REQUIRED when applicable)
+
+GeneReviews (https://www.ncbi.nlm.nih.gov/books/NBK1116/) is the authoritative
+expert-curated clinical reference for Mendelian disorders. Before curating
+phenotypes, you MUST check whether a GeneReviews article exists for the disease.
+If one exists, it is the mandatory phenotype baseline — not just a convenient
+source.
+
+#### 1. Search PubMed for a GeneReviews article
+
+```bash
+curl -sG "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi" \
+  --data-urlencode "db=pubmed" \
+  --data-urlencode "retmode=json" \
+  --data-urlencode "term=<DISEASE_NAME>[TI] GeneReviews[TI]"
+```
+
+If no results, try a broader search: `<DISEASE_NAME> GeneReviews[Book]`
+
+#### 2. If a PMID is found, fetch and cache it
+
+```bash
+just fetch-reference PMID:XXXXXXXX
+```
+
+#### 3. Tag it in the top-level `references:` block
+
+```yaml
+references:
+  - reference: PMID:XXXXXXXX
+    title: "<GeneReviews article title>"
+    tags:
+      - GeneReviews
+```
+
+You can also run `just tag-references` after adding the PMID to inline
+evidence items — the script detects GeneReviews PMIDs from the cached
+abstract and writes the top-level tag automatically.
+
+#### 4. Cross-reference Clinical Characteristics against your YAML
+
+- Read the cached abstract at `references_cache/PMID_XXXXXXXX.md`
+- Identify every phenotype, anomaly, and comorbidity listed in the
+  Clinical Characteristics section of the abstract
+- Compare against your YAML `phenotypes:` section
+- Any GeneReviews-documented phenotype **absent** from your YAML must
+  either be added (with an HPO term and evidence item quoting the
+  GeneReviews abstract) or explicitly explained as out of scope
+
+#### 5. Capture drug-safety warnings
+
+GeneReviews often has an *Agents/Circumstances to Avoid* section.
+If the abstract mentions any, add a note in the relevant treatment entry's
+`description:` and include a GeneReviews evidence item quoting it exactly.
+
+#### 6. Frequency mapping — prose → FrequencyEnum
+
+GeneReviews uses narrative frequency language. Map to the enum as follows:
+
+| GeneReviews phrase | FrequencyEnum | HPO range |
+|---|---|---|
+| "virtually all", "most individuals", ">80%" | `VERY_FREQUENT` | 80–100% |
+| "many", "majority", "common", "~50%–79%", ">30%" | `FREQUENT` | 30–79% |
+| "some", "occasional", "uncommon", "~10%–29%" | `OCCASIONAL` | 5–29% |
+| "rare", "few", "<5%", "infrequently reported" | `VERY_RARE` | 1–4% |
+| "isolated reports", "single case" | (omit frequency) | <1% |
+
+When frequency is ambiguous, **omit `frequency:`** rather than guessing.
+
+#### 7. No GeneReviews article? Document it
+
+If no GeneReviews article exists for the disease, proceed to Step 4
+without this baseline. No action needed — the absence itself is not a
+problem.
+
+---
+
 ### Step 4: Enhance YAML file with evidence for assestions
 
 Use the results of deep research to enhance the yaml file, providing evidence for as many assertions as possible.
@@ -568,6 +645,11 @@ git push
 Before finalizing a new disorder file, verify:
 
 - [ ] Deep research query was performed (document which tool)
+- [ ] GeneReviews article searched for this disease
+  - [ ] If found: PMID fetched, cached, and tagged `GeneReviews` in top-level `references:`
+  - [ ] If found: all Clinical Characteristics phenotypes either captured in YAML or explicitly noted as out of scope
+  - [ ] If found: any drug-safety warnings (Agents to Avoid) reflected in relevant treatment entries
+  - [ ] If not found: no action needed
 - [ ] All PMIDs exist and are for relevant papers
 - [ ] All snippets are exact quotes from abstracts
 - [ ] MONDO term exists and label matches exactly

--- a/.claude/skills/initiate-new-disorder-creation/SKILL.md
+++ b/.claude/skills/initiate-new-disorder-creation/SKILL.md
@@ -179,6 +179,11 @@ phenotypes, you MUST check whether a GeneReviews article exists for the disease.
 If one exists, it is the mandatory phenotype baseline — not just a convenient
 source.
 
+> **Scope:** This step applies primarily to **Mendelian (single-gene) disorders**.
+> For complex, multifactorial, infectious, or cancer entries where GeneReviews
+> coverage is unlikely, skip directly to Step 4 — the PubMed search below will
+> confirm either way.
+
 #### 1. Search PubMed for a GeneReviews article
 
 ```bash
@@ -188,7 +193,7 @@ curl -sG "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi" \
   --data-urlencode "term=<DISEASE_NAME>[TI] GeneReviews[TI]"
 ```
 
-If no results, try a broader search: `<DISEASE_NAME> GeneReviews[Book]`
+If no results, try a broader search: `<DISEASE_NAME> GeneReviews[All Fields]`
 
 #### 2. If a PMID is found, fetch and cache it
 
@@ -220,6 +225,13 @@ abstract and writes the top-level tag automatically.
   either be added (with an HPO term and evidence item quoting the
   GeneReviews abstract) or explicitly explained as out of scope
 
+> **Note:** The cached abstract captures only the structured PubMed abstract,
+> which is a condensed summary of the full GeneReviews chapter. The full
+> *Clinical Characteristics* section in the chapter body often lists additional
+> phenotypes not in the abstract. Cross-reference the deep-research artifact
+> (from Step 3) for comprehensive coverage — treat the abstract as the minimum
+> baseline, not the ceiling.
+
 #### 5. Capture drug-safety warnings
 
 GeneReviews often has an *Agents/Circumstances to Avoid* section.
@@ -234,7 +246,7 @@ GeneReviews uses narrative frequency language. Map to the enum as follows:
 |---|---|---|
 | "virtually all", "most individuals", ">80%" | `VERY_FREQUENT` | 80–100% |
 | "many", "majority", "common", "~50%–79%", ">30%" | `FREQUENT` | 30–79% |
-| "some", "occasional", "uncommon", "~10%–29%" | `OCCASIONAL` | 5–29% |
+| "some", "occasional", "uncommon", "~5%–29%" | `OCCASIONAL` | 5–29% |
 | "rare", "few", "<5%", "infrequently reported" | `VERY_RARE` | 1–4% |
 | "isolated reports", "single case" | (omit frequency) | <1% |
 


### PR DESCRIPTION
## Context and Lineage

This PR is the **continuation of work started in issue #1657** (RFC: Mandatory authoritative source baseline) and **left explicitly pending after PR #1720**.

| Issue / PR | Status | What it did |
|---|---|---|
| #969 | Open | Original gap tracker — GeneReviews phenotypes missing from curation |
| #1657 | Closed | RFC proposing GeneReviews + Orphanet as mandatory baselines |
| #1720 | Merged | Schema extension (`ReferenceTagEnum`, `tags` slot) + `just tag-references` script |
| **This PR** | Open | **Skill updates** — the part #1657 proposed but #1720 explicitly did not do |

When #1720 was raised, @dragon-ai-agent noted in the comments: *"The skill update was intentionally left out of this PR."* This PR picks that up.

---

## What This PR Does

Two skill files are updated — purely additive, no existing steps removed or changed.

### `initiate-new-disorder-creation/SKILL.md` — new Step 3b

A new mandatory step inserted **between** Step 3 (deep research) and Step 4 (YAML enhancement):

1. Search PubMed for a GeneReviews article for the disease (`<NAME>[TI] GeneReviews[TI]`)
2. If found: fetch + cache with `just fetch-reference`, tag with `tags: [GeneReviews]` in top-level `references:`
3. Cross-reference every phenotype in the *Clinical Characteristics* abstract section against the YAML — gaps are mandatory candidates
4. Capture any *Agents/Circumstances to Avoid* drug-safety warnings in treatment entries
5. **Prose-frequency → FrequencyEnum mapping table** (addresses open question #1 from #1657)
6. Explicit no-op path: if no GeneReviews article exists, proceed without this step

Also adds four new GeneReviews items to the Anti-Hallucination Checklist.

### `dismech-pr-review/SKILL.md` — item 15 + updated review criteria

- **Item 15: GeneReviews Baseline Completeness** — two-step check for reviewers: (a) is it tagged? (b) are Clinical Characteristics covered?
- **APPROVE** criteria: GeneReviews baseline check is now an explicit gate
- **REQUEST_CHANGES** criteria: two new blocking conditions:
  - GeneReviews article exists but not tagged in a new Mendelian entry
  - GeneReviews-documented phenotype >10% absent with no documented scoping rationale

---

## Does This Change the Workflow?

**Yes — intentionally and transparently.**

| Who is affected | What changes |
|---|---|
| Curators of new Mendelian disorders | New mandatory Step 3b before writing phenotypes |
| PR review bot | Stricter: two new blocking conditions for Mendelian entries |
| Curators of complex/multifactorial/infectious diseases | No change — Step 3b is a no-op when no GeneReviews article exists |
| Existing KB entries | No retroactive obligation — only new curations are affected |
| Validation pipeline | Unchanged — `just validate`, `just validate-terms`, `just validate-references` untouched |

This strictness is exactly what #1657 proposed. It is raised as a separate PR precisely so maintainers can approve the enforcement level before it affects other agents.

---

## Evidence That This Works in Practice

This workflow was **manually followed during the Wiedemann-Steiner Syndrome curation (PR #2800)** in the same session:
- GeneReviews PMID:35617449 was fetched, cached, and tagged
- Clinical Characteristics cross-reference surfaced 5 missing phenotypes (obstructive sleep apnea, immune dysfunction, GH deficiency, ophthalmologic anomalies, valproate safety warning)
- The automated reviewer confirmed the GeneReviews-sourced additions and flagged the valproate warning as the most critical clinical safety addition
- The approach also caught that genitourinary anomalies (46.8%, FREQUENT) were entirely absent — a blocking omission that the reviewer flagged

---

## Open Questions from #1657 — Status

| Question | Status |
|---|---|
| Frequency mapping table | ✅ Added to Step 3b (prose → FrequencyEnum table) |
| Schema changes for excluded phenotypes | Not in scope here — skill-level enforcement is sufficient for now |
| GeneReviews fetch implementation | Addressed via `just fetch-reference` + NCBI eutils search (existing infrastructure) |
| Enforcement level (blocking vs suggestion) | ✅ Decided: blocking for new Mendelian entries where GeneReviews exists |

The Orphanet baseline (`d2p.py` integration) from #1657 is **out of scope** for this PR — that is a separate, non-trivial task and should be its own PR.

---

## Notes for Reviewers

- **Auto-merge will NOT trigger** for this PR — the auto-merge workflow only applies to `weekly-compliance-*` branches authored by `app/claude`
- This should be reviewed by a human curator before merging, given it changes the mandatory curation checklist
- If the enforcement level (blocking vs suggestion for GeneReviews coverage) feels too strict, the REQUEST_CHANGES criteria in the review skill can be softened — happy to adjust based on feedback

cc @cmungall @caufieldjh