### PR TITLE
Add Adaptive Immune Resistance node to Anaplastic Thyroid Carcinoma (#1112)

### DIFF
--- a/kb/disorders/Anaplastic_Thyroid_Carcinoma.yaml
+++ b/kb/disorders/Anaplastic_Thyroid_Carcinoma.yaml
@@ -1,6 +1,6 @@
 name: Anaplastic Thyroid Carcinoma
 creation_date: '2026-04-12T05:11:48Z'
-updated_date: '2026-05-04T00:00:00Z'
+updated_date: '2026-05-17T00:00:00Z'
 description: >-
   Anaplastic thyroid carcinoma (ATC) is a highly aggressive undifferentiated
   follicular-cell-derived thyroid malignancy that typically emerges through
@@ -63,6 +63,8 @@ pathophysiology:
     description: PI3K pathway activation adds a parallel survival and growth program
   - target: Dedifferentiation and Loss of Thyroid Identity
     description: MAPK-driven tumor evolution culminates in loss of differentiated thyroid functions
+  - target: Adaptive Immune Resistance and Immunosuppressive Microenvironment
+    description: BRAF V600E-mutant tumors show higher tumor-cell PD-L1 positivity, coupling MAPK driver status to adaptive immune resistance
 - name: TP53 Loss and p53-Mediated DNA Damage Response Failure
   description: >-
     Progression to ATC commonly includes late TP53 alteration, which weakens
@@ -217,6 +219,71 @@ pathophysiology:
     term:
       id: GO:0030335
       label: positive regulation of cell migration
+- name: Adaptive Immune Resistance and Immunosuppressive Microenvironment
+  conforms_to: "immune_checkpoint_blockade#Adaptive Immune Resistance"
+  description: >-
+    ATC frequently upregulates tumor-cell PD-L1 within an immune-infiltrated
+    microenvironment. The majority of ATCs are PD-L1-positive and contain
+    abundant CD3+/CD8+ tumor-infiltrating lymphocytes and tumor-associated
+    macrophages, indicating an "immune-adapted" tumor in which pre-existing
+    anti-tumor immunity is actively suppressed through the PD-1/PD-L1 axis.
+    PD-L1 positivity is enriched in BRAF V600E-mutant ATC and is considered
+    predictive of response to anti-PD-1/PD-L1 therapy.
+  cell_types:
+  - preferred_term: CD8+ tumor-infiltrating lymphocyte
+    term:
+      id: CL:0000625
+      label: CD8-positive, alpha-beta T cell
+  - preferred_term: tumor-associated macrophage
+    term:
+      id: CL:0000235
+      label: macrophage
+  biological_processes:
+  - preferred_term: Negative Regulation of T Cell Mediated Immunity
+    modifier: INCREASED
+    term:
+      id: GO:0002710
+      label: negative regulation of T cell mediated immunity
+  evidence:
+  - reference: PMID:39004795
+    reference_title: >-
+      PD-L1 Expression and Its Modulating Factors in Anaplastic Thyroid
+      Carcinoma: A Multi-institutional Study.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Most ATCs (73.2%) were PD-L1-positive.
+    explanation: >-
+      A multi-institutional study of 179 ATCs establishes that the majority of
+      ATCs express tumor-cell PD-L1, the central effector of adaptive immune
+      resistance.
+  - reference: PMID:39004795
+    reference_title: >-
+      PD-L1 Expression and Its Modulating Factors in Anaplastic Thyroid
+      Carcinoma: A Multi-institutional Study.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Tumor cell surface PD-L1 expression is considered predictive of
+      therapeutic response.
+    explanation: >-
+      Links tumor-cell PD-L1 expression to predicted responsiveness to anti-PD
+      checkpoint blockade, the therapeutic corollary of adaptive immune
+      resistance.
+  - reference: PMID:34093774
+    reference_title: >-
+      PD-L1 expression and immune cells in anaplastic carcinoma and poorly
+      differentiated carcinoma of the human thyroid gland: A retrospective
+      study.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      In addition to increased PD-L1 expression, all ATC cases exhibited
+      significantly increased CD3+ and CD8+ T cells, CD68+ and CD163+
+      macrophages, and S100+ dendritic cells compared with the PDTC cases.
+    explanation: >-
+      Demonstrates that PD-L1 upregulation in ATC co-occurs with a brisk T cell
+      and macrophage infiltrate, the hallmark "immune-adapted" state of adaptive
+      immune resistance rather than an immune-desert tumor.
 histopathology:
 - name: Anaplastic Thyroid Carcinoma
   diagnostic: true

--- a/references_cache/PMID_34093774.md
+++ b/references_cache/PMID_34093774.md
@@ -1,0 +1,83 @@
+---
+reference_id: "PMID:34093774"
+title: "PD-L1 expression and immune cells in anaplastic carcinoma and poorly differentiated carcinoma of the human thyroid gland: A retrospective study."
+authors:
+- Cameselle-García S
+- Abdulkader-Sande S
+- Sánchez-Ares M
+- Rodríguez-Carnero G
+- Garcia-Gómez J
+- Gude-Sampedro F
+- Abdulkader-Nallib I
+- Cameselle-Teijeiro JM
+journal: Oncol Lett
+year: '2021'
+doi: 10.3892/ol.2021.12814
+content_type: abstract_only
+---
+
+# PD-L1 expression and immune cells in anaplastic carcinoma and poorly differentiated carcinoma of the human thyroid gland: A retrospective study.
+**Authors:** Cameselle-García S, Abdulkader-Sande S, Sánchez-Ares M, Rodríguez-Carnero G, Garcia-Gómez J, Gude-Sampedro F, Abdulkader-Nallib I, Cameselle-Teijeiro JM
+**Journal:** Oncol Lett (2021)
+**DOI:** [10.3892/ol.2021.12814](https://doi.org/10.3892/ol.2021.12814)
+
+## Content
+
+1. Oncol Lett. 2021 Jul;22(1):553. doi: 10.3892/ol.2021.12814. Epub 2021 May 24.
+
+PD-L1 expression and immune cells in anaplastic carcinoma and poorly 
+differentiated carcinoma of the human thyroid gland: A retrospective study.
+
+Cameselle-García S(1), Abdulkader-Sande S(2), Sánchez-Ares M(2), 
+Rodríguez-Carnero G(3), Garcia-Gómez J(1), Gude-Sampedro F(4)(5), 
+Abdulkader-Nallib I(2)(5), Cameselle-Teijeiro JM(2)(5).
+
+Author information:
+(1)Department of Medical Oncology, University Hospital Complex of Ourense, 
+Galician Healthcare Service, 32005 Ourense, Spain.
+(2)Department of Pathology, Clinical University Hospital of Santiago de 
+Compostela, Health Research Institute of Santiago de Compostela, Galician 
+Healthcare Service, 15706 Santiago de Compostela, Spain.
+(3)Department of Endocrinology and Nutrition, Clinical University Hospital of 
+Santiago de Compostela, Health Research Institute of Santiago de Compostela, 
+Galician Healthcare Service, 15706 Santiago de Compostela, Spain.
+(4)Department of Epidemiology, Clinical University Hospital of Santiago de 
+Compostela, Health Research Institute of Santiago de Compostela, Galician 
+Healthcare Service, 15706 Santiago de Compostela, Spain.
+(5)School of Medicine, University of Santiago de Compostela, 15782 Santiago de 
+Compostela, Spain.
+
+Anaplastic thyroid carcinoma (ATC) and poorly differentiated thyroid carcinoma 
+(PDTC) have limited treatment options, and immune profiling may help select 
+patients for immunotherapy. The prevalence and relevance of programmed death-1 
+ligand (PD-L1) expression and the presence of immune cells in ATC and PDTC has 
+not yet been well established. The present study investigated PD-L1 expression 
+(clone 22C3) and cells in the tumor microenvironment (TME), including 
+tumor-infiltrating lymphocytes (TILs), tumor-associated macrophages (TAMs) and 
+dendritic cells, in whole tissue sections of 15 cases of ATC and 13 cases of 
+PDTC. Immunohistochemical PD-L1 expression using a tumor proportion score (TPS) 
+with a 1% cut-off was detected in 9/15 (60%) of ATC cases and 1/13 (7.7%) of 
+PDTC cases (P=0.006). PD-L1 expression in TILs was limited to the ATC group 
+(73.3 vs. 0% in ATC and PDTC, respectively). In the ATC group, the TPS for tumor 
+positive PD-L1 expression revealed a non-significant trend towards worse 
+survival, but no difference was observed when investigating PD-L1 expression in 
+TILs and TAMs. In addition to increased PD-L1 expression, all ATC cases 
+exhibited significantly increased CD3+ and CD8+ T cells, CD68+ and CD163+ 
+macrophages, and S100+ dendritic cells compared with the PDTC cases. Loss of 
+mutL homolog 1 and PMS1 homolog 2 expression was observed in one ATC case with 
+the highest PD-L1 expression, as well as in the only PDTC case positive for 
+PD-L1. Notably, the latter was the only PDTC case exhibiting positivity for p53 
+and a cellular microenvironment similar to ATC. The current results indicated 
+that PD-L1 expression was frequent in ATC, but rare in PDTC. In addition to 
+PD-L1, the present study suggested that microsatellite instability may serve a 
+role in both the TME and the identification of immunotherapy candidates among 
+patients with PDTC.
+
+Copyright: © Cameselle-García et al.
+
+DOI: 10.3892/ol.2021.12814
+PMCID: PMC8170268
+PMID: 34093774
+
+Conflict of interest statement: The authors declare that they have no competing 
+interests.

--- a/references_cache/PMID_39004795.md
+++ b/references_cache/PMID_39004795.md
@@ -1,0 +1,133 @@
+---
+reference_id: "PMID:39004795"
+title: "PD-L1 Expression and Its Modulating Factors in Anaplastic Thyroid Carcinoma: A Multi-institutional Study."
+authors:
+- Agarwal S
+- Jung CK
+- Gaddam P
+- Hirokawa M
+- Higashiyama T
+- Hang JF
+- Lai WA
+- Keelawat S
+- Liu Z
+- Na HY
+- Park SY
+- Fukuoka J
+- Satoh S
+- Mussazhanova Z
+- Nakashima M
+- Kakudo K
+- Bychkov A
+journal: Am J Surg Pathol
+year: '2024'
+doi: 10.1097/PAS.0000000000002284
+keywords:
+- Humans
+- "B7-H1 Antigen/analysis, metabolism"
+- "Thyroid Carcinoma, Anaplastic/pathology, genetics"
+- Retrospective Studies
+- "Thyroid Neoplasms/pathology, genetics, therapy"
+- Male
+- Female
+- "Biomarkers, Tumor/genetics, analysis"
+- Middle Aged
+- Aged
+- Proto-Oncogene Proteins B-raf/genetics
+- Mutation
+- Adult
+- "Aged, 80 and over"
+- Telomerase/genetics
+- "Promoter Regions, Genetic"
+- Asia
+- Immunohistochemistry
+content_type: abstract_only
+---
+
+# PD-L1 Expression and Its Modulating Factors in Anaplastic Thyroid Carcinoma: A Multi-institutional Study.
+**Authors:** Agarwal S, Jung CK, Gaddam P, Hirokawa M, Higashiyama T, Hang JF, Lai WA, Keelawat S, Liu Z, Na HY, Park SY, Fukuoka J, Satoh S, Mussazhanova Z, Nakashima M, Kakudo K, Bychkov A
+**Journal:** Am J Surg Pathol (2024)
+**DOI:** [10.1097/PAS.0000000000002284](https://doi.org/10.1097/PAS.0000000000002284)
+
+## Content
+
+1. Am J Surg Pathol. 2024 Oct 1;48(10):1233-1244. doi: 
+10.1097/PAS.0000000000002284. Epub 2024 Jul 15.
+
+PD-L1 Expression and Its Modulating Factors in Anaplastic Thyroid Carcinoma: A 
+Multi-institutional Study.
+
+Agarwal S(1), Jung CK(2), Gaddam P(1), Hirokawa M(3), Higashiyama T(4), Hang 
+JF(5), Lai WA(6), Keelawat S(7)(8), Liu Z(9), Na HY(10)(11), Park SY(10)(11), 
+Fukuoka J(12), Satoh S(13), Mussazhanova Z(14), Nakashima M(14), Kakudo K(15), 
+Bychkov A(16).
+
+Author information:
+(1)Department of Pathology, All India Institute of Medical Sciences, New Delhi, 
+India.
+(2)Department of Hospital Pathology, Seoul St. Mary's Hospital, The Catholic 
+University of Korea, Seoul, South Korea.
+(3)Department of Diagnostic Pathology and Cytology, Kuma Hospital, Kobe, Japan.
+(4)Department of Surgery, Kuma Hospital, Kobe, Japan.
+(5)Department of Pathology and Laboratory Medicine, Taipei Veterans General 
+Hospital, Taipei, Taiwan.
+(6)Department of Pathology, Kaohsiung Medical University Hospital, Kaohsiung 
+Medical University, Kaohsiung, Taiwan.
+(7)Department of Pathology, Faculty of Medicine, Chulalongkorn University, 
+Bangkok, Thailand.
+(8)Precision Pathology of Neoplasia Research Group, Department of Pathology, 
+Faculty of Medicine, Chulalongkorn University, Bangkok, Thailand.
+(9)Department of Pathology, Shanghai Jiao Tong University Affiliated Sixth 
+People's Hospital, Shanghai, China.
+(10)Department of Pathology, Seoul National University Bundang Hospital, 
+Seongnam, South Korea.
+(11)Department of Pathology, Seoul National University College of Medicine, 
+Seoul, South Korea.
+(12)Department of Pathology Informatics, Nagasaki University Graduate School of 
+Biomedical Sciences, Nagasaki, Japan.
+(13)Department of Endocrine Surgery, Yamashita Thyroid and Parathyroid Clinic, 
+Fukuoka, Japan.
+(14)Department of Tumor and Diagnostic Pathology, Nagasaki University, Nagasaki, 
+Japan.
+(15)Department of Pathology, Izumi City General Hospital, Izumi, Japan.
+(16)Department of Pathology, Kameda Medical Center, Kamogawa, Chiba, Japan.
+
+Anti-PD immunotherapy is currently under investigation in anaplastic thyroid 
+carcinoma (ATC). Tumor cell surface PD-L1 expression is considered predictive of 
+therapeutic response. Although papillary thyroid carcinoma has been widely 
+studied for PD-L1 expression, there are limited data on ATC. In this 
+retrospective multi-institutional study involving 9 centers across Asia, 179 
+ATCs were assessed for PD-L1 expression using the SP263 (Ventana) clone. A tumor 
+proportion score (TPS) ≥1% was required to consider a case PD-L1-positive. PD-L1 
+expression was compared with the histological patterns, the type of specimen 
+(small or large), tumor molecular profile ( BRAF V600E and TERT promoter 
+mutation status), and patient outcome. PD-L1 expression in any co-existent 
+differentiated thyroid carcinoma (DTC) was evaluated separately and compared 
+with ATC. Most ATCs (73.2%) were PD-L1-positive. The median TPS among positive 
+cases was 36% (IQR 11% to 75%; range 1% to 99%). A high expression (TPS ≥ 50%) 
+was noted in 30.7%. PD-L1-negative cases were more likely to be small specimens 
+( P =0.01). A negative result on small samples, hence, may not preclude 
+expression elsewhere. ATCs having epithelioid and pleomorphic histological 
+patterns were more likely to be PD-L1-positive with higher TPS than sarcomatoid 
+( P <0.01). DTCs were more frequently negative and had lower TPS than ATC ( P 
+<0.01). Such PD-L1 conversion from DTC-negative to ATC-positive was documented 
+in 71% of cases with co-existent DTC. BRAF V600E, but not TERT promoter 
+mutations, correlated significantly with PD-L1-positivity rate ( P =0.039), 
+reinforcing the potential of combining anti-PD and anti-BRAF V600E drugs. PD-L1 
+expression, however, did not impact the patient outcome.
+
+Copyright © 2024 Wolters Kluwer Health, Inc. All rights reserved.
+
+DOI: 10.1097/PAS.0000000000002284
+PMID: 39004795 [Indexed for MEDLINE]
+
+Conflict of interest statement: Conflicts of Interest and Source of Funding: The 
+authors have disclosed that they have no significant relationships with, or 
+financial interest in, any commercial companies pertaining to this article. This 
+research was supported by the following grants/funds/programs: grant (HI21C0940) 
+from the Korean Health Technology R&D Project funded by the Ministry of Health 
+and Welfare, Republic of Korea to C.K.J.; funding received from the Indian 
+Council of Medical Research, New Delhi, India (Order No. 52/29/2020-Bio/BMS) to 
+S.A.; the Atomic Bomb Disease Institute, Nagasaki University; and the Program of 
+the Network-Type Joint Usage/Research Center for Radiation Disaster Medical 
+Science to M.N.


### PR DESCRIPTION
## Summary

Adds one new pathophysiology node to `kb/disorders/Anaplastic_Thyroid_Carcinoma.yaml`:

- **Adaptive Immune Resistance and Immunosuppressive Microenvironment**, with `conforms_to: "immune_checkpoint_blockade#Adaptive Immune Resistance"` (the repo's designated ICB conformance target per `CLAUDE.md`).
- Cell types: CD8+ TIL (`CL:0000625`), tumor-associated macrophage (`CL:0000235`).
- Biological process: negative regulation of T cell mediated immunity (`GO:0002710`, INCREASED) — matches the module node.
- Three validated evidence items from two real, verifiable PMIDs:
  - `PMID:39004795` (Agarwal et al., *Am J Surg Pathol* 2024; 179-ATC multi-institutional study) — 73.2% PD-L1-positive; PD-L1 predictive of anti-PD response.
  - `PMID:34093774` (Cameselle-García et al., *Oncol Lett* 2021) — PD-L1 upregulation co-occurring with brisk CD3+/CD8+ T cell and CD68+/CD163+ macrophage infiltrate ("immune-adapted" state).
- A causal edge from the existing **MAPK-Activating Truncal Driver Alteration** node → the new node, reflecting that BRAF V600E enriches tumor-cell PD-L1 positivity.

This closes the "immune-suppressive TME node / ICB `conforms_to` link" item flagged in the prior scanner triage (issue #1112 comments, 2026-04-27).

## Validation

- `just validate kb/disorders/Anaplastic_Thyroid_Carcinoma.yaml` — ✅ schema + terms + references pass
- `just validate-terms kb/disorders/Anaplastic_Thyroid_Carcinoma.yaml` — ✅ pass
- All 3 snippets confirmed exact whitespace-normalized substrings of the cached abstracts
- `just check-reference-cache-frontmatter` — ✅ OK
- `just validate-graphs` — no ATC-related errors (the repo-wide failure is pre-existing in unrelated files and not introduced here)
- All three ontology terms (`CL:0000625`, `CL:0000235`, `GO:0002710`) verified with OAK

## What this PR intentionally does NOT do

Other prior-triage items (EMT/dedifferentiation already exists as its own node; SWI/SNF node; additional treatments such as lenvatinib/pembrolizumab) are deliberately out of scope for this bounded single-node enrichment and can be batched separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)