### PR TITLE
Add Hepatic Angiosarcoma subtype and chemical carcinogen exposure (#1118)

### DIFF
--- a/kb/disorders/Angiosarcoma.yaml
+++ b/kb/disorders/Angiosarcoma.yaml
@@ -1,6 +1,6 @@
 name: Angiosarcoma
 creation_date: '2026-04-12T05:11:04Z'
-updated_date: '2026-05-16T00:00:00Z'
+updated_date: '2026-05-17T00:00:00Z'
 category: Cancer
 categories:
 - Sarcoma
@@ -79,6 +79,26 @@ has_subtypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "PIK3CA-activating mutations were observed predominantly in primary breast angiosarcoma, which suggested a therapeutic rationale."
     explanation: This supports primary breast angiosarcoma as a biologically distinct subtype with recurrent PIK3CA activation.
+- name: Hepatic Angiosarcoma
+  description: >-
+    Hepatic angiosarcoma is a visceral subtype arising in the liver. It is the
+    prototypic chemically induced angiosarcoma, with a well-established
+    association with occupational and iatrogenic carcinogen exposure (vinyl
+    chloride monomer and thorium dioxide/Thorotrast), and represents the most
+    common location for chemically induced disease.
+  evidence:
+  - reference: PMID:33182685
+    reference_title: Optimal Clinical Management and the Molecular Biology of Angiosarcomas.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "more commonly occur in the head and neck and scalp regions, extremities, breast, heart and great vessels, and visceral organs such as the liver and spleen"
+    explanation: This review identifies the liver as a recognized visceral site of angiosarcoma, supporting hepatic angiosarcoma as a distinct anatomic subtype.
+  - reference: PMID:33182685
+    reference_title: Optimal Clinical Management and the Molecular Biology of Angiosarcomas.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Chemical exposure to vinyl chloride and thorium dioxide have been well-documented to be associated with increased risk of liver AS"
+    explanation: This supports the chemically induced etiology that biologically distinguishes hepatic angiosarcoma from sporadic and radiation-associated disease.
 pathophysiology:
 - name: Angiogenic Signaling Activation
   description: >-
@@ -568,6 +588,18 @@ environmental:
     evidence_source: HUMAN_CLINICAL
     snippet: "Angiosarcoma of the head, neck, face and scalp (HNFS) was associated with a high tumor mutation burden (TMB) and a dominant ultraviolet damage mutational signature"
     explanation: This directly supports ultraviolet-associated mutagenesis in cutaneous head and neck angiosarcoma.
+- name: Chemical carcinogen exposure (vinyl chloride, thorium dioxide)
+  description: >-
+    Occupational and iatrogenic chemical carcinogen exposure, classically vinyl
+    chloride monomer and thorium dioxide (Thorotrast), is a well-documented risk
+    context for hepatic angiosarcoma.
+  evidence:
+  - reference: PMID:33182685
+    reference_title: Optimal Clinical Management and the Molecular Biology of Angiosarcomas.
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Chemical exposure to vinyl chloride and thorium dioxide have been well-documented to be associated with increased risk of liver AS"
+    explanation: This review explicitly identifies vinyl chloride and thorium dioxide exposure as well-documented risk factors for hepatic angiosarcoma.
 treatments:
 - name: Surgical Excision
   description: >-


### PR DESCRIPTION
## Summary

Closes the documented **hepatic / visceral angiosarcoma** gap repeatedly flagged in prior scanner assessments on #1118 (the previously deferred enrichment item, alongside histopathology which merged in #2768).

- Adds a **`Hepatic Angiosarcoma`** entry to `has_subtypes` — the prototypic chemically induced visceral subtype.
- Adds a **`Chemical carcinogen exposure (vinyl chloride, thorium dioxide)`** entry to `environmental`.

## Evidence provenance (low hallucination risk)

All new evidence reuses **`PMID:33182685`** ("Optimal Clinical Management and the Molecular Biology of Angiosarcomas"), which is **already cited in this entry and already in `references_cache/`** — no new reference fetch was required. Both snippets were manually confirmed to be exact substrings of `references_cache/PMID_33182685.md`:

- `"more commonly occur in the head and neck and scalp regions, extremities, breast, heart and great vessels, and visceral organs such as the liver and spleen"` — supports liver as a recognized visceral AS site.
- `"Chemical exposure to vinyl chloride and thorium dioxide have been well-documented to be associated with increased risk of liver AS"` — supports the chemically induced etiology.

`evidence_source: OTHER` matches the existing usage of this review elsewhere in the file.

## Validation

- `just validate kb/disorders/Angiosarcoma.yaml` — schema + terms + references all pass
- `just validate-terms kb/disorders/Angiosarcoma.yaml` — pass
- Manual substring check of both snippets against the cached abstract — exact match
- `pytest tests/test_data.py` (subtype FK / uniqueness / data) — 7778 passed
- Diff is a single file (`kb/disorders/Angiosarcoma.yaml`); unrelated `normalize-cache` churn on three `clinicaltrials_*` cache files was reverted and is not included.

## Intentionally NOT done (out of scope for this bounded run)

- No `subtype_term` MONDO binding on the new subtype — the entry's four pre-existing subtypes also have none, so this preserves the file's current convention rather than guessing a MONDO ID. A consistent subtype_term backfill across all Angiosarcoma subtypes is a separate, larger task.
- No new pathophysiology node for the chemical-carcinogen → hepatic AS mechanism (would require new reference fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)