### PR TITLE
Connect GSD VII pathograph

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_VII.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_VII.yaml
@@ -1,6 +1,6 @@
 name: Glycogen Storage Disease Type VII
 creation_date: "2026-05-11T13:32:18Z"
-updated_date: "2026-05-11T13:32:18Z"
+updated_date: "2026-05-19T04:40:48Z"
 category: Mendelian
 synonyms:
 - Glycogen storage disease due to muscle phosphofructokinase deficiency
@@ -119,9 +119,29 @@ pathophysiology:
   - target: Skeletal Muscle Glycolytic Block
     description: Loss of PFKM function blocks the phosphofructokinase step in skeletal-muscle glycolysis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In Tarui disease, reduced enzyme activity of muscle phosphofructokinase
+        (PFKM) is detected resulting in impaired phosphorylation of fructose
+        6-phosphate to fructose 1,6-bisphosphate.
+      explanation: Human Tarui disease cases support the direct skeletal-muscle glycolytic block caused by reduced PFKM activity.
   - target: Erythrocyte Phosphofructokinase Partial Deficiency
     description: PFKM deficiency reduces erythrocyte glycolytic phosphofructokinase function.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22995305
+      reference_title: Altered allosteric regulation of muscle 6-phosphofructokinase causes Tarui disease.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Tarui disease is a glycogen storage disease (GSD VII) and characterized by
+        exercise intolerance with muscle weakness and cramping, mild myopathy,
+        myoglobinuria and compensated hemolysis.
+      explanation: The study states that PFKM-related Tarui disease includes compensated hemolysis, supporting an erythrocyte branch.
 - name: Skeletal Muscle Glycolytic Block
   description: >-
     Reduced PFKM activity interrupts skeletal-muscle glycolysis at the
@@ -172,27 +192,154 @@ pathophysiology:
   - target: Exercise intolerance
     description: Impaired skeletal-muscle glycolysis limits exertional energy production.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32117019
+      reference_title: Beneficial Effects of Ketogenic Diet on Phosphofructokinase Deficiency (Glycogen Storage Disease Type VII).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        GSD VII) characterized by exercise intolerance with myalgia due to an inability
+        to use glucose as an energy resource.
+      explanation: Clinical report directly links the PFKM glycolytic block to exercise intolerance.
   - target: Muscle cramps
     description: Exertional glycolytic energy failure contributes to muscle cramping.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18421897
+      reference_title: "Tarui disease and distal glycogenoses: clinical and genetic update."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        So far, more than one hundred patients have been described with prominent
+        clinical symptoms characterized by muscle cramps, exercise intolerance,
+        rhabdomyolysis and myoglobinuria, often associated with haemolytic
+        anaemia and hyperuricaemia.
+      explanation: Clinical review identifies muscle cramps among prominent Tarui disease manifestations.
   - target: Myalgia
     description: Inability to use glucose as a muscle energy source is associated with exertional myalgia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32117019
+      reference_title: Beneficial Effects of Ketogenic Diet on Phosphofructokinase Deficiency (Glycogen Storage Disease Type VII).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        GSD VII) characterized by exercise intolerance with myalgia due to an inability
+        to use glucose as an energy resource.
+      explanation: Clinical report links myalgia to inability to use glucose as an energy resource.
   - target: Myoglobinuria
     description: Exertional muscle injury can lead to myoglobinuria.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18421897
+      reference_title: "Tarui disease and distal glycogenoses: clinical and genetic update."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        So far, more than one hundred patients have been described with prominent
+        clinical symptoms characterized by muscle cramps, exercise intolerance,
+        rhabdomyolysis and myoglobinuria, often associated with haemolytic
+        anaemia and hyperuricaemia.
+      explanation: Clinical review identifies myoglobinuria among prominent Tarui disease manifestations.
   - target: Rhabdomyolysis
     description: Severe exertional muscle injury can manifest as rhabdomyolysis.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18421897
+      reference_title: "Tarui disease and distal glycogenoses: clinical and genetic update."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        So far, more than one hundred patients have been described with prominent
+        clinical symptoms characterized by muscle cramps, exercise intolerance,
+        rhabdomyolysis and myoglobinuria, often associated with haemolytic
+        anaemia and hyperuricaemia.
+      explanation: Clinical review identifies rhabdomyolysis among prominent Tarui disease manifestations.
   - target: Low exercise lactate with delayed post-exercise rise
     description: The PFKM step block produces an atypical lactate response during and after exercise.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In conclusion, we show that Tarui disease is associated with low lactate
