### PR TITLE
Connect Danon disease pathograph

### DIFF
--- a/cache/ncit/terms.csv
+++ b/cache/ncit/terms.csv
@@ -413,6 +413,8 @@ NCIT:C6287,Endometrial Endometrioid Adenocarcinoma,2026-05-08T09:47:53.049787
 NCIT:C63341,Anticoagulation Therapy,2026-05-06T15:32:00.128953
 NCIT:C63704,Video-Assisted Thoracic Surgery,2026-05-13T14:51:07.004999
 NCIT:C642,Methotrexate,2026-04-12T22:44:03.436499
+NCIT:C64433,Alanine Aminotransferase Measurement,2026-05-19T05:03:47.591003
+NCIT:C64467,Aspartate Aminotransferase Measurement,2026-05-19T05:03:47.594836
 NCIT:C64483,Indirect Bilirubin Measurement,2026-05-10T18:35:54.452818
 NCIT:C64489,Creatine Kinase Measurement,2026-05-10T18:35:10.111738
 NCIT:C647,Methylprednisolone,2026-05-05T08:31:05.488950

--- a/kb/disorders/Danon_disease.yaml
+++ b/kb/disorders/Danon_disease.yaml
@@ -1,6 +1,6 @@
 name: Danon disease
 creation_date: '2026-02-03T19:04:58Z'
-updated_date: '2026-05-19T11:59:57Z'
+updated_date: '2026-05-19T12:13:45Z'
 category: Mendelian
 disease_term:
   preferred_term: Danon disease
@@ -11,6 +11,12 @@ parents:
 - "Lysosomal storage diseases"
 - "X-linked genetic disorders"
 - "Autophagic vacuolar myopathies"
+references:
+- reference: PMID:32134616
+  title: Danon Disease.
+  tags:
+  - GeneReviews
+  findings: []
 
 description: >
   Danon disease is an X-linked dominant disorder caused by pathogenic variants in LAMP2

--- a/kb/disorders/Danon_disease.yaml
+++ b/kb/disorders/Danon_disease.yaml
@@ -1,6 +1,6 @@
 name: Danon disease
 creation_date: '2026-02-03T19:04:58Z'
-updated_date: '2026-05-03T04:56:20Z'
+updated_date: '2026-05-19T11:59:57Z'
 category: Mendelian
 disease_term:
   preferred_term: Danon disease
@@ -32,6 +32,7 @@ inheritance:
   evidence:
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "inherited as an X"
     explanation: Confirms X-linked dominant inheritance pattern.
 prevalence:
@@ -108,17 +109,18 @@ pathophysiology:
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "LAMP-2 is required for the maturation of"
     explanation: Confirms LAMP-2 is required for autophagosome maturation and its deficiency causes macroautophagy failure.
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "LAMP-2 protein deficiency, mainly LAMP-2B"
     explanation: Confirms LAMP-2B isoform deficiency as the primary molecular defect.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "causes disruption of autophagy"
     explanation: Confirms that LAMP-2 deficiency disrupts autophagy through impaired lysosome-autophagosome fusion.
 
@@ -158,7 +160,7 @@ pathophysiology:
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "impairment due to LAMP-2 deficiency"
     explanation: Confirms that LAMP-2 deficiency causes autophagy impairment and autophagic vacuole accumulation.
   - reference: DOI:10.1038/cddis.2016.475
@@ -187,16 +189,141 @@ pathophysiology:
     term:
       id: GO:0016236
       label: macroautophagy
+  chemical_entities:
+  - preferred_term: glycogen
+    term:
+      id: CHEBI:28087
+      label: glycogen
+    modifier: INCREASED
+  downstream:
+  - target: Cardiac autophagic vacuolar cardiomyopathy
+    description: >
+      Autophagic vacuole accumulation in cardiomyocytes drives Danon
+      cardiomyopathy and hypertrophic-to-dilated cardiac remodeling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Skeletal muscle and hepatic enzyme involvement
+    description: >
+      Autophagic vacuolar myopathy and multisystem tissue involvement produce
+      skeletal myopathy and serum muscle or hepatic enzyme elevations.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Neuroretinal involvement
+    description: >
+      Multisystem LAMP2/autophagy disruption also involves brain and retinal
+      tissues, connecting the core lysosomal defect to neurodevelopmental and
+      visual manifestations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
   evidence:
   - reference: DOI:10.3390/biom14101272
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Pathologically, the disease is characterized by the appearance of unique autophagic vacuoles with sarcolemmal features (AVSFs)."
     explanation: Confirms AVSFs as a pathological hallmark of Danon disease.
   - reference: DOI:10.1038/cddis.2016.475
     supports: PARTIAL
