### PR TITLE
[codex] Improve HHH syndrome pathograph connectivity

### DIFF
--- a/kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
+++ b/kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome
 creation_date: "2026-05-11T07:39:50Z"
-updated_date: "2026-05-11T08:20:40Z"
+updated_date: "2026-05-18T04:30:01Z"
 category: Mendelian
 synonyms:
 - HHH syndrome
@@ -206,6 +206,26 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Ornithine carrier 1 deficiency causes HHH syndrome, characterized by failure of mitochondrial ornithine uptake, hyperammonemia, and accumulation of ornithine and lysine in the cytoplasm."
       explanation: Human cohort report links failure of mitochondrial ornithine uptake to ornithine accumulation.
+  - target: Chorioretinal atrophy
+    description: Rare ocular involvement is reported in the HHH phenotype spectrum and is linked here to the chronic hyperornithinemic transport-defect state.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000533 | Chorioretinal atrophy | Very rare (<4-1%)"
+      explanation: Orphanet records chorioretinal atrophy as a rare HHH phenotype.
+  - target: Chorioretinal hypopigmentation
+    description: Rare chorioretinal hypopigmentation is represented as ocular involvement downstream of the chronic ornithine transport defect.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0040030 | Chorioretinal hypopigmentation | Very rare (<4-1%)"
+      explanation: Orphanet records chorioretinal hypopigmentation as a rare HHH phenotype.
   - target: Urea Cycle Flux Impairment
     description: Mitochondrial ornithine deficiency reduces ornithine-dependent urea-cycle flux.
     causal_link_type: DIRECT
@@ -261,6 +281,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Ornithine carrier 1 deficiency causes HHH syndrome, characterized by failure of mitochondrial ornithine uptake, hyperammonemia, and accumulation of ornithine and lysine in the cytoplasm."
       explanation: Cohort report directly links ORC1 deficiency to hyperammonemia.
+  - target: Hyperammonemic Encephalopathy
+    description: Elevated ammonia during impaired urea-cycle flux drives acute encephalopathic decompensation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36506307
+      reference_title: "Clinical heterogeneity of hyperornithinemia-hyperammonemia-homocitrullinuria syndrome in thirteen palestinian patients and report of a novel variant in the SLC25A15 gene."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major acute clinical presentation found was encephalopathy and liver dysfunction."
+      explanation: Human cohort evidence links HHH metabolic disease to acute encephalopathy.
   - target: Carbamoyl Phosphate Diversion
     description: Reduced ornithine availability leaves carbamoyl phosphate available for diversion into orotic acid and homocitrulline pathways.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -273,6 +303,64 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "The diagnosis relies on clinical signs and the peculiar metabolic triad of hyperammonemia, hyperornithinemia, and urinary excretion of homocitrulline."
       explanation: The diagnostic triad supports a metabolic branch that includes hyperammonemia and homocitrulline production.