+        levels during exercise with a late increase of lactate after exercise and
+        exceptionally high ammonia levels during and after exercise.
+      explanation: Exercise-testing data support the diagnostic lactate profile downstream of the PFKM glycolytic block.
   - target: Exercise-associated hyperammonemia
     description: Decreased glycogen metabolism during exercise is associated with high ammonia levels.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Overuse of protein and purine nucleotide/amino-acid pathways during impaired glycogen metabolism.
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        During exercise, the patients with Tarui disease showed exceptionally high ammonia levels that has previously been explained by overuse of proteins because of decreased glycogen metabolism
+      explanation: Human exercise-testing study supports exercise-associated ammonia elevation downstream of impaired muscle glycogen metabolism.
+  - target: Hyperuricemia
+    description: Abnormal exercise metabolism can be accompanied by hyperuricemia in the clinical Tarui disease syndrome.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18421897
+      reference_title: "Tarui disease and distal glycogenoses: clinical and genetic update."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        So far, more than one hundred patients have been described with prominent
+        clinical symptoms characterized by muscle cramps, exercise intolerance,
+        rhabdomyolysis and myoglobinuria, often associated with haemolytic
+        anaemia and hyperuricaemia.
+      explanation: Clinical review identifies hyperuricemia as associated with prominent Tarui disease manifestations.
   - target: Increased muscle glycogen content
     description: Impaired glycolytic utilization leaves excess glycogen in skeletal muscle.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Both patients with Tarui disease showed in muscle electron microscopic
+        analysis extra lysosomal glycogen accumulations.
+      explanation: Human muscle pathology supports glycogen accumulation downstream of the skeletal-muscle glycolytic block.
+  - target: Muscle weakness
+    description: Skeletal-muscle glycolytic failure manifests as muscle weakness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22995305
+      reference_title: Altered allosteric regulation of muscle 6-phosphofructokinase causes Tarui disease.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Tarui disease is a glycogen storage disease (GSD VII) and characterized by
+        exercise intolerance with muscle weakness and cramping, mild myopathy,
+        myoglobinuria and compensated hemolysis.
+      explanation: This disease overview identifies muscle weakness as part of Tarui disease.
+  - target: Myotonia
+    description: Muscle energy dysfunction is associated with myotonia in Orphanet's GSD VII phenotype record.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:371
+      reference_title: "Glycogen storage disease due to muscle phosphofructokinase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002486 | Myotonia | Very frequent (99-80%)"
+      explanation: Orphanet reports myotonia as a very frequent GSD VII phenotype.
+  - target: Skeletal muscle atrophy
+    description: Chronic skeletal-muscle involvement can include muscle atrophy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:371
+      reference_title: "Glycogen storage disease due to muscle phosphofructokinase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003202 | Skeletal muscle atrophy | Frequent (79-30%)"
+      explanation: Orphanet reports skeletal muscle atrophy as a frequent GSD VII phenotype.
 - name: Erythrocyte Phosphofructokinase Partial Deficiency
   description: >-
     PFKM-related phosphofructokinase deficiency has an erythrocyte clinical arm:
@@ -240,6 +387,26 @@ pathophysiology:
   - target: Hemolytic anemia
     description: Erythrocyte glycolytic enzyme deficiency manifests clinically as compensated hemolysis or hemolytic anemia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22995305
+      reference_title: Altered allosteric regulation of muscle 6-phosphofructokinase causes Tarui disease.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Tarui disease is a glycogen storage disease (GSD VII) and characterized by
+        exercise intolerance with muscle weakness and cramping, mild myopathy,
+        myoglobinuria and compensated hemolysis.
+      explanation: This paper identifies compensated hemolysis as part of Tarui disease.
+    - reference: PMID:18421897
+      reference_title: "Tarui disease and distal glycogenoses: clinical and genetic update."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        So far, more than one hundred patients have been described with prominent
+        clinical symptoms characterized by muscle cramps, exercise intolerance,
+        rhabdomyolysis and myoglobinuria, often associated with haemolytic
+        anaemia and hyperuricaemia.
+      explanation: Clinical review supports hemolytic anemia as a recurring Tarui disease manifestation.
 phenotypes:
 - name: Hemolytic anemia
   frequency: VERY_FREQUENT
@@ -436,7 +603,7 @@ phenotypes:
     explanation: This review reports rhabdomyolysis among prominent symptoms.
 biochemical:
 - name: Low exercise lactate with delayed post-exercise rise
-  presence: Decreased
+  presence: DECREASED
   notes: >-
     Exercise testing shows low lactate during exercise, followed by a delayed
     post-exercise rise that helps distinguish Tarui disease from McArdle
@@ -446,6 +613,22 @@ biochemical:
     term:
       id: CHEBI:24996
       label: lactate
+  readouts:
+  - target: Skeletal Muscle Glycolytic Block
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low exercise lactate with a delayed post-exercise rise reports impaired skeletal-muscle glycolytic flux at the PFKM step.
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In conclusion, we show that Tarui disease is associated with low lactate
+        levels during exercise with a late increase of lactate after exercise and
+        exceptionally high ammonia levels during and after exercise.
+      explanation: The exercise lactate profile is presented as a diagnostic readout of Tarui disease muscle metabolism.
   evidence:
   - reference: PMID:27303362
     reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
@@ -457,13 +640,29 @@ biochemical:
       exceptionally high ammonia levels during and after exercise.
     explanation: The human exercise-testing study supports the characteristic lactate pattern.
 - name: Exercise-associated hyperammonemia