+    evidence_source: MODEL_ORGANISM
     snippet: "Among them, Danon Disease (DD) and glycogen storage disease type II (GSDII) are due to primary lysosomal protein defects."
     explanation: Establishes Danon disease as a lysosomal storage disorder with autophagic vacuolar myopathy.
 
+- name: Cardiac autophagic vacuolar cardiomyopathy
+  description: >
+    LAMP2 deficiency produces vacuolated degenerating cardiomyocytes and a
+    severe cardiomyopathy phenotype with marked left-ventricular hypertrophy,
+    progressive systolic dysfunction, cavity enlargement, heart failure, and
+    risk of sudden death.
+  cell_types:
+  - preferred_term: cardiomyocyte
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  evidence:
+  - reference: PMID:25589223
+    reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "In heart, cardiomyocytes show dramatically increased vacuolation and"
+    explanation: Review of human Danon pathology links LAMP2 deficiency to vacuolated cardiomyocytes.
+  - reference: PMID:19318653
+    reference_title: "Clinical outcome and phenotypic expression in LAMP2 cardiomyopathy."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "LAMP2 cardiomyopathy is a profound disease process characterized by"
+    explanation: Prospective patient follow-up supports severe progressive LAMP2 cardiomyopathy.
+  downstream:
+  - target: Hypertrophic cardiomyopathy
+    description: Danon cardiomyopathy commonly presents as hypertrophic cardiomyopathy.
+    causal_link_type: DIRECT
+  - target: Left ventricular hypertrophy
+    description: Danon cardiac remodeling produces marked left-ventricular hypertrophy.
+    causal_link_type: DIRECT
+  - target: Dilated cardiomyopathy
+    description: Progressive systolic dysfunction and cavity enlargement can evolve into a dilated/end-stage cardiomyopathy phase.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Elevated creatine kinase measurement
+    description: Myocardial damage in Danon disease can be accompanied by elevated CK-MB and other injury biomarkers.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+- name: Skeletal muscle and hepatic enzyme involvement
+  description: >
+    Danon disease includes skeletal autophagic vacuolar myopathy and variable
+    hepatic involvement. Muscle and liver injury can be reflected by elevated
+    CK-MB, myoglobin, troponin, ALT, AST, ALP, and related serum markers.
+  cell_types:
+  - preferred_term: skeletal muscle fiber
+    term:
+      id: CL:0008002
+      label: skeletal muscle fiber
+  evidence:
+  - reference: PMID:25589223
+    reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "hypertrophic cardiomyopathy, myopathy, and intellectual disability."
+    explanation: Review identifies skeletal myopathy as part of the classic Danon triad.
+  - reference: PMID:33680117
+    reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Other symptoms that are less prevalent include hepatic disease"
+    explanation: Patient cohort review notes hepatic disease among Danon manifestations.
+  downstream:
+  - target: Skeletal myopathy
+    description: Autophagic vacuolar muscle involvement produces skeletal myopathy.
+    causal_link_type: DIRECT
+  - target: Elevated circulating creatine kinase concentration
+    description: Muscle and myocardial damage can elevate creatine kinase or CK-MB.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Elevated circulating hepatic transaminase concentration
+    description: Hepatic involvement can elevate ALT and AST transaminases.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Elevated alanine aminotransferase measurement
+    description: ALT elevation is a biochemical readout of hepatic involvement in Danon disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Elevated aspartate aminotransferase measurement
+    description: AST elevation is a biochemical readout of hepatic involvement in Danon disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+- name: Neuroretinal involvement
+  description: >
+    Danon disease can involve brain and retinal tissues, producing intellectual
+    impairment as part of the classic male triad and less common retinal disease
+    such as cone-rod dystrophy with visual impairment.
+  evidence:
+  - reference: PMID:25589223
+    reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "In brain, pale granular neurons and neurons with lipofuscin-like"
+    explanation: Human pathology review supports brain involvement in Danon disease.
+  - reference: DOI:10.3390/genes14081539
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "visual impairment due to cone–rod dystrophy."
+    explanation: Case report documents retinal dystrophy with visual impairment in Danon disease.
+  downstream:
+  - target: Intellectual disability
+    description: Brain involvement contributes to intellectual disability in the classic Danon triad.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+  - target: Retinal dystrophy
+    description: Retinal involvement can manifest as cone-rod dystrophy and visual impairment.
+    causal_link_type: DIRECT
 - name: Impaired mitophagy
   description: >
     Defective autophagosome-lysosome fusion specifically impairs the mitophagy
