### PR TITLE
Connect inherited threoninemia pathograph

### DIFF
--- a/kb/disorders/Inherited_Threoninemia.yaml
+++ b/kb/disorders/Inherited_Threoninemia.yaml
@@ -1,7 +1,7 @@
 name: Inherited Threoninemia
 category: Mendelian
 creation_date: '2026-03-11T00:00:00Z'
-updated_date: '2026-05-08T00:00:00Z'
+updated_date: '2026-05-19T07:16:03Z'
 synonyms:
 - Hyperthreoninaemia
 - Hyperthreoninemia
@@ -264,6 +264,69 @@ pathophysiology:
       explanation: >
         The index threonine dehydratase deficiency case is explicitly presented
         as an NKH-like disorder.
+  - target: Intellectual disability
+    description: >
+      Neurodevelopmental impairment has been reported in patients with
+      hyperthreoninemia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        The sibling report directly states mental retardation in a patient with
+        hyperthreoninemia and hyperthreoninuria.
+  - target: Hepatomegaly
+    description: >
+      Hepatomegaly has been reported with systemic threonine accumulation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        The sibling report directly lists hepatomegaly with the
+        hyperthreoninemia/hyperthreoninuria phenotype.
+  - target: Failure to thrive
+    description: >
+      Physical growth impairment has been reported in patients with
+      hyperthreoninemia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        The report supports physical growth impairment, mapped conservatively
+        to the broader failure-to-thrive phenotype.
+  - target: Retinal dystrophy (Leber congenital amaurosis phenotype)
+    description: >
+      Leber congenital amaurosis was reported in siblings with
+      hyperthreoninemia, but causality remains uncertain.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        We suspect a close relationship between hyperthreoninemia and Leber's
+        congenital amaurosis in these siblings.
+      explanation: >
+        The authors explicitly suggest a relationship but do not establish a
+        causal mechanism, so the edge is retained as partial and indirect.
 - name: NKH-like secondary hyperglycinemia
   description: >
     Threonine dehydratase deficiency was reported as a probable cause and new
@@ -315,6 +378,52 @@ pathophysiology:
       explanation: >
         The index case is explicitly described as presenting with classical
         non-ketotic hyperglycinemia symptoms.
+  - target: Seizures
+    description: Seizures are part of the NKH symptom complex invoked for the index threoninemia case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        The NKH review enumerates seizures among salient NKH features, supporting
+        this symptom branch for the threoninemia case's NKH-like presentation.
+  - target: Lethargy
+    description: Lethargy is part of the NKH symptom complex invoked for the index threoninemia case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        The NKH review enumerates lethargy among salient NKH features, supporting
+        this symptom branch for the threoninemia case's NKH-like presentation.
+  - target: Feeding difficulties
+    description: Feeding difficulties are part of the NKH symptom complex invoked for the index threoninemia case.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:6301756
+      reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: >
+        The salient features of nonketotic hyperglycinemia include apnea, feeding
+        difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
+        significant developmental delay, and, in most instances, early death.
+      explanation: >
+        The NKH review enumerates feeding difficulties among salient NKH
+        features, supporting this symptom branch for the threoninemia case's
+        NKH-like presentation.
 phenotypes:
 - category: Metabolic
   name: Hyperthreoninemia
@@ -660,6 +769,28 @@ biochemical:
     values, is the primary diagnostic biomarker. Reported values include 2.0-5.3
     mg/dl (normal 0.78-1.82 mg/dl) and approximately 19-fold elevation in the
     threonine dehydratase deficiency case.
+  biomarker_term:
+    preferred_term: L-threonine
+    term:
+      id: CHEBI:16857
+      label: L-threonine
+  readouts:
+  - target: Systemic threonine accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated plasma or serum threonine reports systemic threonine accumulation.
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Her serum threonine level was increased (2.0 to 5.3 mg/dl;
+        normal, 0.78 to 1.82 mg/dl).
+      explanation: >
+        Quantitative serum threonine elevation supports circulating threonine
+        as a diagnostic readout of systemic accumulation.
   evidence:
   - reference: PMID:3083684
     reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
@@ -674,6 +805,28 @@ biochemical:
   presence: INCREASED
   context: >
     Elevated urinary threonine excretion accompanies the plasma elevation.
+  biomarker_term:
+    preferred_term: L-threonine
+    term:
+      id: CHEBI:16857
+      label: L-threonine
+  readouts:
+  - target: Systemic threonine accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary threonine reports systemic threonine excess with renal excretion.
+    evidence:
+    - reference: PMID:3083684
+      reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        He also had hyperthreoninemia, hyperthreoninuria, hepatomegaly,
+        and mental and physical retardation.
+      explanation: >
+        Hyperthreoninuria supports urinary threonine as a positive diagnostic
+        readout of systemic threonine accumulation.
   evidence:
   - reference: PMID:3083684
     reference_title: "Leber's congenital amaurosis associated with hyperthreoninemia."

--- a/kb/disorders/Inherited_Threoninemia.yaml
+++ b/kb/disorders/Inherited_Threoninemia.yaml
@@ -385,7 +385,7 @@ pathophysiology:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -400,7 +400,7 @@ pathophysiology:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -415,7 +415,7 @@ pathophysiology:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -502,7 +502,7 @@ phenotypes:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -518,7 +518,7 @@ phenotypes:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -533,7 +533,7 @@ phenotypes:
     - reference: PMID:6301756
       reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
       supports: PARTIAL
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: >
         The salient features of nonketotic hyperglycinemia include apnea, feeding
         difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -568,7 +568,7 @@ phenotypes:
   - reference: PMID:6301756
     reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
     supports: PARTIAL
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >
       The salient features of nonketotic hyperglycinemia include apnea, feeding
       difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -658,7 +658,7 @@ phenotypes:
   - reference: PMID:6301756
     reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
     supports: PARTIAL
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >
       The salient features of nonketotic hyperglycinemia include apnea, feeding
       difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,
@@ -695,7 +695,7 @@ phenotypes:
   - reference: PMID:6301756
     reference_title: "Nonketotic hyperglycinemia: clinical, biochemical, and therapeutic considerations."
     supports: PARTIAL
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: >
       The salient features of nonketotic hyperglycinemia include apnea, feeding
       difficulties, lethargy, seizures, abnormal muscle tone and reflex activity,


### PR DESCRIPTION
## Summary
- added downstream edges from systemic threonine accumulation to clinical phenotypes including intellectual disability, hepatomegaly, failure to thrive, and retinal dystrophy
- connected NKH-like secondary hyperglycinemia to seizures, lethargy, and feeding difficulties with cached evidence
- added plasma and urinary threonine biomarker readouts for systemic threonine accumulation

## Validation
- just validate kb/disorders/Inherited_Threoninemia.yaml
- uv run python -m dismech.graph --validate kb/disorders/Inherited_Threoninemia.yaml
- manual snippet audit: total=46 exact=0 normalized=46 skipped=0 missing=0
- just check-reference-cache-frontmatter
- git diff --check

Unrelated validation cache churn was restored before pushing.