### PR TITLE
Connect cerebrotendinous xanthomatosis pathograph

### DIFF
--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-19T10:27:18Z'
+updated_date: '2026-05-19T10:37:45Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -613,16 +613,6 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "HP:0001138 | Optic neuropathy | Frequent"
       explanation: Orphanet reports optic neuropathy as frequent.
-  - target: Nystagmus
-    description: Eye movement abnormalities are modeled under the ocular/visual pathway branch.
-    causal_link_type: UNKNOWN
-    evidence:
-    - reference: ORPHA:909
-      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
-      supports: SUPPORT
-      evidence_source: OTHER
-      snippet: "HP:0000639 | Nystagmus | Frequent"
-      explanation: Orphanet reports nystagmus as frequent.
   - target: Optic disc pallor
     description: Optic disc pallor is modeled as optic pathway involvement.
     causal_link_type: UNKNOWN
@@ -696,6 +686,16 @@ pathophysiology:
   - target: Ataxia
     description: Cerebellar involvement produces ataxia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Nystagmus
+    description: Cerebellar and ocular-motor pathway involvement can produce nystagmus.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000639 | Nystagmus | Frequent"
+      explanation: Orphanet reports nystagmus as frequent.
   - target: Gait disturbance
     description: Cerebellar and long-tract involvement impair gait.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -2005,6 +2005,8 @@ references:
   findings: []
 - reference: PMID:20301583
   title: Cerebrotendinous Xanthomatosis.
+  tags:
+  - GeneReviews
   findings: []
 - reference: PMID:20494109
   title: "Cerebrotendinous xanthomatosis: an inborn error in bile acid synthesis with defined mutations but still a challenge."

--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-09T05:50:50Z'
+updated_date: '2026-05-19T10:27:18Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -371,6 +371,21 @@ pathophysiology:
   - target: Ocular cholestanol deposition and cataractogenesis
     description: Multisystemic cholestanol deposition includes the eye and contributes to early cataract disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Skeletal, bone-density, and appendicular involvement
+    description: >
+      CTX can include bone and appendicular involvement; cached evidence does
+      not resolve the intermediate mechanism linking sterol storage to
+      osteoporosis and distal morphology findings.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Xanthomas have been reported in the lung, bones, and central nervous system."
+      explanation: >
+        GeneReviews notes that CTX xanthomas can involve bone, supporting a
+        skeletal/appendicular involvement branch.
   - target: Chronic diarrhea
     description: Bile-acid synthetic failure and abnormal sterol metabolism contribute to early gastrointestinal disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -409,6 +424,66 @@ pathophysiology:
   - target: Abnormality of the Achilles tendon
     description: Achilles tendon involvement is a characteristic tendon xanthoma location.
     causal_link_type: DIRECT
+- name: Skeletal, bone-density, and appendicular involvement
+  description: >
+    CTX includes bone-density loss and distal appendicular findings in the
+    curated phenotype record. These are modeled as a conservative branch from
+    systemic sterol accumulation because the cached evidence supports the
+    manifestations but not a single resolved mechanism.
+  evidence:
+  - reference: PMID:20301583
+    reference_title: "Cerebrotendinous Xanthomatosis."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Xanthomas have been reported in the lung, bones, and central nervous system."
+    explanation: GeneReviews notes that xanthomas can involve bone in CTX.
+  - reference: ORPHA:909
+    reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000939 | Osteoporosis | Frequent"
+    explanation: Orphanet reports osteoporosis as a frequent CTX phenotype.
+  downstream:
+  - target: Osteoporosis
+    description: Bone involvement and surveillance-relevant bone-density loss are captured as osteoporosis.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000939 | Osteoporosis | Frequent"
+      explanation: Orphanet reports osteoporosis as a frequent CTX phenotype.
+  - target: Abnormal finger morphology
+    description: Orphanet records frequent finger morphology abnormalities, but the intermediate mechanism is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001167 | Abnormality of finger | Frequent"
+      explanation: Orphanet reports finger morphology abnormality as frequent.
+  - target: Abnormal tibia morphology
+    description: Orphanet records frequent tibial morphology abnormalities, but the intermediate mechanism is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002992 | Abnormality of tibia morphology | Frequent"
+      explanation: Orphanet reports tibial morphology abnormality as frequent.
+  - target: Abnormality of the plantar skin of foot
+    description: Orphanet records frequent plantar skin involvement, but the intermediate mechanism is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100872 | Abnormality of the plantar skin of foot | Frequent"
+      explanation: Orphanet reports plantar skin abnormality as frequent.
 - name: CNS sterol deposition and white-matter injury
   description: >
     Cholestanol and precursor accumulation in brain tissue is associated with
@@ -473,6 +548,26 @@ pathophysiology:
   - target: Hyperintensity of cerebral white matter on MRI
     description: White-matter injury is visible on MRI.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Abnormal auditory evoked potentials
