### PR TITLE
Add somatic second-hit / Knudson two-hit node to AIP pituitary adenoma (#1405)

### DIFF
--- a/kb/disorders/AIP-related_pituitary_adenoma_predisposition.yaml
+++ b/kb/disorders/AIP-related_pituitary_adenoma_predisposition.yaml
@@ -1,6 +1,6 @@
 name: AIP-related pituitary adenoma predisposition
 creation_date: '2026-04-16T19:22:53Z'
-updated_date: '2026-04-30T00:00:00Z'
+updated_date: '2026-05-17T00:00:00Z'
 category: Mendelian
 categories:
 - Hereditary Cancer Syndrome
@@ -223,6 +223,77 @@ pathophysiology:
       explanation: >-
         This study causally links a pathogenic AIP variant to the
         SSTR2/ZAC1/IL-6/phospho-STAT3 program in somatotroph cells.
+  - target: Somatic second-hit AIP inactivation
+    description: >-
+      The germline AIP loss-of-function allele acts as the first ("inherited")
+      hit; a somatic second hit at the wild-type AIP locus on 11q13 (loss of
+      heterozygosity / large-scale chromosomal deletion) completes biallelic
+      inactivation per the Knudson two-hit tumor-suppressor model.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32336638
+      reference_title: "Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting pituitary adenoma: Case report and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Whole-exome sequencing showed a heterozygous germline mutation in the
+        AIP gene suggesting pituitary adenoma predisposition. Analysis of the
+        tumor tissue revealed a large-scale deletion on chromosome 11
+        overlapping with AIP leading to bi-allelic AIP loss.
+      explanation: >-
+        This documents the germline AIP first hit followed by a somatic
+        large-scale 11q deletion as the second hit, supporting progression
+        from constitutional predisposition to biallelic somatic inactivation.
+- name: Somatic second-hit AIP inactivation
+  description: >-
+    Completion of the Knudson two-hit tumor-suppressor model in AIP-related
+    pituitary tumorigenesis: on the background of a constitutional germline
+    AIP loss-of-function allele, a somatic second hit at the remaining
+    wild-type AIP allele on 11q13 (loss of heterozygosity, frequently via a
+    large-scale chromosomal deletion) eliminates residual AIP function in the
+    tumor-initiating somatotroph clone.
+  gene:
+    preferred_term: AIP
+    modifier: ABSENT
+    term:
+      id: hgnc:358
+      label: AIP
+  locations:
+  - preferred_term: pituitary gland
+    term:
+      id: UBERON:0000007
+      label: pituitary gland
+  evidence:
+  - reference: PMID:32336638
+    reference_title: "Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting pituitary adenoma: Case report and review of literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Analysis of the tumor tissue revealed a large-scale deletion on
+      chromosome 11 overlapping with AIP leading to bi-allelic AIP loss.
+    explanation: >-
+      This directly documents a somatic second hit (large-scale 11q deletion
+      spanning AIP) producing biallelic AIP loss in the tumor, the defining
+      event of the two-hit model in this disorder.
+  downstream:
+  - target: Defective Gi-cAMP restraint in somatotrophs
+    description: >-
+      Biallelic AIP inactivation in the somatotroph clone drives the
+      AIP-loss tumorigenic program (defective Gi-cAMP restraint) that
+      produces a GH-secreting adenoma.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32336638
+      reference_title: "Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting pituitary adenoma: Case report and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Coincident germline and somatic AIP mutations were likely causal in
+        formation of a GH-secreting adenoma with an aggressive phenotype.
+      explanation: >-
+        This links completed biallelic (germline + somatic) AIP loss to
+        formation of the GH-secreting somatotroph adenoma, connecting the
+        two-hit event to the downstream AIP-loss tumorigenic mechanism.
 - name: Disrupted AIP-AHR chaperone interaction
   description: >-
     AIP is an aryl hydrocarbon receptor-interacting co-chaperone. Loss of AIP

--- a/references_cache/PMID_32336638.md
+++ b/references_cache/PMID_32336638.md
@@ -1,0 +1,79 @@
+---
+reference_id: "PMID:32336638"
+title: "Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting pituitary adenoma: Case report and review of literature."
+authors:
+- Gummadavelli A
+- Dinauer C
+- McGuone D
+- Vining EM
+- Erson-Omay EZ
+- Omay SB
+journal: J Clin Neurosci
+year: '2020'
+doi: 10.1016/j.jocn.2020.04.103
+keywords:
+- Child
+- "Chromosomes, Human, Pair 11/genetics"
+- Germ-Line Mutation
+- "Gigantism/etiology, genetics"
+- "Growth Hormone-Secreting Pituitary Adenoma/complications, pathology, surgery"
+- Heterozygote
+- Humans
+- Intracellular Signaling Peptides and Proteins/genetics
+- Male
+- Phenotype
+- "Pituitary Neoplasms/genetics, pathology"
+- Sequence Deletion
+content_type: abstract_only
+---
+
+# Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting pituitary adenoma: Case report and review of literature.
+**Authors:** Gummadavelli A, Dinauer C, McGuone D, Vining EM, Erson-Omay EZ, Omay SB
+**Journal:** J Clin Neurosci (2020)
+**DOI:** [10.1016/j.jocn.2020.04.103](https://doi.org/10.1016/j.jocn.2020.04.103)
+
+## Content
+
+1. J Clin Neurosci. 2020 Aug;78:420-422. doi: 10.1016/j.jocn.2020.04.103. Epub
+2020  Apr 24.
+
+Large-scale second-hit AIP deletion causing a pediatric growth hormone-secreting 
+pituitary adenoma: Case report and review of literature.
+
+Gummadavelli A(1), Dinauer C(2), McGuone D(3), Vining EM(4), Erson-Omay EZ(5), 
+Omay SB(6).
+
+Author information:
+(1)Department of Neurosurgery, Yale University School of Medicine, 333 Cedar 
+Street, New Haven, CT 06520, USA.
+(2)Department of Surgery (Pediatric Endocrinology), Yale University School of 
+Medicine, 333 Cedar Street, New Haven, CT 06520, USA.
+(3)Department of Pathology, Yale University School of Medicine, 333 Cedar 
+Street, New Haven, CT 06520, USA.
+(4)Department of Surgery (Otolaryngology), Yale University School of Medicine, 
+333 Cedar Street, New Haven, CT 06520, USA.
+(5)Department of Neurosurgery, Yale University School of Medicine, 333 Cedar 
+Street, New Haven, CT 06520, USA. Electronic address: zeynep.erson@yale.edu.
+(6)Department of Neurosurgery, Yale University School of Medicine, 333 Cedar 
+Street, New Haven, CT 06520, USA. Electronic address: sacit.omay@yale.edu.
+
+Gigantism (early-onset acromegaly) is a rare pediatric disorder caused by a 
+growth hormone (GH)-secreting pituitary adenoma. Approximately 50% patients of 
+gigantism have a germline mutation, most commonly an inactivating mutation in 
+the aryl-hydrocarbon interacting receptor protein (AIP) gene on chromosome 
+11q13.2. We present an 11-year-old male patient with a GH-secreting pituitary 
+macroadenoma who presented with excessive growth spurts, behavioral changes, and 
+frontal headaches. He was successfully treated with an endoscopic endonasal 
+gross total resection and subsequently demonstrated biochemical cure. 
+Whole-exome sequencing showed a heterozygous germline mutation in the AIP gene 
+suggesting pituitary adenoma predisposition. Analysis of the tumor tissue 
+revealed a large-scale deletion on chromosome 11 overlapping with AIP leading to 
+bi-allelic AIP loss. Coincident germline and somatic AIP mutations were likely 
+causal in formation of a GH-secreting adenoma with an aggressive phenotype. This 
+case exemplifies the need for early diagnosis and curative surgery in the 
+management of AIP-mutated pituitary adenomas.
+
+Copyright © 2020 Elsevier Ltd. All rights reserved.
+
+DOI: 10.1016/j.jocn.2020.04.103
+PMID: 32336638 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Closes the one substantive gap flagged in #1405 (2026-05-16 scanner assessment): issue node #1 explicitly calls for the **two-hit tumor-suppressor model — germline AIP LOF + somatic second hit (LOH) at 11q13** — but the existing `Germline AIP loss-of-function predisposition` node captured only the germline first hit.

This PR adds:
- A new pathophysiology node **`Somatic second-hit AIP inactivation`** (biallelic AIP loss via somatic 11q LOH / large-scale deletion completing the Knudson model; `gene: AIP modifier: ABSENT`, `locations: pituitary gland`).
- A `DIRECT` downstream edge `Germline AIP loss-of-function predisposition` → `Somatic second-hit AIP inactivation`.
- A `DIRECT` downstream edge from the new node → existing `Defective Gi-cAMP restraint in somatotrophs` (completed biallelic loss → GH-secreting somatotroph tumorigenesis).
- New reference **PMID:32336638** (Gummadavelli et al., *J Clin Neurosci* 2020 — pediatric GH adenoma with germline AIP + somatic large-scale 11q deletion → biallelic loss), cached via `just fetch-reference`. Three evidence snippets, all verified as exact substrings of the fetched abstract.
- `updated_date` bumped to 2026-05-17.

## Validation

- `just validate kb/disorders/AIP-related_pituitary_adenoma_predisposition.yaml` → schema ✅, terms ✅, references ✅ (all passed).
- `just validate-graphs`: new nodes/edges resolve cleanly. The single AIP graph warning (`Early-onset GH-secreting pituitary macroadenomas` terminal target) is **pre-existing** on `main` (original line 307), and `validate-graphs` already fails repo-wide on unmodified `main` — not introduced here.

## Scope / risk

Low. Bounded single-node augmentation of an already-comprehensive, validating entry; no existing content modified. Evidence is a single well-targeted human case report explicitly demonstrating the germline+somatic two-hit; the node description frames it as the general Knudson model. Draft pending automated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)