### PR TITLE
[codex] Connect CACT treatments and biomarkers

### DIFF
--- a/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
+++ b/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carnitine-acylcarnitine Translocase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-09T11:28:10Z'
+updated_date: '2026-05-18T18:45:28Z'
 synonyms:
 - CACT deficiency
 - CACTD
@@ -521,6 +521,19 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Hyperammonemia and cardiac arrhythmia are prominent in early-onset disease, with high rates of cardiac arrest.
       explanation: GeneReviews supports hyperammonemia as a prominent early-onset clinical manifestation.
+  - target: Seizures
+    description: Severe hypoglycemia and hyperammonemia during CACTD crises can be accompanied by seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute metabolic decompensation with hypoglycemia and hyperammonemia.
+    - Cerebral energy failure and hyperammonemic neurotoxicity.
+    evidence:
+    - reference: PMID:34449152
+      reference_title: "Clinical and molecular characteristics of carnitineacylcarnitine translocase deficiency with c.270delC and a novel c.408C>A variant."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: CACTD is characterized by severe episodes of hypoglycemia and hyperammonemia, seizures, cardiomyopathy, liver dysfunction, severe neurological damage, and muscle weakness.
+      explanation: CACTD case series directly lists seizures with severe hypoglycemia and hyperammonemia.
   - target: Global developmental delay
     description: Recurrent hyperammonemia and acute brain injury can lead to developmental delay or intellectual disability.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -774,7 +787,13 @@ phenotypes:
     term:
       id: HP:0001250
       label: Seizure
-  notes: Seizures are reported during metabolic decompensation in CACT deficiency, but the available abstracts do not provide a specific snippet mentioning seizures.
+  evidence:
+  - reference: PMID:34449152
+    reference_title: "Clinical and molecular characteristics of carnitineacylcarnitine translocase deficiency with c.270delC and a novel c.408C>A variant."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: CACTD is characterized by severe episodes of hypoglycemia and hyperammonemia, seizures, cardiomyopathy, liver dysfunction, severe neurological damage, and muscle weakness.
+    explanation: CACTD case series directly supports seizures as part of the clinical spectrum.
 - name: Encephalopathy
   description: 'Severe neonatal metabolic decompensation can include encephalopathy due to combined energy failure, hypoglycemia, and hyperammonemia.
 
@@ -867,6 +886,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: The ratios of the primary markers (C16 + C18:1)/C2, C16/C2, C16:1/C3, and C16:1-OH/C3 can facilitate the diagnosis of CACT deficiency, thereby increasing sensitivity and reducing false-positivity.
     explanation: Study demonstrates improved diagnostic performance of ratio indices over single markers.
+  readouts:
+  - target: Toxic acylcarnitine accumulation and secondary carnitine depletion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased long-chain acylcarnitine ratio indices report the abnormal acylcarnitine accumulation pattern caused by CACT deficiency and improve newborn-screening discrimination.
+    evidence:
+    - reference: PMID:37305732
+      reference_title: "Increased acylcarnitine ratio indices in newborn screening for carnitine-acylcarnitine translocase deficiency shows increased sensitivity and reduced false-positivity."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: An acylcarnitine ratio analysis showed that C14/C3, C16/C2, C16/C3, C18/C3, C16:1/C3, and C16:1-OH/C3 were significantly increased in all 15 patients.
+      explanation: Ratio indices are increased in genetically confirmed CACT deficiency and therefore read out the acylcarnitine accumulation state.
 - name: Dicarboxylic aciduria
   presence: INCREASED
   context: 'Urinary dicarboxylic acid excretion can be seen when impaired mitochondrial long-chain fatty acid oxidation redirects substrates toward alternative oxidation pathways.