@@ -276,7 +403,7 @@ phenotypes:
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "triad of hypertrophic cardiomyopathy, skeletal muscle"
     explanation: Review confirms hypertrophic cardiomyopathy as part of the defining clinical triad.
   - reference: PMID:19318653
@@ -287,6 +414,7 @@ phenotypes:
     explanation: Prospective study of 7 LAMP2 patients documenting severe cardiac disease leading to death before age 25.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Danon disease is a severe multisystem disorder clinically characterized by hypertrophic cardiomyopathy, skeletal myopathy and mental retardation in male patients"
     explanation: Confirms hypertrophic cardiomyopathy as a primary clinical feature of Danon disease.
 
@@ -304,17 +432,18 @@ phenotypes:
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "triad of hypertrophic cardiomyopathy, skeletal muscle"
     explanation: Review confirms skeletal muscle weakness as part of the defining clinical triad.
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "small basophilic granules scattered in myofibers"
     explanation: Describes characteristic muscle biopsy findings of autophagic vacuoles with sarcolemmal features in skeletal muscle.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Danon disease is a severe multisystem disorder clinically characterized by hypertrophic cardiomyopathy, skeletal myopathy and mental retardation in male patients"
     explanation: Confirms skeletal myopathy as part of the clinical triad in affected males.
 
@@ -338,11 +467,12 @@ phenotypes:
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "hypertrophic cardiomyopathy, myopathy, and intellectual disability."
     explanation: Confirms intellectual disability as part of the classic clinical triad.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Danon disease is a severe multisystem disorder clinically characterized by hypertrophic cardiomyopathy, skeletal myopathy and mental retardation in male patients"
     explanation: Confirms intellectual disability (mental retardation) as a defining feature in males.
 
@@ -371,6 +501,7 @@ phenotypes:
     explanation: Documents ventricular pre-excitation in 6 of 7 Danon disease patients at diagnosis.
   - reference: DOI:10.3390/genes14081539
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "mild ventricular pre-excitation known as"
     explanation: Case report documenting WPW syndrome as an early manifestation in a Danon disease patient.
 
@@ -387,6 +518,7 @@ phenotypes:
   evidence:
   - reference: DOI:10.3390/genes14081539
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "visual impairment due to"
     explanation: Documents retinal dystrophy (cone-rod dystrophy) as a clinical manifestation in Danon disease.
 
@@ -430,7 +562,7 @@ phenotypes:
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Cardiac involvement can be fatal"
     explanation: Confirms cardiac disease progression is fatal without transplantation.
 
@@ -471,6 +603,98 @@ phenotypes:
     snippet: "hepatic lesions [alanine aminotransferase (ALT), 246 IU/; aspartate aminotransferase (AST), 241 IU/l; alkaline phosphatase (ALP), 249 IU/l]"
     explanation: Documents elevated circulating ALT and AST values as serum evidence of hepatic involvement in a Danon disease patient.
 
