### PR TITLE
[codex] Improve 2-Methylbutyryl-CoA dehydrogenase pathograph connectivity

### DIFF
--- a/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 2-Methylbutyryl-CoA Dehydrogenase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-09T11:45:26Z'
+updated_date: '2026-05-18T15:13:54Z'
 synonyms:
 - Short/branched-chain acyl-CoA dehydrogenase deficiency
 - SBCADD
@@ -323,6 +323,77 @@ pathophysiology:
     term:
       id: CL:0000125
       label: glial cell
+  downstream:
+  - target: Developmental delay
+    description: 2-MBG-associated oxidative brain stress provides a plausible mechanistic branch for developmental delay in symptomatic SBCADD.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical onset occurs in newborns or later in life with seizures, developmental delay, hypotonia, and failure to thrive."
+      explanation: Human literature review supports developmental delay among symptomatic SBCADD features; the oxidative-stress node supplies the mechanistic context.
+  - target: Seizures
+    description: Neural oxidative stress is a plausible contributor to seizures in the symptomatic minority.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical onset occurs in newborns or later in life with seizures, developmental delay, hypotonia, and failure to thrive."
+      explanation: Human literature review supports seizures among symptomatic SBCADD features; the oxidative-stress node supplies the mechanistic context.
+  - target: Muscular hypotonia
+    description: 2-MBG-associated brain oxidative stress provides a plausible mechanism for hypotonia in symptomatic SBCADD.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical onset occurs in newborns or later in life with seizures, developmental delay, hypotonia, and failure to thrive."
+      explanation: Human literature review supports hypotonia among symptomatic SBCADD features; the oxidative-stress node supplies the mechanistic context.
+  - target: Microcephaly
+    description: Longitudinal neurodevelopmental complications can include microcephaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "On longitudinal follow-up, epilepsy, developmental delay, microcephaly, and autism can develop."
+      explanation: Human follow-up data support microcephaly as a longitudinal feature; the oxidative-stress node supplies the mechanistic context.
+  - target: Autism
+    description: Longitudinal neurodevelopmental complications can include autism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "On longitudinal follow-up, epilepsy, developmental delay, microcephaly, and autism can develop."
+      explanation: Human follow-up data support autism as a longitudinal feature; the oxidative-stress node supplies the mechanistic context.
+  - target: Dyskinetic cerebral palsy
+    description: Severe neurologic injury in early reported patients included athetoid cerebral palsy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:12837870
+      reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "One patient developed athetoid cerebral palsy, and another had severe motor developmental delay with muscle atrophy."
+      explanation: Early patient observations support severe motor neurologic outcomes; the oxidative-stress node supplies the mechanistic context.
+  - target: Skeletal muscle atrophy
+    description: Severe motor developmental delay in early SBCADD cases included muscle atrophy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:12837870
+      reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "One patient developed athetoid cerebral palsy, and another had severe motor developmental delay with muscle atrophy."
+      explanation: Early patient observations support muscle atrophy in a severe motor presentation; the oxidative-stress node supplies the mechanistic context.
   evidence:
   - reference: PMID:22967964
     reference_title: "2-Methylbutyrylglycine induces lipid oxidative damage and decreases the antioxidant defenses in rat brain."
@@ -345,6 +416,17 @@ pathophysiology:
     term:
       id: GO:0042594
       label: response to starvation
+  downstream:
+  - target: Failure to thrive
+    description: Symptomatic SBCADD onset during metabolic vulnerability can include failure to thrive.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical onset occurs in newborns or later in life with seizures, developmental delay, hypotonia, and failure to thrive."
+      explanation: Literature review lists failure to thrive among symptomatic SBCADD presentations, consistent with decompensation during metabolic vulnerability.
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
@@ -685,11 +767,37 @@ biochemical:
   context: 'Elevated C5-acylcarnitine in blood is the primary newborn screening marker for SBCADD. C5 is isobaric with isovalerylcarnitine on standard tandem mass spectrometry, requiring second-tier testing to distinguish SBCADD from isovaleric acidemia.
 
     '
