### PR TITLE
[codex] Improve GSD IV pathograph connectivity

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
@@ -290,11 +290,6 @@ pathophysiology:
     description: >
       Polyglucosan is abnormal glycogen material and is captured clinically as
       abnormal muscle glycogen content.
-  - target: Polyglucosan
-    causal_link_type: DIRECT
-    description: >
-      Polyglucosan is the biochemical storage product created by deficient
-      glycogen branching.
   - target: Hepatic polyglucosan storage and liver injury
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >

--- a/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
@@ -272,6 +272,12 @@ pathophysiology:
   description: >
     Impaired glycogen synthesis causes accumulation of poorly branched glycogen,
     also called polyglucosan, in multiple organs.
+  chemical_entities:
+  - preferred_term: poorly branched glycogen / polyglucosan
+    term:
+      id: CHEBI:28087
+      label: glycogen
+    modifier: INCREASED
   biological_processes:
   - preferred_term: glycogen metabolic process
     term:
@@ -284,6 +290,11 @@ pathophysiology:
     description: >
       Polyglucosan is abnormal glycogen material and is captured clinically as
       abnormal muscle glycogen content.
+  - target: Polyglucosan
+    causal_link_type: DIRECT
+    description: >
+      Polyglucosan is the biochemical storage product created by deficient
+      glycogen branching.
   - target: Hepatic polyglucosan storage and liver injury
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >
@@ -298,6 +309,11 @@ pathophysiology:
     description: >
       Skeletal muscle, peripheral nerve, and central nervous system storage
       contribute to neuromuscular manifestations across the GSD IV continuum.
+  - target: Generalized abnormality of skin
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: >
+      Orphanet records a generalized skin abnormality in GSD IV; the
+      intermediate mechanism from systemic polyglucosan storage is unresolved.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -335,6 +351,24 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
   - target: Portal hypertension
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Hepatosplenomegaly
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Hepatic storage disease can produce combined liver and spleen enlargement.
+  - target: Failure to thrive
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Progressive hepatic GSD IV causes infantile failure to thrive together with hepatomegaly and liver dysfunction.
+  - target: Prolonged prothrombin time
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Hepatic dysfunction can impair coagulation factor synthesis and prolong prothrombin time.
+  - target: Prolonged partial thromboplastin time
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Hepatic dysfunction can produce broader coagulation abnormalities, including prolonged partial thromboplastin time.
+  - target: Ascites
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Portal-hypertension and liver-failure complications can include ascites.
+  - target: Esophageal varix
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Portal-hypertension complications can include esophageal varices.
   evidence:
   - reference: PMID:23285490
     reference_title: Glycogen Storage Disease Type IV.
@@ -403,6 +437,24 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
   - target: Peripheral neuropathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Severe muscular hypotonia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Severe neuromuscular involvement can manifest as severe muscular hypotonia.
+  - target: Skeletal muscle atrophy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Chronic skeletal-muscle polyglucosan storage can manifest with skeletal muscle atrophy.
+  - target: Flexion contracture
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Severe fetal or neuromuscular involvement can be accompanied by flexion contractures.
+  - target: Spastic paraparesis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Adult polyglucosan body disease causes corticospinal and peripheral nerve involvement with spastic paraparesis.
+  - target: Polyhydramnios
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Fatal perinatal neuromuscular disease can present in utero with polyhydramnios.
+  - target: Nonimmune hydrops fetalis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Fatal perinatal neuromuscular disease can present in utero with fetal hydrops.
   evidence:
   - reference: PMID:23285490
     reference_title: Glycogen Storage Disease Type IV.
@@ -1133,6 +1185,12 @@ biochemical:
   context: >
     Reduced or deficient glycogen branching enzyme activity is the primary
     biochemical defect in GSD IV.
+  readouts:
+  - target: GBE1 deficiency and impaired glycogen branching
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced glycogen branching enzyme activity reports the primary GBE1 enzyme defect.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -1151,6 +1209,17 @@ biochemical:
   context: >
     Poorly branched glycogen/polyglucosan accumulates downstream of impaired
     glycogen branching.
+  biomarker_term:
+    preferred_term: polyglucosan
+    term:
+      id: CHEBI:28087
+      label: glycogen
+  readouts:
+  - target: Poorly branched glycogen and polyglucosan accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased polyglucosan reports abnormal poorly branched glycogen storage.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -1389,6 +1458,8 @@ references:
       hepatic, neuromuscular and/or cardiac symptoms.
 - reference: PMID:23285490
   title: Glycogen Storage Disease Type IV.
+  tags:
+  - GeneReviews
   findings:
   - statement: >
       GeneReviews defines the GSD IV clinical continuum, diagnostic testing, and


### PR DESCRIPTION
## Summary
- connected the GSD IV graph from GBE1 branching-enzyme deficiency through abnormal glycogen/polyglucosan storage to isolated hepatic, coagulation, portal-hypertension, prenatal, neuromuscular, dermatologic, and biochemical readout nodes
- added CHEBI-backed glycogen/polyglucosan chemical coverage and readout wiring for glycogen branching enzyme activity and polyglucosan storage
- tagged the existing GeneReviews reference PMID:23285490 in the top-level references block
- addressed Claude's non-blocking readout-cycle suggestion by removing the redundant downstream edge to the `Polyglucosan` biochemical node while keeping the readout link

## Graph audit
Before: nodes=45, edges=32, components=16, isolated=15, orphan_targets=0, integrity_issues=0.
After: nodes=45, edges=47, components=1, isolated=0, orphan_targets=0, integrity_issues=0.

## Validation
- `just validate kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml`
- `just validate-terms kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml`
- `just validate-references kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml` (Total checks: 0)
- manual snippet audit: 85 evidence items, 6 unique references, all snippets found
- graph audit: nodes=45, edges=47, components=1, isolated=0, orphan_targets=0, integrity_issues=0
- `git diff --check`

## Scope notes
This PR changes only `kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml`; no term or reference cache files are intentionally changed. Unrelated ClinicalTrials cache churn from validation was restored before commit.