### PR TITLE
[codex] Improve HMG-CoA synthase deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency
 creation_date: '2026-05-04T09:20:00Z'
-updated_date: '2026-05-04T09:20:00Z'
+updated_date: '2026-05-18T15:36:48Z'
 category: Mendelian
 description: >
   3-hydroxy-3-methylglutaryl-CoA synthase deficiency is an autosomal
@@ -288,6 +288,87 @@ pathophysiology:
     description: Severe acute crises may include seizures.
   - target: Hepatomegaly
     description: Hepatic metabolic stress during crises is associated with hepatomegaly.
+  - target: Hypoketotic hypoglycemia
+    description: Ketogenesis failure during catabolic stress produces hypoglycemia with inadequate ketone production.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "decompensation with hypoglycemia, dicarboxyluria and inadequate ketonuria."
+      explanation: The systematic review identifies hypoglycemia with inadequate ketonuria as the core acute decompensation pattern.
+  - target: Vomiting
+    description: Catabolic decompensation often presents with vomiting or cyclic-vomiting-like episodes.
+    evidence:
+    - reference: PMID:39143735
+      reference_title: "Mitochondrial HMG-CoA Synthase Deficiency: A Cyclic Vomiting Mimic Without Reliable Biochemical Markers."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "episodes of vomiting and lethargy, often associated with hypoglycemia or"
+      explanation: The case report links vomiting episodes with hypoglycemia or other metabolic abnormalities in HMGCS2 deficiency.
+  - target: Lethargy
+    description: Energy failure during acute episodes can manifest as lethargy and altered responsiveness.
+    evidence:
+    - reference: PMID:39143735
+      reference_title: "Mitochondrial HMG-CoA Synthase Deficiency: A Cyclic Vomiting Mimic Without Reliable Biochemical Markers."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "episodes of vomiting and lethargy, often associated with hypoglycemia or"
+      explanation: The case report documents lethargy during recurrent metabolic episodes.
+  - target: Encephalopathy
+    description: Severe decompensation can progress to encephalopathy.
+    evidence:
+    - reference: PMID:40548098
+      reference_title: "HMG-CoA Synthase-2 Deficiency: Neonatal Hyperammonemic Coma and Abnormal Metabolic Screening Resembling Maple Syrup Urine Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hypoketotic hypoglycemia, metabolic acidosis, hepatomegaly, and encephalopathy"
+      explanation: The neonatal case report states encephalopathy among characteristic severe decompensation features.
+  - target: Coma
+    description: Severe neonatal or childhood crises may progress to coma.
+    evidence:
+    - reference: PMID:40548098
+      reference_title: "HMG-CoA Synthase-2 Deficiency: Neonatal Hyperammonemic Coma and Abnormal Metabolic Screening Resembling Maple Syrup Urine Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "on day of life 7 with a sepsis-like condition, coma, metabolic acidosis, and"
+      explanation: The neonatal case presented with coma during metabolic decompensation.
+  - target: Hyperammonemia
+    description: Severe crisis physiology can include hyperammonemia, particularly in neonatal presentations.
+    evidence:
+    - reference: PMID:35308163
+      reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "five patients had hyperammonemia, four patients had hyperuricemia"
+      explanation: The Chinese patient series supports hyperammonemia as a crisis-associated biochemical feature.
+  - target: Dyspnea
+    description: Acute metabolic acidosis and decompensation can present with dyspnea.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "consciousness, dyspnea, seizures and hepatomegaly."
+      explanation: The systematic review lists dyspnea among first-episode symptoms.
+  - target: Elevated hepatic transaminase
+    description: Hepatic stress during acute crises can include increased aminotransferases.
+    evidence:
+    - reference: PMID:35308163
+      reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "different degree of hepatomegaly and increased aminotransferase, severe"
+      explanation: The Chinese patient series documents increased aminotransferase during severe acute presentations.
+  - target: Abnormal metabolism or homeostasis
+    description: Acute decompensation represents the systemic metabolic-homeostasis phenotype caused by failed fasting ketogenesis.
+    evidence:
+    - reference: ORPHA:35701
+      reference_title: "3-hydroxy-3-methylglutaryl-CoA synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001939 | Abnormality of metabolism/homeostasis | Very frequent (99-80%)"
+      explanation: Orphanet records abnormal metabolism/homeostasis as a very frequent phenotype.
 - name: Acute-Phase Acetylcarnitine and Organic Acid Pattern
   description: >
     HMGCS2 deficiency can be difficult to recognize biochemically because
