### PR TITLE
Connect adult polyglucosan body disease pathograph

### DIFF
--- a/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
+++ b/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
@@ -1,6 +1,6 @@
 name: Adult Polyglucosan Body Disease
 creation_date: "2026-05-07T18:30:00Z"
-updated_date: "2026-05-19T10:59:50Z"
+updated_date: "2026-05-19T11:09:57Z"
 category: Mendelian
 description: >-
   Adult polyglucosan body disease is an autosomal recessive, adult-onset
@@ -266,6 +266,26 @@ pathophysiology:
       evidence_source: OTHER
       snippet: "| HP:0002839 | Urinary bladder sphincter dysfunction | Very frequent (99-80%) |"
       explanation: Orphanet lists urinary bladder sphincter dysfunction as very frequent.
+  - target: Orthostatic hypotension
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Autonomic dysfunction in classic GBE1-APBD can include orthostatic hypotension.
+    evidence:
+    - reference: PMID:20301758
+      reference_title: "GBE1 Adult Polyglucosan Body Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "autonomic dysfunction (associated with orthostatic hypotension and constipation)"
+      explanation: GeneReviews links APBD autonomic dysfunction to orthostatic hypotension.
+  - target: Constipation
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Autonomic dysfunction in classic GBE1-APBD can include constipation.
+    evidence:
+    - reference: PMID:20301758
+      reference_title: "GBE1 Adult Polyglucosan Body Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "autonomic dysfunction (associated with orthostatic hypotension and constipation)"
+      explanation: GeneReviews links APBD autonomic dysfunction to constipation.
   - target: Peripheral neuropathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Peripheral nerve storage pathology produces axonal neuropathy.
@@ -815,6 +835,37 @@ phenotypes:
     evidence_source: OTHER
     snippet: "| HP:0002839 | Urinary bladder sphincter dysfunction | Very frequent (99-80%) |"
     explanation: Orphanet lists urinary bladder sphincter dysfunction as very frequent.
+- category: Cardiovascular
+  name: Orthostatic hypotension
+  description: >-
+    Orthostatic hypotension can occur as part of APBD autonomic dysfunction.
+  phenotype_term:
+    preferred_term: Orthostatic hypotension
+    term:
+      id: HP:0001278
+      label: Orthostatic hypotension
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "autonomic dysfunction (associated with orthostatic hypotension and constipation)"
+    explanation: GeneReviews lists orthostatic hypotension as part of APBD autonomic dysfunction.
+- category: Gastrointestinal
+  name: Constipation
+  description: Constipation can occur as part of APBD autonomic dysfunction.
+  phenotype_term:
+    preferred_term: Constipation
+    term:
+      id: HP:0002019
+      label: Constipation
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "autonomic dysfunction (associated with orthostatic hypotension and constipation)"
+    explanation: GeneReviews lists constipation as part of APBD autonomic dysfunction.
 - category: Neurologic
   name: EMG abnormality
   frequency: OCCASIONAL
@@ -981,6 +1032,118 @@ treatments:
       neuromusculoskeletal assessments, (c) laboratory investigations, (d) liver
       and heart transplantation, and (e) long-term follow-up care.
     explanation: This supports multidisciplinary supportive management and follow-up for GSD IV/APBD.
