### PR TITLE
Connect methionine cycle pathograph readouts

### DIFF
--- a/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
+++ b/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
@@ -1323,6 +1323,14 @@ treatments:
   - target: MAT1A S-Adenosylmethionine Synthesis Defect
     treatment_effect: RESTORES
     description: Replacing liver tissue may restore hepatic MAT I/III activity in refractory disease.
+references:
+- reference: PMID:40440437
+  title: "Homocystinuria due to Deficiency of N(5,10)-Methylenetetrahydrofolate Reductase Activity."
+  tags:
+  - GeneReviews
+  found_in:
+  - Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism-deep-research-falcon.md
+  findings: []
 notes: >-
   Falcon deep research supported curation of this MONDO entry as a
   pathway-level Mendelian grouping rather than a single disease mechanism. This

--- a/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
+++ b/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
@@ -1,6 +1,6 @@
 name: Inborn Disorder of Methionine Cycle and Sulfur Amino Acid Metabolism
 creation_date: "2026-05-10T16:47:28Z"
-updated_date: "2026-05-10T18:29:49Z"
+updated_date: "2026-05-19T07:37:41Z"
 category: Mendelian
 description: >-
   Inborn disorder of methionine cycle and sulfur amino acid metabolism is a
@@ -265,6 +265,53 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Severely affected patients usually present during childhood with learning difficulties, ectopia lentis and skeletal abnormalities; they are pyridoxine non-responders (NR) or partial responders (PR) and require treatment with a low-methionine diet and/or betaine."
       explanation: The E-HOD registry treatment paper ties severe CBS deficiency to the major ocular, skeletal, and neurodevelopmental clinical pattern.
+  - target: Thromboembolism
+    description: Homocysteine accumulation in CBS deficiency contributes to thromboembolic disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - toxic homocysteine accumulation
+    evidence:
+    - reference: PMID:40095936
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cystathionine β-synthase (CBS) deficiency (classical homocystinuria) has a wide range of severity. Mildly affected patients typically present as adults with thromboembolism and respond to treatment with pyridoxine."
+      explanation: The clinical registry paper directly lists thromboembolism as an adult presentation of CBS deficiency.
+  - target: Ectopia lentis
+    description: Severe CBS deficiency includes ocular connective-tissue involvement with ectopia lentis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - toxic homocysteine accumulation
+    - connective-tissue injury
+    evidence:
+    - reference: PMID:27778219
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severely affected patients usually present in childhood with ectopia lentis, learning difficulties and skeletal abnormalities."
+      explanation: The guideline statement directly supports ectopia lentis in severe childhood-onset CBS deficiency.
+  - target: Specific learning disability
+    description: Severe CBS deficiency can include neurodevelopmental learning difficulties.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - toxic homocysteine accumulation
+    - neurologic involvement
+    evidence:
+    - reference: PMID:27778219
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severely affected patients usually present in childhood with ectopia lentis, learning difficulties and skeletal abnormalities."
+      explanation: The guideline statement directly supports learning difficulties in severe childhood-onset CBS deficiency.
+  - target: Abnormality of the skeletal system
+    description: Severe CBS deficiency includes skeletal abnormalities as part of the homocystinuria phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - toxic homocysteine accumulation
+    - connective-tissue injury
+    evidence:
+    - reference: PMID:27778219
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severely affected patients usually present in childhood with ectopia lentis, learning difficulties and skeletal abnormalities."
+      explanation: The guideline statement directly supports skeletal abnormalities in severe childhood-onset CBS deficiency.
 - name: Cobalamin-Dependent Remethylation and Mutase Cofactor Failure
   description: >-
     MMACHC-related cblC disease impairs intracellular cobalamin processing,
@@ -334,6 +381,105 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "The most frequent clinical symptoms were neuropathy/myelopathy, encephalopathy, psychiatric symptoms, thrombotic microangiopathy, seizures, kidney disease, mild to severe pulmonary hypertension with heart failure and thrombotic phenomena."
       explanation: The systematic review summarizes the recurring multisystem manifestations of late-onset cblC disease.
