### PR TITLE
Connect GM3 synthase deficiency pathograph

### DIFF
--- a/kb/disorders/GM3_Synthase_Deficiency.yaml
+++ b/kb/disorders/GM3_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: GM3 synthase deficiency
 category: Mendelian
 creation_date: '2026-05-04T13:48:31Z'
-updated_date: '2026-05-19T10:01:36Z'
+updated_date: '2026-05-19T10:12:46Z'
 synonyms:
 - ST3GAL5-CDG
 - Amish infantile epilepsy syndrome
@@ -569,6 +569,19 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "hypotonic tetraparesis"
       explanation: Orphanet records hypotonic tetraparesis, supporting hypotonia.
+  - target: Scoliosis
+    description: >
+      Scoliosis is reported in ST3GAL5-related salt-and-pepper syndrome, but the
+      cached evidence does not resolve the intermediate skeletal or neuromotor
+      mechanism.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:24026681
+      reference_title: "A mutation in a ganglioside biosynthetic enzyme, ST3GAL5, results in salt & pepper syndrome, a neurocutaneous disorder with altered glycolipid and glycoprotein glycosylation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "severe intellectual disability, epilepsy, scoliosis, choreoathetosis, dysmorphic facial features and altered dermal pigmentation"
+      explanation: The salt-and-pepper syndrome report includes scoliosis in the human clinical phenotype.
   - target: Microcephaly
     description: >
       Severe neurodevelopmental disease is associated with progressive
@@ -869,6 +882,27 @@ phenotypes:
     evidence_source: OTHER
     snippet: "Dysmorphic facial features may be associated."
     explanation: Orphanet notes that dysmorphic facial features may be associated.
+- name: Scoliosis
+  frequency: OCCASIONAL
+  description: Scoliosis has been reported in ST3GAL5-related salt-and-pepper syndrome.
+  phenotype_term:
+    preferred_term: Scoliosis
+    term:
+      id: HP:0002650
+      label: Scoliosis
+  evidence:
+  - reference: PMID:24026681
+    reference_title: "A mutation in a ganglioside biosynthetic enzyme, ST3GAL5, results in salt & pepper syndrome, a neurocutaneous disorder with altered glycolipid and glycoprotein glycosylation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "severe intellectual disability, epilepsy, scoliosis, choreoathetosis, dysmorphic facial features and altered dermal pigmentation"
+    explanation: The human salt-and-pepper syndrome report includes scoliosis.
+  - reference: PMID:36833282
+    reference_title: "Whole Exome Sequencing Reveals a Novel Homozygous Variant in the Ganglioside Biosynthetic Enzyme, ST3GAL5 Gene in a Saudi Family Causing Salt and Pepper Syndrome."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "choreoathetosis, scoliosis, and dermal pigmentation along with dysmorphic facial"
+    explanation: The Saudi family report summarizes scoliosis among SPDRS clinical features.
 - name: Microcephaly
   frequency: FREQUENT
   description: Microcephaly is reported in a substantial fraction of non-Amish patients.

--- a/kb/disorders/GM3_Synthase_Deficiency.yaml
+++ b/kb/disorders/GM3_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: GM3 synthase deficiency
 category: Mendelian
 creation_date: '2026-05-04T13:48:31Z'
-updated_date: '2026-05-04T13:48:31Z'
+updated_date: '2026-05-19T10:01:36Z'
 synonyms:
 - ST3GAL5-CDG
 - Amish infantile epilepsy syndrome
@@ -207,6 +207,13 @@ pathophysiology:
   - target: GM3 and downstream ganglioside depletion
     description: Loss of GM3 synthase activity depletes GM3 and biosynthetic derivatives.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15502825
+      reference_title: Infantile-onset symptomatic epilepsy syndrome caused by a homozygous loss-of-function mutation of GM3 synthase.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "complete lack of GM3 ganglioside and its biosynthetic derivatives"
+      explanation: Plasma biochemical analysis directly links loss of GM3 synthase activity to absent GM3 ganglioside derivatives.
 - name: GM3 and downstream ganglioside depletion
   description: >
     Because GM3 is the precursor for most complex gangliosides, GM3 synthase loss
@@ -256,8 +263,27 @@ pathophysiology:
   downstream:
   - target: Glycosphingolipid remodeling
     description: Ganglioside depletion shifts glycosphingolipid composition and glycosylation programs.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24026681
