### PR TITLE
[codex] Connect APRT deficiency renal phenotypes

### DIFF
--- a/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
+++ b/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Adenine Phosphoribosyltransferase Deficiency
 category: Mendelian
 creation_date: "2026-05-10T09:34:20Z"
-updated_date: "2026-05-18T22:34:51Z"
+updated_date: "2026-05-18T22:44:37Z"
 synonyms:
 - APRT deficiency
 - 2,8-dihydroxyadenine urolithiasis
@@ -398,6 +398,12 @@ pathophysiology:
     description: DHA stone disease and urinary tract irritation can present with hematuria.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012587 | Macroscopic hematuria | Occasional (29-5%)"
+      explanation: Orphanet records macroscopic hematuria as an occasional phenotype in APRT deficiency.
     - reference: PMID:30443743
       reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
       supports: SUPPORT

--- a/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
+++ b/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Adenine Phosphoribosyltransferase Deficiency
 category: Mendelian
 creation_date: "2026-05-10T09:34:20Z"
-updated_date: "2026-05-10T23:55:30Z"
+updated_date: "2026-05-18T22:34:51Z"
 synonyms:
 - APRT deficiency
 - 2,8-dihydroxyadenine urolithiasis
@@ -384,6 +384,76 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Three patients presented with AKI due to obstructive stone disease"
       explanation: Human registry data directly link obstructive stone disease to AKI at presentation.
+  - target: Recurrent urinary tract infections
+    description: Stone disease and urinary tract obstruction can predispose to recurrent urinary tract infections.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other well-known clinical features in children include reddish-brown diaper stains in young children, acute kidney injury (AKI) due to bilateral obstructive DHA calculi, recurrent urinary tract infections and hematuria"
+      explanation: Pediatric registry evidence lists recurrent urinary tract infections with obstructive DHA calculi among known clinical features.
+  - target: Macroscopic hematuria
+    description: DHA stone disease and urinary tract irritation can present with hematuria.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "recurrent urinary tract infections and hematuria"
+      explanation: Pediatric registry evidence supports hematuria as a clinical feature accompanying APRT stone disease.
+  - target: Dysuria
+    description: Urinary tract irritation from DHA stones and crystalluria can produce painful urination.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100518 | Dysuria | Frequent (79-30%)"
+      explanation: Orphanet records dysuria as a frequent phenotype in APRT deficiency.
+  - target: Flank pain
+    description: Obstructive stone events can present with flank pain.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0030157 | Flank pain | Occasional (29-5%)"
+      explanation: Orphanet records flank pain as an APRT deficiency phenotype.
+  - target: Abdominal colic
+    description: Colicky abdominal pain can accompany urinary tract stone events.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011848 | Abdominal colic | Occasional (29-5%)"
+      explanation: Orphanet records abdominal colic as an APRT deficiency phenotype.
+  - target: Urinary retention
+    description: Obstructive urinary stone disease can contribute to urinary retention.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000016 | Urinary retention | Occasional (29-5%)"
+      explanation: Orphanet records urinary retention as an occasional phenotype in APRT deficiency.
+  - target: Urinary hesitancy
+    description: Lower urinary tract obstruction and irritation can manifest as urinary hesitancy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000019 | Urinary hesitancy | Occasional (29-5%)"
+      explanation: Orphanet records urinary hesitancy as an occasional phenotype in APRT deficiency.
 - name: Renal tubular crystal deposition and obstruction
   description: >
     2,8-DHA crystals deposit in renal tubules. Small crystals can be taken up by
@@ -521,6 +591,26 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "approximately 20%-25% of affected individuals develop end-stage renal disease (ESRD)"
       explanation: GeneReviews supports progression to ESRD when treatment is inadequate.
