### PR TITLE
[codex] Improve Arginase Deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Arginase_Deficiency.yaml
+++ b/kb/disorders/Arginase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Arginase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T16:40:30Z'
+updated_date: '2026-05-18T14:02:11Z'
 synonyms:
 - Argininemia
 - Hyperargininemia
@@ -105,6 +105,19 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: This genetic disorder is caused by 40+ mutations found fairly uniformly spread throughout the ARG1 gene, resulting in partial or complete loss of enzyme function, which catalyzes the hydrolysis of arginine to ornithine and urea.
       explanation: Supports decreased arginase activity as a direct consequence of ARG1 pathogenic variants.
+  - target: Hepatomegaly
+    description: Hepatic ARG1 deficiency can present with cholestatic liver disease and hepatosplenomegaly in neonatal cases.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cholestatic liver disease
+    - hepatic dysfunction
+    evidence:
+    - reference: PMID:21229317
+      reference_title: "Neonatal cholestasis: an uncommon presentation of hyperargininemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: In case 1, diagnosis was established at 2 months of age upon investigation of the etiology of cholestatic injury pattern and hepatosplenomegaly
+      explanation: Supports hepatic involvement with hepatosplenomegaly as a manifestation of ARG1 deficiency.
 - name: Impaired ureagenesis and hyperargininemia
   description: 'Loss of ARG1 activity causes persistent hyperargininemia with plasma arginine levels exceeding 300 umol/L, impaired nitrogen disposal, and intermittent hyperammonemia during catabolic stress. Unlike other urea cycle disorders, hyperammonemia is relatively infrequent, and the dominant disease driver is chronic arginine toxicity.
 
@@ -271,12 +284,19 @@ pathophysiology:
     snippet: Different factors, such as the accumulation of arginine, ammonia, and guanidino compounds, act as neurotoxins and may account for the neurological sequelae observed in the disease.
     explanation: Directly supports neurotoxicity from accumulated arginine-related metabolites.
   downstream:
-  - target: White matter pathology and dysmyelination
-    description: Chronic metabolite neurotoxicity contributes to progressive CNS injury and white matter pathology.
+  - target: CNS white matter pathology
+    description: Chronic metabolite neurotoxicity contributes to neuronal damage and downstream white matter pathology.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - chronic neurotoxic metabolite exposure
-    - progressive neurological deterioration
+    - neuronal damage
+    evidence:
+    - reference: PMID:18321250
+      reference_title: "Neuroimaging findings in hyperargininemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Though the pathogenesis of neuronal damage in hyperargininemia is not clear, high serum and cerebrospinal fluid arginine levels can be directly related with neuronal damage.
+      explanation: Supports a metabolite-neurotoxicity link from elevated arginine to CNS injury.
   - target: Spastic paraparesis
     description: Metabolite neurotoxicity underlies the progressive spastic paraparesis hallmark of ARG1-D.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -338,32 +358,32 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: The disease is associated with progressive development of spasticity and other symptoms, including seizures, developmental delay, cognitive impairment, and hepatic pathology.
       explanation: Supports developmental delay and cognitive impairment as part of the downstream neurological phenotype.
-- name: White matter pathology and dysmyelination
-  description: 'Central nervous system white matter pathology with dysmyelination is modeled as a substrate for progressive spasticity in ARG1 deficiency.
+  - target: Microcephaly
+    description: Progressive neurologic involvement in ARG1 deficiency can include microcephaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23920045
+      reference_title: "Lethal phenotype in conditional late-onset arginase 1 deficiency in the mouse."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: It usually presents with an insidious onset and manifests with a progressive neurological syndrome with microcephaly, spasticity, seizures, clonus, spastic diplegia, and failure to thrive
+      explanation: The paper's background summarizes reported human clinical features, supporting microcephaly as part of the neurologic syndrome but not defining the exact causal intermediate.
+- name: CNS white matter pathology
+  description: 'White matter lesions, altered white-matter MRS patterns, and cortical or cerebellar atrophy are modeled as central nervous system substrates for progressive spasticity in ARG1 deficiency.
 
     '
-  biological_processes:
-  - preferred_term: myelination
-    term:
-      id: GO:0042552
-      label: myelination
-  cell_types:
-  - preferred_term: oligodendrocyte
-    term:
-      id: CL:0000128
-      label: oligodendrocyte
   locations:
   - preferred_term: white matter
     term:
       id: UBERON:0002316
       label: white matter
   evidence:
-  - reference: PMID:39449289
-    reference_title: "Exploring RNA therapeutics for urea cycle disorders."
-    supports: PARTIAL
-    evidence_source: MODEL_ORGANISM
-    snippet: LNP-formulated mRNA therapy has been assayed preclinically for citrullinemia type I (CTLN1), adolescent and adult citrin deficiency, argininosuccinic aciduria, arginase deficiency and ornithine transcarbamylase deficiency, in the latter case has progressed to the clinical trials phase.
-    explanation: Confirms preclinical mRNA therapy testing for arginase deficiency but does not specifically address myelination outcomes.
+  - reference: PMID:20456883
+    reference_title: "A long-term survival case of arginase deficiency with severe multicystic white matter and compound mutations."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: The magnetic resonance imaging (MRI) of our case showed severe multicystic white matter lesions with cortical atrophy
+    explanation: Directly supports clinically observed white matter pathology in ARG1 deficiency.
   - reference: PMID:22633632
     reference_title: "Clinical features and neurologic progression of hyperargininemia."
     supports: SUPPORT
@@ -371,6 +391,16 @@ pathophysiology:
     snippet: Progressive spastic diplegia constituted the key clinical abnormality in this group, but variability in clinical presentation and progression were evident in our series.
     explanation: Clinical evidence of progressive spasticity consistent with corticospinal tract and white matter pathology.
   downstream:
+  - target: Abnormal cerebral white matter morphology
+    description: White matter lesions and abnormal white-matter imaging are captured as abnormal cerebral white matter morphology.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20456883
+      reference_title: "A long-term survival case of arginase deficiency with severe multicystic white matter and compound mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The magnetic resonance imaging (MRI) of our case showed severe multicystic white matter lesions with cortical atrophy
+      explanation: Directly connects the white matter pathology mechanism to the neuroimaging phenotype node.
   - target: Spastic paraparesis
     description: White matter and corticospinal tract pathology contributes to progressive spastic paraparesis.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -451,6 +481,17 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: Arginase 1 Deficiency (ARG1-D) is a rare debilitating, progressive, inherited, metabolic disease characterized by marked increases in plasma arginine (pArg) and its metabolites, with increased morbidity, substantial reductions in quality of life, and premature mortality.
     explanation: Confirms that metabolite accumulation is part of the ARG1-D clinical spectrum.
+  sequelae:
+  - target: Encephalopathy
+    description: Hyperammonemic crises can present with acute encephalopathy or coma.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41684183
+      reference_title: "Cluster of Severe Arginase 1 Deficiency in the Comoros: Clinical, Neuroimaging, and Molecular Features in 17 Patients From Mayotte Compared With 10 From Paris."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The main clinical features at diagnosis included hyperammonemic coma (with or without liver failure) and neurodevelopmental delay with spastic diplegia.
+      explanation: Supports hyperammonemic coma as a severe acute neurologic manifestation downstream of hyperammonemia.
 - name: Seizures
   frequency: FREQUENT
   description: 'Seizures occur in approximately 60-75% of patients and are linked to the epileptogenic properties of accumulated guanidino compounds. Seizure frequency may be more common than historically reported.
@@ -560,9 +601,14 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: Hyperargininemia is an autosomal recessive metabolic disorder caused by a deficiency of enzyme arginase I. It is a rare pan-ethnic disease with a clinical presentation distinct from that of other urea cycle disorders, and hyperammonemic encephalopathy is not usually observed.
     explanation: Confirms that hyperammonemic encephalopathy can occur but is not a usual finding.
+  - reference: PMID:41684183
+    reference_title: "Cluster of Severe Arginase 1 Deficiency in the Comoros: Clinical, Neuroimaging, and Molecular Features in 17 Patients From Mayotte Compared With 10 From Paris."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: The main clinical features at diagnosis included hyperammonemic coma (with or without liver failure) and neurodevelopmental delay with spastic diplegia.
+    explanation: Describes hyperammonemic coma at diagnosis in a severe ARG1-D cohort, supporting acute encephalopathy as a disease manifestation.
 - name: Hepatomegaly
-  frequency: OCCASIONAL
-  description: 'Hepatic involvement including hepatomegaly may occur, reflecting the primary hepatic expression of ARG1 and metabolic stress on the liver.
+  description: 'Hepatic involvement including hepatomegaly or hepatosplenomegaly may occur, particularly in rare neonatal cholestatic presentations of ARG1 deficiency.
 
     '
   phenotype_term:
@@ -571,6 +617,13 @@ phenotypes:
       id: HP:0002240
       label: Hepatomegaly
   notes: Hepatomegaly has been reported in case reports of ARG1 deficiency but robust frequency data are lacking.
+  evidence:
+  - reference: PMID:21229317
+    reference_title: "Neonatal cholestasis: an uncommon presentation of hyperargininemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: In case 1, diagnosis was established at 2 months of age upon investigation of the etiology of cholestatic injury pattern and hepatosplenomegaly
+    explanation: Supports hepatosplenomegaly as part of hepatic presentation in ARG1 deficiency.
 - name: Hyperargininemia
   frequency: VERY_FREQUENT
   description: 'Persistent elevation of plasma arginine, often exceeding 300 umol/L, is the defining biochemical feature. Plasma arginine levels are the primary biomarker for disease monitoring and therapeutic response.
@@ -606,8 +659,7 @@ phenotypes:
       snippet: ARG1-deficient patients exhibit hyperargininemia with spastic paraparesis, progressive neurological and intellectual impairment, persistent growth retardation, and infrequent episodes of hyperammonemia
       explanation: Supports growth retardation as part of the hyperargininemia clinical syndrome.
 - name: Abnormal cerebral white matter morphology
-  frequency: FREQUENT
-  description: 'Neuroimaging abnormalities including white matter changes, cerebral atrophy, and cerebellar atrophy are commonly observed and correlate with the progressive neurological deterioration.
+  description: 'Neuroimaging abnormalities including white matter lesions, altered white-matter MRS metabolite patterns, cerebral atrophy, and cerebellar atrophy have been reported in hyperargininemia.
 
     '
   phenotype_term:
@@ -616,15 +668,20 @@ phenotypes:
       id: HP:0002500
       label: Abnormal cerebral white matter morphology
   evidence:
-  - reference: PMID:22633632
-    reference_title: "Clinical features and neurologic progression of hyperargininemia."
+  - reference: PMID:20456883
+    reference_title: "A long-term survival case of arginase deficiency with severe multicystic white matter and compound mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: Features distinguishing hyperargininemia from cerebral palsy and hereditary spastic paraplegia are emphasized in this large series of patients.
-    explanation: Clinical and neuroimaging findings help distinguish hyperargininemia from other spastic disorders.
+    snippet: The magnetic resonance imaging (MRI) of our case showed severe multicystic white matter lesions with cortical atrophy
+    explanation: Directly supports abnormal cerebral white matter morphology in ARG1 deficiency.
+  - reference: PMID:18321250
+    reference_title: "Neuroimaging findings in hyperargininemia."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: We observed mild cerebral and cerebellar atrophy and infarct at bilateral posterior putamen and insular cortex localization on conventional images and elevated choline/creatine ratios and abnormal peak at 3.8 ppm
+    explanation: Supports cerebral and white-matter neuroimaging abnormalities in hyperargininemia.
 - name: Microcephaly
-  frequency: OCCASIONAL
-  description: 'Microcephaly has been reported in some patients, likely reflecting the chronic neurotoxic effects on brain development during critical periods of growth.
+  description: 'Microcephaly has been reported as part of the progressive neurological syndrome in some patients with ARG1 deficiency; the precise causal intermediate is uncertain.
 
     '
   phenotype_term:
@@ -632,7 +689,14 @@ phenotypes:
     term:
       id: HP:0000252
       label: Microcephaly
-  notes: Microcephaly has been reported in some ARG1-deficient patients but the abstract does not specifically quantify this finding.
+  notes: Microcephaly has been reported in some ARG1-deficient patients but available abstracts do not quantify its frequency.
+  evidence:
+  - reference: PMID:23920045
+    reference_title: "Lethal phenotype in conditional late-onset arginase 1 deficiency in the mouse."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: It usually presents with an insidious onset and manifests with a progressive neurological syndrome with microcephaly, spasticity, seizures, clonus, spastic diplegia, and failure to thrive
+    explanation: The paper's background summarizes reported human clinical features of arginase deficiency and includes microcephaly.
 biochemical:
 - name: Plasma arginine
   presence: INCREASED
@@ -917,6 +981,17 @@ treatments:
     term:
       id: MAXO:0000079
       label: genetic counseling
+  target_mechanisms:
+  - target: ARG1 pathogenic variants
+    treatment_effect: MODULATES
+    description: Counseling and reproductive testing are anchored to the family's ARG1 pathogenic variants.
+    evidence:
+    - reference: PMID:20301338
+      reference_title: "Arginase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Carrier testing for at-risk relatives and prenatal testing for pregnancies at increased risk are possible if the ARG1 pathogenic variants in the family are known.
+      explanation: GeneReviews supports carrier and prenatal testing when familial ARG1 variants are known.
   evidence:
   - reference: PMID:26467175
     reference_title: "Arginase-1 deficiency."