@@ -997,6 +1029,36 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Impaired mitochondrial long-chain fatty acid oxidation
+    treatment_effect: BYPASSES
+    description: High carbohydrate intake and long-chain fat restriction reduce dependence on the blocked long-chain FAO pathway and limit lipolysis.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: It is essential to provide the patient with sufficient glucose to prevent lipolysis and to avoid the use of fatty acids as fuel as far as possible.
+      explanation: Nutritional management review explains the bypass rationale for glucose provision and fatty-acid fuel avoidance in FAODs.
+  - target: Catabolic stress-triggered metabolic decompensation
+    treatment_effect: INHIBITS
+    description: Preventing fasting and maintaining uninterrupted calories reduces catabolic decompensation risk.
+    evidence:
+    - reference: PMID:39203843
+      reference_title: "Nutritional Management of Patients with Fatty Acid Oxidation Disorders."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Dietary management consists of preventing periods of fasting and restricting fat intake by increasing carbohydrate intake, while maintaining an adequate and uninterrupted caloric intake.
+      explanation: Review supports diet as prevention of fasting-driven decompensation in FAODs.
+  target_phenotypes:
+  - preferred_term: Hypoketotic hypoglycemia
+    term:
+      id: HP:0001985
+      label: Hypoketotic hypoglycemia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
   evidence:
   - reference: PMID:35862567
     reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
@@ -1025,6 +1087,49 @@ treatments:
     term:
       id: MAXO:0000106
       label: nutritional supplementation
+    therapeutic_agent:
+    - preferred_term: triheptanoin
+      term:
+        id: CHEBI:17855
+        label: triglyceride
+  target_mechanisms:
+  - target: Impaired mitochondrial long-chain fatty acid oxidation
+    treatment_effect: BYPASSES
+    description: Triheptanoin provides a medium odd-chain triglyceride energy substrate and anaplerotic support when long-chain fatty acid oxidation is impaired.
+    evidence:
+    - reference: PMID:35862567
+      reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The mainstay of therapy is a high-carbohydrate diet (>60% of total caloric intake) with restriction of long-chain dietary fat (to <10% of total calories) and treatment with the anaplerotic agent triheptanoin (to provide 25%-35% of total calories).
+      explanation: GeneReviews identifies triheptanoin as an anaplerotic treatment for CACT deficiency.
+  - target: Catabolic stress-triggered metabolic decompensation
+    treatment_effect: INHIBITS
+    description: Triheptanoin reduces catabolic and metabolic decompensation episodes in long-chain FAODs.
+    evidence:
+    - reference: PMID:39375714
+      reference_title: "Triheptanoin in patients with long-chain fatty acid oxidation disorders: clinical experience in Italy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The significant improvement in clinical outcome measures after the administration of triheptanoin highlights that this treatment approach can be more effective than MCT supplementation in patients with LC-FAOD.
+      explanation: Clinical cohort supports triheptanoin reducing decompensation burden in long-chain FAODs.
+  target_phenotypes:
+  - preferred_term: Hypertrophic cardiomyopathy
+    term:
+      id: HP:0001639
+      label: Hypertrophic cardiomyopathy
+  - preferred_term: Cardiac arrhythmia
+    term:
+      id: HP:0011675
+      label: Arrhythmia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  - preferred_term: Rhabdomyolysis
+    term:
+      id: HP:0003201
+      label: Rhabdomyolysis
   evidence:
   - reference: PMID:39375714
     reference_title: "Triheptanoin in patients with long-chain fatty acid oxidation disorders: clinical experience in Italy."
@@ -1041,6 +1146,26 @@ treatments:
     term:
       id: MAXO:0000088
       label: dietary intervention
+  target_mechanisms:
+  - target: Impaired mitochondrial long-chain fatty acid oxidation
+    treatment_effect: BYPASSES
+    description: Medium-chain triglycerides provide calories that bypass the long-chain carnitine shuttle defect.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Formula should have reduced long-chain fat plus mediumchain triglyceride (MCT) supplementation.
+      explanation: Review supports MCT supplementation as a bypass dietary strategy for CACT deficiency.
+  target_phenotypes:
+  - preferred_term: Hypoketotic hypoglycemia
+    term:
+      id: HP:0001985
+      label: Hypoketotic hypoglycemia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
   evidence:
   - reference: PMID:35862567
     reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
@@ -1057,6 +1182,17 @@ treatments:
     term:
       id: MAXO:0010006
       label: carnitine supplementation
+  target_mechanisms:
+  - target: Toxic acylcarnitine accumulation and secondary carnitine depletion
+    treatment_effect: MODULATES
+    description: Carnitine supplementation replenishes low free carnitine, although benefit is uncertain and use is guided by carnitine levels.
+    evidence:
+    - reference: PMID:35862567
+      reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Fasting is avoided or limited, and carnitine supplemented at ~100 mg/kg/day is recommended.
+      explanation: GeneReviews recommends carnitine supplementation as part of routine CACT deficiency management.
   evidence:
   - reference: PMID:29502916
     reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
