### PR TITLE
[codex] Improve infantile hypercalcemia pathograph connectivity

### DIFF
--- a/kb/disorders/Infantile_Hypercalcemia.yaml
+++ b/kb/disorders/Infantile_Hypercalcemia.yaml
@@ -834,14 +834,14 @@ biochemical:
       reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "and/or 1,25(OH)2D3, symptomatic hypercalcaemia"
+      snippet: "hypercalcaemia with elevated 1,25(OH)2D3 levels"
       explanation: The cohort background links high vitamin D metabolite exposure to symptomatic hypercalcemia.
   evidence:
   - reference: PMID:33099630
     reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "and/or 1,25(OH)2D3, symptomatic hypercalcaemia"
+    snippet: "hypercalcaemia with elevated 1,25(OH)2D3 levels"
     explanation: Long-term outcome paper links high vitamin D metabolite exposure to symptomatic hypercalcemia.
   - reference: PMID:33516786
     reference_title: "Analysis of vitamin D(3) metabolites in survivors of infantile idiopathic hypercalcemia caused by CYP24A1 mutation or SLC34A1 mutation."

--- a/kb/disorders/Infantile_Hypercalcemia.yaml
+++ b/kb/disorders/Infantile_Hypercalcemia.yaml
@@ -1,7 +1,7 @@
 name: Infantile Hypercalcemia
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-03T00:00:00Z'
+updated_date: '2026-05-18T17:13:44Z'
 synonyms:
 - Autosomal recessive infantile hypercalcemia
 - Familial infantile hypercalcemia with suppressed intact parathyroid hormone
@@ -203,6 +203,14 @@ pathophysiology:
   downstream:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     description: Impaired vitamin D catabolism increases active vitamin D exposure and calcium absorption/signaling.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21675912
+      reference_title: "Mutations in CYP24A1 and idiopathic infantile hypercalcemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The presence of CYP24A1 mutations explains the increased sensitivity to vitamin D"
+      explanation: The discovery paper links CYP24A1 pathogenic variants to vitamin D hypersensitivity and symptomatic hypercalcemia.
 - name: SLC34A1 renal phosphate transport defect
   description: >
     SLC34A1 encodes the renal sodium-phosphate cotransporter NaPi-IIa. Defective
@@ -253,6 +261,27 @@ pathophysiology:
   downstream:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     description: Renal phosphate wasting stimulates inappropriate 1,25-dihydroxyvitamin D3 generation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Proximal tubular phosphate wasting.
+    - Increased 1,25-dihydroxyvitamin D3 generation.
+    evidence:
+    - reference: PMID:26047794
+      reference_title: "Autosomal-Recessive Mutations in SLC34A1 Encoding Sodium-Phosphate Cotransporter 2A Cause Idiopathic Infantile Hypercalcemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "renal phosphate wasting and symptomatic hypercalcemia"
+      explanation: The SLC34A1 discovery paper links renal phosphate wasting to symptomatic hypercalcemia.
+  - target: Hypophosphatemia
+    description: SLC34A1 loss reduces renal phosphate reabsorption, producing serum phosphate depletion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32866123
+      reference_title: "Idiopathic infantile hypercalcemia: mutations in SLC34A1 and CYP24A1 in two siblings and fathers."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Both of them also had hypophosphatemia and decreased tubular phosphate reabsorption."
+      explanation: Human family report supports hypophosphatemia from renal phosphate wasting in the IIH spectrum.
 - name: Active vitamin D excess and PTH-independent hypercalcemia
   description: >
     CYP24A1-associated impaired catabolism or SLC34A1-associated excessive
@@ -295,6 +324,104 @@ pathophysiology:
   downstream:
   - target: Nephrocalcinosis and chronic kidney injury
     description: Persistent calcium and vitamin D abnormalities promote renal calcium deposition and kidney injury.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - PTH-independent hypercalcemia.