+  - target: Oliguria
+    description: Advanced renal dysfunction or obstructive AKI can reduce urine output.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100520 | Oliguria | Occasional (29-5%)"
+      explanation: Orphanet records oliguria as an occasional renal phenotype in APRT deficiency.
+  - target: Hypertension
+    description: Chronic kidney disease and renal dysfunction can contribute to hypertension.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:976
+      reference_title: "Adenine phosphoribosyltransferase deficiency"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000822 | Hypertension | Frequent (79-30%)"
+      explanation: Orphanet records hypertension as a frequent phenotype in APRT deficiency, consistent with downstream renal dysfunction.
 phenotypes:
 - category: Biochemical
   name: Abnormal APRT enzyme activity
@@ -871,6 +961,19 @@ biochemical:
   context: >
     Absent or markedly reduced APRT activity in red cell lysates is the
     diagnostic biochemical defect.
+  readouts:
+  - target: APRT molecular function deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Absent red-cell APRT activity directly reports the proximal APRT molecular function deficiency.
+    evidence:
+    - reference: PMID:22934314
+      reference_title: "Adenine Phosphoribosyltransferase Deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The diagnosis of APRT deficiency is established in a proband by absence of APRT enzyme activity in red cell lysates"
+      explanation: GeneReviews identifies absent APRT enzyme activity as the diagnostic biochemical readout.
   evidence:
   - reference: PMID:22934314
     reference_title: "Adenine Phosphoribosyltransferase Deficiency."
@@ -889,6 +992,24 @@ biochemical:
   context: >
     2,8-DHA is formed and hyperexcreted in urine, where crystalluria and stone
     formation provide diagnostic and treatment-monitoring readouts.
+  biomarker_term:
+    preferred_term: 2,8-dihydroxyadenine
+    term:
+      id: CHEBI:183641
+      label: 2,8-dihydroxyadenine
+  readouts:
+  - target: Adenine conversion to 2,8-dihydroxyadenine
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary 2,8-DHA reports the abnormal XOR-mediated adenine conversion caused by APRT loss.
+    evidence:
+    - reference: PMID:30443743
+      reference_title: "Long-term renal outcomes of APRT deficiency presenting in childhood."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In the absence of APRT activity, adenine is converted by xanthine oxidoreductase (XOR; xanthine dehydrogenase/oxidase) to the poorly soluble 2,8-dihydroxyadenine (DHA) which is excreted in the urine in excessive amounts."
+      explanation: Human registry evidence identifies urinary 2,8-DHA excess as a biochemical readout of the abnormal conversion step.
   evidence:
   - reference: ORPHA:976
     reference_title: "Adenine phosphoribosyltransferase deficiency"
@@ -1196,6 +1317,8 @@ references:
   - statement: Review summarizes DHA formation, urinary precipitation, diagnostic tools, and treatment importance.
 - reference: PMID:22934314
   title: Adenine Phosphoribosyltransferase Deficiency.
+  tags:
+  - GeneReviews
   found_in:
   - PubMed evidence curation
   findings:


### PR DESCRIPTION
## Summary

- connects APRT deficiency stone/crystal-nephropathy mechanisms to renal and lower urinary tract phenotypes including recurrent UTIs, hematuria, dysuria, flank pain, abdominal colic, urinary retention, urinary hesitancy, oliguria, and hypertension
- adds biochemical readout links for reduced APRT enzyme activity and increased urinary 2,8-dihydroxyadenine
- tags the existing APRT GeneReviews reference at the top-level reference block
- addresses Claude's non-blocking hematuria note by adding ORPHA:976 macroscopic-hematuria evidence directly to that edge

## Validation

- rebased onto current `origin/main` before initial push; fetched again before follow-up push
- `just validate kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml`
- manual snippet audit: 108 snippets checked, 0 failures; 72 exact substring matches and 36 whitespace-normalized matches due to reference-cache line wrapping
- `git diff --check`
- graph audit: 30 nodes / 16 edges / 14 components / 13 isolates before; 30 nodes / 27 edges / 5 components / 4 isolates after

## Scope

- `kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml` only
- restored unrelated ClinicalTrials cache churn after validation