+  readouts:
+  - target: Impaired isoleucine catabolism via SBCAD loss-of-function
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated C5-acylcarnitine reports the upstream SBCAD-dependent isoleucine catabolic block.
+    evidence:
+    - reference: PMID:31555323
+      reference_title: "Biochemical, Clinical, and Genetic Characteristics of Short/Branched Chain Acyl-CoA Dehydrogenase Deficiency in Chinese Patients by Newborn Screening."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "all patients showed slightly or moderately elevated C5-carnitine concentrations"
+      explanation: Newborn-screening cohort supports elevated C5-carnitine as the screening readout of SBCADD.
 - name: 2-Methylbutyrylglycine (2-MBG) in urine
   presence: INCREASED
   context: 'Elevated urinary 2-methylbutyrylglycine is the diagnostic hallmark of SBCADD. Detection of 2-MBG by urine organic acid analysis or acylglycine profiling confirms the diagnosis after elevated C5 is found on newborn screening.
 
     '
+  readouts:
+  - target: Impaired isoleucine catabolism via SBCAD loss-of-function
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary 2-MBG reports the isoleucine S-pathway block and upstream 2-methylbutyryl-CoA-derived metabolite accumulation.
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Increased urinary excretion of 2-methylbutyrylglycine (2MBG) is the hallmark of SBCAD deficiency."
+      explanation: Literature review identifies urinary 2-MBG as the hallmark diagnostic readout.
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
@@ -706,6 +814,19 @@ biochemical:
   context: '2-Ethylhydracrylic acid is a urinary organic acid marker of SBCADD, produced by increased flux through the R-pathway of isoleucine oxidation. The 2-EHA peak often exceeds the 2-MBG peak on organic acid analysis and may facilitate diagnosis.
 
     '
+  readouts:
+  - target: Metabolic rerouting via the R-pathway of isoleucine oxidation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary 2-EHA reports increased R-pathway flux downstream of the S-pathway SBCAD block.
+    evidence:
+    - reference: PMID:15615815
+      reference_title: "2-ethylhydracrylic aciduria in short/branched-chain acyl-CoA dehydrogenase deficiency: application to diagnosis and implications for the R-pathway of isoleucine oxidation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In multiple urine samples, organic acid analysis revealed a prominent 2-EHA peak usually exceeding the size of the 2-MBG peak."
+      explanation: Patient urine organic acid analysis directly supports 2-EHA as a readout of R-pathway rerouting.
   evidence:
   - reference: PMID:15615815
     reference_title: "2-ethylhydracrylic aciduria in short/branched-chain acyl-CoA dehydrogenase deficiency: application to diagnosis and implications for the R-pathway of isoleucine oxidation."
@@ -732,6 +853,19 @@ biochemical:
   context: 'In cell models of SBCAD deficiency, C3-carnitine is substantially decreased, reflecting the broader impact of SBCAD on mitochondrial acyl-CoA handling beyond the direct isoleucine pathway metabolites. This is an in vitro observation and not a standard clinical biomarker.
 
     '
+  readouts:
+  - target: ACAD substrate promiscuity and compensatory enzymology
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    interpretation: Decreased C3-carnitine reports broader ACADSB-dependent acylcarnitine remodeling in knockout cells.
+    evidence:
+    - reference: PMID:37309295
+      reference_title: "Acyl-CoA dehydrogenase substrate promiscuity: Challenges and opportunities for development of substrate reduction therapy in disorders of valine and isoleucine metabolism."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "deletion of ACADSB in HEK-293 cells led to an equally strong decrease in C3-carnitine when compared to wild-type cells."
+      explanation: ACADSB knockout cell data support decreased C3-carnitine as an in vitro readout of broader ACAD substrate handling.
   evidence:
   - reference: PMID:37309295
     reference_title: "Acyl-CoA dehydrogenase substrate promiscuity: Challenges and opportunities for development of substrate reduction therapy in disorders of valine and isoleucine metabolism."
@@ -842,6 +976,17 @@ treatments:
     term:
       id: MAXO:0010006
       label: carnitine supplementation