+      reference_title: "A mutation in a ganglioside biosynthetic enzyme, ST3GAL5, results in salt & pepper syndrome, a neurocutaneous disorder with altered glycolipid and glycoprotein glycosylation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "revealed collateral alterations in response to loss of complex gangliosides"
+      explanation: Patient fibroblast glycomic analysis supports glycosphingolipid and glycan remodeling after complex ganglioside loss.
   - target: Neural cell signaling vulnerability
     description: Complex ganglioside loss alters cell-surface signaling in neural lineage cells.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - altered neural glycosphingolipid profiles
+    - altered receptor tyrosine kinase signaling
+    evidence:
+    - reference: PMID:37676252
+      reference_title: Neural-specific alterations in glycosphingolipid biosynthesis and cell signaling associated with two human ganglioside GM3 synthase deficiency variants.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "To explore how loss of GM3 impacts neural-specific glycolipid glycosylation and cell signaling"
+      explanation: Patient-derived neural lineage models directly investigate how GM3 loss alters neural glycolipid glycosylation and signaling.
 - name: Glycosphingolipid remodeling
   description: >
     Loss of the GM3 branch alters glycosphingolipid composition and collateral
@@ -290,6 +316,51 @@ pathophysiology:
   downstream:
   - target: Neural cell signaling vulnerability
     description: Altered glycosphingolipid profiles perturb membrane and receptor signaling states.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37676252
+      reference_title: Neural-specific alterations in glycosphingolipid biosynthesis and cell signaling associated with two human ganglioside GM3 synthase deficiency variants.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Altered GSL profiles in GM3SD cells"
+      explanation: Altered glycosphingolipid profiles are directly observed in GM3 synthase-deficient neural lineage cells.
+  - target: Abnormality of skin pigmentation
+    description: >
+      Glycolipid and glycoprotein glycosylation remodeling is associated with
+      the neurocutaneous pigmentation phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24026681
+      reference_title: "A mutation in a ganglioside biosynthetic enzyme, ST3GAL5, results in salt & pepper syndrome, a neurocutaneous disorder with altered glycolipid and glycoprotein glycosylation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "altered dermal pigmentation"
+      explanation: The salt-and-pepper syndrome report links ST3GAL5 disease to altered dermal pigmentation.
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "abnormalities of skin pigmentation"
+      explanation: Orphanet records abnormal skin pigmentation as a feature.
+  - target: Abnormal facial shape
+    description: >
+      Dysmorphic facial features are reported in ST3GAL5-related
+      neurocutaneous disease, but the cached evidence does not resolve the
+      intermediate morphogenetic mechanism.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:24026681
+      reference_title: "A mutation in a ganglioside biosynthetic enzyme, ST3GAL5, results in salt & pepper syndrome, a neurocutaneous disorder with altered glycolipid and glycoprotein glycosylation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "dysmorphic facial features"
+      explanation: The salt-and-pepper syndrome report lists dysmorphic facial features.
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Dysmorphic facial features may be associated."
+      explanation: Orphanet records dysmorphic facial features as an associated finding.
 - name: Neural cell signaling vulnerability
   description: >
     Complex ganglioside depletion in patient-derived neural lineage cells alters
@@ -338,12 +409,178 @@ pathophysiology:
   downstream:
   - target: Seizure
     description: Neural membrane and signaling disruption contributes to severe infantile epilepsy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:15502825
+      reference_title: Infantile-onset symptomatic epilepsy syndrome caused by a homozygous loss-of-function mutation of GM3 synthase.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Infantile-onset symptomatic epilepsy syndrome"
+      explanation: The original clinical report defines the disease by infantile-onset symptomatic epilepsy.
+    - reference: PMID:30209782
+      reference_title: Oral Ganglioside Supplement Improves Growth and Development in Patients with Ganglioside GM3 Synthase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "intractable seizures"
+      explanation: Clinical supplementation study lists intractable seizures as a core manifestation.
   - target: Global developmental delay
     description: Neural-lineage signaling and survival defects contribute to severe developmental impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "severe developmental delay or developmental regression"
+      explanation: Orphanet records severe developmental delay as part of the progressive phenotype.
   - target: Visual impairment
     description: Neural tissue vulnerability contributes to cortical visual impairment and optic pathway disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Visual impairment due to cortical atrophy"
+      explanation: Orphanet links visual impairment to cortical atrophy.
   - target: Hearing impairment
     description: Ganglioside biology in neural tissues is linked to the sensorineural phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34906476
