### PR TITLE
Connect BTBGD pathograph

### DIFF
--- a/kb/disorders/Biotin_Thiamine_Responsive_Basal_Ganglia_Disease.yaml
+++ b/kb/disorders/Biotin_Thiamine_Responsive_Basal_Ganglia_Disease.yaml
@@ -1,6 +1,6 @@
 name: Biotin-Thiamine-Responsive Basal Ganglia Disease
 creation_date: "2026-05-07T13:45:22Z"
-updated_date: "2026-05-07T13:45:22Z"
+updated_date: "2026-05-19T04:01:29Z"
 description: >-
   Biotin-thiamine-responsive basal ganglia disease is a rare autosomal
   recessive neurometabolic disorder caused by biallelic SLC19A3 variants that
@@ -243,6 +243,19 @@ pathophysiology:
   - target: Stress-triggered cerebral thiamine-transport failure
     causal_link_type: DIRECT
     description: Mutant SLC19A3 limits the adaptive thiamine-transport response needed during physiologic stress.
+    evidence:
+    - reference: PMID:24372704
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        exposure of fibroblasts to stress factors such as acidosis or hypoxia markedly upregulated SLC19A3 in control cells, but failed to elevate SLC19A3 expression in the patient's fibroblasts.
+      explanation: Patient fibroblast data directly support impaired stress-induced SLC19A3 upregulation downstream of the transporter defect.
+    - reference: PMID:24372704
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        They also suggest that episodes of encephalopathy are caused by a substantially reduced capacity of mutant neuronal cells to increase SLC19A3 expression, necessary to adapt to stress conditions.
+      explanation: Authors connect mutant neuronal-cell stress adaptation to encephalopathic episodes.
 - name: Stress-triggered cerebral thiamine-transport failure
   description: >-
     Febrile illness, acidosis, hypoxia, and other stressors fail to induce
@@ -281,9 +294,31 @@ pathophysiology:
   - target: Basal ganglia and gray-matter injury
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Cerebral thiamine-transport failure produces Wernicke-like injury with basal ganglia vulnerability.
+    evidence:
+    - reference: PMID:24372704
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        These results demonstrate ubiquitously reduced thiamine transporter function in the cerebral gray matter, and neuropathological alterations similar to Wernicke's disease in BTBGD.
+      explanation: Human brain/tissue findings support gray-matter thiamine-transporter failure and Wernicke-like neuropathology.
   - target: Lactic acidosis
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Severe infantile presentations may include elevated lactate/lactic acidosis during metabolic decompensation.
+    intermediate_mechanisms:
+    - metabolic decompensation during infantile encephalopathic presentations
+    evidence:
+    - reference: PMID:27896110
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Four different phenotypes have been described; infantile lactic acidosis with encephalopathy
+      explanation: Clinical review links lactic acidosis with the infantile encephalopathic BTBGD presentation, supporting an indirect edge.
+    - reference: PMID:27896110
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Biochemical analysis revealed elevated blood lactate at 3.8 mmol/L (nl 0.6-2.2)
+      explanation: Patient biochemical testing documents lactate elevation during evaluation of BTBGD.
 - name: Basal ganglia and gray-matter injury
   description: >-
     Impaired cerebral thiamine transport injures basal ganglia and other gray
@@ -320,15 +355,118 @@ pathophysiology:
   - target: Subacute encephalopathy
     causal_link_type: DIRECT
     description: Cerebral gray-matter injury manifests clinically as acute or subacute encephalopathy.
-  - target: Seizures
+    evidence:
+    - reference: ORPHA:65284
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare genetic neurological disorder characterized by subacute encephalopathy with confusion, seizures, and movement disorder, often following a history of febrile illness.
+      explanation: Orphanet defines BTBGD by subacute encephalopathy in the setting of this basal ganglia disease.
+  - target: Confusion
     causal_link_type: DIRECT