+    - Hypercalciuria and renal calcium deposition.
+    evidence:
+    - reference: ORPHA:300547
+      supports: SUPPORT
+      snippet: "early-onset hypercalcemia, hypophosphatemia, hypercalciuria, decreased intact parathyroid hormone serum levels and medullary nephrocalcinosis"
+      explanation: Orphanet's defining biochemical pattern links hypercalcemia and hypercalciuria with nephrocalcinosis.
+  - target: Hypercalcemia
+    description: Active vitamin D excess drives the defining PTH-independent hypercalcemia phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:300547
+      supports: SUPPORT
+      snippet: "early-onset hypercalcemia"
+      explanation: Orphanet defines infantile hypercalcemia by early-onset hypercalcemia.
+  - target: Hypercalciuria
+    description: Vitamin D-driven calcium excess is accompanied by urinary calcium wasting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:300547
+      supports: SUPPORT
+      snippet: "hypercalciuria"
+      explanation: Orphanet lists hypercalciuria in the characteristic biochemical phenotype.
+  - target: Failure to thrive
+    description: Symptomatic infantile hypercalcemia manifests with failure to thrive.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:21675912
+      reference_title: "Mutations in CYP24A1 and idiopathic infantile hypercalcemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hypercalcemia, failure to thrive, vomiting, dehydration, and nephrocalcinosis."
+      explanation: The CYP24A1 discovery paper lists failure to thrive in the symptomatic hypercalcemia presentation.
+  - target: Vomiting
+    description: Hypercalcemia causes gastrointestinal symptoms including vomiting or emesis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:21675912
+      reference_title: "Mutations in CYP24A1 and idiopathic infantile hypercalcemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hypercalcemia, failure to thrive, vomiting, dehydration, and nephrocalcinosis."
+      explanation: The discovery paper lists vomiting in the hypercalcemic infantile presentation.
+  - target: Dehydration
+    description: Vomiting and polyuria during symptomatic hypercalcemia contribute to dehydration.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Emesis.
+    - Polyuria from calcium-mediated renal concentrating impairment.
+    evidence:
+    - reference: PMID:21675912
+      reference_title: "Mutations in CYP24A1 and idiopathic infantile hypercalcemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "vomiting, dehydration, and nephrocalcinosis."
+      explanation: The discovery paper lists dehydration among hypercalcemic infant symptoms.
+  - target: Constipation
+    description: Symptomatic hypercalcemia includes gastrointestinal dysmotility with constipation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "polyuria, dehydration, constipation, generalized hypotonia"
+      explanation: The long-term cohort background lists constipation among symptomatic hypercalcemia features.
+  - target: Polyuria
+    description: Hypercalcemia can impair renal concentrating function and produce polyuria.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "symptomatic hypercalcaemia, including emesis, anorexia, polyuria"
+      explanation: The long-term cohort background lists polyuria among symptomatic hypercalcemia features.
+  - target: Hypotonia
+    description: Infantile symptomatic hypercalcemia may include generalized hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "dehydration, constipation, generalized hypotonia"
+      explanation: The long-term cohort background lists generalized hypotonia among symptomatic hypercalcemia features.
+  - target: Hypertension
+    description: Symptomatic hypercalcemia descriptions include arterial hypertension in the IIH spectrum.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "generalized hypotonia, arterial hypertension"
+      explanation: The long-term cohort background lists arterial hypertension among symptomatic hypercalcemia features.
 - name: Nephrocalcinosis and chronic kidney injury
   description: >
     Hypercalcemia and hypercalciuria drive renal calcium deposition, medullary
@@ -318,6 +445,43 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "nephrocalcinosis and CKD developed in a large group of subjects."
     explanation: Long-term follow-up links the disorder to nephrocalcinosis and CKD.