+- name: Physical therapy
+  description: >-
+    Individualized physical therapy is recommended to improve flexibility,
+    reduce spasticity, maintain or improve joint mobility, and support
+    activities of daily living.
+  treatment_term:
+    preferred_term: physical therapy
+    term:
+      id: MAXO:0000011
+      label: physical therapy
+  target_phenotypes:
+  - preferred_term: Spasticity
+    term:
+      id: HP:0001257
+      label: Spasticity
+  - preferred_term: Limitation of joint mobility
+    term:
+      id: HP:0001376
+      label: Limitation of joint mobility
+  - preferred_term: Gait disturbance
+    term:
+      id: HP:0001288
+      label: Gait disturbance
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      An individualized physical therapy program can improve flexibility, reduce
+      spasticity, maintain or improve joint mobility
+    explanation: GeneReviews recommends individualized physical therapy for flexibility, spasticity, and joint mobility.
+- name: Anticholinergic bladder pharmacotherapy
+  description: >-
+    Anticholinergic drugs may be used as symptom-directed management for spastic
+    bladder in GBE1-APBD.
+  treatment_term:
+    preferred_term: pharmacotherapy
+    term:
+      id: MAXO:0000058
+      label: pharmacotherapy
+    therapeutic_agent:
+    - preferred_term: anticholinergic agent
+      term:
+        id: NCIT:C66880
+        label: Anticholinergic Agent
+  target_phenotypes:
+  - preferred_term: Neurogenic bladder
+    term:
+      id: HP:0000011
+      label: Neurogenic bladder
+  - preferred_term: Urinary bladder sphincter dysfunction
+    term:
+      id: HP:0002839
+      label: Urinary bladder sphincter dysfunction
+  - preferred_term: Urinary incontinence
+    term:
+      id: HP:0000020
+      label: Urinary incontinence
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Spastic bladder may be managed with anticholinergic drugs"
+    explanation: GeneReviews supports anticholinergic drugs for spastic bladder management.
+- name: Bladder catheterization
+  description: >-
+    Clean intermittent catheterization or an indwelling bladder catheter may be
+    used to prevent urosepsis in spastic bladder.
+  treatment_term:
+    preferred_term: catheterization
+    term:
+      id: MAXO:0001389
+      label: catheterization
+  target_phenotypes:
+  - preferred_term: Neurogenic bladder
+    term:
+      id: HP:0000011
+      label: Neurogenic bladder
+  - preferred_term: Urinary bladder sphincter dysfunction
+    term:
+      id: HP:0002839
+      label: Urinary bladder sphincter dysfunction
+  - preferred_term: Urinary incontinence
+    term:
+      id: HP:0000020
+      label: Urinary incontinence
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "clean intermittent catheterization or an indwelling bladder catheter to prevent urosepsis"
+    explanation: GeneReviews supports catheterization approaches for spastic bladder management.
+- name: Genetic counseling
+  description: >-
+    Genetic counseling informs autosomal recessive recurrence risk and options
+    for carrier, prenatal, and preimplantation genetic testing once familial
+    GBE1 variants are known.
+  treatment_term:
+    preferred_term: genetic counseling
+    term:
+      id: MAXO:0000079
+      label: genetic counseling
+  evidence:
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "GBE1-APBD is inherited in an autosomal recessive manner."
+    explanation: GeneReviews supports genetic counseling for autosomal recessive GBE1-APBD.
 - name: Triheptanoin pharmacotherapy trial
   description: >-
     Triheptanoin was tested as an anaplerotic therapy for APBD, but the

--- a/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
+++ b/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
@@ -1,6 +1,6 @@
 name: Adult Polyglucosan Body Disease
 creation_date: "2026-05-07T18:30:00Z"
-updated_date: "2026-05-07T18:30:00Z"
+updated_date: "2026-05-19T10:49:14Z"
 category: Mendelian
 description: >-
   Adult polyglucosan body disease is an autosomal recessive, adult-onset
@@ -67,12 +67,37 @@ pathophysiology:
       id: GO:0005977
       label: glycogen metabolic process
     modifier: ABNORMAL
+  molecular_functions:
+  - preferred_term: 1,4-alpha-glucan branching enzyme activity
+    term:
+      id: GO:0003844
+      label: 1,4-alpha-glucan branching enzyme activity
+    modifier: DECREASED
+  chemical_entities:
+  - preferred_term: glycogen
+    term:
+      id: CHEBI:28087
+      label: glycogen
+    modifier: ABNORMAL
   downstream:
   - target: Polyglucosan body accumulation
     causal_link_type: DIRECT
     description: >-
       Impaired glycogen branching leads to accumulation of poorly branched
       glycogen known as polyglucosan.