+    description: CNS pathway involvement can be detected as abnormal auditory evoked potentials.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0006958 | Abnormal auditory evoked potentials | Frequent"
+      explanation: Orphanet reports abnormal auditory evoked potentials as frequent.
+  - target: Abnormality of somatosensory evoked potentials
+    description: CNS and sensory pathway involvement can be detected as abnormal somatosensory evoked potentials.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0007377 | Abnormality of somatosensory evoked potentials | Frequent"
+      explanation: Orphanet reports abnormal somatosensory evoked potentials as frequent.
 - name: Ocular cholestanol deposition and cataractogenesis
   description: >
     Multisystemic cholestanol deposition includes the eye, and CTX commonly
@@ -508,6 +603,56 @@ pathophysiology:
   - target: Visual impairment
     description: Childhood cataracts can reduce vision.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Optic neuropathy
+    description: Ocular and visual pathway involvement includes optic neuropathy.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001138 | Optic neuropathy | Frequent"
+      explanation: Orphanet reports optic neuropathy as frequent.
+  - target: Nystagmus
+    description: Eye movement abnormalities are modeled under the ocular/visual pathway branch.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000639 | Nystagmus | Frequent"
+      explanation: Orphanet reports nystagmus as frequent.
+  - target: Optic disc pallor
+    description: Optic disc pallor is modeled as optic pathway involvement.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000543 | Optic disc pallor | Frequent"
+      explanation: Orphanet reports optic disc pallor as frequent.
+  - target: Abnormality of visual evoked potentials
+    description: Visual pathway involvement can be detected as abnormal visual evoked potentials.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000649 | Abnormality of visual evoked potentials | Frequent"
+      explanation: Orphanet reports abnormal visual evoked potentials as frequent.
+  - target: Abnormal retinal vascular morphology
+    description: Retinal vascular abnormalities are modeled under ocular involvement.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008046 | Abnormal retinal vascular morphology | Frequent"
+      explanation: Orphanet reports abnormal retinal vascular morphology as frequent.
 - name: Cerebellar, corticospinal, and bulbar pathway dysfunction
   description: >
     Progressive CNS involvement affects cerebellar, corticospinal, and bulbar
@@ -578,6 +723,26 @@ pathophysiology:
   - target: Abnormality of the dentate nucleus
     description: Dentate nucleus involvement is a characteristic MRI abnormality.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Abnormal cerebellar peduncle morphology
+    description: Cerebellar tract disease can involve the cerebellar peduncles.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0011931 | Abnormality of the cerebellar peduncle | Frequent"
+      explanation: Orphanet reports cerebellar peduncle abnormality as frequent.
+  - target: Abnormal motor evoked potentials
+    description: Corticospinal pathway involvement can be detected as abnormal motor evoked potentials.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012896 | Abnormal motor evoked potentials | Frequent"
+      explanation: Orphanet reports abnormal motor evoked potentials as frequent.
 - name: Extrapyramidal and neuropsychiatric involvement
   description: >
     Progressive CNS disease also involves extrapyramidal and neuropsychiatric
@@ -611,6 +776,16 @@ pathophysiology:
   - target: Abnormality of extrapyramidal motor function
     description: Extrapyramidal system involvement causes abnormal extrapyramidal motor function.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Abnormal globus pallidus morphology
+    description: Globus pallidus abnormalities are modeled under the extrapyramidal/basal ganglia branch.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002453 | Abnormal globus pallidus morphology | Frequent"
+      explanation: Orphanet reports globus pallidus morphology abnormality as frequent.
   - target: Orofacial dyskinesia
     description: Extrapyramidal motor involvement can include orofacial dyskinesia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES


### PR DESCRIPTION
## Summary

- Selected Cerebrotendinous_Xanthomatosis.yaml as an under-connected inherited metabolic disorder pathograph.
- Added a conservative skeletal/bone-density/appendicular involvement branch from systemic sterol accumulation.
- Added evidence-backed downstream links for the previously unreached ocular, neurophysiologic, neuroimaging, skeletal, and appendicular phenotypes.
- Kept new uncertain mechanisms conservative with UNKNOWN where the cached evidence supports the phenotype association but not a resolved intermediate mechanism.

## Connectivity

Before: phenotypes=48 reached=34 unreached=14; biochemical=3 reached=3.

After: phenotypes=48 reached=48 unreached=[]; biochemical=3 reached=3; pathophysiology=11; downstream_edges=65; GO_bp=7 GO_mf=1 chem=4.

## Validation

- just validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- just check-reference-cache-frontmatter
- git diff --check
- manual snippet audit: total=134 exact=102 normalized=32 skipped=0 missing=0

Unrelated reference-cache churn from validators was restored before commit; the PR is scoped to kb/disorders/Cerebrotendinous_Xanthomatosis.yaml.