+  downstream:
+  - target: Nephrocalcinosis
+    description: Renal calcium deposition manifests as nephrocalcinosis on ultrasound.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "nephrocalcinosis in 16 of 18 (88%) patients"
+      explanation: Follow-up renal ultrasound detected nephrocalcinosis in most molecularly confirmed survivors.
+  - target: Chronic kidney disease
+    description: Persistent nephrocalcinosis and tubulointerstitial injury can progress to chronic kidney disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Nephrocalcinosis.
+    - Tubulointerstitial inflammation and fibrosis.
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "nephrocalcinosis and tubulointerstitial injury resulting in CKD"
+      explanation: The cohort discussion links nephrocalcinosis and tubulointerstitial injury to CKD.
+  - target: Nephrolithiasis
+    description: The same calcium/vitamin D metabolism disturbance can produce nephrolithiasis as well as nephrocalcinosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypercalcemia and hypercalciuria.
+    - Renal calcium crystal deposition.
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Nephrocalcinosis and/or nephrolithiasis is a typical consequence of IH as well as CYP24A1 and SLC34A1 mutations"
+      explanation: The long-term outcome review explicitly identifies nephrolithiasis as a typical renal consequence.
 phenotypes:
 - name: Hypercalcemia
   description: Severe early-onset PTH-independent hypercalcemia is the defining clinical feature.
@@ -564,6 +728,19 @@ biochemical:
 - name: Elevated serum calcium
   presence: INCREASED
   context: Hypercalcemia is the central biochemical abnormality and is independent of PTH.
+  readouts:
+  - target: Active vitamin D excess and PTH-independent hypercalcemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated serum calcium is the central diagnostic readout of vitamin D-driven PTH-independent hypercalcemia.
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "serum calcium levels >2.6"
+      explanation: The long-term cohort used elevated serum calcium as a biochemical marker in molecularly confirmed survivors.
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -578,6 +755,17 @@ biochemical:
 - name: Increased urinary calcium
   presence: INCREASED
   context: Hypercalciuria accompanies hypercalcemia and contributes to nephrocalcinosis risk.
+  readouts:
+  - target: Active vitamin D excess and PTH-independent hypercalcemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary calcium reports downstream calcium excess and renal calcium wasting.
+    evidence:
+    - reference: ORPHA:300547
+      supports: SUPPORT
+      snippet: "hypercalciuria"
+      explanation: Orphanet lists hypercalciuria as part of the characteristic infantile hypercalcemia biochemical phenotype.
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -586,6 +774,19 @@ biochemical:
 - name: Decreased serum phosphate
   presence: DECREASED
   context: Hypophosphatemia is part of the Orphanet definition and is mechanistically central in SLC34A1-associated disease.
+  readouts:
+  - target: SLC34A1 renal phosphate transport defect
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low serum phosphate is a diagnostic readout of renal phosphate wasting in SLC34A1-associated disease.
+    evidence:
+    - reference: PMID:32866123
+      reference_title: "Idiopathic infantile hypercalcemia: mutations in SLC34A1 and CYP24A1 in two siblings and fathers."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Both of them also had hypophosphatemia and decreased tubular phosphate reabsorption."
+      explanation: Human family report connects hypophosphatemia with decreased tubular phosphate reabsorption.
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -600,6 +801,17 @@ biochemical:
 - name: Suppressed intact parathyroid hormone
   presence: DECREASED
   context: Low intact PTH distinguishes the PTH-independent hypercalcemia state.
+  readouts:
+  - target: Active vitamin D excess and PTH-independent hypercalcemia
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Suppressed intact PTH distinguishes the vitamin D-driven hypercalcemia from PTH-mediated hypercalcemia.
+    evidence:
+    - reference: ORPHA:300547
+      supports: SUPPORT
+      snippet: "decreased intact parathyroid hormone serum levels"
+      explanation: Orphanet includes decreased intact PTH in the characteristic biochemical pattern.
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -611,6 +823,19 @@ biochemical:
     CYP24A1 variants disturb active vitamin D catabolism, while SLC34A1 variants
     increase 1,25-dihydroxyvitamin D3 generation downstream of phosphate
     wasting.
+  readouts:
+  - target: Active vitamin D excess and PTH-independent hypercalcemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated or inappropriately high active vitamin D metabolites read out the convergent biochemical mechanism.
+    evidence:
+    - reference: PMID:33099630
+      reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "and/or 1,25(OH)2D3, symptomatic hypercalcaemia"
+      explanation: The cohort background links high vitamin D metabolite exposure to symptomatic hypercalcemia.
   evidence:
   - reference: PMID:33099630
     reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
