### PR TITLE
[codex] Connect NAGS deficiency phenotypes and readouts

### DIFF
--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: N-Acetylglutamate Synthase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-08T10:22:33Z'
+updated_date: '2026-05-18T18:29:40Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -55,6 +55,16 @@ pathophysiology:
       id: UBERON:0002107
       label: liver
   downstream:
+  - target: N-acetylglutamate (NAG)
+    description: Loss of NAGS enzyme activity lowers production of N-acetylglutamate, the endogenous CPS1 activator.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26068232
+      reference_title: "The N-Acetylglutamate Synthase Family: Structures, Function and Mechanisms."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: N-acetylglutamate synthase (NAGS) catalyzes the production of N-acetylglutamate (NAG) from acetyl-CoA and L-glutamate.
+      explanation: Directly supports NAG as the product of NAGS and therefore the depleted metabolite when NAGS function is deficient.
   - target: Loss of CPS1 activation and impaired ureagenesis
     description: NAG depletion prevents normal allosteric activation of CPS1.
     causal_link_type: DIRECT
@@ -219,6 +229,46 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: N-Acetylglutamate synthase (NAGS) deficiency is an extremely rare autosomal recessive metabolic disorder affecting the urea cycle, leading to episodes of hyperammonemia which can cause significant morbidity and mortality.
       explanation: Directly identifies hyperammonemia as the downstream clinical manifestation of NAGS deficiency.
+  - target: Vomiting
+    description: Acute hyperammonemic decompensation can present with nausea and vomiting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: During the hospitalization, hyperammonemia associated with confusion, psychomotor agitation (i.e., echolalia and motor stereotypies), nausea, and vomiting was detected several times, mainly in the evening.
+      explanation: This NAGS deficiency case directly links hyperammonemia episodes with nausea and vomiting.
+  - target: Lethargy
+    description: Hyperammonemic NAGS deficiency can present with reduced alertness and lethargy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Adult patients are very rare and often unrecognized. They may present with a self-selected low protein diet, headaches, vomiting, lethargy, behavioural changes, confusion, episodes of altered consciousness, and hyperammonemic encephalopathy
+      explanation: The NAGS deficiency review lists lethargy among late-onset clinical manifestations linked to hyperammonemic encephalopathy.
+  - target: Headache
+    description: Late-onset NAGS deficiency can manifest with recurrent headaches driven by hyperammonemia and/or hypoargininemia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Headaches in UCD patients are often recurrent, associated with behavioural symptoms, nausea and vomiting, or a self-selected low protein diet, and are due to hyperammonemia and/or hypoargininemia.
+      explanation: The NAGS case review directly links recurrent UCD headaches to hyperammonemia and/or hypoargininemia.
+  - target: Respiratory alkalosis
+    description: Neonatal urea-cycle hyperammonemia can first present with tachypnea and respiratory alkalosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33113778
+      reference_title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We report a series of three newborns presenting irritability, poor feeding and tachypnea. Their first gas analysis revealed respiratory alkalosis. Hyperammonemia was confirmed, and three different enzymatic blocks in the urea cycle were diagnosed.
+      explanation: Human neonatal UCD cases show respiratory alkalosis as an early presentation of confirmed hyperammonemia.
   - target: Hyperammonemic astrocyte stress and glutamine accumulation
     description: Circulating ammonia crosses into the CNS and is converted to glutamine in astrocytes.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -291,6 +341,16 @@ pathophysiology:
       id: UBERON:0000955
       label: brain
   downstream:
+  - target: Seizures
+    description: Hyperammonemic CNS stress can cause epileptiform activity and seizures during decompensation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: EEG showed abnormalities which were consistent with non-convulsive status epilepticus.
+      explanation: This NAGS deficiency case documents seizure-spectrum EEG abnormalities during a hyperammonemic crisis.
   - target: Cytotoxic cerebral edema and intracranial hypertension
     description: Astrocytic osmotic stress can progress to cerebral edema and life-threatening intracranial complications.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -348,6 +408,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Intra cranial hypertension appears inducing coma, cerebral engagement and death of the patient.
       explanation: Mechanistic UCD review links intracranial hypertension to coma and death.