+  - target: Hyperhomocystinemia
+    description: cblC remethylation failure contributes to elevated homocysteine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32071835
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cobalamin C (cblC) deficiency is the most common inborn error of intracellular cobalamin metabolism caused by pathogenic variant(s) in MMACHC and manifests with methylmalonic acidemia, hyperhomocysteinemia, and hypomethioninemia with a variable age of presentation."
+      explanation: Adult cblC evidence directly identifies hyperhomocysteinemia as part of the biochemical phenotype.
+  - target: Hypomethioninemia
+    description: Reduced cobalamin-dependent remethylation lowers methionine production in cblC disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The disease is characterised by an elevation of methylmalonic acid (MMA) and homocysteine and a decreased production of methionine."
+      explanation: The systematic review directly supports decreased methionine production in cblC disease.
+  - target: Methylmalonic acidemia
+    description: Failed adenosylcobalamin support for methylmalonyl-CoA mutase raises methylmalonic acid in cblC disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The disease is characterised by an elevation of methylmalonic acid (MMA) and homocysteine and a decreased production of methionine."
+      explanation: The systematic review directly supports methylmalonic acid elevation in cblC disease.
+  - target: Peripheral neuropathy
+    description: Combined methylmalonic acidemia and homocystinuria in late-onset cblC disease can manifest as neuropathy or myelopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - reduced methionine production
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The most frequent clinical symptoms were neuropathy/myelopathy, encephalopathy, psychiatric symptoms, thrombotic microangiopathy, seizures, kidney disease, mild to severe pulmonary hypertension with heart failure and thrombotic phenomena."
+      explanation: The systematic review lists neuropathy/myelopathy among the most frequent late-onset cblC symptoms.
+  - target: Mental deterioration
+    description: Late-onset cblC disease can progress to cognitive decline.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - neuropsychiatric cblC disease
+    evidence:
+    - reference: PMID:37770946
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Besides the initial symptoms, the disease progressed in most patients and cognitive decline became the most frequent symptom overall."
+      explanation: The late-onset cblC cohort supports progressive cognitive decline as a frequent manifestation.
+  - target: Psychosis
+    description: Adult cblC disease can present with psychiatric disease including psychosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - neuropsychiatric cblC disease
+    evidence:
+    - reference: PMID:32071835
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A regimen of high-dose hydroxocobalamin (25 mg/day) together with betaine and folic acid resulted in rapid and sustainable biochemical correction, resolution of psychosis, improvement of neurological functions, and amelioration of brain and spinal cord lesions."
+      explanation: The adult cblC report documents psychosis as a neuropsychiatric manifestation that resolved with metabolic therapy.
+  - target: Chronic kidney disease
+    description: Late-onset cblC disease can include renal involvement.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - thrombotic microangiopathy and renal injury
+    evidence:
+    - reference: PMID:32071835
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Individuals with late-onset cblC may be asymptomatic until manifesting neuropsychiatric symptoms, thromboembolic events, and renal disease."
+      explanation: The adult cblC report directly identifies renal disease as a late-onset manifestation.
+  - target: Pulmonary arterial hypertension
+    description: Late-onset cblC disease can include pulmonary hypertension with heart failure.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - vascular injury
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The most frequent clinical symptoms were neuropathy/myelopathy, encephalopathy, psychiatric symptoms, thrombotic microangiopathy, seizures, kidney disease, mild to severe pulmonary hypertension with heart failure and thrombotic phenomena."
+      explanation: The systematic review directly lists pulmonary hypertension with heart failure among frequent late-onset cblC symptoms.
+  - target: Seizure
+    description: Late-onset cblC disease can involve seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - combined methylmalonic acidemia and homocystinuria
+    - neurologic cblC disease
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The most frequent clinical symptoms were neuropathy/myelopathy, encephalopathy, psychiatric symptoms, thrombotic microangiopathy, seizures, kidney disease, mild to severe pulmonary hypertension with heart failure and thrombotic phenomena."
+      explanation: The systematic review directly lists seizures among frequent late-onset cblC symptoms.
 - name: MTHFR Remethylation Deficiency
   description: >-
     Severe MTHFR deficiency is a folate-metabolism disorder that blocks
@@ -370,6 +516,12 @@ pathophysiology:
   - target: Hyperhomocystinemia
     description: The remethylation block increases plasma homocysteine.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18658082
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Severe methylenetetrahydrofolate reductase deficiency is an autosomal recessive metabolic disorder of folate metabolism causing elevated plasma homocysteine levels and homocystinuria (MIM 236250)."
+      explanation: The case report directly supports elevated plasma homocysteine as a consequence of severe MTHFR deficiency.
 - name: MAT1A S-Adenosylmethionine Synthesis Defect
   description: >-
     MAT1A deficiency reduces hepatic methionine adenosyltransferase I/III
