### PR TITLE
[codex] Improve phenylketonuria pathograph connectivity

### DIFF
--- a/kb/disorders/Phenylketonuria.yaml
+++ b/kb/disorders/Phenylketonuria.yaml
@@ -1,6 +1,6 @@
 name: Phenylketonuria
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-04-27T05:24:24Z'
+updated_date: '2026-05-18T04:44:34Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -642,6 +642,46 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "If untreated, this brain dysfunction results in severe intellectual disability, epilepsy and behavioural problems."
       explanation: Links brain dysfunction directly to neurologic and cognitive outcomes.
+  - target: Encephalopathy
+    description: Severe phenylalanine-mediated brain dysfunction can manifest as encephalopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001298 | Encephalopathy | Occasional (29-5%)"
+      explanation: Orphanet records encephalopathy in the PKU phenotype spectrum.
+  - target: EEG Abnormality
+    description: Phenylalanine-mediated brain dysfunction can be reflected by abnormal EEG findings.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002353 | EEG abnormality | Frequent (79-30%)"
+      explanation: Orphanet records EEG abnormality as a frequent PKU phenotype.
+  - target: Tremor
+    description: PKU brain dysfunction can include tremor as a motor manifestation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30570999
+      reference_title: "Phenylketonuria (PKU)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These signs can include musty odor from skin and urine, fair skin, eczema, seizures, tremors, and hyperactivity."
+      explanation: Clinical overview lists tremors among PKU signs.
+  - target: Ataxia
+    description: PKU neurologic involvement can include ataxia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001251 | Ataxia | Occasional (29-5%)"
+      explanation: Orphanet records ataxia in the PKU phenotype spectrum.
 - name: White Matter and Subcortical Structural Injury
   description: Treated adults still exhibit white-matter damage and subcortical volume loss associated with phenylalanine burden.
   cell_types:
@@ -683,6 +723,36 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Furthermore, diffusion tensor imaging metrics in adults with phenylketonuria were related to performance in attention and executive functions."
       explanation: Connects white matter microstructure abnormalities to neurocognitive deficits.
+  - target: Abnormal Cerebral White Matter Morphology
+    description: Persistent white-matter injury is the mechanistic counterpart of the HPO white-matter morphology phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37265600
+      reference_title: "Compromised white matter is related to lower cognitive performance in adults with phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In conclusion, our findings demonstrate that white matter alterations in early-treated phenylketonuria persist into adulthood, are most prominent in the posterior white matter and are likely to be driven by axonal damage."
+      explanation: Directly supports persistent cerebral white matter alterations in PKU.
+  - target: Lower Limb Spasticity
+    description: White-matter and subcortical motor-pathway injury can contribute to lower-limb spasticity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002061 | Lower limb spasticity | Occasional (29-5%)"
+      explanation: Orphanet records lower-limb spasticity in the PKU phenotype spectrum.
+  - target: Cerebral Visual Impairment
+    description: Cerebral visual impairment is represented as an occasional neurologic manifestation downstream of brain structural injury.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100704 | Cerebral visual impairment | Occasional (29-5%)"
+      explanation: Orphanet records cerebral visual impairment in the PKU phenotype spectrum.
 - name: Neurocognitive Dysfunction
   description: PKU causes global and executive cognitive impairment, especially when metabolic control is poor or untreated.
   cell_types:
@@ -716,6 +786,78 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "If untreated, this brain dysfunction results in severe intellectual disability, epilepsy and behavioural problems."
       explanation: Supports epilepsy as a downstream neurologic consequence.
+  - target: Global Developmental Delay
+    description: Untreated or poorly controlled PKU neurotoxicity can manifest as global developmental delay.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Frequent (79-30%)"
+      explanation: Orphanet records global developmental delay as a frequent PKU phenotype.
+  - target: Specific Learning Disability
+    description: Persistent cognitive and executive dysfunction can manifest as specific learning disability.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - reduced global intelligence and executive function.
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001328 | Specific learning disability | Frequent (79-30%)"
+      explanation: Orphanet records specific learning disability as a frequent PKU phenotype.
+  - target: Short Attention Span
+    description: Adult PKU neurocognitive effects include attention and executive-function impairment.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37265600
+      reference_title: "Compromised white matter is related to lower cognitive performance in adults with phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Furthermore, diffusion tensor imaging metrics in adults with phenylketonuria were related to performance in attention and executive functions."
+      explanation: Human neuroimaging study links PKU white-matter metrics to attention and executive-function performance.
+  - target: Atypical Behavior
+    description: PKU brain dysfunction can present with behavioral problems.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:34017006
+      reference_title: "Phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "If untreated, this brain dysfunction results in severe intellectual disability, epilepsy and behavioural problems."
+      explanation: Review directly links untreated PKU brain dysfunction to behavioral problems.
+  - target: Anxiety
+    description: Neuropsychiatric effects of PKU include anxiety in the phenotype spectrum.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000739 | Anxiety | Occasional (29-5%)"
+      explanation: Orphanet records anxiety in the PKU phenotype spectrum.
+  - target: Depression
+    description: Neuropsychiatric effects of PKU include depression in the phenotype spectrum.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000716 | Depression | Occasional (29-5%)"
+      explanation: Orphanet records depression in the PKU phenotype spectrum.
+  - target: Dementia
+    description: Severe chronic neurocognitive deterioration can manifest as dementia in some PKU patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000726 | Dementia | Occasional (29-5%)"
+      explanation: Orphanet records dementia in the PKU phenotype spectrum.
 - name: Impaired Melanin Biosynthesis
   description: Reduced tyrosine availability limits melanin synthesis in untreated or poorly controlled disease.
   biological_processes:
@@ -782,6 +924,26 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "These signs can include musty odor from skin and urine, fair skin, eczema, seizures, tremors, and hyperactivity."
       explanation: Supports eczema as part of the clinical path downstream of PKU metabolism, though precise intermediates are not specified by this source.
+  - target: Phenylalaninuria
+    description: Urinary phenylalanine and phenylketone excretion reflects overflow alternative phenylalanine metabolism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:716
+      reference_title: "Phenylketonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0032351 | Phenylalaninuria | Very frequent (99-80%)"
+      explanation: Orphanet records phenylalaninuria as a very frequent PKU biochemical phenotype.
+  - target: Phenylpyruvic Acid
+    description: Phenylpyruvic acid is a measured urinary readout of phenylketone accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21565303
+      reference_title: "Study on urinary metabolic profile of phenylketonuria by micellar electrokinetic capillary chromatography with dual electrochemical detection--potential clinical application in fast diagnosis of phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The urinary metabolic marker compounds, namely phenylpyruvic acid (PPA), 2-hydroxyphenylacetic acid (oOPAA), 4-hydroxyphenylacetic acid (pOPAA), phenyllactic acid (PLA) and phenylacetic acid (PAA) of phenylketonuric individuals were detected"
+      explanation: Human urinary metabolite profiling supports phenylpyruvic acid as a phenylketone readout.
 diagnosis:
 - name: Newborn Screening for Hyperphenylalaninemia
   description: Initial diagnosis is made from heel-prick dried blood spot screening.
@@ -1407,6 +1569,17 @@ biochemical:
 - name: Blood Phenylalanine
   presence: Elevated
   context: Greater than 120 micromol/L, often greater than 1200 micromol/L in classic PKU
+  biomarker_term:
+    preferred_term: L-phenylalanine
+    term:
+      id: CHEBI:58095
+      label: L-phenylalanine zwitterion
+  readouts:
+  - target: Hyperphenylalaninemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated blood phenylalanine reports impaired PAH-dependent phenylalanine clearance.
   evidence:
   - reference: PMID:24385074
     reference_title: "Phenylalanine hydroxylase deficiency: diagnosis and management guideline."
@@ -1423,6 +1596,17 @@ biochemical:
 - name: Blood Tyrosine
   presence: Decreased
   context: Low due to blocked conversion from phenylalanine
+  biomarker_term:
+    preferred_term: L-tyrosine
+    term:
+      id: CHEBI:58315
+      label: L-tyrosine zwitterion
+  readouts:
+  - target: Relative Tyrosine Deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lower blood tyrosine reports reduced PAH-mediated conversion of phenylalanine to tyrosine.
   evidence:
   - reference: PMID:30570999
     reference_title: "Phenylketonuria (PKU)."
@@ -1439,6 +1623,17 @@ biochemical:
 - name: Phenylalanine to Tyrosine Ratio
   presence: Elevated
   context: Diagnostic marker
+  readouts:
+  - target: Hyperphenylalaninemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated Phe/Tyr ratio reports combined phenylalanine accumulation and reduced tyrosine production.
+  - target: Relative Tyrosine Deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated Phe/Tyr ratio reports the biochemical imbalance produced by impaired PAH flux.
   evidence:
   - reference: PMID:35952926
     reference_title: "Newborn screening and genetic features of patients with hyperphenylalaninemia in a southern Chinese population."
@@ -1455,6 +1650,17 @@ biochemical:
 - name: Phenylpyruvic Acid
   presence: Elevated
   context: Alternative metabolite in urine
+  biomarker_term:
+    preferred_term: phenylpyruvate
+    term:
+      id: CHEBI:26008
+      label: phenylpyruvate
+  readouts:
+  - target: Phenylketone Accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary phenylpyruvic acid reports diversion of excess phenylalanine into phenylketone metabolites.
   evidence:
   - reference: PMID:21565303
     reference_title: "Study on urinary metabolic profile of phenylketonuria by micellar electrokinetic capillary chromatography with dual electrochemical detection--potential clinical application in fast diagnosis of phenylketonuria."