-    description: Injured basal ganglia and cerebral networks can produce seizures.
+    description: The encephalopathic gray-matter injury state includes confusion or altered mental status.
+    evidence:
+    - reference: ORPHA:65284
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare genetic neurological disorder characterized by subacute encephalopathy with confusion, seizures, and movement disorder, often following a history of febrile illness.
+      explanation: Orphanet lists confusion as part of the BTBGD encephalopathic presentation.
+  - target: Seizures
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Injured cerebral networks during BTBGD episodes are associated with seizures.
+    evidence:
+    - reference: ORPHA:65284
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare genetic neurological disorder characterized by subacute encephalopathy with confusion, seizures, and movement disorder, often following a history of febrile illness.
+      explanation: Orphanet lists seizures within the defining encephalopathic presentation.
+    - reference: PMID:35532649
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report a 49-year-old lady presenting with rapidly progressive cognitive impairment, seizures, hypersomnolence, ataxia, and generalized dystonia of 3 weeks duration.
+      explanation: Adult BTBGD case documents seizures together with acute neurologic deterioration.
   - target: Movement disorder and dystonia
     causal_link_type: DIRECT
     description: Basal ganglia injury produces extrapyramidal movement disorder and dystonia.
+    evidence:
+    - reference: ORPHA:65284
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        A rare genetic neurological disorder characterized by subacute encephalopathy with confusion, seizures, and movement disorder, often following a history of febrile illness.
+      explanation: Orphanet identifies movement disorder as part of the defining basal ganglia disease presentation.
+    - reference: PMID:35532649
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report a 49-year-old lady presenting with rapidly progressive cognitive impairment, seizures, hypersomnolence, ataxia, and generalized dystonia of 3 weeks duration.
+      explanation: Adult BTBGD case documents generalized dystonia during the episode.
+  - target: Cogwheel rigidity
+    causal_link_type: DIRECT
+    description: Basal ganglia dysfunction in classic BTBGD produces extrapyramidal cogwheel rigidity.
+    evidence:
+    - reference: PMID:24260777
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dystonia and cogwheel rigidity are nearly always present"
+      explanation: GeneReviews states that cogwheel rigidity is nearly always present in classic BTBGD.
+  - target: Hyperreflexia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: BTBGD can include corticospinal or upper-motor-neuron signs such as hyperreflexia during classic presentations.
+    evidence:
+    - reference: PMID:24260777
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hyperreflexia, ankle clonus, and Babinski responses are common."
+      explanation: GeneReviews lists hyperreflexia among common classic BTBGD neurologic signs.
+  - target: Dysphagia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: BTBGD encephalopathic CNS injury can include bulbar dysfunction with dysphagia.
+    evidence:
+    - reference: PMID:27905264
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The disease is characterized by subacute encephalopathy with confusion, dysphagia, dysarthria, and seizures.
+      explanation: Clinical review links dysphagia to the BTBGD encephalopathic presentation.
+  - target: Dysarthria
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: BTBGD encephalopathic CNS injury can include dysarthria.
+    evidence:
+    - reference: PMID:27905264
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The disease is characterized by subacute encephalopathy with confusion, dysphagia, dysarthria, and seizures.
+      explanation: Clinical review links dysarthria to the BTBGD encephalopathic presentation.
+  - target: Ataxia
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: Wernicke-like gray-matter involvement can present with ataxia in adult BTBGD.
+    evidence:
+    - reference: PMID:35532649
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report a 49-year-old lady presenting with rapidly progressive cognitive impairment, seizures, hypersomnolence, ataxia, and generalized dystonia of 3 weeks duration.
+      explanation: Adult BTBGD case documents ataxia with rapidly progressive neurologic involvement.
   - target: Bilateral basal ganglia MRI abnormalities
     causal_link_type: DIRECT
     description: Basal ganglia lesions are visible as characteristic bilateral MRI signal abnormalities.
+    evidence:
+    - reference: ORPHA:65284
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Imaging may reveal bilateral lesions in the basal ganglia."
+      explanation: Orphanet directly supports bilateral basal ganglia imaging abnormalities.
+    - reference: PMID:35532649
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The magnetic resonance imaging (MRI) of the brain revealed T2-hyperintensities in the basal ganglia, thalamus, cortical, subcortical regions with striatal necrosis suggestive of BTBGD
+      explanation: Adult case report documents MRI-visible basal ganglia and broader gray-matter injury.
 histopathology:
 - name: Necrotic and hemorrhagic basal ganglia lesions
   description: >-