@@ -429,6 +581,36 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Patients with demyelination showed significantly higher blood methionine concentrations at baseline (1102 vs. 396 µmol/L), and their blood methionine remained markedly elevated despite a low-methionine diet."
       explanation: The cohort provides a quantitative association between higher methionine and demyelination.
+  - target: Hypermethioninemia
+    description: MAT I/III deficiency causes persistent isolated methionine elevation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39511588
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with demyelination showed significantly higher blood methionine concentrations at baseline (1102 vs. 396 µmol/L), and their blood methionine remained markedly elevated despite a low-methionine diet."
+      explanation: The MAT I/III cohort directly documents markedly elevated blood methionine.
+  - target: Abnormal cerebral white matter morphology
+    description: Severe persistent hypermethioninemia in MAT I/III deficiency can cause cerebral white-matter injury.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - persistent isolated hypermethioninemia
+    - demyelination
+    evidence:
+    - reference: PMID:39511588
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Methionine adenosyltransferase I/III deficiency is not just a benign disease. Severe persistent hypermethioninemia can cause brain injuries, especially in the white matter."
+      explanation: The cohort directly links severe persistent hypermethioninemia with white-matter brain injury.
+  - target: Delayed speech and language development
+    description: MAT I/III deficiency can include delayed language development as part of its neurologic spectrum.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:39511588
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Of these 15 patients, 10 demonstrated neurological abnormalities, with delayed language development, learning difficulties or abnormal brain imaging findings."
+      explanation: The MAT I/III cohort directly documents delayed language development among neurologically affected patients.
 phenotypes:
 - name: Hyperhomocystinemia
   category: Laboratory abnormality
@@ -675,6 +857,45 @@ biochemical:
   context: >-
     Increased total homocysteine is a shared biomarker in CBS deficiency,
     MTHFR deficiency, and cblC disease.
+  biomarker_term:
+    preferred_term: homocysteine
+    term:
+      id: CHEBI:17230
+      label: homocysteine
+  readouts:
+  - target: CBS Transsulfuration Block
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated total homocysteine reports impaired CBS-dependent transsulfuration in classical homocystinuria.
+    evidence:
+    - reference: PMID:27778219
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Cystathionine beta-synthase (CBS) deficiency is a rare inherited disorder in the methionine catabolic pathway, in which the impaired synthesis of cystathionine leads to accumulation of homocysteine."
+      explanation: CBS deficiency guidelines directly support homocysteine accumulation from the transsulfuration block.
+  - target: MTHFR Remethylation Deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated plasma homocysteine reports the folate-remethylation block in severe MTHFR deficiency.
+    evidence:
+    - reference: PMID:18658082
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Severe methylenetetrahydrofolate reductase deficiency is an autosomal recessive metabolic disorder of folate metabolism causing elevated plasma homocysteine levels and homocystinuria (MIM 236250)."
+      explanation: The case report directly supports plasma homocysteine elevation in MTHFR deficiency.
+  - target: Cobalamin-Dependent Remethylation and Mutase Cofactor Failure
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated homocysteine is one component of the combined cblC biochemical pattern.
+    evidence:
+    - reference: PMID:32071835
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cobalamin C (cblC) deficiency is the most common inborn error of intracellular cobalamin metabolism caused by pathogenic variant(s) in MMACHC and manifests with methylmalonic acidemia, hyperhomocysteinemia, and hypomethioninemia with a variable age of presentation."
+      explanation: Adult cblC evidence directly supports hyperhomocysteinemia in the combined biochemical pattern.
   evidence:
   - reference: PMID:27778219
     supports: SUPPORT
@@ -686,6 +907,23 @@ biochemical:
   context: >-
     Persistent methionine elevation is the defining biomarker of MAT I/III
     deficiency and can be severe enough to associate with demyelination.