+biochemical:
+- name: Elevated creatine kinase measurement
+  presence: INCREASED
+  notes: >
+    Danon disease cardiomyopathy and myopathy can be accompanied by elevated
+    CK-MB and other serum markers of myocardial or muscle injury.
+  biomarker_term:
+    preferred_term: Creatine Kinase Measurement
+    term:
+      id: NCIT:C64489
+      label: Creatine Kinase Measurement
+  readouts:
+  - target: Cardiac autophagic vacuolar cardiomyopathy
+    relationship: CORRELATES_WITH
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated CK-MB and related injury markers support muscle or myocardial damage in Danon disease.
+    evidence:
+    - reference: PMID:33680117
+      reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "creatine kinase isoenzyme MB (CK-MB), 7.9 ng/ml"
+      explanation: Patient laboratory data document elevated CK-MB among myocardial damage markers.
+  evidence:
+  - reference: PMID:33680117
+    reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "creatine kinase isoenzyme MB (CK-MB), 7.9 ng/ml"
+    explanation: Patient laboratory findings support elevated CK-MB as a biochemical abnormality.
+- name: Elevated alanine aminotransferase measurement
+  presence: INCREASED
+  notes: >
+    ALT elevation is reported with Danon hepatic involvement and can accompany
+    the multisystem muscle/cardiac phenotype.
+  biomarker_term:
+    preferred_term: Alanine Aminotransferase Measurement
+    term:
+      id: NCIT:C64433
+      label: Alanine Aminotransferase Measurement
+  readouts:
+  - target: Skeletal muscle and hepatic enzyme involvement
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated ALT reports hepatic enzyme involvement in Danon disease.
+    evidence:
+    - reference: PMID:33680117
+      reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "alanine aminotransferase (ALT), 246 IU/"
+      explanation: Patient laboratory data document elevated ALT.
+  evidence:
+  - reference: PMID:33680117
+    reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "alanine aminotransferase (ALT), 246 IU/"
+    explanation: Patient laboratory findings support elevated ALT.
+- name: Elevated aspartate aminotransferase measurement
+  presence: INCREASED
+  notes: >
+    AST elevation is reported with Danon hepatic involvement and can accompany
+    multisystem LAMP2 disease.
+  biomarker_term:
+    preferred_term: Aspartate Aminotransferase Measurement
+    term:
+      id: NCIT:C64467
+      label: Aspartate Aminotransferase Measurement
+  readouts:
+  - target: Skeletal muscle and hepatic enzyme involvement
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated AST reports hepatic enzyme involvement in Danon disease.
+    evidence:
+    - reference: PMID:33680117
+      reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "aspartate aminotransferase (AST), 241 IU/l"
+      explanation: Patient laboratory data document elevated AST.
+  evidence:
+  - reference: PMID:33680117
+    reference_title: "Clinical and molecular characterization of seven patients with Danon disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "aspartate aminotransferase (AST), 241 IU/l"
+    explanation: Patient laboratory findings support elevated AST.
+
 histopathology:
 - name: Autophagic vacuoles with sarcolemmal features
   diagnostic: true
@@ -485,6 +709,7 @@ histopathology:
   evidence:
   - reference: DOI:10.3390/biom14101272
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Pathologically, the disease is characterized by the appearance of unique autophagic vacuoles with sarcolemmal features (AVSFs)."
     explanation: Confirms AVSFs as a defining pathological hallmark of Danon disease.
 
@@ -505,13 +730,13 @@ genetic:
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Danon disease is caused by loss-of-function mutations"
     explanation: Confirms loss-of-function LAMP2 mutations as the cause of Danon disease.
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Most mutations lead to splicing defects"
     explanation: Documents the mutation spectrum including splicing and truncation mutations.
   - reference: PMID:33680117
@@ -522,10 +747,12 @@ genetic:
     explanation: Confirms LAMP2 loss-of-function as the molecular cause.
   - reference: DOI:10.3390/biom14101272
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Danon disease, an X-linked dominant vacuolar cardiomyopathy and skeletal myopathy, is caused by a primary deficiency of lysosome-associated membrane protein-2 (LAMP-2)."
     explanation: Confirms LAMP-2 deficiency as the cause of Danon disease.
   - reference: DOI:10.3390/genes14081539
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "Genetic testing revealed an Xq24 microdeletion encompassing the entire LAMP2 gene."
     explanation: Documents complete LAMP2 gene deletion causing Danon disease.
 
@@ -552,10 +779,12 @@ genetic:
     explanation: Documents striking phenotypic differences between female carriers and affected males.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "Danon disease is a severe multisystem disorder clinically characterized by hypertrophic cardiomyopathy, skeletal myopathy and mental retardation in male patients, and by a milder phenotype (predominantly involving cardiac muscle) in female patients."
     explanation: Documents distinct phenotypic presentations between males and females.
   - reference: DOI:10.3390/genes14081539
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "Danon disease is typically lethal by the mid-twenties in male patients due to cardiomyopathy and heart failure. Female patients usually present with milder and variable symptoms."
     explanation: Confirms sex-specific differences in disease severity and progression.
 