+  - target: Reduced glycogen branching enzyme activity
+    causal_link_type: DIRECT
+    description: >-
+      Pathogenic GBE1 variants reduce or abolish glycogen branching enzyme
+      activity.
+    evidence:
+    - reference: PMID:36796138
+      reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        reduced or deficient glycogen branching enzyme activity.
+      explanation: Clinical practice resource identifies reduced or deficient glycogen branching enzyme activity in GSD IV/APBD.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -103,6 +128,12 @@ pathophysiology:
       id: GO:0005977
       label: glycogen metabolic process
     modifier: ABNORMAL
+  chemical_entities:
+  - preferred_term: poorly branched glycogen
+    term:
+      id: CHEBI:28087
+      label: glycogen
+    modifier: INCREASED
   downstream:
   - target: Neurogenic bladder
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -114,6 +145,24 @@ pathophysiology:
     description: >-
       Peripheral nerve involvement produces axonal neuropathy and distal sensory
       impairment.
+  - target: Peripheral nerve, autonomic, and neuromuscular involvement
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: >-
+      Polyglucosan storage involves peripheral nerve, autonomic fibers, and
+      skeletal muscle, providing a shared branch for bladder, neuropathic,
+      sensory, EMG, weakness, and mobility-complication phenotypes.
+    evidence:
+    - reference: PMID:33141444
+      reference_title: "GBE1-related disorders: Adult polyglucosan body disease and its neuromuscular phenotypes."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        deficiency of glycogen-branching enzyme and secondary storage of glycogen
+        in the form of polyglucosan bodies, involving the skeletal muscle,
+        diaphragm, peripheral nerve (including autonomic fibers), brain white
+        matter, spinal cord, nerve roots, cerebellum, brainstem and to a lesser
+        extent heart, lung, kidney, and liver cells.
+      explanation: Clinical review supports peripheral nerve, autonomic, and skeletal muscle involvement downstream of polyglucosan storage.
   - target: Spasticity
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >-
@@ -152,6 +201,118 @@ pathophysiology:
       systems and are often associated with glycogen branching enzyme (GBE)
       deficiency.
     explanation: This links GBE deficiency to polyglucosan body accumulation in central and peripheral nervous systems.