@@ -924,10 +999,20 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: Arginase-1 (ARG1) deficiency is a rare autosomal recessive disorder that affects the liver-based urea cycle, leading to impaired ureagenesis.
     explanation: Autosomal recessive inheritance pattern supports the role of genetic counseling.
+  - reference: PMID:20301338
+    reference_title: "Arginase Deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "GENETIC COUNSELING: Arginase deficiency is inherited in an autosomal recessive manner."
+    explanation: GeneReviews directly supports genetic counseling for autosomal recessive inheritance.
 notes: 'Key distinguishing features of ARG1 deficiency among urea cycle disorders: (1) hyperammonemia is infrequent rather than dominant; (2) progressive spastic paraparesis is the hallmark presentation; (3) the disease is often initially confused with cerebral palsy or hereditary spastic paraplegia; (4) chronic arginine toxicity and guanidino compound accumulation drive neurological injury rather than acute ammonia crises. The Phase 3 PEACE trial of pegzilarginase represents a major advance, demonstrating that sustained arginine normalization is achievable and associated with functional mobility improvements. Gene therapy and mRNA therapeutic approaches are in preclinical development. Caution is warranted in extrapolating mouse model findings, as the lethal disease phenotype in mice is substantially more severe than in humans.
 
   '
 references:
+- reference: PMID:20301338
+  title: "Arginase Deficiency."
+  tags:
+  - GeneReviews
 - reference: DOI:10.1002/jimd.12609
   title: 'Gene therapy for urea cycle defects: An update from historical perspectives to future prospects'
   found_in:

--- a/kb/disorders/Arginase_Deficiency.yaml
+++ b/kb/disorders/Arginase_Deficiency.yaml
@@ -934,6 +934,7 @@ treatments:
   description: 'Seizure management with appropriate antiepileptic drugs, given that seizures occur in 60-75% of patients. Seizure control is an important aspect of supportive care.
 
     '
+  notes: Valproic acid should be avoided in ARG1 deficiency because it can exacerbate hyperammonemia.
   treatment_term:
     preferred_term: antiepileptic drug therapy
     term:
@@ -946,6 +947,12 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: Seizures in hyperargininemia may be more common than reported in previous studies.
     explanation: High seizure frequency supports the need for antiepileptic management.
+  - reference: PMID:20301338
+    reference_title: "Arginase Deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Agents/circumstances to avoid: Valproic acid (exacerbates hyperammonemia)."
+    explanation: GeneReviews identifies valproic acid as an agent to avoid because it can exacerbate hyperammonemia.
   target_phenotypes:
   - preferred_term: Seizure
     term:

--- a/references_cache/PMID_20301338.md
+++ b/references_cache/PMID_20301338.md
@@ -1,0 +1,104 @@
+---
+reference_id: "PMID:20301338"
+title: Arginase Deficiency.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Sun A
+- Crombez EA
+- Wong D
+year: '1993'
+content_type: abstract_only
+---
+
+# Arginase Deficiency.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Sun A, Crombez EA, Wong D
+
+## Content
+
+1. Arginase Deficiency.
+
+Sun A(1), Crombez EA(2), Wong D(3).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2004 Oct 21 [updated 2020 May 28].
+
+Author information:
+(1)Seattle Children's Hospital;, University of Washington, Seattle, Washington
+(2)Ultragenyx Pharmaceutical Inc, Novato, California
+(3)University of California Los Angeles Medical Center, Los Angeles, California
+
+CLINICAL CHARACTERISTICS: Arginase deficiency in untreated individuals is
+characterized by episodic hyperammonemia of variable degree that is infrequently
+severe enough to be life threatening or to cause death. Most commonly, birth and
+early childhood are normal. Untreated individuals have slowing of linear growth
+at age one to three years, followed by development of spasticity, plateauing of
+cognitive development, and subsequent loss of developmental milestones. If
+untreated, arginase deficiency usually progresses to severe spasticity, loss of
+ambulation, complete loss of bowel and bladder control, and severe intellectual
+disability. Seizures are common and are usually controlled easily. Individuals
+treated from birth, either as a result of newborn screening or having an
+affected older sib, appear to have minimal symptoms.
+DIAGNOSIS/TESTING: The diagnosis of arginase deficiency is established in a
+proband with suggestive clinical and/or biochemical findings and confirmed by
+identification of biallelic pathogenic variants in ARG1 or, in limited
+instances, by failure to detect arginase enzyme activity (usually <1% of normal)
+in red blood cell extracts.
+MANAGEMENT: Treatment of manifestations: Management should closely mirror that
+for urea cycle disorders, except that individuals with arginase deficiency are
+not as likely to have episodes of hyperammonemia; if present, such episodes
+respond to conservative management (e.g., intravenous fluid administration).
+Treatment should involve a team coordinated by a metabolic specialist. Routine
+outpatient management includes restriction of dietary protein and consideration
+of oral nitrogen-scavenging drugs (in those who have chronic or recurrent
+hyperammonemia). Treatment of an acutely ill (comatose and encephalopathic)
+individual requires: rapid reduction of plasma ammonia concentration; use of
+pharmacologic agents (sodium benzoate and/or sodium
+phenylbutyrate/phenylacetate) to promote excretion of excess nitrogen through
+alternative pathways; and introduction of calories supplied by carbohydrates and
+fat to reduce catabolism and the amount of excess nitrogen in the diet while
+avoiding overhydration and resulting cerebral edema. Standard treatment for
+seizures, spasticity, developmental delay / intellectual disability, and joint
+contractures. In those with persistent hepatic synthetic function abnormalities,
+fresh-frozen plasma should be considered prior to surgical procedures. In the
+rare instance of progression to hepatic fibrosis and cirrhosis, liver
+transplantation can be considered. Prevention of primary manifestations:
+Maintenance of plasma arginine concentration as near normal as possible through
+restriction of dietary protein and use of oral nitrogen-scavenging drugs as
+necessary to treat hyperammonemia. Liver transplantation eliminates
+hyperargininemia and presumably the risk for hyperammonemia but is rarely
+necessary in arginase deficiency. Surveillance: Regular follow up at intervals
+determined by age and degree of metabolic stability. Assessment of metabolic
+control (plasma ammonia, amino acid profile, and nutritional labs) at least
+monthly for the first year of life and as determined by a metabolic specialist
+after the first year of life; guanidinoacetate and liver function tests every
+six to 12 months; monitoring of growth and developmental progress at each visit.
+Agents/circumstances to avoid: Valproic acid (exacerbates hyperammonemia).
+Evaluation of relatives at risk: Plasma quantitative amino acid analysis,
+molecular genetic testing (if the family-specific pathogenic variants are
+known), or enzymatic testing in all sibs (especially younger ones) of a proband
+to allow early diagnosis and treatment of those found to be affected. Pregnancy
+management: In general, affected pregnant women should continue dietary protein
+restriction and ammonia-scavenging medications (after an appropriate
+benefit/risk calculation) based on their clinical course before pregnancy.
+Other: Immunizations on the usual schedule; appropriate use of antipyretics as
+indicated (ibuprofen preferred over acetaminophen).
+GENETIC COUNSELING: Arginase deficiency is inherited in an autosomal recessive
+manner. At conception, each sib of an affected individual has a 25% chance of
+being affected, a 50% chance of being an asymptomatic carrier, and a 25% chance
+of being unaffected and not a carrier. Heterozygotes (carriers) are
+asymptomatic. Carrier testing for at-risk relatives and prenatal testing for
+pregnancies at increased risk are possible if the ARG1 pathogenic variants in
+the family are known.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 20301338


### PR DESCRIPTION
## Summary

Strengthens the Arginase Deficiency pathograph by connecting the remaining isolated clinical and management nodes into the causal graph.

- Replaces the weak RNA-therapeutics/myelination support with direct neuroimaging evidence for CNS white matter pathology.
- Connects encephalopathy, hepatomegaly, microcephaly, abnormal white matter morphology, and genetic counseling with evidence-backed edges.
- Adds the Arginase Deficiency GeneReviews cache via `just fetch-reference PMID:20301338`.

## Validation

- `just validate kb/disorders/Arginase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Arginase_Deficiency.yaml`
- `just validate-terms kb/disorders/Arginase_Deficiency.yaml`
- `just validate-references kb/disorders/Arginase_Deficiency.yaml` (0 automated checks; manual snippet audit passed)
- `just check-reference-cache-frontmatter`
- Manual graph audit: 33 nodes / 37 edges / 1 component / 0 isolated / 0 orphan targets / 0 integrity issues
- `git diff --check`

Unrelated ClinicalTrials cache churn was restored before commit.