@@ -627,6 +852,19 @@ biochemical:
 - name: Increased 25(OH)D3 to 24,25(OH)2D3 ratio
   presence: INCREASED
   context: A high 25(OH)D3/24,25(OH)2D3 ratio is a biochemical marker of CYP24A1-associated disease.
+  readouts:
+  - target: CYP24A1 vitamin D catabolism defect
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: A high 25(OH)D3/24,25(OH)2D3 ratio reports impaired CYP24A1-dependent 24-hydroxylation.
+    evidence:
+    - reference: PMID:33516786
+      reference_title: "Analysis of vitamin D(3) metabolites in survivors of infantile idiopathic hypercalcemia caused by CYP24A1 mutation or SLC34A1 mutation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "extremely high 25(OH)D3/2425(OH)2D3 ratio values."
+      explanation: Vitamin D metabolite profiling found very high ratios in CYP24A1-associated survivors.
   evidence:
   - reference: PMID:33516786
     reference_title: "Analysis of vitamin D(3) metabolites in survivors of infantile idiopathic hypercalcemia caused by CYP24A1 mutation or SLC34A1 mutation."
@@ -810,6 +1048,19 @@ treatments:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     treatment_effect: MODULATES
     description: Limits vitamin D-driven calcium absorption and active metabolite exposure.
+  target_phenotypes:
+  - preferred_term: Hypercalcemia
+    term:
+      id: HP:0003072
+      label: Hypercalcemia
+  - preferred_term: Hypercalciuria
+    term:
+      id: HP:0002150
+      label: Hypercalciuria
+  - preferred_term: Nephrocalcinosis
+    term:
+      id: HP:0000121
+      label: Nephrocalcinosis
   evidence:
   - reference: PMID:28470390
     reference_title: "Biallelic mutations in CYP24A1 or SLC34A1 as a cause of infantile idiopathic hypercalcemia (IIH) with vitamin D hypersensitivity: molecular study of 11 historical IIH cases."
@@ -840,6 +1091,15 @@ treatments:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     treatment_effect: MODULATES
     description: Correcting phosphate depletion reduces inappropriate 1,25-dihydroxyvitamin D3 generation.
+  target_phenotypes:
+  - preferred_term: Hypophosphatemia
+    term:
+      id: HP:0002148
+      label: Hypophosphatemia
+  - preferred_term: Hypercalcemia
+    term:
+      id: HP:0003072
+      label: Hypercalcemia
   evidence:
   - reference: PMID:26047794
     reference_title: "Autosomal-Recessive Mutations in SLC34A1 Encoding Sodium-Phosphate Cotransporter 2A Cause Idiopathic Infantile Hypercalcemia."
@@ -870,6 +1130,19 @@ treatments:
   - target: SLC34A1 renal phosphate transport defect
     treatment_effect: MODULATES
     description: Phosphate replacement addresses hypophosphatemia in phosphate-wasting presentations.
+  target_phenotypes:
+  - preferred_term: Hypercalcemia
+    term:
+      id: HP:0003072
+      label: Hypercalcemia
+  - preferred_term: Dehydration
+    term:
+      id: HP:0001944
+      label: Dehydration
+  - preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
   evidence:
   - reference: PMID:32866123
     reference_title: "Idiopathic infantile hypercalcemia: mutations in SLC34A1 and CYP24A1 in two siblings and fathers."
@@ -892,6 +1165,19 @@ treatments:
   - target: Nephrocalcinosis and chronic kidney injury
     treatment_effect: MODULATES
     description: Monitoring and supportive care aim to detect and limit chronic renal sequelae.
+  target_phenotypes:
+  - preferred_term: Nephrocalcinosis
+    term:
+      id: HP:0000121
+      label: Nephrocalcinosis
+  - preferred_term: Chronic kidney disease
+    term:
+      id: HP:0012622
+      label: Chronic kidney disease
+  - preferred_term: Nephrolithiasis
+    term:
+      id: HP:0000787
+      label: Nephrolithiasis
   evidence:
   - reference: PMID:33099630
     reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
@@ -931,6 +1217,23 @@ treatments:
   - target: Nephrocalcinosis and chronic kidney injury
     treatment_effect: MODULATES
     description: Aims to reduce persistent metabolic exposure that contributes to renal calcification and CKD.
