### PR TITLE
[codex] Improve alkaptonuria pathograph connectivity

### DIFF
--- a/kb/disorders/Alkaptonuria.yaml
+++ b/kb/disorders/Alkaptonuria.yaml
@@ -1,7 +1,7 @@
 name: Alkaptonuria
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-08T00:00:00Z'
+updated_date: '2026-05-18T12:07:30Z'
 synonyms:
 - Hereditary ochronosis
 - Homogentisic acid oxidase deficiency
@@ -255,6 +255,28 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "based on the detection of a significant amount of HGA in the urine (usually 1 to"
       explanation: GeneReviews identifies urinary HGA detection as the biochemical diagnostic marker.
+  - target: Aminoaciduria
+    description: The urinary organic-acid abnormality is represented clinically as aminoaciduria dominated by homogentisic acid excess.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003355 | Aminoaciduria | Very frequent (99-80%)"
+      explanation: Orphanet lists aminoaciduria as a very frequent urinary biochemical manifestation.
+  - target: Nephrolithiasis
+    description: Urinary tract involvement in alkaptonuria includes renal stones.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - urinary homogentisic acid excess and stone complications
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "surgical intervention for prostate stones and renal"
+      explanation: GeneReviews lists renal stones among manifestations requiring intervention.
   - target: Dark urine
     description: Urinary HGA oxidizes on standing or air exposure, darkening urine.
     causal_link_type: DIRECT
@@ -358,6 +380,178 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "painful and severe form of"
       explanation: Disease primer links HGA-derived ochronosis to painful osteoarthropathy.
+  - target: Joint stiffness
+    description: Ochronotic arthropathy and cartilage degeneration produce joint stiffness.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic osteoarthropathy
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001387 | Joint stiffness | Very frequent (99-80%)"
+      explanation: Orphanet lists joint stiffness as a very frequent musculoskeletal manifestation.
+  - target: Joint swelling
+    description: Ochronotic arthropathy can manifest as joint swelling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic osteoarthropathy
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001386 | Joint swelling | Very frequent (99-80%)"
+      explanation: Orphanet lists joint swelling as a very frequent musculoskeletal manifestation.
+  - target: Joint dislocation
+    description: Severe ochronotic joint disease can be associated with joint dislocation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cartilage degeneration and ochronotic osteoarthropathy
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001373 | Joint dislocation | Very frequent (99-80%)"
+      explanation: Orphanet lists joint dislocation as a very frequent musculoskeletal manifestation.
+  - target: Back pain
+    description: Axial ochronotic arthropathy involving the spine produces back pain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - spine ochronotic osteoarthropathy
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003418 | Back pain | Frequent (79-30%)"
+      explanation: Orphanet lists back pain as a frequent axial musculoskeletal manifestation.
+  - target: Intervertebral disk calcification
+    description: Spinal connective-tissue degeneration includes intervertebral disk calcification.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - spinal cartilage and disk degeneration
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005645 | Intervertebral disk calcification | Very frequent (99-80%)"
+      explanation: Orphanet lists intervertebral disk calcification as a very frequent spinal finding.
+  - target: Cartilage calcification
+    description: Ochronotic cartilage degeneration includes calcification of cartilage.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cartilage ochronosis
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100593 | Calcification of cartilage | Very frequent (99-80%)"
+      explanation: Orphanet lists cartilage calcification as a very frequent manifestation.
+  - target: Cartilage destruction
+    description: Pigment deposition and degeneration can destroy cartilage.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic cartilage degeneration
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100773 | Cartilage destruction | Frequent (79-30%)"
+      explanation: Orphanet lists cartilage destruction as a frequent manifestation.
+  - target: Tendon rupture
+    description: Ochronotic involvement of collagen-rich tendon and ligament tissue increases rupture risk.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic tendon degeneration
+    evidence:
+    - reference: PMID:38453957
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "include kidney and prostate stones, aortic stenosis, bone fractures, and tendon,"
+      explanation: Disease primer lists tendon, ligament, and muscle ruptures among alkaptonuria manifestations.
+  - target: Thickened Achilles tendon
+    description: Ochronotic tendon involvement can manifest as Achilles tendon thickening.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ochronotic tendon degeneration
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0004690 | Thickened Achilles tendon | Frequent (79-30%)"
+      explanation: Orphanet lists thickened Achilles tendon as a frequent tendon manifestation.
+  - target: Hearing abnormality
+    description: Ochronotic pigment in ear cartilage can be associated with hearing abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ear cartilage ochronosis
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000364 | Hearing abnormality | Very frequent (99-80%)"
+      explanation: Orphanet lists hearing abnormality as a very frequent manifestation.
+  - target: Abnormality of vision
+    description: Ocular ochronosis and scleral/corneal pigmentation can contribute to visual abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ocular connective-tissue pigmentation
+    evidence:
+    - reference: ORPHA:56
+      reference_title: "Alkaptonuria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000504 | Abnormality of vision | Very frequent (99-80%)"
+      explanation: Orphanet lists abnormality of vision as a very frequent ocular manifestation.
+  - target: Aortic valve calcification
+    description: Ochronotic cardiovascular connective-tissue involvement can produce aortic valve calcification.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cardiovascular ochronosis and valve calcification
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: |-
+        pigment in the sclera, ear cartilage, and skin of the hands; aortic or mitral
+        valve calcification or regurgitation and occasionally aortic dilatation; renal
+      explanation: GeneReviews lists aortic valve calcification among manifestations.
+  - target: Mitral valve calcification
+    description: Ochronotic cardiovascular connective-tissue involvement can produce mitral valve calcification.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cardiovascular ochronosis and valve calcification
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: |-
+        pigment in the sclera, ear cartilage, and skin of the hands; aortic or mitral
+        valve calcification or regurgitation and occasionally aortic dilatation; renal
+      explanation: GeneReviews lists mitral valve calcification among manifestations.
+  - target: Coronary artery calcification
+    description: Later cardiovascular complications include coronary artery calcification.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cardiovascular ochronosis and calcification
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "CT imaging to detect coronary artery calcification."
+      explanation: GeneReviews surveillance guidance supports coronary artery calcification as a recognized manifestation.
 phenotypes:
 - name: Elevated urinary homogentisic acid
   frequency: VERY_FREQUENT