@@ -1073,6 +1209,48 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Catabolic stress-triggered metabolic decompensation
+    treatment_effect: INHIBITS
+    description: High-dextrose fluids reverse catabolism and reduce endogenous lipolysis during acute crises.
+    evidence:
+    - reference: PMID:35862567
+      reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Administration of high-dextrose-containing fluids: oral/enteral carbohydrate polymer (at home) or intravenous dextrose (in the hospital)."
+      explanation: GeneReviews supports high-dextrose fluids as acute therapy for CACT deficiency crises.
+  - target: Hyperammonemia during metabolic crises
+    treatment_effect: INHIBITS
+    description: High-rate dextrose infusion is the most effective acute intervention for CACT-associated hyperammonemia.
+    evidence:
+    - reference: PMID:35862567
+      reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hyperammonemia is most sensitive to high rates of dextrose infusion (12-15 g/kg/day glucose for infants and 10-12 g/kg/day for children age 1-6 years), while ammonia scavenging medications (sodium benzoate, sodium phenylbutyrate) are of limited efficacy.
+      explanation: GeneReviews directly identifies high-rate dextrose as the most effective hyperammonemia-directed acute intervention.
+  target_phenotypes:
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  - preferred_term: Hypoketotic hypoglycemia
+    term:
+      id: HP:0001985
+      label: Hypoketotic hypoglycemia
+  - preferred_term: Cardiac arrhythmia
+    term:
+      id: HP:0011675
+      label: Arrhythmia
+  - preferred_term: Hypertrophic cardiomyopathy
+    term:
+      id: HP:0001639
+      label: Hypertrophic cardiomyopathy
+  - preferred_term: Rhabdomyolysis
+    term:
+      id: HP:0003201
+      label: Rhabdomyolysis
   evidence:
   - reference: PMID:35862567
     reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
@@ -1089,6 +1267,27 @@ treatments:
     term:
       id: MAXO:0000124
       label: disease screening
+  target_phenotypes:
+  - preferred_term: Hypoketotic hypoglycemia
+    term:
+      id: HP:0001985
+      label: Hypoketotic hypoglycemia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  - preferred_term: Cardiac arrhythmia
+    term:
+      id: HP:0011675
+      label: Arrhythmia
+  - preferred_term: Hypertrophic cardiomyopathy
+    term:
+      id: HP:0001639
+      label: Hypertrophic cardiomyopathy
+  - preferred_term: Global developmental delay
+    term:
+      id: HP:0001263
+      label: Global developmental delay
   evidence:
   - reference: PMID:37305732
     reference_title: "Increased acylcarnitine ratio indices in newborn screening for carnitine-acylcarnitine translocase deficiency shows increased sensitivity and reduced false-positivity."
@@ -1127,6 +1326,30 @@ treatments:
     term:
       id: MAXO:0000950
       label: supportive care
+  target_mechanisms:
+  - target: Catabolic stress-triggered metabolic decompensation
+    treatment_effect: INHIBITS
+    description: Avoiding fasting and maintaining emergency plans reduce catabolic stress exposures that precipitate crises.
+    evidence:
+    - reference: PMID:35862567
+      reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Agents/circumstances to avoid: Prolonged fasting, catabolic illness (fever, intercurrent infection), inadequate caloric provision during times of catabolic stress (including during fasting), prolonged strenuous physical activity, and prolonged administration of anesthetics containing high levels of long-chain fatty acids (e.g., propofol)."
+      explanation: GeneReviews lists fasting and catabolic illness as exposures to avoid in CACT deficiency.
+  target_phenotypes:
+  - preferred_term: Hypoketotic hypoglycemia
+    term:
+      id: HP:0001985
+      label: Hypoketotic hypoglycemia
+  - preferred_term: Hyperammonemia
+    term:
+      id: HP:0001987
+      label: Hyperammonemia
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
   evidence:
   - reference: PMID:35862567
     reference_title: "Carnitine-Acylcarnitine Translocase Deficiency."