+  biomarker_term:
+    preferred_term: methionine
+    term:
+      id: CHEBI:16811
+      label: methionine
+  readouts:
+  - target: MAT1A S-Adenosylmethionine Synthesis Defect
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated blood methionine reports impaired MAT I/III-dependent methionine-to-S-adenosylmethionine flux.
+    evidence:
+    - reference: PMID:39511588
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with demyelination showed significantly higher blood methionine concentrations at baseline (1102 vs. 396 µmol/L), and their blood methionine remained markedly elevated despite a low-methionine diet."
+      explanation: The MAT I/III cohort supports blood methionine elevation as a readout of the MAT1A-related defect.
   evidence:
   - reference: PMID:39511588
     supports: SUPPORT
@@ -696,6 +934,23 @@ biochemical:
   presence: DECREASED
   context: >-
     Low methionine is characteristic of remethylation failure in cblC disease.
+  biomarker_term:
+    preferred_term: methionine
+    term:
+      id: CHEBI:16811
+      label: methionine
+  readouts:
+  - target: Cobalamin-Dependent Remethylation and Mutase Cofactor Failure
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased methionine reports impaired remethylation in cblC disease.
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The disease is characterised by an elevation of methylmalonic acid (MMA) and homocysteine and a decreased production of methionine."
+      explanation: The cblC systematic review supports decreased methionine production as part of the combined biochemical pattern.
   evidence:
   - reference: PMID:38245797
     supports: SUPPORT
@@ -708,6 +963,23 @@ biochemical:
     Methylmalonic acid elevation distinguishes combined intracellular
     cobalamin-processing disorders such as cblC from isolated CBS and MTHFR
     remethylation defects.
+  biomarker_term:
+    preferred_term: methylmalonic acid
+    term:
+      id: CHEBI:30860
+      label: methylmalonic acid
+  readouts:
+  - target: Cobalamin-Dependent Remethylation and Mutase Cofactor Failure
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated methylmalonic acid reports impaired adenosylcobalamin-dependent methylmalonyl-CoA handling in cblC disease.
+    evidence:
+    - reference: PMID:38245797
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The disease is characterised by an elevation of methylmalonic acid (MMA) and homocysteine and a decreased production of methionine."
+      explanation: The cblC systematic review directly supports MMA elevation in the combined biochemical pattern.
   evidence:
   - reference: PMID:38245797
     supports: SUPPORT

--- a/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
+++ b/kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
@@ -1330,10 +1330,14 @@ references:
   - GeneReviews
   found_in:
   - Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism-deep-research-falcon.md
-  findings: []
+  findings:
+  - statement: Homocystinuria due to deficiency of N(5,10)-MTHFR activity is inherited in an autosomal recessive manner.
+    supporting_text: "GENETIC COUNSELING: Homocystinuria due to deficiency of N(5,10)-MTHFR activity is inherited in an autosomal recessive manner."
+  - statement: Molecular diagnosis of MTHFR-deficiency homocystinuria can be established by biallelic pathogenic variants in MTHFR.
+    supporting_text: "biallelic pathogenic variants in MTHFR identified by molecular genetic testing."
 notes: >-
   Falcon deep research supported curation of this MONDO entry as a
   pathway-level Mendelian grouping rather than a single disease mechanism. This
   entry therefore emphasizes the best-supported component disorders and shared
   biochemical/clinical logic, while leaving more granular subtype-specific
-  modeling to dedicated disease pages where they already exist.
+  modeling to dedicated disease pages or future subtype-specific entries.


### PR DESCRIPTION
## Summary
- added evidence-backed downstream links from CBS, cblC, MTHFR, and MAT1A pathway mechanisms to the disorder phenotypes
- connected all 16 phenotype entries from the pathophysiology graph, including vascular, ocular, skeletal, neuropsychiatric, renal, pulmonary, seizure, and white-matter manifestations
- added CHEBI-backed biomarker terms and diagnostic readouts for total homocysteine, methionine, and methylmalonic acid

## Coverage after change
- pathophysiology nodes: 5
- downstream edges: 26
- phenotype targets reached: 16/16
- GO biological-process annotations: 13
- biochemical readouts: 6

## Validation
- just validate kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
- uv run python -m dismech.graph --validate kb/disorders/Inborn_Disorder_of_Methionine_Cycle_and_Sulfur_Amino_Acid_Metabolism.yaml
- manual snippet audit: total=83 exact=3 normalized=80 skipped=0 missing=0
- just check-reference-cache-frontmatter
- git diff --check

Unrelated validation cache churn was restored before pushing.