### PR TITLE
[codex] Fix boss skill frontmatter

### DIFF
--- a/.claude/skills/boss/SKILL.md
+++ b/.claude/skills/boss/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: boss
-description: Use ONLY when the user explicitly asks to orchestrate parallel external agents (Codex or Claude Code) in tmux sessions via tp (tmux-pilot). Or when a user tells you that you're the boss or orchestrator. You can also use this if you are an operclaw agent. NEVER auto-invoke for a generic "do this in parallel" request. For in-process subagents, use superpowers:dispatching-parallel-agents instead.
-argument-hint: '[ "curate" | "new" | "status" | "kill" | "research" | <QUESTION> ] [INFO]'
+description: >
+  Use ONLY when the user explicitly asks to orchestrate parallel external agents
+  (Codex or Claude Code) in tmux sessions via tp (tmux-pilot). Or when a user
+  tells you that you're the boss or orchestrator. You can also use this if you
+  are an operclaw agent. NEVER auto-invoke for a generic "do this in parallel"
+  request. For in-process subagents, use superpowers:dispatching-parallel-agents
+  instead.
 ---
 
 # boss: orchestrate multiple agents in the dismech repo


### PR DESCRIPTION
## Summary

Fix the `boss` skill metadata so Codex can load it without reporting an invalid `SKILL.md` YAML error.

## Root Cause

The `boss` skill frontmatter used an extra `argument-hint` metadata key and kept the long trigger description on a single plain scalar line. The local skill validator expects the standard `name` and `description` metadata shape.

## Changes

- Converted the `description` field to block-scalar YAML, matching other repo skills.
- Removed the nonstandard `argument-hint` frontmatter key. Invocation hints remain documented in the body examples.

## Validation

- `python3 /Users/cjm/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/boss`
- `git diff --check -- .claude/skills/boss/SKILL.md`