+- name: Peripheral nerve, autonomic, and neuromuscular involvement
+  description: >-
+    APBD storage pathology affects peripheral nerves, autonomic fibers, nerve
+    roots, and skeletal muscle, producing bladder sphincter dysfunction,
+    neuropathy with distal sensory impairment, weakness, EMG abnormalities, and
+    secondary mobility or skin complications.
+  biological_processes:
+  - preferred_term: transmission of nerve impulse
+    term:
+      id: GO:0019226
+      label: transmission of nerve impulse
+    modifier: ABNORMAL
+  evidence:
+  - reference: PMID:33141444
+    reference_title: "GBE1-related disorders: Adult polyglucosan body disease and its neuromuscular phenotypes."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      deficiency of glycogen-branching enzyme and secondary storage of glycogen
+      in the form of polyglucosan bodies, involving the skeletal muscle,
+      diaphragm, peripheral nerve (including autonomic fibers), brain white
+      matter, spinal cord, nerve roots, cerebellum, brainstem and to a lesser
+      extent heart, lung, kidney, and liver cells.
+    explanation: Clinical review supports the affected peripheral, autonomic, and neuromuscular tissues.
+  - reference: DOI:10.1002/ana.23598
+    reference_title: "Adult polyglucosan body disease: Natural History and Key Magnetic Resonance Imaging Findings"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The most common clinical findings were neurogenic bladder (100%), spastic
+      paraplegia with vibration loss (90%), and axonal neuropathy (90%).
+    explanation: Natural history cohort supports autonomic bladder involvement, vibration loss, and axonal neuropathy.
+  downstream:
+  - target: Neurogenic bladder
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Autonomic involvement produces neurogenic bladder.
+  - target: Urinary incontinence
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Neurogenic bladder and autonomic dysfunction lead to urinary incontinence.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0000020 | Urinary incontinence | Very frequent (99-80%) |"
+      explanation: Orphanet lists urinary incontinence as very frequent in APBD.
+  - target: Urinary bladder sphincter dysfunction
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Autonomic and bladder pathway involvement produces bladder sphincter dysfunction.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0002839 | Urinary bladder sphincter dysfunction | Very frequent (99-80%) |"
+      explanation: Orphanet lists urinary bladder sphincter dysfunction as very frequent.
+  - target: Peripheral neuropathy
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Peripheral nerve storage pathology produces axonal neuropathy.
+  - target: Distal sensory impairment
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Axonal neuropathy with vibration loss produces distal sensory impairment.
+    evidence:
+    - reference: DOI:10.1002/ana.23598
+      reference_title: "Adult polyglucosan body disease: Natural History and Key Magnetic Resonance Imaging Findings"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The most common clinical findings were neurogenic bladder (100%),
+        spastic paraplegia with vibration loss (90%), and axonal neuropathy
+        (90%).
+      explanation: Vibration loss in the APBD cohort supports distal sensory impairment.
+  - target: Muscle weakness
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Skeletal muscle and neuromuscular involvement can manifest as weakness.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0001324 | Muscle weakness | Very frequent (99-80%) |"
+      explanation: Orphanet lists muscle weakness as very frequent.
+  - target: EMG abnormality
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Neuromuscular involvement can produce abnormal electromyography.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0003457 | EMG abnormality | Occasional (29-5%) |"
+      explanation: Orphanet lists EMG abnormality as occasional.
+  - target: Limitation of joint mobility
+    causal_link_type: UNKNOWN
+    description: Reduced mobility and neuromuscular disease may contribute to joint mobility limitation.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0001376 | Limitation of joint mobility | Occasional (29-5%) |"
+      explanation: Orphanet lists limitation of joint mobility as occasional.
+  - target: Skin ulcer
+    causal_link_type: UNKNOWN
+    description: Skin ulcers are modeled as a secondary complication of neuropathy or reduced mobility.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0200042 | Skin ulcer | Frequent (79-30%) |"
+      explanation: Orphanet lists skin ulcer as frequent.
 - name: White matter and motor tract degeneration
   description: >-
     APBD neuroimaging shows white matter abnormalities and medulla/spinal
@@ -164,6 +325,56 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
   - target: Dementia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Ataxia
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Cerebellar and brainstem involvement can produce ataxia.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0001251 | Ataxia | Occasional (29-5%) |"
+      explanation: Orphanet lists ataxia as occasional.
+  - target: Atypical behavior
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: White matter and cognitive involvement can be accompanied by behavioral changes.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0000708 | Atypical behavior | Frequent (79-30%) |"
+      explanation: Orphanet lists atypical behavior as frequent.
+  - target: Intellectual disability
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    description: APBD cognitive involvement is linked conservatively to the Orphanet intellectual disability phenotype.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0001249 | Intellectual disability | Very frequent (99-80%) |"
+      explanation: Orphanet lists intellectual disability as very frequent.
+  - target: Hemiparesis
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    description: Motor tract degeneration can produce paresis phenotypes.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0001269 | Hemiparesis | Very frequent (99-80%) |"
+      explanation: Orphanet lists hemiparesis as very frequent.
+  - target: Abnormality of extrapyramidal motor function
+    causal_link_type: UNKNOWN
+    description: Orphanet lists extrapyramidal motor involvement, but cached evidence does not resolve the intermediate mechanism.
+    evidence:
+    - reference: ORPHA:206583
+      reference_title: Adult polyglucosan body disease
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "| HP:0002071 | Abnormality of extrapyramidal motor function | Occasional (29-5%) |"
+      explanation: Orphanet lists extrapyramidal motor abnormality as occasional.
   evidence:
   - reference: DOI:10.1002/ana.23598
     reference_title: "Adult polyglucosan body disease: Natural History and Key Magnetic Resonance Imaging Findings"