@@ -447,6 +585,36 @@ phenotypes:
       We report a 49-year-old lady presenting with rapidly progressive cognitive impairment, seizures, hypersomnolence, ataxia, and generalized dystonia of 3 weeks duration.
     explanation: Genetically confirmed adult BTBGD case documents generalized dystonia.
 - category: Neurological
+  name: Cogwheel rigidity
+  description: >-
+    Cogwheel rigidity is nearly always present in classic BTBGD, consistent
+    with extrapyramidal basal ganglia dysfunction.
+  phenotype_term:
+    preferred_term: Cogwheel rigidity
+    term:
+      id: HP:0002396
+      label: Cogwheel rigidity
+  evidence:
+  - reference: PMID:24260777
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Dystonia and cogwheel rigidity are nearly always present"
+    explanation: GeneReviews states that cogwheel rigidity is nearly always present in classic BTBGD.
+- category: Neurological
+  name: Hyperreflexia
+  description: Hyperreflexia is a common neurologic sign in classic BTBGD.
+  phenotype_term:
+    preferred_term: Hyperreflexia
+    term:
+      id: HP:0001347
+      label: Hyperreflexia
+  evidence:
+  - reference: PMID:24260777
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "hyperreflexia, ankle clonus, and Babinski responses are common."
+    explanation: GeneReviews lists hyperreflexia among common classic BTBGD neurologic signs.
+- category: Neurological
   name: Dysphagia
   description: Dysphagia can occur during BTBGD encephalopathic presentations.
   phenotype_term:
@@ -551,12 +719,30 @@ phenotypes:
       Typical MRI findings include cortical, subcortical white matter lesions, and bilateral abnormal signal intensity in the basal ganglia with less frequent involvement of thalami, brain stem, cerebellum and cervical spine
     explanation: Full-text review summarizes broader MRI involvement beyond the basal ganglia.
 biochemical:
-- name: Lactic acidosis
+- name: Blood lactate elevation
   presence: INCREASED
   context: >-
     Infantile BTBGD may present with lactic acidosis with encephalopathy, and
     affected patients can show elevated blood lactate during the diagnostic
     evaluation.
+  biomarker_term:
+    preferred_term: lactate
+    term:
+      id: CHEBI:24996
+      label: lactate
+  readouts:
+  - target: Lactic acidosis
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated blood lactate is the biochemical measurement underlying the lactic acidosis phenotype in infantile BTBGD presentations.
+    evidence:
+    - reference: PMID:27896110
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Biochemical analysis revealed elevated blood lactate at 3.8 mmol/L (nl 0.6-2.2)
+      explanation: Patient testing directly documents elevated blood lactate.
   evidence:
   - reference: PMID:27896110
     supports: SUPPORT
@@ -641,9 +827,57 @@ treatments:
   - target: SLC19A3 thiamine transporter deficiency
     treatment_effect: BYPASSES
     description: High-dose thiamine increases substrate availability despite reduced SLC19A3 transporter function.
+    evidence:
+    - reference: PMID:27896110
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        This treatment strategy is supported by in vitro studies suggesting that high doses of thiamine and biotin restore insufficient thiamine transport by overexpression of SLC19A3 gene
+      explanation: Human clinical case report/review cites in vitro support that high-dose vitamins restore insufficient SLC19A3-mediated thiamine transport.
   - target: Stress-triggered cerebral thiamine-transport failure
     treatment_effect: MODULATES
     description: Early vitamin supplementation supports thiamine availability during stress-triggered episodes.
+    evidence:
+    - reference: PMID:27905264
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Children presenting with unexplained encephalopathy and MRI abnormalities including bilateral signal alteration of caudate nucleus and putamen should raise the suspicion for BTBGD and be started immediately on biotin and thiamine regimen since the prognosis of the disease is affected by the timing of treatment initiation.
+      explanation: Clinical review supports immediate vitamin treatment during suspected encephalopathic episodes.
+  target_phenotypes:
+  - preferred_term: Encephalopathy
+    term:
+      id: HP:0001298
+      label: Encephalopathy
+    temporality: SUBACUTE
+  - preferred_term: Confusion
+    term:
+      id: HP:0001289
+      label: Confusion
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  - preferred_term: Dysphagia
+    term:
+      id: HP:0002015
+      label: Dysphagia
+  - preferred_term: Dysarthria
+    term:
+      id: HP:0001260
+      label: Dysarthria
+  - preferred_term: Dystonia
+    term:
+      id: HP:0001332
+      label: Dystonia
+  - preferred_term: Ataxia
+    term:
+      id: HP:0001251
+      label: Ataxia
+  - preferred_term: Abnormal basal ganglia morphology
+    term:
+      id: HP:0002134
+      label: Abnormal basal ganglia morphology
   evidence:
   - reference: ORPHA:65284
     supports: SUPPORT