@@ -575,7 +804,7 @@ treatments:
   - reference: PMID:25589223
     reference_title: "Danon disease: a phenotypic expression of LAMP-2 deficiency."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "transplantation is the only therapeutic option."
     explanation: Confirms cardiac transplantation as the only therapeutic option for Danon disease cardiomyopathy.
   - reference: PMID:19318653
@@ -586,6 +815,7 @@ treatments:
     explanation: Prospective study supporting early consideration of heart transplantation for LAMP2 patients.
   - reference: DOI:10.1111/nan.12587
     supports: SUPPORT
+    evidence_source: OTHER
     snippet: "in male patients, the prognosis is poor due to rapid progression towards heart failure, and only heart transplantation modifies the disease course."
     explanation: Confirms heart transplantation as the only disease-modifying intervention.
 
@@ -604,11 +834,12 @@ treatments:
   - reference: PMID:34737089
     reference_title: "Clinical features of Danon disease and insights gained from LAMP-2 deficiency models."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "gene therapies anticipate"
     explanation: Confirms gene therapy clinical trials are underway for Danon disease.
   - reference: DOI:10.3390/biom14101272
     supports: PARTIAL
+    evidence_source: OTHER
     snippet: "Although the pathogenetic mechanism of Danon disease remains unestablished, the first clinical trials using AAV vectors have finally begun in recent years. The development of novel therapies is expected in the future."
     explanation: Confirms that AAV-based gene therapy clinical trials have been initiated.
 
@@ -626,6 +857,7 @@ clinical_trials:
   evidence:
   - reference: clinicaltrials:NCT03882437
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "This is a non-randomized open-label Phase 1 study to evaluate the safety and toxicity of gene therapy using a recombinant adeno-associated virus serotype 9 (AAV9) containing the human lysosome-associated membrane protein 2 isoform B (LAMP2B) transgene (investigational product (IP), RP-A501) in male patients with Danon Disease (DD)."
     explanation: ClinicalTrials.gov describes the first-in-human RP-A501 gene therapy study in male Danon disease patients.
 - name: NCT06092034
@@ -642,6 +874,7 @@ clinical_trials:
   evidence:
   - reference: clinicaltrials:NCT06092034
     supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
     snippet: "This is a single arm Phase 2 trial to evaluate the efficacy and safety of RP-A501, a recombinant adeno-associated virus serotype 9 (AAV9) containing the human lysosome-associated membrane protein 2 isoform B (LAMP2B) transgene, in male patients with Danon Disease."
     explanation: ClinicalTrials.gov documents the active Phase 2 RP-A501 gene therapy study in Danon disease.
 

