### PR TITLE
[codex] Improve Argininosuccinic Aciduria pathograph connectivity

### DIFF
--- a/kb/disorders/Argininosuccinic_Aciduria.yaml
+++ b/kb/disorders/Argininosuccinic_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: Argininosuccinic Aciduria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-05T16:40:30Z'
+updated_date: '2026-05-18T14:31:01Z'
 synonyms:
 - Argininosuccinate lyase deficiency
 - ASLD
@@ -258,6 +258,45 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Patients present with developmental delay, epilepsy and movement disorder, associated with NO-mediated downregulation of central catecholamine biosynthesis.
       explanation: Supports epilepsy as part of the linked neurological phenotype.
+  - target: Intellectual disability
+    description: ASLD long-term neurocognitive deficits can occur without hyperammonemic episodes, implicating ASL functions outside hepatic ureagenesis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ammonia-independent ASL function
+    - tissue-specific ASL deficiency
+    evidence:
+    - reference: PMID:22241104
+      reference_title: "Argininosuccinate lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: These long-term complications can occur in the absence of hyperammonemic episodes, implying that ASL has functions outside of its role in ureagenesis and the tissue-specific lack of ASL may be responsible for these manifestations.
+      explanation: Supports neurocognitive disability as part of an ammonia-independent ASLD mechanism.
+  - target: Muscular hypotonia
+    description: Hypotonia and fatigue are neurodegeneration-related symptoms tracked in the ASLD neurological phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neurodegeneration-related symptoms
+    - central catecholamine dysregulation
+    evidence:
+    - reference: PMID:38044746
+      reference_title: "The incidence of movement disorder increases with age and contrasts with subtle and limited neuroimaging abnormalities in argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "We identified 60 patients and specifically looked for neurodegeneration-related symptoms: movement disorder such as ataxia, tremor and dystonia, hypotonia/fatigue and abnormal behaviour."
+      explanation: Supports hypotonia/fatigue as part of the late neurological ASLD phenotype.
+  - target: Abnormal behavior
+    description: Abnormal behaviour is part of the neurodegeneration-related symptom spectrum reported in ASA cohorts.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neurodegeneration-related symptoms
+    - central catecholamine dysregulation
+    evidence:
+    - reference: PMID:38044746
+      reference_title: "The incidence of movement disorder increases with age and contrasts with subtle and limited neuroimaging abnormalities in argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "We identified 60 patients and specifically looked for neurodegeneration-related symptoms: movement disorder such as ataxia, tremor and dystonia, hypotonia/fatigue and abnormal behaviour."
+      explanation: Supports abnormal behaviour as part of the reported ASLD neurological symptom spectrum.
   - target: Oxidative stress and glutathione dysregulation
     description: Endothelial ASL loss reduces NO production and is accompanied by oxidative stress.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -455,6 +494,12 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: Patients present with developmental delay, epilepsy and movement disorder, associated with NO-mediated downregulation of central catecholamine biosynthesis.
     explanation: Supports neurocognitive deficits as a key feature of ASA with NO-mediated mechanism.
+  - reference: PMID:22241104
+    reference_title: "Argininosuccinate lyase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "long-term complications that include liver dysfunction, neurocognitive deficits, and hypertension."
+    explanation: Identifies neurocognitive deficits as a long-term complication of ASLD.
 - name: Seizures
   frequency: FREQUENT
   description: 'Epilepsy is a common neurological manifestation in ASA. In a Saudi cohort with severe neonatal phenotype, seizures were present in all affected patients. Seizures may occur even with good metabolic control.
@@ -886,6 +931,24 @@ treatments:
     term:
       id: MAXO:0000079
       label: genetic counseling
+  target_mechanisms:
+  - target: ASL (argininosuccinate lyase) variants
+    treatment_effect: MODULATES
+    description: Counseling and molecular diagnosis are anchored to the family's ASL pathogenic variants.
+    evidence:
+    - reference: PMID:26843370
+      reference_title: "NGS in argininosuccinic aciduria detects a mutation (D145G) which drives alternative splicing of ASL: a case report study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Argininosuccinic aciduria (ASAuria; OMIM 207900) is a rare autosomal recessive heterogeneous urea cycle disorder
+      explanation: Supports autosomal recessive ASL-related disease as the basis for genetic counseling.
+  evidence:
+  - reference: PMID:26843370
+    reference_title: "NGS in argininosuccinic aciduria detects a mutation (D145G) which drives alternative splicing of ASL: a case report study."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: This study also demonstrates the value of NGS in the identification of mutations and molecular diagnosis for ASAuria families.
+    explanation: Supports molecular diagnosis of ASA families as part of genetic counseling.
   notes: >-
     Genetic counseling is essential for ASA families due to autosomal recessive inheritance,
     25% recurrence risk, and the well-characterized molecular basis of the disease
@@ -906,6 +969,11 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: Interrogations have raised about the benefit of newborn screening or liver transplantation on the neurological phenotype.
     explanation: Supports newborn screening availability while noting uncertainty about neurological benefit.
+  target_phenotypes:
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
 - name: mRNA therapy (investigational)
   description: 'Lipid nanoparticle-delivered human ASL mRNA is an emerging investigational therapy that has shown preclinical efficacy in correcting both glutathione metabolism and ureagenesis in ASL-deficient mouse models, with rescue of chronic liver disease. This approach supports clinical translation for ASA.
 


### PR DESCRIPTION
## Summary

Strengthens the Argininosuccinic Aciduria pathograph by connecting the remaining isolated nodes into the disease graph.

- Adds evidence-backed downstream links from the NO/neurocognitive branch to intellectual disability, hypotonia/fatigue, and abnormal behavior.
- Connects genetic counseling to ASL pathogenic variants with autosomal recessive/molecular diagnosis evidence.
- Connects newborn screening to the hyperammonemia phenotype so the screening intervention is no longer isolated.

## Validation

- `just validate kb/disorders/Argininosuccinic_Aciduria.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Argininosuccinic_Aciduria.yaml`
- `just validate-terms kb/disorders/Argininosuccinic_Aciduria.yaml`
- `just validate-references kb/disorders/Argininosuccinic_Aciduria.yaml` (0 automated checks; manual snippet audit passed)
- Manual graph audit: 33 nodes / 37 edges / 1 component / 0 isolated / 0 orphan targets / 0 integrity issues
- `git diff --check`

Unrelated ClinicalTrials cache churn was restored before commit.