+  - target: Liver Dysfunction and Coagulation Abnormality
+    description: The urea-cycle transport defect is associated with acute and chronic hepatic dysfunction, transaminase elevation, and coagulation abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Metabolic decompensation with hepatic nitrogen-disposal stress.
+    evidence:
+    - reference: PMID:36506307
+      reference_title: "Clinical heterogeneity of hyperornithinemia-hyperammonemia-homocitrullinuria syndrome in thirteen palestinian patients and report of a novel variant in the SLC25A15 gene."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major acute clinical presentation found was encephalopathy and liver dysfunction."
+      explanation: Cohort evidence supports liver dysfunction as a major presentation in HHH syndrome.
+  - target: Respiratory alkalosis
+    description: Hyperammonemic urea-cycle decompensation can present with tachypnea and respiratory alkalosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hyperventilation during acute hyperammonemic crisis.
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001950 | Respiratory alkalosis | Occasional (29-5%)"
+      explanation: Orphanet records respiratory alkalosis in the HHH phenotype spectrum.
+  - target: Protein avoidance
+    description: Chronic nitrogen intolerance can manifest as aversion to protein-rich foods.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Protein intake increases nitrogen load when urea-cycle flux is impaired.
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Alternatively, patients show a chronic course with aversion for protein rich foods, developmental delay/intellectual disability, myoclonic seizures, ataxia and pyramidal dysfunction."
+      explanation: Systematic review supports protein aversion within the chronic HHH phenotype.
+  - target: Failure to thrive
+    description: Recurrent metabolic stress and chronic protein intolerance contribute to poor growth.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001508 | Failure to thrive | Frequent (79-30%)"
+      explanation: Orphanet records failure to thrive as a frequent HHH phenotype.
+  - target: Abnormality of citrulline metabolism
+    description: Disturbed mitochondrial ornithine entry perturbs urea-cycle intermediate handling, including circulating citrulline.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced ornithine availability alters ornithine transcarbamylase substrate flux and downstream citrulline production.
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011965 | Abnormality of citrulline metabolism | Very frequent (99-80%)"
+      explanation: Orphanet records abnormality of citrulline metabolism as very frequent in HHH syndrome.
 - name: Carbamoyl Phosphate Diversion
   description: >-
     When ornithine-dependent mitochondrial flux is impaired, excess carbamoyl
@@ -358,6 +446,86 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "HP:0006846 | Acute encephalopathy | Frequent (79-30%)"
       explanation: Orphanet records acute encephalopathy as a frequent phenotype.
+  - target: Lethargy
+    description: Acute hyperammonemic encephalopathy can present with lethargy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Lethargy and coma are frequent at disease onset, whereas pyramidal dysfunction and cognitive/behavioural abnormalities represent the most common clinical features in late-onset cases or during the disease course."
+      explanation: Systematic review directly links lethargy to acute disease onset.
+  - target: Confusion
+    description: Hyperammonemic encephalopathy can manifest as episodic confusion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Acute clinical signs include intermittent episodes of vomiting, confusion or coma and hepatitis-like attacks."
+      explanation: Systematic review directly lists confusion among acute clinical signs.
+  - target: Coma
+    description: Severe acute hyperammonemic encephalopathy can progress to coma.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Acute clinical signs include intermittent episodes of vomiting, confusion or coma and hepatitis-like attacks."
+      explanation: Systematic review directly lists coma among acute clinical signs.
+  - target: Episodic vomiting
+    description: Acute metabolic decompensation includes intermittent vomiting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Acute clinical signs include intermittent episodes of vomiting, confusion or coma and hepatitis-like attacks."
+      explanation: Systematic review directly lists vomiting among acute clinical signs.
+  - target: Feeding difficulties
+    description: Neonatal or infantile hyperammonemic decompensation can present with poor feeding.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011968 | Feeding difficulties | Frequent (79-30%)"
+      explanation: Orphanet records feeding difficulties as a frequent HHH phenotype.
+  - target: Tachypnea
+    description: Acute metabolic decompensation can include tachypnea.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002789 | Tachypnea | Frequent (79-30%)"
+      explanation: Orphanet records tachypnea as a frequent HHH phenotype.
+  - target: Seizure
+    description: Hyperammonemic brain dysfunction can include seizures during the HHH disease course.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001250 | Seizure | Occasional (29-5%)"
+      explanation: Orphanet records seizures in the HHH phenotype spectrum.
+  - target: Generalized myoclonic seizure
+    description: Myoclonic seizures occur within the chronic and episodic neurologic HHH phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Alternatively, patients show a chronic course with aversion for protein rich foods, developmental delay/intellectual disability, myoclonic seizures, ataxia and pyramidal dysfunction."
+      explanation: Systematic review lists myoclonic seizures in the chronic HHH course.
   - target: Chronic Neurocognitive and Pyramidal Tract Dysfunction
     description: Recurrent metabolic injury and disease-specific mechanisms are associated with chronic neurocognitive and pyramidal tract involvement.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -400,6 +568,46 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria syndrome, are clinically characterized by highly penetrant spastic paraplegia."
       explanation: Review evidence supports spastic paraplegia as a prominent HHH syndrome neurologic phenotype.