--- a/references_cache/PMID_32134616.md
+++ b/references_cache/PMID_32134616.md
@@ -1,0 +1,94 @@
+---
+reference_id: "PMID:32134616"
+title: Danon Disease.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Taylor MRG
+- Adler ED
+year: '1993'
+content_type: abstract_only
+---
+
+# Danon Disease.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Taylor MRG, Adler ED
+
+## Content
+
+1. Danon Disease.
+
+Taylor MRG(1), Adler ED(2).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2020 Mar 5 [updated 2024 May 23].
+
+Author information:
+(1)Adult Medical Genetics Program, University of Colorado Anschutz Medical
+Campus, Aurora, Colorado
+(2)Division of Cardiology, University of California San Diego, San Diego,
+California
+
+CLINICAL CHARACTERISTICS: Danon disease is a multisystem condition with
+predominant involvement of the heart, skeletal muscles, and retina, with
+overlying cognitive dysfunction. Males are typically more severely affected than
+females. Males usually present with childhood onset concentric hypertrophic
+cardiomyopathy that is progressive and often requires heart transplantation.
+Rarely, hypertrophic cardiomyopathy can evolve to resemble dilated
+cardiomyopathy. Most affected males also have cardiac conduction abnormalities.
+Skeletal muscle weakness may lead to delayed acquisition of motor milestones.
+Learning disability and intellectual disability, most often in the mild range,
+are common. Additionally, affected males can develop retinopathy with subsequent
+visual impairment. The clinical features in females are broader and more
+variable. Females are more likely to have dilated cardiomyopathy, with a smaller
+proportion requiring heart transplantation compared to affected males. Cardiac
+conduction abnormalities, skeletal muscle weakness, mild cognitive impairment,
+and pigmentary retinopathy are variably seen in affected females.
+DIAGNOSIS/TESTING: The diagnosis of Danon disease is established in a proband
+(male or female) with suggestive findings and/or a hemizygous (in males) or a
+heterozygous (in females) pathogenic variant in LAMP2 identified by molecular
+genetic testing.
+MANAGEMENT: Treatment of manifestations: While the age of onset and progression
+of disease are typically later and slower in females, the management approach in
+males and females is similar. Standard treatment guidelines for hypertrophic
+cardiomyopathy and heart failure; consideration of ablation therapy in those
+with cardiac pre-excitation and arrhythmia; physical therapy for skeletal muscle
+weakness; standard treatment for developmental delay / intellectual disability;
+use of low vision aids for those with retinopathy. Surveillance:
+Electrocardiography at least annually with echocardiography and cardiac MRI at
+least every one to two years; ambulatory arrhythmia monitoring as needed based
+on symptoms; annual assessment of strength and for neurologic changes;
+monitoring of developmental progress, educational needs, and behavior at each
+visit with formal developmental assessments every three to five years during
+childhood; ophthalmology evaluation at least every three to five years.
+Agents/circumstances to avoid: Avoidance of dehydration or over-diuresis in
+those with heart failure; in the presence of significant cardiac hypertrophy
+with obstruction and/or symptomatic arrhythmia, consideration of instituting the
+guidelines for physical exertion for individuals with sarcomeric hypertrophic
+cardiomyopathy. Evaluation of relatives at risk: It is appropriate to clarify
+the genetic status of apparently asymptomatic older and younger at-risk
+relatives of an affected individual in order to identify as early as possible
+those who would benefit from prompt initiation of treatment and surveillance.
+Pregnancy management: Management should be guided by the degree of overt disease
+in the pregnant woman and per guidelines for pregnant women with hypertrophic or
+dilated cardiomyopathy, depending on their condition.
+GENETIC COUNSELING: Danon disease is inherited in an X-linked manner. If the
+mother of the proband has a LAMP2 pathogenic variant, the chance of transmitting
+it in each pregnancy is 50%. Males who have a pathogenic variant in LAMP2 will
+transmit the pathogenic variant to all of their daughters and none of their
+sons. Males who inherit the pathogenic variant will be affected; females who
+inherit the pathogenic variant will be heterozygous and may have features of
+Danon disease. Once the causative pathogenic variant has been identified in an
+affected family member, prenatal testing and preimplantation genetic testing for
+Danon disease for a pregnancy at increased risk are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 32134616


### PR DESCRIPTION
## Summary
- Added cardiac, skeletal/hepatic, and neuroretinal intermediate pathophysiology branches downstream of Danon autophagic vacuole accumulation.
- Connected all existing Danon phenotypes to the LAMP2/autophagy mechanism, including cardiomyopathy/LVH/DCM, skeletal myopathy, intellectual disability, retinal dystrophy, CK elevation, and transaminase elevation.
- Added structured biochemical readouts for elevated CK/CK-MB, ALT, and AST, with biomarker readout links back to cardiac or hepatic/muscle involvement.
- Added glycogen as an increased chemical entity on the autophagic vacuole/glycogen-storage node.
- Filled missing `evidence_source` classifications in this file while touching the evidence blocks.

## Validation
- `just validate kb/disorders/Danon_disease.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Danon_disease.yaml`
- Manual snippet audit: `total=60 exact=60 normalized=0 missing=0`
- `just check-reference-cache-frontmatter`
- `git diff --check`

## Connectivity Audit
- Before: phenotypes `9 reached=1`, biochemical `0`
- After: phenotypes `9 reached=9`, biochemical `3 reached=3`
- GO/CHEBI/NCIT coverage after: GO BP `6`, GO MF `1`, chemical entities `1`; NCIT ALT/AST measurement rows added to cache.

## Scope Note
Recurring unrelated `references_cache` normalization churn was restored before commit. The remaining cache change is only `cache/ncit/terms.csv` for ALT/AST measurement terms required by the new biochemical readouts.