+  target_phenotypes:
+  - preferred_term: Hypercalcemia
+    term:
+      id: HP:0003072
+      label: Hypercalcemia
+  - preferred_term: Hypercalciuria
+    term:
+      id: HP:0002150
+      label: Hypercalciuria
+  - preferred_term: Nephrocalcinosis
+    term:
+      id: HP:0000121
+      label: Nephrocalcinosis
+  - preferred_term: Chronic kidney disease
+    term:
+      id: HP:0012622
+      label: Chronic kidney disease
   evidence:
   - reference: PMID:33099630
     reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
@@ -945,6 +1248,38 @@ treatments:
     snippet: "long-term use and safety of both imidazole derivative and rifampicin in patients with CYP24A1 mutations have not been studied."
     explanation: Discussion identifies imidazole-derivative and rifampicin approaches while emphasizing limited long-term safety data.
 references:
+- reference: ORPHA:300547
+  title: Autosomal recessive infantile hypercalcemia
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:21675912
+  title: Mutations in CYP24A1 and idiopathic infantile hypercalcemia.
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:26047794
+  title: Autosomal-Recessive Mutations in SLC34A1 Encoding Sodium-Phosphate Cotransporter 2A Cause Idiopathic Infantile Hypercalcemia.
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:28470390
+  title: 'Biallelic mutations in CYP24A1 or SLC34A1 as a cause of infantile idiopathic hypercalcemia (IIH) with vitamin D hypersensitivity: molecular study of 11 historical IIH cases.'
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:32866123
+  title: 'Idiopathic infantile hypercalcemia: mutations in SLC34A1 and CYP24A1 in two siblings and fathers.'
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:33099630
+  title: Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations.
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:33516786
+  title: Analysis of vitamin D(3) metabolites in survivors of infantile idiopathic hypercalcemia caused by CYP24A1 mutation or SLC34A1 mutation.
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
+- reference: PMID:38504242
+  title: Biallelic and monoallelic pathogenic variants in CYP24A1 and SLC34A1 genes cause idiopathic infantile hypercalcemia.
+  found_in:
+  - Infantile_Hypercalcemia-deep-research-falcon.md
 - reference: DOI:10.1007/s00467-022-05740-w
   title: Idiopathic infantile hypercalcemia in children with chronic kidney disease due to kidney hypodysplasia
   found_in:


### PR DESCRIPTION
## Summary

Improves `Infantile_Hypercalcemia.yaml` pathograph connectivity by connecting the CYP24A1/SLC34A1 metabolic mechanisms to symptomatic hypercalcemia, renal sequelae, biochemical readouts, and treatment targets.

Key changes:

- Adds evidence-backed downstream edges from vitamin D/phosphate mechanisms to hypercalcemia, hypercalciuria, hypophosphatemia, failure to thrive, vomiting, dehydration, constipation, polyuria, hypotonia, hypertension, nephrocalcinosis, CKD, and nephrolithiasis.
- Adds diagnostic readout links for serum calcium, urinary calcium, serum phosphate, intact PTH, active vitamin D exposure, and the 25(OH)D3/24,25(OH)2D3 ratio.
- Adds treatment target phenotypes for vitamin D/calcium exposure reduction, phosphate supplementation, acute hypercalcemia management, renal monitoring, and active vitamin D metabolite suppression.
- Adds top-level ORPHA/PMID bibliography rows for all evidence references used in the file.

Graph connectivity improved from 32 nodes / 16 edges / 20 components / 19 isolated nodes to 32 nodes / 50 edges / 1 component / 0 isolated nodes.

## Validation

- `just validate kb/disorders/Infantile_Hypercalcemia.yaml`
- `just validate-references kb/disorders/Infantile_Hypercalcemia.yaml` (validator reports 0 formal checks for this file after the full validate command; formal reference checks passed when snippets were introduced)
- `just validate-terms kb/disorders/Infantile_Hypercalcemia.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Infantile_Hypercalcemia.yaml`
- `git diff --check`
- manual normalized snippet audit: 107 evidence snippets found across 11 unique references

Unrelated ClinicalTrials cache timestamp churn was restored before commit.