+  - target: Abnormal pyramidal sign
+    description: Progressive upper-motor-neuron involvement produces abnormal pyramidal signs.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36506307
+      reference_title: "Clinical heterogeneity of hyperornithinemia-hyperammonemia-homocitrullinuria syndrome in thirteen palestinian patients and report of a novel variant in the SLC25A15 gene."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Nervous system involvement was common, progressive, and presented with signs of upper motor neuron disease as well as variable degrees of cognitive impairment."
+      explanation: Cohort evidence supports upper-motor-neuron signs in HHH syndrome.
+  - target: Hyperreflexia
+    description: Upper-motor-neuron involvement commonly manifests as hyperreflexia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001347 | Hyperreflexia | Very frequent (99-80%)"
+      explanation: Orphanet records hyperreflexia as a very frequent HHH phenotype.
+  - target: Clonus
+    description: Pyramidal tract dysfunction can manifest as clonus.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002169 | Clonus | Frequent (79-30%)"
+      explanation: Orphanet records clonus as a frequent HHH phenotype.
+  - target: Spastic gait
+    description: Pyramidal tract dysfunction can produce a spastic gait pattern.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002064 | Spastic gait | Occasional (29-5%)"
+      explanation: Orphanet records spastic gait in the HHH phenotype spectrum.
   - target: Cognitive impairment
     description: Progressive neurologic involvement includes variable cognitive impairment.
     causal_link_type: DIRECT
@@ -410,6 +618,110 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Nervous system involvement was common, progressive, and presented with signs of upper motor neuron disease as well as variable degrees of cognitive impairment."
       explanation: Cohort evidence directly links HHH syndrome to cognitive impairment.
+  - target: Intellectual disability
+    description: Chronic neurocognitive involvement includes developmental delay and intellectual disability.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Alternatively, patients show a chronic course with aversion for protein rich foods, developmental delay/intellectual disability, myoclonic seizures, ataxia and pyramidal dysfunction."
+      explanation: Systematic review directly lists developmental delay/intellectual disability in the chronic course.
+  - target: Neurodevelopmental delay
+    description: Chronic neurologic involvement often includes neurodevelopmental delay.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Alternatively, patients show a chronic course with aversion for protein rich foods, developmental delay/intellectual disability, myoclonic seizures, ataxia and pyramidal dysfunction."
+      explanation: Systematic review directly lists developmental delay in the chronic course.
+  - target: Specific learning disability
+    description: Chronic cognitive involvement can manifest as learning disability.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic neurocognitive impairment.
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001328 | Specific learning disability | Frequent (79-30%)"
+      explanation: Orphanet records specific learning disability as a frequent HHH phenotype.
+  - target: Progressive cerebellar ataxia
+    description: Chronic neurologic involvement includes progressive ataxia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Alternatively, patients show a chronic course with aversion for protein rich foods, developmental delay/intellectual disability, myoclonic seizures, ataxia and pyramidal dysfunction."
+      explanation: Systematic review lists ataxia in the chronic HHH course.
+  - target: Poor coordination
+    description: Cerebellar and motor-system involvement can manifest as poor coordination.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Chronic ataxic motor impairment.
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002370 | Poor coordination | Frequent (79-30%)"
+      explanation: Orphanet records poor coordination as a frequent HHH phenotype.
+  - target: Generalized hypotonia
+    description: Early neurologic involvement can include generalized hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001290 | Generalized hypotonia | Frequent (79-30%)"
+      explanation: Orphanet records generalized hypotonia as a frequent HHH phenotype.
+  - target: Impaired vibratory sensation
+    description: Chronic neurologic involvement can include sensory pathway impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002495 | Impaired vibratory sensation | Frequent (79-30%)"
+      explanation: Orphanet records impaired vibratory sensation as a frequent HHH phenotype.
+  - target: Speech apraxia
+    description: Chronic neurodevelopmental and motor-planning involvement can manifest as speech apraxia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011098 | Speech apraxia | Frequent (79-30%)"
+      explanation: Orphanet records speech apraxia as a frequent HHH phenotype.
+  - target: Cerebral cortical atrophy
+    description: Chronic neurologic injury is associated with cerebral cortical atrophy in the HHH phenotype spectrum.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002120 | Cerebral cortical atrophy | Frequent (79-30%)"
+      explanation: Orphanet records cerebral cortical atrophy as a frequent HHH phenotype.
+  - target: Multifocal cerebral white matter abnormalities
+    description: Chronic neurologic disease can include multifocal cerebral white matter abnormalities.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0007052 | Multifocal cerebral white matter abnormalities | Occasional (29-5%)"
+      explanation: Orphanet records multifocal cerebral white matter abnormalities in the HHH phenotype spectrum.
 - name: Liver Dysfunction and Coagulation Abnormality
   description: >-
     HHH syndrome frequently includes decreased liver function, transaminase