--- a/references_cache/PMID_34449152.md
+++ b/references_cache/PMID_34449152.md
@@ -1,0 +1,74 @@
+---
+reference_id: "PMID:34449152"
+title: "Clinical and molecular characteristics of carnitineacylcarnitine translocase deficiency with c.270delC and a novel c.408C>A variant."
+authors:
+- Gürbüz BB
+- Yılmaz DY
+- Özgül RK
+- Koşukcu C
+- Dursun A
+- Sivri HS
+- Coşkun T
+- Tokatlı A
+journal: Turk J Pediatr
+year: '2021'
+doi: 10.24953/turkjped.2021.04.017
+keywords:
+- Carnitine
+- Carnitine Acyltransferases/genetics
+- Female
+- Humans
+- "Lipid Metabolism, Inborn Errors"
+- Membrane Transport Proteins
+- Muscular Diseases
+- Mutation
+- Pregnancy
+content_type: abstract_only
+---
+
+# Clinical and molecular characteristics of carnitineacylcarnitine translocase deficiency with c.270delC and a novel c.408C>A variant.
+**Authors:** Gürbüz BB, Yılmaz DY, Özgül RK, Koşukcu C, Dursun A, Sivri HS, Coşkun T, Tokatlı A
+**Journal:** Turk J Pediatr (2021)
+**DOI:** [10.24953/turkjped.2021.04.017](https://doi.org/10.24953/turkjped.2021.04.017)
+
+## Content
+
+1. Turk J Pediatr. 2021;63(4):691-696. doi: 10.24953/turkjped.2021.04.017.
+
+Clinical and molecular characteristics of carnitineacylcarnitine translocase
+deficiency with c.270delC and a novel c.408C>A variant.
+
+Gürbüz BB(1), Yılmaz DY(2), Özgül RK(2), Koşukcu C(3), Dursun A(1), Sivri HS(1),
+Coşkun T(1), Tokatlı A(1).
+
+Author information:
+(1)Department of Pediatric Metabolism, Hacettepe University Faculty of Medicine,
+Ankara.
+(2)Department of Pediatric Metabolism, Hacettepe University Institute of Child
+Health, Ankara.
+(3)Department of Bioinformatics, Hacettepe University Institute of Health
+Sciences, Ankara, Turkey.
+
+BACKGROUND: Carnitine-acylcarnitine translocase deficiency (CACTD) is a rare,
+autosomal recessive, and highly lethal fatty acid oxidation (FAO) disorder
+caused by defective acylcarnitine transport across the mitochondrial membrane.
+CACTD is characterized by severe episodes of hypoglycemia and hyperammonemia,
+seizures, cardiomyopathy, liver dysfunction, severe neurological damage, and
+muscle weakness. Herein, we described the clinical features, biochemical, and
+molecular findings of three patients with CACTD, presented with poor feeding,
+hypoglycemia, liver dysfunctions, and hyperammonemia, but died despite intensive
+treatment.
+CASES: All cases had similar signs and symptoms like poor feeding and
+respiratory failure associated with liver dysfunction. Urinary organic acid
+profiles in the presence of hypoglycemia and hyperammonemia led us to the
+possible diagnosis of one of fatty acid β-oxidation defects. Results of the
+molecular analyses were compatible with CACTD. In addition to known mutation
+(c.270delC;p.Phe91Leufs*38) we detected a novel one (c.408C > A;p.Cys136*).
+CONCLUSIONS: All three cases died despite a very intensive therapy. Based on our
+experience with these three cases, it can be said that CACTD has a relatively
+poor prognosis, molecular studies are of most importance in suspected cases for
+the final diagnosis and such studies might be of help while giving genetic
+counselling and guidance to parents for future pregnancies.
+
+DOI: 10.24953/turkjped.2021.04.017
+PMID: 34449152 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- connect CACT therapies to mechanisms and target phenotypes, including diet, triheptanoin, MCT, carnitine, acute dextrose management, newborn screening, and fasting/emergency planning
- add a diagnostic readout edge for acylcarnitine ratio indices
- add CACT-specific PMID:34449152 evidence for seizures and connect seizures downstream of crisis hyperammonemia/hypoglycemia

## Graph impact
- Before: 38 nodes, 30 edges, 11 components, 10 isolated nodes
- After: 38 nodes, 62 edges, 2 components, 1 isolated node
- Remaining isolated: Genetic counseling

## Validation
- just validate kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
- just validate-references kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
- just validate-terms kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
- git diff --check
- manual normalized snippet audit: 94 snippets across 13 references matched cached text

## Scope control
- Fetched PMID:34449152 using just fetch-reference; no reference cache hand-editing
- Restored unrelated ClinicalTrials cache churn after validation
- Rebasing onto current origin/main completed before push