@@ -630,6 +841,20 @@ phenotypes:
     evidence_source: OTHER
     snippet: "| HP:0200042 | Skin ulcer | Frequent (79-30%) |"
     explanation: Orphanet lists skin ulcer as frequent.
+biochemical:
+- name: Reduced glycogen branching enzyme activity
+  presence: DECREASED
+  context: >-
+    Reduced or deficient GBE1 glycogen branching enzyme activity is the proximal
+    biochemical abnormality that drives poorly branched glycogen storage.
+  evidence:
+  - reference: PMID:36796138
+    reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      reduced or deficient glycogen branching enzyme activity.
+    explanation: Clinical practice resource identifies deficient glycogen branching enzyme activity in GSD IV/APBD.
 genetic:
 - name: GBE1
   association: Causative

--- a/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
+++ b/kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
@@ -1,6 +1,6 @@
 name: Adult Polyglucosan Body Disease
 creation_date: "2026-05-07T18:30:00Z"
-updated_date: "2026-05-19T10:49:14Z"
+updated_date: "2026-05-19T10:59:50Z"
 category: Mendelian
 description: >-
   Adult polyglucosan body disease is an autosomal recessive, adult-onset
@@ -233,6 +233,15 @@ pathophysiology:
       The most common clinical findings were neurogenic bladder (100%), spastic
       paraplegia with vibration loss (90%), and axonal neuropathy (90%).
     explanation: Natural history cohort supports autonomic bladder involvement, vibration loss, and axonal neuropathy.
+  - reference: PMID:20301758
+    reference_title: "GBE1 Adult Polyglucosan Body Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      neurogenic bladder, gait difficulties (i.e., spasticity and weakness) from
+      mixed upper and lower motor neuron involvement, sensory loss predominantly
+      in the distal lower extremities, autonomic dysfunction
+    explanation: GeneReviews summarizes the same bladder, motor, sensory, and autonomic involvement in classic GBE1-APBD.
   downstream:
   - target: Neurogenic bladder
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -1029,6 +1038,23 @@ references:
       A glycogen storage disease of adults characterized by progressive upper
       and lower motor neuron dysfunction, progressive neurogenic bladder and
       cognitive difficulties that can lead to dementia.
+- reference: PMID:20301758
+  title: GBE1 Adult Polyglucosan Body Disease.
+  tags:
+  - GeneReviews
+  findings:
+  - statement: >-
+      GeneReviews summarizes classic GBE1-APBD as adult-onset neurogenic
+      bladder, gait difficulty from spasticity and weakness, distal sensory
+      loss, autonomic dysfunction, and mild cognitive difficulty.
+    supporting_text: >-
+      Most individuals with classic GBE1 adult polyglucosan body disease
+      (GBE1-APBD) present after age 40 years with unexplained progressive
+      neurogenic bladder, gait difficulties (i.e., spasticity and weakness)
+      from mixed upper and lower motor neuron involvement, sensory loss
+      predominantly in the distal lower extremities, autonomic dysfunction
+      (associated with orthostatic hypotension and constipation), and mild
+      cognitive difficulties (often executive dysfunction).
 - reference: DOI:10.1002/ana.23598
   title: "Adult polyglucosan body disease: Natural History and Key Magnetic Resonance Imaging Findings"
   findings:

--- a/references_cache/PMID_20301758.md
+++ b/references_cache/PMID_20301758.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:20301758"
+title: GBE1 Adult Polyglucosan Body Disease.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Akman HO
+- Lossos A
+- Kakhlon O
+year: '1993'
+content_type: abstract_only
+---
+
+# GBE1 Adult Polyglucosan Body Disease.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Akman HO, Lossos A, Kakhlon O
+
+## Content
+
+1. GBE1 Adult Polyglucosan Body Disease.
+
+Akman HO(1), Lossos A(2), Kakhlon O(2).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2009 Apr 2 [updated 2020 Sep 17].
+
+Author information:
+(1)Department of Neurology, Columbia University Medical Center, New York, New
+York
+(2)Hadassah-Hebrew University Medical Center, Jerusalem, Israel
+
+CLINICAL CHARACTERISTICS: Most individuals with classic GBE1 adult polyglucosan
+body disease (GBE1-APBD) present after age 40 years with unexplained progressive
+neurogenic bladder, gait difficulties (i.e., spasticity and weakness) from mixed
+upper and lower motor neuron involvement, sensory loss predominantly in the
+distal lower extremities, autonomic dysfunction (associated with orthostatic
+hypotension and constipation), and mild cognitive difficulties (often executive
+dysfunction). Some affected individuals without classic GBE1-APBD have atypical
+phenotypes including Alzheimer disease-like dementia and axonal neuropathy,
+stroke-like episodes, and diaphragmatic failure; others may have a history of
+infantile liver disease.
+DIAGNOSIS/TESTING: The diagnosis of GBE1-APBD is established in a proband with
+suggestive findings and biallelic GBE1 pathogenic variants identified by
+molecular genetic testing. Note: GBE enzyme assay (in any tissue) is not a
+first-line diagnostic test for GBE1-APBD.
+MANAGEMENT: Treatment of manifestations: Optimally, symptomatic care is provided
+by a multidisciplinary team that includes specialists in physical medicine
+rehabilitation, urology, and behavioral neurology or psychology. An
+individualized physical therapy program can improve flexibility, reduce
+spasticity, maintain or improve joint mobility, and facilitate activities of
+daily living; antispasmodic drugs may decrease cramps and facilitate walking.
+Spastic bladder may be managed with anticholinergic drugs and clean intermittent
+catheterization or an indwelling bladder catheter to prevent urosepsis;
+treatment of recurrent urinary infections is essential. Treatment of cognitive
+decline and psychiatric manifestations is per standard practice. Surveillance:
+Routine: neurologic assessments to monitor progression of upper motor neuron and
+lower motor neuron signs and to assess for new manifestations; urologic
+evaluations for complications of spastic bladder; occupational and physical
+therapy assessments regarding activities of daily living; and mental health
+assessments.
+GENETIC COUNSELING: GBE1-APBD is inherited in an autosomal recessive manner. If
+both parents are known to be heterozygous for a GBE1 pathogenic variant, each
+sib of an affected individual has at conception a 25% chance of being affected,
+a 50% chance of being an asymptomatic heterozygote (carrier), and a 25% chance
+of being unaffected and not a carrier. Once the GBE1 pathogenic variants have
+been identified in the family, carrier testing for at-risk relatives and
+prenatal and preimplantation genetic testing for GBE1-APBD are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 20301758


### PR DESCRIPTION
## Summary

- Selected Adult_Polyglucosan_Body_Disease.yaml as an under-connected inherited metabolic disorder pathograph.
- Added GO molecular-function coverage for GBE1 1,4-alpha-glucan branching enzyme activity and CHEBI glycogen coverage for the initial metabolic component.
- Added a reduced glycogen branching enzyme activity biochemical readout.
- Added a peripheral/autonomic/neuromuscular involvement branch and conservative downstream edges for the previously unreached urinary, sensory, weakness, EMG, musculoskeletal, skin, cognitive/behavioral, ataxic, hemiparetic, and extrapyramidal phenotypes.

## Connectivity

Before: phenotypes=18 reached=6 unreached=12; biochemical=0; GO_bp=6 GO_mf=0 chem=0.

After: phenotypes=18 reached=18 unreached=[]; biochemical=1 reached=1 unreached=[]; pathophysiology=5; downstream_edges=25; GO_bp=7 GO_mf=1 chem=2.

## Validation

- just validate kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
- uv run python -m dismech.graph --validate kb/disorders/Adult_Polyglucosan_Body_Disease.yaml
- just check-reference-cache-frontmatter
- git diff --check
- manual snippet audit: total=60 exact=46 normalized=14 skipped=0 missing=0

Unrelated reference-cache churn from validators was restored before commit; the PR is scoped to kb/disorders/Adult_Polyglucosan_Body_Disease.yaml.