@@ -663,6 +897,32 @@ treatments:
     snippet: >-
       It is considered a treatable condition if vitamin supplementation, most commonly with thiamine and biotin, is initiated early.
     explanation: Child neurology review emphasizes early thiamine/biotin supplementation.
+- name: Avoidance of sodium valproate and ACTH
+  description: >-
+    Sodium valproate should be avoided for epilepsy treatment in BTBGD, and
+    ACTH used for epileptic spasms can induce status dystonicus.
+  role: Agents/circumstances to avoid
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+  target_phenotypes:
+  - preferred_term: Seizure
+    term:
+      id: HP:0001250
+      label: Seizure
+  - preferred_term: Dystonia
+    term:
+      id: HP:0001332
+      label: Dystonia
+  evidence:
+  - reference: PMID:24260777
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Avoid use of sodium valproate to treat epilepsy. Use of ACTH to treat epileptic spasms can induce status dystonicus.
+    explanation: GeneReviews explicitly lists sodium valproate and ACTH as agents/circumstances to avoid in BTBGD.
 - name: Genetic counseling
   description: >-
     Families benefit from counseling about autosomal recessive recurrence risk
@@ -696,3 +956,9 @@ differential_diagnoses:
     snippet: >-
       Our report adds to the genotype-phenotype correlation, highlighting the clinical importance of considering SLC19A3 gene defects as part of the differential diagnosis for Leigh syndrome.
     explanation: Case report directly identifies Leigh syndrome as an important differential diagnosis.
+references:
+- reference: PMID:24260777
+  title: Biotin-Thiamine-Responsive Basal Ganglia Disease.
+  tags:
+  - GeneReviews
+  findings: []

