### PR TITLE
Connect hereditary orotic aciduria phenotypes

### DIFF
--- a/kb/disorders/Hereditary_Orotic_Aciduria.yaml
+++ b/kb/disorders/Hereditary_Orotic_Aciduria.yaml
@@ -1,6 +1,6 @@
 name: Hereditary Orotic Aciduria
 creation_date: "2026-05-11T11:08:06Z"
-updated_date: "2026-05-17T20:22:15Z"
+updated_date: "2026-05-19T08:14:52Z"
 category: Mendelian
 synonyms:
 - Orotidylic decarboxylase deficiency
@@ -292,6 +292,118 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "It has been reported that the main immunodeficiency in patients with HOA is the selective impairment in T cell function with intact humoral immunity."
       explanation: The case-report discussion links HOA to selective T-cell functional impairment.
+  - target: Anemia
+    description: Pyrimidine nucleotide deficiency causes megaloblastic marrow changes that manifest clinically as anemia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - megaloblastic erythropoietic failure
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001903 | Anemia | Very frequent (99-80%)"
+      explanation: Orphanet lists anemia as a very frequent hereditary orotic aciduria phenotype.
+  - target: Aminoaciduria
+    description: Aminoaciduria is reported in hereditary orotic aciduria, but the cached evidence does not define the renal tubular intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003355 | Aminoaciduria | Very frequent (99-80%)"
+      explanation: Orphanet lists aminoaciduria as a very frequent hereditary orotic aciduria phenotype.
+  - target: Abnormality of the ureter
+    description: Ureter abnormality is reported in hereditary orotic aciduria, but the causal developmental intermediate is not resolved in cached evidence.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000069 | Abnormality of the ureter | Frequent (79-30%)"
+      explanation: Orphanet lists abnormality of the ureter as a frequent phenotype.
+  - target: Hypertelorism
+    description: Hypertelorism is part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000316 | Hypertelorism | Frequent (79-30%)"
+      explanation: Orphanet lists hypertelorism as a frequent phenotype.
+  - target: Posteriorly rotated ears
+    description: Posteriorly rotated ears are part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000358 | Posteriorly rotated ears | Frequent (79-30%)"
+      explanation: Orphanet lists posteriorly rotated ears as a frequent phenotype.
+  - target: Wide nasal bridge
+    description: Wide nasal bridge is part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000431 | Wide nasal bridge | Frequent (79-30%)"
+      explanation: Orphanet lists wide nasal bridge as a frequent phenotype.
+  - target: Downslanted palpebral fissures
+    description: Downslanted palpebral fissures are part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000494 | Downslanted palpebral fissures | Frequent (79-30%)"
+      explanation: Orphanet lists downslanted palpebral fissures as a frequent phenotype.
+  - target: Hip dysplasia
+    description: Hip dysplasia is part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001385 | Hip dysplasia | Frequent (79-30%)"
+      explanation: Orphanet lists hip dysplasia as a frequent phenotype.
+  - target: Patent ductus arteriosus
+    description: Patent ductus arteriosus is reported in hereditary orotic aciduria, but the cached evidence does not define the cardiac developmental intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001643 | Patent ductus arteriosus | Frequent (79-30%)"
+      explanation: Orphanet lists patent ductus arteriosus as a frequent phenotype.
+  - target: Splenomegaly
+    description: Splenomegaly is reported in hereditary orotic aciduria, but the cached evidence does not define the intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001744 | Splenomegaly | Frequent (79-30%)"
+      explanation: Orphanet lists splenomegaly as a frequent phenotype.
+  - target: Abnormal toenail morphology
+    description: Abnormal toenail morphology is part of the reported congenital phenotype spectrum; the cached evidence does not specify a causal morphogenetic intermediate.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008388 | Abnormal toenail morphology | Frequent (79-30%)"
+      explanation: Orphanet lists abnormal toenail morphology as a frequent phenotype.
 - name: T Cell Immunodeficiency
   description: >-
     Hereditary orotic aciduria can include selective impairment of T-cell
@@ -632,6 +744,19 @@ biochemical:
     interpretation: >-
       Increased urinary orotic acid reports upstream UMPS-dependent pyrimidine
       biosynthesis failure and supports biochemical diagnosis.
+    evidence:
+    - reference: ORPHA:30
+      reference_title: "Hereditary orotic aciduria (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "associated with massive urinary overexcretion of orotic acid"
+      explanation: Orphanet identifies massive urinary orotic acid overexcretion as the disease-defining biomarker.
+    - reference: PMID:33489760
+      reference_title: "Hereditary orotic aciduria (HOA): A novel uridine-5-monophosphate synthase (UMPS) mutation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Further findings of crystalluria and a significant urinary excretion of orotic acid in our patient (>266.1 mmol/mol creatinine; reference range 0.2–1.5) supported the diagnosis."
+      explanation: Marked urinary orotic acid elevation supports this biomarker as a diagnostic readout of the UMPS block.
   biomarker_term:
     preferred_term: orotic acid
     term:

--- a/kb/disorders/Hereditary_Orotic_Aciduria.yaml
+++ b/kb/disorders/Hereditary_Orotic_Aciduria.yaml
@@ -210,7 +210,9 @@ pathophysiology:
       explanation: The article directly connects the UMPS block to urinary metabolite excretion.
   - target: Megaloblastic anemia
     description: Pyrimidine nucleotide deficiency affects rapidly dividing marrow precursors, producing megaloblastic anemia.
-    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - megaloblastic erythropoietic failure
     evidence:
     - reference: PMID:36999056
       reference_title: "Hereditary orotic aciduria identified by newborn screening."


### PR DESCRIPTION
## Summary
- added evidence-backed downstream links from the UMPS/UMP synthetase block to the remaining Orphanet-supported phenotypes
- kept lower-confidence congenital/renal/dysmorphic links as causal_link_type UNKNOWN where cached evidence supports association but not an intermediate
- added evidence directly to the urinary orotic acid diagnostic readout

## Coverage after change
- pathophysiology nodes: 3
- downstream edges: 21
- phenotype targets reached: 19/19
- GO biological-process annotations: 3
- biochemical readouts: 1, now with direct evidence

## Validation
- just validate kb/disorders/Hereditary_Orotic_Aciduria.yaml
- uv run python -m dismech.graph --validate kb/disorders/Hereditary_Orotic_Aciduria.yaml
- manual snippet audit: total=76 exact=67 normalized=9 skipped=0 missing=0
- just check-reference-cache-frontmatter
- git diff --check

Unrelated validation cache churn was restored before pushing.