-  presence: Increased
+  presence: INCREASED
   notes: Tarui disease exercise testing shows high ammonia during and after exercise.
   biomarker_term:
     preferred_term: ammonia
     term:
       id: CHEBI:16134
       label: ammonia
+  readouts:
+  - target: Skeletal Muscle Glycolytic Block
+    relationship: CORRELATES_WITH
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: High ammonia during and after exercise tracks with the abnormal exercise metabolism caused by the PFKM glycolytic block.
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        In conclusion, we show that Tarui disease is associated with low lactate
+        levels during exercise with a late increase of lactate after exercise and
+        exceptionally high ammonia levels during and after exercise.
+      explanation: The study identifies exceptionally high exercise ammonia as part of the diagnostic Tarui disease profile.
   evidence:
   - reference: PMID:27303362
     reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
@@ -474,6 +673,44 @@ biochemical:
       levels during exercise with a late increase of lactate after exercise and
       exceptionally high ammonia levels during and after exercise.
     explanation: The same exercise-testing study supports increased ammonia during and after exercise.
+- name: Muscle glycogen accumulation
+  presence: INCREASED
+  notes: Extra-lysosomal glycogen accumulation in skeletal muscle reflects impaired glycolytic utilization of muscle glycogen.
+  biomarker_term:
+    preferred_term: glycogen
+    term:
+      id: CHEBI:28087
+      label: glycogen
+  readouts:
+  - target: Skeletal Muscle Glycolytic Block
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased muscle glycogen content reports failed glycogen utilization caused by the skeletal-muscle PFKM block.
+    evidence:
+    - reference: PMID:27303362
+      reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Both patients with Tarui disease showed in muscle electron microscopic
+        analysis extra lysosomal glycogen accumulations.
+      explanation: Human muscle electron microscopy documents glycogen accumulation in Tarui disease.
+  evidence:
+  - reference: ORPHA:371
+    reference_title: "Glycogen storage disease due to muscle phosphofructokinase deficiency (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0009051 | Increased muscle glycogen content | Very frequent (99-80%)"
+    explanation: Orphanet reports increased muscle glycogen content as very frequent.
+  - reference: PMID:27303362
+    reference_title: Unique Exercise Lactate Profile in Muscle Phosphofructokinase Deficiency (Tarui Disease); Difference Compared with McArdle Disease.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Both patients with Tarui disease showed in muscle electron microscopic
+      analysis extra lysosomal glycogen accumulations.
+    explanation: Human muscle pathology supports glycogen accumulation.
 diagnosis:
 - name: Exercise lactate and ammonia profiling
   description: >-
@@ -555,6 +792,31 @@ treatments:
     term:
       id: HP:0003326
       label: Myalgia
+  - preferred_term: Muscle cramps
+    term:
+      id: HP:0003394
+      label: Muscle spasm
+  target_mechanisms:
+  - target: Skeletal Muscle Glycolytic Block
+    treatment_effect: BYPASSES
+    description: Ketogenic diet supplies non-glucose fuel during a disorder defined by inability to use glucose efficiently as a muscle energy resource.
+    evidence:
+    - reference: PMID:32117019
+      reference_title: Beneficial Effects of Ketogenic Diet on Phosphofructokinase Deficiency (Glycogen Storage Disease Type VII).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        GSD VII) characterized by exercise intolerance with myalgia due to an inability
+        to use glucose as an energy resource.
+      explanation: The report frames GSD VII as impaired glucose use, supporting diet as a bypass of the glycolytic energy limitation.
+    - reference: PMID:32117019
+      reference_title: Beneficial Effects of Ketogenic Diet on Phosphofructokinase Deficiency (Glycogen Storage Disease Type VII).
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        During the 5 years on KD, the patient's muscle symptoms had alleviated
+        and exercise tolerance had improved.
+      explanation: Long-term clinical response supports ketogenic diet acting on the skeletal-muscle energy limitation.
   evidence:
   - reference: PMID:32117019
     reference_title: Beneficial Effects of Ketogenic Diet on Phosphofructokinase Deficiency (Glycogen Storage Disease Type VII).


### PR DESCRIPTION
## Summary
- add evidence-backed causal edge support from PFKM deficiency through skeletal-muscle glycolytic block and erythrocyte involvement
- connect disconnected muscle, hemolysis, hyperuricemia, lactate, ammonia, and glycogen branches
- add biochemical readouts for exercise lactate, exercise ammonia, and muscle glycogen accumulation
- connect ketogenic diet to the skeletal-muscle glycolytic block and add muscle cramps as a target phenotype

## Validation
- `just validate kb/disorders/Glycogen_Storage_Disease_Type_VII.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Glycogen_Storage_Disease_Type_VII.yaml`
- manual snippet audit: total=55 exact=29 normalized=26 skipped=0 missing=0
- `git diff --check`

## Notes
- reference validator reported `Total checks: 0`, so snippets were manually audited against cached references
- unrelated reference-cache normalization churn was restored before commit