### PR TITLE
docs: Add deep-research hallucination verification SOP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,6 +561,27 @@ cat references_cache/pmid_12345678.md
 just validate-references kb/disorders/MyDisease.yaml
 ```
 
+### 2a. Deep-Research (Falcon/DR) Tool Outputs — Extra Verification Needed
+
+Deep-research tools (Falcon, DGO, etc.) synthesize information across many sources but are **known to fabricate or misattribute citations, misquote snippets, and invent ontology identifiers**. When using DR outputs for curation:
+
+**Treat DR outputs as *leads*, not ground truth.** Every PMID, snippet, and ontology term from a DR summary must be independently verified before committing.
+
+**Three categories of hallucination risk:**
+1. **Fabricated PMIDs** — The cited paper does not exist, or the PMID belongs to an unrelated paper
+2. **Misquoted snippets** — The snippet is paraphrased or invented rather than an exact quote from the real abstract
+3. **Invented ontology terms** — HP, GO, CL, MAXO, CHEBI, or NCIT identifiers that don't exist or whose canonical label doesn't match `term.label`
+
+**Mandatory verification workflow for any curation step sourced from DR:**
+1. For **each new PMID** cited: run `just fetch-reference PMID:XXXX` to fetch the real abstract
+2. For **each snippet**: manually verify it is an exact substring of the abstract by comparing against the cached file in `references_cache/PMID_XXXX.md`
+3. For **each ontology term** (HP, GO, CL, MAXO, CHEBI, NCIT): verify the term exists and its canonical label matches `term.label` by running `just validate-terms-file kb/disorders/YourDisease.yaml`
+4. Run the full validation suite before committing (see Validation Workflow below)
+
+If a DR-suggested citation cannot be verified against the real abstract, do not use it. Find an alternative source or remove the claim entirely.
+
+**Historical note:** Issue #1737 audited DR-sourced entries and found ~1% hallucination rate in the cache layer — the dismech validation stack catches these errors, but only *after* the curator runs the checks. Treating DR outputs as leads rather than ground truth is the most reliable protection.
+
 ### 3. Validation Workflow
 
 Before committing changes to any disorder file:


### PR DESCRIPTION
## Summary

Document mandatory verification workflow for deep-research (Falcon/DR) tool outputs in the dismech curation SOP. The new section guides agents to treat DR outputs as leads, not ground truth, and provides explicit verification steps for PMIDs, snippets, and ontology terms.

## Changes

- Added section 2a to "Standard Operating Procedure: Adding/Editing Evidence" in CLAUDE.md
- Defines three hallucination risk categories observed in issue #1737 audit
- Specifies four-step verification workflow for any DR-sourced curation
- Links to historical audit findings (~1% hallucination rate in cache layer)

## Context

This resolves the "Document the DR hallucination risk in CLAUDE.md / curation SOP" action item from issue #1737 after the automated curation scanner completed audits of COPA Syndrome (#1724), CADASIL Type 1 (#1725), and the full Falcon deep-research batch 2 (#2316) — all 12 files audited clean, with zero hallucinations detected in the final PR-validation-stage files.

The validator strengthening (PR #2444) merged on 2026-05-10. This documentation closes out the practical guidance items from the issue's task list.

## Validation

- CLAUDE.md renders cleanly
- Links within the doc reference existing sections correctly
- SOP mirrors the three-part validation workflow already in place (`just validate`, `just validate-references`, `just validate-terms-file`)

Closes #1737

🤖 Generated with Claude Code