+      reference_title: GM3 synthase deficiency in non-Amish patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "optic atrophy or pale papillae, and hearing loss"
+      explanation: The non-Amish cohort reports hearing loss among main features.
+  - target: Irritability
+    description: >
+      Severe neural dysfunction in infancy is associated with prominent
+      irritability.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30209782
+      reference_title: Oral Ganglioside Supplement Improves Growth and Development in Patients with Ganglioside GM3 Synthase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "severe irritability, intractable seizures, and profound intellectual disability"
+      explanation: Clinical supplementation study lists severe irritability alongside core neurologic features.
+  - target: Feeding difficulties
+    description: >
+      Early neurologic disease is associated with poor feeding in infancy.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "poor feeding, failure to thrive"
+      explanation: Orphanet records poor feeding in the initial infantile presentation.
+  - target: Failure to thrive
+    description: >
+      Infantile neurologic disease and poor feeding are associated with failure
+      to thrive.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - poor feeding
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "poor feeding, failure to thrive"
+      explanation: Orphanet lists poor feeding and failure to thrive together in the initial presentation.
+  - target: Growth delay
+    description: >
+      Feeding difficulty, failure to thrive, and severe neurodevelopmental
+      disease are associated with postnatal growth impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - failure to thrive
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "followed by postnatal growth impairment"
+      explanation: Orphanet records postnatal growth impairment in the later disease course.
+  - target: Developmental regression
+    description: >
+      Neural-lineage signaling and survival defects are associated with
+      developmental regression in the progressive disease course.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "developmental delay or developmental regression"
+      explanation: Orphanet explicitly includes developmental regression.
+  - target: Intellectual disability
+    description: >
+      Severe neural dysfunction is associated with profound intellectual
+      disability.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34906476
+      reference_title: GM3 synthase deficiency in non-Amish patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "severe to profound intellectual disability"
+      explanation: The non-Amish cohort reports severe to profound intellectual disability.
+  - target: Optic atrophy
+    description: >
+      Neural and optic pathway vulnerability is associated with optic atrophy or
+      pale papillae.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34906476
+      reference_title: GM3 synthase deficiency in non-Amish patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "optic atrophy or pale papillae, and hearing loss"
+      explanation: The non-Amish cohort reports optic atrophy or pale papillae.
+  - target: Choreoathetosis
+    description: >
+      Neural signaling vulnerability is associated with hyperkinetic movement
+      disorder including choreoathetosis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "choreoathetosis and hypotonic tetraparesis"
+      explanation: Orphanet records choreoathetosis as a gradually appearing movement phenotype.
+    - reference: PMID:34906476
+      reference_title: GM3 synthase deficiency in non-Amish patients.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "14 of 16 had\na hyperkinetic movement disorder"
+      explanation: The non-Amish cohort reports hyperkinetic movement disorder in 14 of 16 patients.
+  - target: Hypotonia
+    description: >
+      Neural motor system involvement is associated with hypotonic tetraparesis.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:370933
+      reference_title: "GM3 synthase deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hypotonic tetraparesis"
+      explanation: Orphanet records hypotonic tetraparesis, supporting hypotonia.
+  - target: Microcephaly
+    description: >
+      Severe neurodevelopmental disease is associated with progressive
+      microcephaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:35628171
+      reference_title: Ganglioside GM3 Synthase Deficiency in Mouse Models and Human Patients.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "progressive microcephaly, intellectual"
+      explanation: Review summarizes progressive microcephaly among human GM3 synthase deficiency features.
 phenotypes:
 - name: Irritability
   frequency: FREQUENT


### PR DESCRIPTION
## Summary

- Adds evidence and causal labels to the existing GM3 synthase loss, ganglioside depletion, glycosphingolipid remodeling, and neural signaling edges.
- Connects all existing GM3 synthase deficiency phenotypes, including feeding/growth, developmental, sensory, movement, microcephaly, pigmentation, and facial-shape readouts.
- Keeps causal labels conservative for clinical phenotypes where cached evidence supports association but not a fully resolved intermediate pathway.

## Connectivity

Before: pathophysiology=4, downstream_edges=8, phenotypes=16 reached=4 unreached=12, GO_bp=5, GO_mf=1, chem=3.

After: pathophysiology=4, downstream_edges=20, phenotypes=16 reached=16 unreached=0, GO_bp=5, GO_mf=1, chem=3.

## Validation

- just validate kb/disorders/GM3_Synthase_Deficiency.yaml: passed
- uv run python -m dismech.graph --validate kb/disorders/GM3_Synthase_Deficiency.yaml: passed
- just check-reference-cache-frontmatter: passed
- git diff --check: passed
- Manual snippet audit: total=81 exact=77 normalized=4 skipped=0 missing=0

## Notes

- Recurring unrelated reference-cache normalization churn was restored before commit.
- No references_cache/*.md files were hand-edited or committed.