@@ -433,6 +745,79 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "The major acute clinical presentation found was encephalopathy and liver dysfunction."
     explanation: Cohort evidence supports liver dysfunction as a major acute manifestation.
+  downstream:
+  - target: Decreased liver function
+    description: Hepatic involvement manifests as decreased liver function.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001410 | Decreased liver function | Frequent (79-30%)"
+      explanation: Orphanet records decreased liver function as a frequent HHH phenotype.
+  - target: Hepatitis
+    description: HHH hepatic involvement can include hepatitis-like attacks.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Acute clinical signs include intermittent episodes of vomiting, confusion or coma and hepatitis-like attacks."
+      explanation: Systematic review lists hepatitis-like attacks among acute HHH signs.
+  - target: Hepatic failure
+    description: Severe hepatic involvement can progress to hepatic failure in rare cases.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001399 | Hepatic failure | Very rare (<4-1%)"
+      explanation: Orphanet records hepatic failure as a rare HHH phenotype.
+  - target: Hepatomegaly
+    description: Hepatic involvement can manifest as hepatomegaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002240 | Hepatomegaly | Frequent (79-30%)"
+      explanation: Orphanet records hepatomegaly as a frequent HHH phenotype.
+  - target: Elevated circulating hepatic transaminase concentration
+    description: Liver injury in HHH syndrome is reflected by elevated circulating hepatic transaminases.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Three out of four cases presented with hyperammonemia, elevated transaminases, and uraciluria."
+      explanation: Human cohort data document elevated transaminases in HHH presentations.
+  - target: Elevated hepatic transaminases
+    description: Elevated hepatic transaminases provide a biochemical readout of the liver-dysfunction branch.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Three out of four cases presented with hyperammonemia, elevated transaminases, and uraciluria."
+      explanation: Human cohort data document elevated transaminases in HHH presentations.
+  - target: Abnormality of the coagulation cascade
+    description: Hepatic dysfunction can be accompanied by coagulation abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced hepatic synthetic function.
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All four cases demonstrated hyperornithinemia and prolonged prothrombin time."
+      explanation: Human cohort data support a coagulation abnormality accompanying HHH syndrome.
 phenotypes:
 - name: Chorioretinal atrophy
   frequency: VERY_RARE


### PR DESCRIPTION
## Summary

- Connect HHH syndrome's existing urea-cycle transport mechanism to acute hyperammonemic, chronic neurocognitive/pyramidal, liver/coagulation, ocular, and biochemical readout branches.
- Reuse cached ORPHA and PMID evidence; no new references or cache files are introduced.
- Improve pathograph connectivity from 37 components to 1 connected component while preserving the existing core GO coverage for ornithine transport and urea-cycle impairment.

## Validation

- `just validate kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml`
- Graph audit: 57 nodes, 61 edges, 1 component, 0 isolated nodes, 0 orphans, 0 integrity issues
- Manual snippet audit: 138 evidence items, 73 unique snippets, 7 unique references; all snippets found in cached references after whitespace normalization
- `git diff --check`

## Scope Notes

Recurring unrelated ClinicalTrials cache normalization churn was restored and is not included in this PR.