+  - target: Intellectual disability
+    description: Severe or recurrent hyperammonemic brain injury can leave lasting cognitive sequelae.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33179600
+      reference_title: "Primary hyperammonaemia: Current diagnostic and therapeutic strategies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Newborns who are often affected by hyper-ammonaemic encephalopathy carry a potential risk of severe brain damage, which may lead to death.
+      explanation: Severe hyperammonemic encephalopathy provides the brain-injury mechanism underlying long-term cognitive sequelae.
   evidence:
   - reference: PMID:33409766
     reference_title: "Management of late onset urea cycle disorders-a remaining challenge for the intensivist?"
@@ -586,6 +656,13 @@ phenotypes:
   notes: >-
     Respiratory alkalosis from hyperventilation is a recognized feature of acute hyperammonemia
     in urea cycle disorders generally but specific frequency data for NAGS deficiency are limited.
+  evidence:
+  - reference: PMID:33113778
+    reference_title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: We report a series of three newborns presenting irritability, poor feeding and tachypnea. Their first gas analysis revealed respiratory alkalosis. Hyperammonemia was confirmed, and three different enzymatic blocks in the urea cycle were diagnosed.
+    explanation: Human neonatal UCD cases support respiratory alkalosis as an early hyperammonemia presentation.
 biochemical:
 - name: Plasma ammonia
   presence: INCREASED
@@ -688,6 +765,19 @@ biochemical:
     term:
       id: CHEBI:44337
       label: N-acetyl-L-glutamate(2-)
+  readouts:
+  - target: NAGS molecular function deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased NAG reports loss of NAGS catalytic product formation, although direct NAG measurement is not routine clinically.
+    evidence:
+    - reference: PMID:26068232
+      reference_title: "The N-Acetylglutamate Synthase Family: Structures, Function and Mechanisms."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: N-acetylglutamate synthase (NAGS) catalyzes the production of N-acetylglutamate (NAG) from acetyl-CoA and L-glutamate.
+      explanation: NAG is the direct enzymatic product of NAGS, so decreased NAG is a direct biochemical readout of NAGS function deficiency.
   evidence:
   - reference: PMID:26068232
     reference_title: "The N-Acetylglutamate Synthase Family: Structures, Function and Mechanisms."
@@ -950,6 +1040,38 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Systemic hyperammonemia and glutamine diversion
+    treatment_effect: INHIBITS
+    description: Crisis plans and anticatabolic supportive measures reduce ammonia generation and prevent recurrent hyperammonemic decompensation.
+    evidence:
+    - reference: PMID:38637895
+      reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Follow-up of patients with NAGS deficiency should include plans for illness and for disruption of carbamylglutamate access, including nutrition management strategies such as protein restriction.
+      explanation: NAGS-specific management guidance supports crisis planning to prevent recurrent hyperammonemia.
+  target_phenotypes:
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+  - preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
+  - preferred_term: Lethargy
+    term:
+      id: HP:0001254
+      label: Lethargy
+  - preferred_term: Seizures
+    term:
+      id: HP:0001250
+      label: Seizure
   evidence:
   - reference: PMID:38637895
     reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."


### PR DESCRIPTION
## Summary
- connect NAGS molecular function deficiency to depleted N-acetylglutamate and add a NAG readout edge
- link hyperammonemia/CNS stress to vomiting, lethargy, headache, respiratory alkalosis, seizures, and long-term cognitive sequelae with cached exact snippets
- connect acute supportive-care planning to systemic hyperammonemia and crisis phenotypes

## Graph impact
- Before: 35 nodes, 26 edges, 11 components, 10 isolated nodes
- After: 35 nodes, 39 edges, 3 components, 2 isolated nodes
- Remaining isolated: Failure to thrive, Genetic counseling

## Validation
- just validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
- just validate-references kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
- just validate-terms kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
- git diff --check
- manual normalized snippet audit: 84 snippets across 11 references matched cached text

## Scope control
- Restored unrelated ClinicalTrials cache churn after validation
- No references_cache files hand-edited