+  target_mechanisms:
+  - target: Impaired isoleucine catabolism via SBCAD loss-of-function
+    treatment_effect: MODULATES
+    description: Carnitine supplementation supports conjugation and biochemical management of accumulated acyl-CoA intermediates without correcting the enzyme defect.
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Carnitine supplementation and valproate avoidance appear to be indicated."
+      explanation: Review recommends carnitine supplementation in SBCADD management.
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
@@ -872,6 +1017,17 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Stress-sensitive metabolic decompensation
+    treatment_effect: INHIBITS
+    description: Fasting avoidance and emergency protocols aim to prevent acute catabolic episodes that precipitate decompensation.
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Providing an emergency protocol for the management of acute catabolic episodes seems reasonable in asymptomatic patients with SBCAD deficiency."
+      explanation: Emergency protocols directly target acute catabolic episodes in SBCADD.
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
@@ -902,6 +1058,17 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Stress-sensitive metabolic decompensation
+    treatment_effect: MODULATES
+    description: Dietary management historically aimed to reduce metabolic stress, although long-term efficacy is uncertain.
+    evidence:
+    - reference: PMID:12837870
+      reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The continued efficacy of long-term dietary therapy instituted presymptomatically remains to be established."
+      explanation: Early dietary management was used presymptomatically, but long-term efficacy remains uncertain.
   evidence:
   - reference: PMID:12837870
     reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
@@ -932,6 +1099,17 @@ treatments:
     term:
       id: MAXO:0000058
       label: pharmacotherapy
+  target_mechanisms:
+  - target: Stress-sensitive metabolic decompensation
+    treatment_effect: INHIBITS
+    description: Valproate avoidance reduces iatrogenic risk of acute metabolic instability in a disorder managed around catabolic vulnerability.
+    evidence:
+    - reference: PMID:30730842
+      reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Carnitine supplementation and valproate avoidance appear to be indicated."
+      explanation: Review recommends valproate avoidance in SBCADD management, consistent with preventing treatment-triggered metabolic decompensation.
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."
@@ -952,6 +1130,11 @@ treatments:
     term:
       id: MAXO:0000124
       label: disease screening
+  target_phenotypes:
+  - preferred_term: Elevated circulating acylcarnitine concentration
+    term:
+      id: HP:0045045
+      label: Elevated circulating acylcarnitine concentration
   evidence:
   - reference: PMID:12837870
     reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
@@ -972,6 +1155,17 @@ treatments:
     term:
       id: MAXO:0000079
       label: genetic counseling
+  target_mechanisms:
+  - target: ACADSB molecular function deficiency
+    treatment_effect: MODULATES
+    description: Counseling addresses the autosomal recessive ACADSB cause, recurrence risk, and prenatal testing rather than directly modifying metabolism.
+    evidence:
+    - reference: PMID:12837870
+      reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A sibling of the first patient is asymptomatic after prenatal diagnosis and early treatment."
+      explanation: Prenatal diagnosis in an affected family supports genetics-informed counseling and recurrence-risk management.
   evidence:
   - reference: PMID:12837870
     reference_title: "Prospective diagnosis of 2-methylbutyryl-CoA dehydrogenase deficiency in the Hmong population by newborn screening using tandem mass spectrometry."
@@ -992,6 +1186,23 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  - preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
+  - preferred_term: Microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+  - preferred_term: Autism
+    term:
+      id: HP:0000717
+      label: Autism
   evidence:
   - reference: PMID:30730842
     reference_title: "Clinical, biochemical, and molecular spectrum of short/branched-chain acyl-CoA dehydrogenase deficiency: two new cases and review of literature."


### PR DESCRIPTION
## Summary
- Connects the 2-Methylbutyryl-CoA dehydrogenase deficiency pathograph into a single component by adding evidence-backed downstream phenotype edges, biochemical readout links, and treatment target links.
- Adds diagnostic biomarker readouts for C5-acylcarnitine, urinary 2-MBG, urinary 2-EHA, and an in vitro C3-carnitine readout.
- Preserves the existing initial metabolic GO coverage for isoleucine and branched-chain amino acid catabolism while linking downstream neurologic, growth, screening, monitoring, and management nodes.

## Graph audit
- `origin/main`: 32 nodes, 17 edges, 16 components, 15 isolated, 0 orphan targets, 0 integrity issues
- `working`: 32 nodes, 39 edges, 1 component, 0 isolated, 0 orphan targets, 0 integrity issues

## Validation
- `just validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`
- Manual snippet audit: 78 evidence items, 10 unique references, all snippets found in cache
- `git diff --check`

## Scope
- Intentional change is limited to `kb/disorders/2-Methylbutyryl-CoA_Dehydrogenase_Deficiency.yaml`.
- Restored unrelated ClinicalTrials cache churn after validation.
