### PR TITLE
Add datasets section to standalone MED13_Syndrome.yaml (#1139)

### DIFF
--- a/kb/disorders/MED13_Syndrome.yaml
+++ b/kb/disorders/MED13_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: MED13 Syndrome
 creation_date: '2026-04-11T12:00:00Z'
-updated_date: '2026-04-15T03:42:15Z'
+updated_date: '2026-05-18T00:00:00Z'
 category: Mendelian
 synonyms:
 - Intellectual developmental disorder, autosomal dominant 61
@@ -748,3 +748,79 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+datasets:
+- accession: "geo:GSE298801"
+  title: Cardiomyocyte-specific Med13/Med13L double knockout RNA-seq
+  description: >-
+    Bulk RNA-seq from adult murine cardiomyocytes after inducible knockout of Med13
+    and Med13L. Double knockout results in lethal heart failure within 6 weeks,
+    with significant gene dysregulation of fibrotic pathways and calcium handling.
+    Demonstrates that Med13 and Med13L function redundantly in the adult heart to
+    maintain basal cardiac function and transcription, relevant to the congenital
+    heart defects observed in MED13 syndrome.
+  organism:
+    preferred_term: mouse
+    term:
+      id: NCBITaxon:10090
+      label: Mus musculus
+  data_type: BULK_RNA_SEQ
+  sample_count: 8
+  sample_types:
+  - preferred_term: cardiomyocyte
+    tissue_term:
+      preferred_term: heart
+      term:
+        id: UBERON:0000948
+        label: heart
+  conditions:
+  - Med13/Med13L cardiomyocyte-specific double knockout
+  - wild-type control
+  genes:
+  - preferred_term: MED13
+    term:
+      id: hgnc:22474
+      label: MED13
+  - preferred_term: MED13L
+    term:
+      id: hgnc:22962
+      label: MED13L
+  publication: PMID:40989238
+  findings:
+  - statement: Med13 and Med13L are functionally redundant in adult cardiomyocytes
+  - statement: Double knockout causes lethal heart failure with fibrotic and calcium handling gene dysregulation
+  - statement: Similar gene dysregulation patterns across Mediator cardiac knockouts (Med13/13L, Med12, Med1, Med30)
+  evidence:
+  - reference: PMID:40989238
+    supports: SUPPORT
+    evidence_source: MODEL_ORGANISM
+    snippet: "Med13/13L knockout resulted in decreased cardiac function leading to lethal heart failure in a median timeframe of 6 weeks from the start of tamoxifen."
+    explanation: Mouse model demonstrates functional redundancy of Med13 and Med13L in heart and lethal consequences of combined loss.
+
+- accession: "clinicaltrials:NCT01238250"
+  title: "Online Study of People Who Have Genetic Changes and Features of Autism: Simons Searchlight"
+  description: >-
+    Simons Searchlight is a large prospective observational registry enrolling
+    individuals with rare genetic neurodevelopmental variants including MED13.
+    Collects medical history, developmental milestones, behavioral assessments,
+    and longitudinal follow-up data. As of 2024, includes approximately 15
+    individuals with MED13 variants, providing natural-history data for MED13
+    syndrome.
+  organism:
+    preferred_term: human
+    term:
+      id: NCBITaxon:9606
+      label: Homo sapiens
+  sample_types:
+  - preferred_term: clinical phenotype data
+  conditions:
+  - MED13 pathogenic variants
+  genes:
+  - preferred_term: MED13
+    term:
+      id: hgnc:22474
+      label: MED13
+  findings:
+  - statement: Longitudinal natural history data for MED13 syndrome available to qualified researchers
+  notes: >-
+    Data available to qualified researchers via SFARI Base (https://base.sfari.org).
+    Over 7,000 total participants enrolled across all gene cohorts as of 2024.


### PR DESCRIPTION
## Summary

Closes the only material compliance gap on the standalone
`kb/disorders/MED13_Syndrome.yaml` entry: `datasets:` was entirely
absent (compliance reported `datasets: MISSING`, 0%).

This PR ports the **two MED13-relevant dataset entries** from the
already-validated `Mediator_Complex_Neurodevelopmental_Disorder.yaml`
umbrella file into the standalone root entry:

- **`geo:GSE298801`** — Med13/Med13L cardiomyocyte-specific double-knockout
  RNA-seq (`PMID:40989238`, MODEL_ORGANISM). Directly relevant to the
  congenital heart defect phenotype already curated in this entry.
- **`clinicaltrials:NCT01238250`** — Simons Searchlight registry,
  longitudinal natural-history data for MED13-variant individuals
  (no `evidence:` block, matching the umbrella; `findings`/`notes` only).

The MED13L-only dataset (`geo:GSE277054`) was intentionally **not**
ported — it is MED13L-specific and not relevant to this MED13 root entry.

This is a faithful port of content already verified in the umbrella
file, not new authored claims. The `PMID:40989238` snippet is the exact
validator-verified form (whitespace-normalized substring of the cached
abstract). `updated_date` bumped per CLAUDE.md convention.

## Validation

- `just validate kb/disorders/MED13_Syndrome.yaml` → ✅ all pass (schema + references + terms)
- `just validate-references kb/disorders/MED13_Syndrome.yaml` → ✅ pass
- `just validate-terms kb/disorders/MED13_Syndrome.yaml` → ✅ pass
- `datasets` compliance: 0% (MISSING) → **100%**

## What this PR intentionally does NOT do

- Does not add evidence to the 3 generic supportive treatments
  (speech therapy / genetic counseling / supportive care) — those lack
  cleanly quotable disease-specific abstracts; deferred rather than
  risk fabricated snippets per the CLAUDE.md evidence SOP.
- Does not touch the umbrella file or the merged ubiquitination work.

Refs #1139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)