@@ -765,6 +959,24 @@ biochemical:
   context: >
     Urinary HGA is substantially increased and is the primary biochemical
     diagnostic marker.
+  biomarker_term:
+    preferred_term: homogentisic acid
+    term:
+      id: CHEBI:44747
+      label: homogentisic acid
+  readouts:
+  - target: Homogentisic acid accumulation and oxidation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary HGA reports the upstream HGD block and systemic HGA accumulation.
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "based on the detection of a significant amount of HGA in the urine (usually 1 to"
+      explanation: GeneReviews identifies urinary HGA as the diagnostic biochemical readout of alkaptonuria.
   evidence:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
@@ -783,6 +995,19 @@ biochemical:
   context: >
     Reduced HGD enzyme activity is the proximal biochemical defect that impairs
     tyrosine catabolism.
+  readouts:
+  - target: HGD molecular function deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced homogentisate 1,2-dioxygenase activity directly reports HGD molecular function deficiency.
+    evidence:
+    - reference: PMID:20301627
+      reference_title: "Alkaptonuria."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Alkaptonuria is caused by deficiency of homogentisate"
+      explanation: GeneReviews supports the enzyme activity deficit as the proximal HGD mechanism.
   evidence:
   - reference: PMID:20301627
     reference_title: "Alkaptonuria."
@@ -917,6 +1142,8 @@ references:
   findings: []
 - reference: PMID:20301627
   title: Alkaptonuria.
+  tags:
+  - GeneReviews
   found_in:
   - Alkaptonuria-deep-research-cyberian-codex.md
   findings: []

--- a/kb/disorders/Alkaptonuria.yaml
+++ b/kb/disorders/Alkaptonuria.yaml
@@ -256,15 +256,21 @@ pathophysiology:
       snippet: "based on the detection of a significant amount of HGA in the urine (usually 1 to"
       explanation: GeneReviews identifies urinary HGA detection as the biochemical diagnostic marker.
   - target: Aminoaciduria
-    description: The urinary organic-acid abnormality is represented clinically as aminoaciduria dominated by homogentisic acid excess.
-    causal_link_type: DIRECT
+    description: >
+      Orphanet retains a broad aminoaciduria HPO annotation for the urinary
+      biochemical phenotype; the more specific elevated urinary homogentisic
+      acid phenotype is modeled separately.
+    causal_link_type: UNKNOWN
     evidence:
     - reference: ORPHA:56
       reference_title: "Alkaptonuria (Orphanet structured-database record)"
       supports: SUPPORT
       evidence_source: OTHER
       snippet: "HP:0003355 | Aminoaciduria | Very frequent (99-80%)"
-      explanation: Orphanet lists aminoaciduria as a very frequent urinary biochemical manifestation.
+      explanation: >
+        Orphanet lists aminoaciduria as a very frequent broad urinary
+        biochemical annotation, distinct from the separately modeled elevated
+        urinary homogentisic acid phenotype.
   - target: Nephrolithiasis
     description: Urinary tract involvement in alkaptonuria includes renal stones.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -940,7 +946,10 @@ phenotypes:
     explanation: GeneReviews supports scleral pigmentation as a manifestation.
 - name: Aminoaciduria
   frequency: VERY_FREQUENT
-  description: Aminoaciduria captures the urinary organic-acid abnormality dominated by homogentisic acid excess.
+  description: >
+    Orphanet annotates aminoaciduria as a very frequent broad urinary
+    biochemical phenotype; the canonical and more specific abnormality is
+    elevated urinary homogentisic acid.
   phenotype_term:
     preferred_term: Aminoaciduria
     term:


### PR DESCRIPTION
## Summary
- Connect alkaptonuria pathograph phenotypes through the HGD deficiency -> HGA accumulation/oxidation -> ochronotic tissue degeneration mechanism chain.
- Add downstream support for urinary, musculoskeletal, ocular/ear, cardiovascular, tendon, and renal manifestations using exact cached snippets from Orphanet, GeneReviews, and the 2024 disease primer.
- Add explicit biochemical readouts for urinary homogentisic acid and reduced homogentisate 1,2-dioxygenase activity, including CHEBI annotation for homogentisic acid, and tag the GeneReviews reference.

## Graph Audit
- Before: nodes=30 edges=15 components=17 isolated=16 orphan_targets=0 integrity_issues=0
- After: nodes=30 edges=33 components=1 isolated=0 orphan_targets=0 integrity_issues=0

## Validation
- `just validate kb/disorders/Alkaptonuria.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Alkaptonuria.yaml`
- `just validate-terms kb/disorders/Alkaptonuria.yaml`
- `just validate-references kb/disorders/Alkaptonuria.yaml` (0 checks; followed by manual audit)
- Manual snippet audit: 94 evidence items, 8 unique references, all snippets found in cache
- Manual graph audit: nodes=30 edges=33 components=1 isolated=0 orphan_targets=0 integrity_issues=0
- `git diff --check`

## Scope
- Only `kb/disorders/Alkaptonuria.yaml` is intentionally changed.
- Unrelated validator churn in ClinicalTrials cache files was restored before commit.