--- a/references_cache/PMID_24260777.md
+++ b/references_cache/PMID_24260777.md
@@ -1,0 +1,105 @@
+---
+reference_id: "PMID:24260777"
+title: Biotin-Thiamine-Responsive Basal Ganglia Disease.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Tabarki B
+- Al-Hashem A
+- Ortigoza-Escobar JD
+- Alsharhan H
+- Alfadhel M
+year: '1993'
+content_type: abstract_only
+---
+
+# Biotin-Thiamine-Responsive Basal Ganglia Disease.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Tabarki B, Al-Hashem A, Ortigoza-Escobar JD, Alsharhan H, Alfadhel M
+
+## Content
+
+1. Biotin-Thiamine-Responsive Basal Ganglia Disease.
+
+Tabarki B(1), Al-Hashem A(2)(3), Ortigoza-Escobar JD(4)(5)(6), Alsharhan H(7),
+Alfadhel M(8)(9).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2013 Nov 21 [updated 2025 Jan 9].
+
+Author information:
+(1)Prince Sultan Military and Medical City, Riyadh, Saudi Arabia
+(2)King Fahad Specialist Hospital, Dammam, Saudi Arabia
+(3)SEHA Virtual Hospital, Riyadh, Saudi Arabia
+(4)Movement Disorders Unit, Pediatric Neurology Department, Institut de Recerca,
+Hospital Sant Joan de Déu Barcelona, Barcelona, Spain
+(5)European Reference Network for Rare Neurological Diseases (ERN-RND),
+Barcelona, Spain
+(6)U-703 Centre for Biomedical Research on Rare Diseases (CIBER-ER), Instituto
+de Salud Carlos III, Barcelona, Spain
+(7)College of Medicine, Kuwait University, Kuwait City, Kuwait
+(8)King Abdulaziz Medical City, Riyadh, Saudi Arabia
+(9)King Saud Bin Abdulaziz University for Health Sciences, Riyadh, Saudi Arabia
+
+CLINICAL CHARACTERISTICS: Biotin-thiamine-responsive basal ganglia disease
+(BTBGD) may present in early infancy, childhood, or adulthood. Early-infantile
+BTBGD presents before age three months with vomiting, feeding difficulties,
+encephalopathy, hypotonia, seizures, and respiratory failure. Classic BTBGD
+presents between ages three and ten years with recurrent subacute encephalopathy
+manifesting as confusion, seizures, ataxia, supranuclear facial palsy, external
+ophthalmoplegia, and/or dysphagia that, if left untreated, can eventually lead
+to coma and even death. Dystonia and cogwheel rigidity are nearly always
+present; hyperreflexia, ankle clonus, and Babinski responses are common.
+Hemiparesis or quadriparesis may be seen. Episodes are often triggered by
+febrile illness or mild trauma or stress. Simple partial or generalized seizures
+are easily controlled with anti-seizure medication. Adult Wernicke-like
+encephalopathy BTBGD, described in three individuals to date, presents after age
+ten years with acute onset of status epilepticus, ataxia, nystagmus, diplopia,
+and ophthalmoplegia. Prompt administration of biotin and thiamine early in the
+disease course results in partial or complete improvement within days in classic
+and adult BTBGD; however, most infants with early-infantile BTBGD have a poor
+outcome.
+DIAGNOSIS/TESTING: The diagnosis of BTBGD is established in a proband with
+biallelic pathogenic variants in SLC19A3 identified by molecular genetic
+testing.
+MANAGEMENT: Targeted therapies: Biotin (5-10 mg/kg/day) and thiamine (up to 40
+mg/kg/day with a maximum of 1,500 mg daily) are given orally as early in the
+disease course as possible and are continued lifelong. During acute
+decompensations thiamine may be increased to double the regular dose and given
+intravenously. Disease manifestations typically resolve within days in classic
+and adult BTBGD. Supportive care: Acute encephalopathic episodes may require
+care in an ICU to manage seizures and increased intracranial pressure; thiamine
+may be increased to double the regular dose and given intravenously.
+Anti-seizure medication is used to control seizures. Treatment of dystonia is
+symptomatic and includes administration of trihexyphenidyl or levodopa.
+Rehabilitation, physical therapy, occupational therapy, and speech therapy as
+needed and adaptation of educational programs to meet individual needs.
+Education of the family regarding the importance of lifelong adherence to
+medical therapy. Surveillance: At each visit, review neurologic status and
+assess developmental progress, educational needs, social support, and need for
+care coordination. Agents/circumstances to avoid: Avoid use of sodium valproate
+to treat epilepsy. Use of ACTH to treat epileptic spasms can induce status
+dystonicus. Evaluation of relatives at risk: It is appropriate to clarify the
+genetic status of apparently asymptomatic older and younger sibs of an affected
+individual to identify as early as possible those who would benefit from prompt
+initiation of treatment with biotin and thiamine and information about
+agents/circumstances to avoid. Pregnancy management: Affected women should
+continue thiamine and biotin during pregnancy.
+GENETIC COUNSELING: BTBGD is inherited in an autosomal recessive manner. If both
+parents are known to be heterozygous for an SLC19A3 pathogenic variant, each sib
+of an affected individual has at conception a 25% chance of being affected, a
+50% chance of being an asymptomatic carrier, and a 25% chance of being
+unaffected and not a carrier. Once the SLC19A3 pathogenic variants have been
+identified in an affected family member, carrier testing for at-risk family
+members and prenatal/preimplantation genetic testing for BTBGD are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 24260777


### PR DESCRIPTION
## Summary
- add evidence-backed causal edges from SLC19A3 thiamine transport failure through stress-triggered cerebral failure to CNS injury and neurologic phenotypes
- add CHEBI-backed blood lactate biochemical readout for the lactic acidosis phenotype
- connect high-dose thiamine/biotin therapy to mechanism targets and expected clinical targets

## Validation
- `just validate kb/disorders/Biotin_Thiamine_Responsive_Basal_Ganglia_Disease.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Biotin_Thiamine_Responsive_Basal_Ganglia_Disease.yaml`
- manual snippet audit: total=71 exact=30 normalized=41 missing=0
- `git diff --check`

## Notes
- reference validator reported `Total checks: 0` for this file, so snippets were manually audited against cached references
- unrelated reference-cache normalization churn was restored before commit