@@ -641,6 +722,19 @@ biochemical:
   context: >
     Ketone production is inappropriately low during hypoglycemia and catabolic
     stress.
+  readouts:
+  - target: Impaired Hepatic Ketogenesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Inadequate ketone body production reports the hepatic ketogenesis block during fasting or illness.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "decompensation with hypoglycemia, dicarboxyluria and inadequate ketonuria."
+      explanation: Inadequate ketonuria directly supports decreased ketone bodies as a readout of impaired ketogenesis.
   evidence:
   - reference: PMID:39798988
     reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -653,6 +747,19 @@ biochemical:
   context: >
     Urinary 4HMP is a useful acute-phase diagnostic marker, although it may be
     detected retrospectively.
+  readouts:
+  - target: Acute-Phase Acetylcarnitine and Organic Acid Pattern
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary 4HMP is an acute-phase biochemical marker that reports the HMGCS2 deficiency organic-acid pattern.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "4-hydroxy-6-methyl-2-pyrone (4HMP) was detected in 33/35 urine samples taken"
+      explanation: The systematic review supports 4HMP as a frequent acute-phase readout.
   evidence:
   - reference: PMID:39798988
     reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -665,6 +772,19 @@ biochemical:
   context: >
     Urinary dicarboxylic acid levels are commonly elevated during metabolic
     decompensation.
+  readouts:
+  - target: Acute-Phase Acetylcarnitine and Organic Acid Pattern
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Dicarboxylic aciduria reports the acute organic-acid pattern seen during HMGCS2 decompensation.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dicarboxylic acid levels were elevated in 54/56 cases."
+      explanation: The systematic review quantifies dicarboxylic acid elevation during acute episodes.
   evidence:
   - reference: PMID:39798988
     reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -677,6 +797,19 @@ biochemical:
   context: >
     An increased plasma acetylcarnitine to free carnitine ratio can help
     identify HMGCS2 deficiency during acute decompensation.
+  readouts:
+  - target: Acute-Phase Acetylcarnitine and Organic Acid Pattern
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: An increased plasma C2/C0 ratio reports acetylcarnitine accumulation during the acute-phase HMGCS2 biochemical pattern.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "increased plasma C2/C0 acylcarnitine ratio to facilitate the"
+      explanation: The systematic review recommends the C2/C0 ratio as a diagnostic readout.
   evidence:
   - reference: PMID:39798988
     reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -860,6 +993,17 @@ treatments:
     term:
       id: MAXO:0000079
       label: genetic counseling
+  target_mechanisms:
+  - target: HMGCS2 Loss of Function
+    treatment_effect: MODULATES
+    description: Counseling addresses the autosomal recessive HMGCS2 cause and recurrence risk rather than directly changing metabolism.
+    evidence:
+    - reference: ORPHA:35701
+      reference_title: "3-hydroxy-3-methylglutaryl-CoA synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Autosomal recessive"
+      explanation: Autosomal recessive inheritance supports genetics-informed counseling and recurrence-risk management.
   evidence:
   - reference: ORPHA:35701
     reference_title: "3-hydroxy-3-methylglutaryl-CoA synthase deficiency (Orphanet structured-database record)"


### PR DESCRIPTION
## Summary
- Connects the 3-hydroxy-3-methylglutaryl-CoA synthase deficiency pathograph into a single component by linking acute decompensation to isolated crisis phenotypes.
- Adds diagnostic readout edges for decreased ketone bodies, urinary 4HMP, dicarboxylic acids, and plasma C2/C0 acylcarnitine ratio.
- Adds a conservative genetic-counseling mechanism target tied to the autosomal recessive HMGCS2 loss-of-function etiology.

## Graph audit
- `origin/main`: 29 nodes, 14 edges, 15 components, 14 isolated, 0 orphan targets, 0 integrity issues
- `working`: 29 nodes, 28 edges, 1 component, 0 isolated, 0 orphan targets, 0 integrity issues

## Validation
- `just validate kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml`
- Manual snippet audit: 81 evidence items, 9 unique references, all snippets found in cache
- `git diff --check`

## Scope
- Intentional change is limited to `kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml`.
- Restored unrelated ClinicalTrials cache churn after validation.