@@ -1664,6 +1870,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Hyperphenylalaninemia
+    treatment_effect: MODULATES
+    description: Phenylalanine-free formula supports protein requirements while limiting phenylalanine burden.
+    evidence:
+    - reference: PMID:21555948
+      reference_title: "Phenylalanine hydroxylase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The mainstay of treatment for hyperphenylalaninemia involves a low-protein diet and use of a phenylalanine-free medical formula."
+      explanation: GeneReviews supports phenylalanine-free medical formula as part of hyperphenylalaninemia management.
   evidence:
   - reference: PMID:21555948
     reference_title: "Phenylalanine hydroxylase deficiency."
@@ -1971,6 +2188,13 @@ computational_models:
     evidence_source: COMPUTATIONAL
     snippet: "We built a three-compartment model, made the common transport across the BBB explicit, and included dopamine and serotonin synthesis as parts of the brain function to be delivered by FBA."
     explanation: Directly supports model architecture and PKU-relevant mechanistic scope.
+  modeled_mechanisms:
+  - target: Competitive Large Neutral Amino Acid Transport at the Blood-Brain Barrier
+    description: The FBA model explicitly represents shared BBB aromatic amino acid transport.
+  - target: Reduced Dopamine Biosynthesis
+    description: The FBA model includes dopamine synthesis as a brain-function objective affected by PKU metabolic constraints.
+  - target: Reduced Serotonin Biosynthesis
+    description: The FBA model includes serotonin synthesis as a brain-function objective affected by PKU metabolic constraints.
   notes: Explains brain-specific pathology and why Phe restriction outperforms Tyr supplementation
 - name: Recon3D with PAH knockout
   description: Human genome-scale metabolic model simulating phenylalanine hydroxylase deficiency
@@ -1994,6 +2218,11 @@ computational_models:
     evidence_source: COMPUTATIONAL
     snippet: "Recon3D represents the most comprehensive human metabolic network model to date, accounting for 3,288 open reading frames (representing 17% of functionally annotated human genes), 13,543 metabolic reactions involving 4,140 unique metabolites, and 12,890 protein structures."
     explanation: Supports use of Recon3D as a genome-scale computational base model for metabolic disease simulation.
+  modeled_mechanisms:
+  - target: Hepatic PAH Enzyme Deficiency
+    description: PAH knockout in Recon3D models the primary PAH-deficiency reaction defect.
+  - target: Hyperphenylalaninemia
+    description: PAH knockout is used to simulate the metabolic consequence of impaired phenylalanine clearance.
 - name: Harvey Whole-Body PKU Model
   description: Sex-specific whole-body model for organ-resolved IEM biomarker prediction.
   model_type: GENOME_SCALE_METABOLIC
@@ -2019,6 +2248,11 @@ computational_models:
     evidence_source: COMPUTATIONAL
     snippet: "We also illustrate that the WBM models can predict known biomarkers of inherited metabolic diseases in different biofluids."
     explanation: Supports biomarker prediction capability relevant to PKU and related IEM applications.
+  modeled_mechanisms:
+  - target: Hepatic PAH Enzyme Deficiency
+    description: Whole-body PAH absence models the inherited metabolic block across organs.
+  - target: Hyperphenylalaninemia
+    description: Whole-body modeling is used for inherited metabolic disease biomarker prediction, including phenylalanine-related biomarkers.
   notes: Whole-body WBM framework supports organ-resolved biomarker prediction in inherited metabolic disease.
 classifications:
   harrisons_chapter:


### PR DESCRIPTION
## Summary

- Connect isolated PKU neurocognitive, imaging, motor, psychiatric, and biochemical phenotype/readout nodes to existing PAH deficiency, hyperphenylalaninemia, brain toxicity, white-matter injury, and phenylketone mechanisms.
- Add CHEBI-backed biomarker terms/readouts for blood phenylalanine, blood tyrosine, Phe/Tyr ratio, and phenylpyruvic acid.
- Link medical formula and computational models to their existing target mechanisms.
- Keep food-source/aspartame exposure annotations standalone because the current graph extractor does not model environmental downstream edges.

## Validation

- `just validate kb/disorders/Phenylketonuria.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Phenylketonuria.yaml`
- Graph audit: 59 nodes, 64 edges, 9 components, 8 isolated nodes, 0 orphans, 0 integrity issues
  - Largest mechanism component improved from 28 nodes to 51 nodes
  - Remaining isolated nodes are five environmental exposure annotations plus growth delay, osteopenia, and maternal-PKU cardiovascular morphology
- Manual snippet audit: 165 evidence items audited, 98 unique snippets, 34 unique references; all audited snippets found in cached references after whitespace normalization
- `git diff --check`

## Scope Notes

Generated enum-cache and unrelated ClinicalTrials cache churn from local validation was restored and is not included in this PR.
