### PR TITLE
Add reference_title to all Wolman Disease evidence items (#1321)

### DIFF
--- a/kb/disorders/Wolman_Disease.yaml
+++ b/kb/disorders/Wolman_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wolman Disease
 creation_date: '2026-04-14T19:53:03Z'
-updated_date: '2026-05-10T12:07:15Z'
+updated_date: '2026-05-17T16:00:00Z'
 category: Mendelian
 description: >
   Wolman disease is the rapidly progressive infantile phenotype of lysosomal acid
@@ -33,6 +33,7 @@ inheritance:
       label: Autosomal recessive inheritance
   evidence:
   - reference: PMID:28786388
+    reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal acid lipase deficiency is a rare, autosomal recessive condition caused by mutations in the gene encoding lysosomal acid lipase (LIPA) that result in reduced or absent activity of this essential enzyme."
@@ -45,6 +46,7 @@ progression:
     hepatosplenomegaly, liver dysfunction, and progressive gastrointestinal disease.
   evidence:
   - reference: PMID:24832708
+    reference_title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "In early onset LAL deficiency, clinical manifestations start in the first few weeks of life with persistent vomiting, failure to thrive, hepatosplenomegaly, liver dysfunction and hepatic failure."
@@ -56,6 +58,7 @@ progression:
     in infancy.
   evidence:
   - reference: PMID:34906190
+    reference_title: "Sebelipase alfa enzyme replacement therapy in Wolman disease: a nationwide cohort with up to ten years of follow-up."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Wolman disease (WD), the rapidly progressive phenotype of lysosomal acid lipase (LAL) deficiency, presents in neonates with failure to thrive and hepatosplenomegaly, and leads to multi-organ failure and death before 12 months of age."
@@ -76,12 +79,14 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:28786388
+      reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Lysosomal acid lipase deficiency is a rare, autosomal recessive condition caused by mutations in the gene encoding lysosomal acid lipase (LIPA) that result in reduced or absent activity of this essential enzyme."
       explanation: This review directly connects LIPA mutations to reduced or absent lysosomal acid lipase activity.
   evidence:
   - reference: PMID:28786388
+    reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal acid lipase deficiency is a rare, autosomal recessive condition caused by mutations in the gene encoding lysosomal acid lipase (LIPA) that result in reduced or absent activity of this essential enzyme."
@@ -117,17 +122,20 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:36204319
+      reference_title: "Lysosomal acid lipase deficiency: A rare inherited dyslipidemia but potential ubiquitous factor in the development of atherosclerosis and fatty liver disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Lysosomal acid lipase (LAL), encoded by the gene LIPA, is the sole neutral lipid hydrolase in lysosomes, responsible for cleavage of cholesteryl esters and triglycerides into their component parts."
       explanation: This review defines LAL as the lysosomal hydrolase responsible for cleaving cholesteryl esters and triglycerides, supporting the hydrolysis block caused by deficiency.
   evidence:
   - reference: PMID:30866656
+    reference_title: "Lysosomal Acid Lipase in Lipid Metabolism and Beyond."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal acid lipase (LAL), encoded by the lipase A ( LIPA) gene, hydrolyzes cholesteryl esters and triglycerides to generate free fatty acids and cholesterol in the cell."
     explanation: This review provides the core enzymatic function that is lost in Wolman disease.
   - reference: PMID:36204319
+    reference_title: "Lysosomal acid lipase deficiency: A rare inherited dyslipidemia but potential ubiquitous factor in the development of atherosclerosis and fatty liver disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal acid lipase (LAL), encoded by the gene LIPA, is the sole neutral lipid hydrolase in lysosomes, responsible for cleavage of cholesteryl esters and triglycerides into their component parts."
@@ -162,12 +170,14 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:23624251
+      reference_title: "Hepatic cholesteryl ester accumulation in lysosomal acid lipase deficiency: non-invasive identification and treatment monitoring by magnetic resonance."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Lysosomal Acid Lipase (LAL) deficiency is a rare metabolic storage disease, caused by a marked reduction in activity of LAL, which leads to accumulation of cholesteryl esters (CE) and triglycerides (TG) in lysosomes in many tissues."
       explanation: Human LAL deficiency data directly support lysosomal cholesteryl ester and triglyceride storage downstream of reduced LAL activity.
   evidence:
   - reference: PMID:30866656
+    reference_title: "Lysosomal Acid Lipase in Lipid Metabolism and Beyond."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal acid lipase (LAL), encoded by the lipase A ( LIPA) gene, hydrolyzes cholesteryl esters and triglycerides to generate free fatty acids and cholesterol in the cell."
@@ -218,6 +228,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
@@ -227,6 +238,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
@@ -236,17 +248,20 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
       explanation: The review supports adrenal structural disease in rapidly progressive LAL-D, consistent with adrenal cortical lipid storage as a direct tissue-specific extension of multisystem neutral-lipid storage.
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
     explanation: This review directly supports multisystem lysosomal cholesteryl ester and triglyceride storage in macrophages and parenchymal cells.
   - reference: PMID:23624251
+    reference_title: "Hepatic cholesteryl ester accumulation in lysosomal acid lipase deficiency: non-invasive identification and treatment monitoring by magnetic resonance."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Lysosomal Acid Lipase (LAL) deficiency is a rare metabolic storage disease, caused by a marked reduction in activity of LAL, which leads to accumulation of cholesteryl esters (CE) and triglycerides (TG) in lysosomes in many tissues."
@@ -279,6 +294,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:28179030
+      reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -288,12 +304,14 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:28179030
+      reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
       explanation: The study identifies massive hepatosplenomegaly as a hallmark manifestation of infantile LAL-D.
   evidence:
   - reference: PMID:28179030
+    reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -314,6 +332,7 @@ pathophysiology:
       label: liver
   evidence:
   - reference: PMID:28786388
+    reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Wolman's disease is a severe disorder that presents during infancy, resulting in failure to thrive, hepatomegaly, and hepatic failure, and an average life expectancy of less than 4 months."
@@ -327,6 +346,7 @@ pathophysiology:
     - impaired growth and nutritional status
     evidence:
     - reference: PMID:28786388
+      reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Wolman's disease is a severe disorder that presents during infancy, resulting in failure to thrive, hepatomegaly, and hepatic failure, and an average life expectancy of less than 4 months."
@@ -355,12 +375,14 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
       explanation: The review links infantile LAL-D gastrointestinal disturbance with malabsorption-driven growth failure.
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "LAL deficiency leads to the accumulation of cholesteryl esters and triglycerides within the lysosomes, macrophages, and parenchymal cells in most tissue types, including those in the liver, gastrointestinal tract, and lymph nodes but excluding the central nervous system."
@@ -381,11 +403,13 @@ pathophysiology:
       label: small intestine
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
     explanation: This review directly links gastrointestinal disturbance and growth failure to malabsorption in infantile Wolman disease.
   - reference: PMID:34020687
+    reference_title: "Enzyme replacement therapy and hematopoietic stem cell transplant: a new paradigm of treatment in Wolman disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "The gastrointestinal symptoms are particularly improved after HCT, with reduced diarrhoea and vomiting. This allows gradual structured normalisation of diet with improved tolerance of dietary fat. Histologically there are reduced cholesterol clefts, fewer foamy macrophages and an improved villous structure."
@@ -396,6 +420,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
@@ -405,6 +430,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:28179030
+      reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -414,6 +440,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:24832708
+      reference_title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "In early onset LAL deficiency, clinical manifestations start in the first few weeks of life with persistent vomiting, failure to thrive, hepatosplenomegaly, liver dysfunction and hepatic failure."
@@ -423,6 +450,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
@@ -438,6 +466,7 @@ pathophysiology:
       label: adrenal cortex
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
@@ -448,6 +477,7 @@ pathophysiology:
     causal_link_type: DIRECT
     evidence:
     - reference: PMID:24832708
+      reference_title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Adrenal calcification is a striking feature but is present in only about 50% of cases."
@@ -463,6 +493,7 @@ phenotypes:
       label: Failure to thrive
   evidence:
   - reference: PMID:28179030
+    reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -478,6 +509,7 @@ phenotypes:
       label: Hepatosplenomegaly
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
@@ -492,6 +524,7 @@ phenotypes:
       label: Diarrhea
   evidence:
   - reference: PMID:28179030
+    reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -506,6 +539,7 @@ phenotypes:
       label: Vomiting
   evidence:
   - reference: PMID:24832708
+    reference_title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "In early onset LAL deficiency, clinical manifestations start in the first few weeks of life with persistent vomiting, failure to thrive, hepatosplenomegaly, liver dysfunction and hepatic failure."
@@ -520,6 +554,7 @@ phenotypes:
       label: Malabsorption
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants with rapidly progressive LAL-D present with gastrointestinal disturbance, adrenomegaly with calcification, hepatosplenomegaly, growth failure due to malabsorption, and systemic inflammation."
@@ -535,6 +570,7 @@ phenotypes:
       label: Adrenal calcification
   evidence:
   - reference: PMID:24832708
+    reference_title: "Infant case of lysosomal acid lipase deficiency: Wolman's disease."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Adrenal calcification is a striking feature but is present in only about 50% of cases."
@@ -549,6 +585,7 @@ phenotypes:
       label: Anemia
   evidence:
   - reference: PMID:28179030
+    reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Infants presenting with lysosomal acid lipase deficiency have marked failure to thrive, diarrhea, massive hepatosplenomegaly, anemia, rapidly progressive liver disease, and death typically in the first 6 months of life"
@@ -590,6 +627,7 @@ treatments:
     description: Sebelipase alfa replaces missing lysosomal acid lipase activity at the proximal defect.
     evidence:
     - reference: PMID:28179030
+      reference_title: "Survival in infants treated with sebelipase Alfa for lysosomal acid lipase deficiency: an open-label, multicenter, dose-escalation study."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Sebelipase alfa markedly improved survival with substantial clinically meaningful improvements in growth and other key disease manifestations in infants with rapidly progressive lysosomal acid lipase deficiency"
@@ -599,6 +637,7 @@ treatments:
     description: Enzyme replacement lowers the stored neutral-lipid burden downstream of the LAL deficiency.
     evidence:
     - reference: PMID:23624251
+      reference_title: "Hepatic cholesteryl ester accumulation in lysosomal acid lipase deficiency: non-invasive identification and treatment monitoring by magnetic resonance."
       supports: SUPPORT
       evidence_source: MODEL_ORGANISM
       snippet: "A significant decrease in hepatic CE was observed in LAL-deficient rats following treatment with sebelipase alfa."
@@ -618,11 +657,13 @@ treatments:
       label: Anemia
   evidence:
   - reference: PMID:34906190
+    reference_title: "Sebelipase alfa enzyme replacement therapy in Wolman disease: a nationwide cohort with up to ten years of follow-up."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Early ERT initiation allowed 100% survival with positive outcomes."
     explanation: Long-term cohort follow-up supports strong clinical benefit from early sebelipase alfa initiation.
   - reference: PMID:33407676
+    reference_title: "Long-term survival with sebelipase alfa enzyme replacement therapy in infants with rapidly progressive lysosomal acid lipase deficiency: final results from 2 open-label studies."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "The findings of these 2 studies of infants with rapidly progressive LAL-D demonstrated that enzyme replacement therapy with sebelipase alfa prolonged survival with normal psychomotor development, improved growth, hematologic parameters, and liver parameters, and was generally well tolerated, with an acceptable safety profile."
@@ -643,6 +684,7 @@ treatments:
     description: Dietary substrate reduction and GI-focused nutritional management reduce intestinal stress and improve absorption and growth.
     evidence:
     - reference: PMID:41599846
+      reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Dietary substrate (lipid) reduction, known as substrate reduction therapy, is essential for optimal management in LAL-D."
@@ -666,6 +708,7 @@ treatments:
       label: Vomiting
   evidence:
   - reference: PMID:41599846
+    reference_title: "Best Practices for the Nutritional Management of Infantile-Onset Lysosomal Acid Lipase Deficiency: A Case-Based Discussion."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Treatment takes the two-pronged approach of sebelipase alfa, a human lysosomal acid lipase enzyme replacement therapy (ERT) that improves lipid metabolism, combined with nutritional management."
@@ -683,6 +726,7 @@ differential_diagnoses:
       label: cholesteryl ester storage disease
   evidence:
   - reference: PMID:28786388
+    reference_title: "Wolman's disease and cholesteryl ester storage disorder: the phenotypic spectrum of lysosomal acid lipase deficiency."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Cholesteryl ester storage disorder arises later in life and is less severe, although the two diseases share many common features, including dyslipidaemia and transaminitis."


### PR DESCRIPTION
## Summary

- Adds `reference_title` to all 44 evidence items in `kb/disorders/Wolman_Disease.yaml` that were missing it
- Wolman Disease is the compliance outlier in the lysosomal storage disease family (67.6% vs 94–99% for the other four child diseases of #1321)
- All 10 PMIDs referenced in the file were already cached; titles were verified against `references_cache/PMID_*.md` frontmatter

## Compliance impact

| Before | After |
|--------|-------|
| 67.6% global / 67.4% weighted | **99.3% global / 100.0% weighted** |

The only remaining gap is `datasets: 0.0%`, which requires separate research into registry data.

## Validation

```
✅ Schema validation: No issues found
✅ Term validation: All checks passed
✅ Reference validation: All validations passed
```

## Context

This is a bounded medium-effort augmentation targeting issue #1321 (Lysosomal storage diseases curation project). All five child diseases in that epic now have entries; Wolman Disease was the only one with substantially suboptimal compliance.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)