### PR TITLE
Connect hypotonia-cystinuria syndrome pathograph

### DIFF
--- a/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
+++ b/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hypotonia-cystinuria syndrome
 creation_date: "2026-05-08T16:18:38Z"
-updated_date: "2026-05-19T12:30:35Z"
+updated_date: "2026-05-19T12:50:28Z"
 synonyms:
 - HCS
 - Hypotonia-cystinuria 2p21 deletion syndrome
@@ -50,12 +50,20 @@ references:
   title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
   found_in:
   - Hypotonia-Cystinuria_Syndrome-deep-research-falcon.md
+- reference: PMID:21222627
+  title: "PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients."
+  found_in:
+  - Hypotonia-Cystinuria_Syndrome-deep-research-falcon.md
 - reference: PMID:22480232
   title: "Cystinuria: an inborn cause of urolithiasis."
   found_in:
   - Hypotonia-Cystinuria_Syndrome-deep-research-falcon.md
 - reference: PMID:32066273
   title: "Evaluation and Medical Management of Patients with Cystine Nephrolithiasis: A Consensus Statement."
+  found_in:
+  - Hypotonia-Cystinuria_Syndrome-deep-research-falcon.md
+- reference: clinicaltrials:NCT02640443
+  title: "Sulfamethoxazole for the Treatment of Primary PREPL Deficiency (In Dutch: Sulfamethoxazole Ter Behandeling Van Primaire PREPL deficiëntie)"
   found_in:
   - Hypotonia-Cystinuria_Syndrome-deep-research-falcon.md
 definitions:
@@ -297,10 +305,10 @@ pathophysiology:
       id: hgnc:30228
       label: PREPL
   cell_types:
-  - preferred_term: neuron
+  - preferred_term: motor neuron
     term:
-      id: CL:0000540
-      label: neuron
+      id: CL:0000100
+      label: motor neuron
   biological_processes:
   - preferred_term: synaptic vesicle exocytosis
     modifier: DECREASED
@@ -736,7 +744,7 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "Patients present with generalized hypotonia at birth, nephrolithiasis, growth hormone deficiency, minor facial dysmorphism, and failure to thrive"
     explanation: The article reports minor facial dysmorphism; HP:0001999 is used as a broad non-coarse facial-shape binding.
-- category: Craniofacial
+- category: Oral
   name: Xerostomia
   description: Xerostomia is reported as part of the broader PREPL deficiency phenotype.
   phenotype_term:
@@ -829,6 +837,42 @@ genetic:
     snippet: "the extended phenotype can be attributed to the deletion of PREPL."
     explanation: This directly attributes the non-cystinuria syndromic phenotype to PREPL deletion.
 treatments:
+- name: Human growth hormone replacement therapy
+  description: >
+    Recombinant human growth hormone therapy can be considered for the PREPL-related
+    growth retardation and growth hormone deficiency component.
+  treatment_term:
+    preferred_term: human growth hormone replacement therapy
+    term:
+      id: MAXO:0000780
+      label: human growth hormone replacement therapy
+  target_phenotypes:
+  - preferred_term: Growth hormone deficiency
+    term:
+      id: HP:0034323
+      label: Reduced circulating growth hormone concentration
+  - preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  target_mechanisms:
+  - target: PREPL-related growth and appetite dysregulation
+    treatment_effect: MODULATES
+    description: Replacement therapy addresses the growth hormone deficiency component of the PREPL-related growth phenotype.
+    evidence:
+    - reference: PMID:21222627
+      reference_title: "PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Growth retardation is usually observed, which responds well to growth hormone therapy."
+      explanation: The review summarizes observed response of PREPL-associated growth retardation to growth hormone therapy.
+  evidence:
+  - reference: PMID:21222627
+    reference_title: "PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Growth retardation is usually observed, which responds well to growth hormone therapy."
+    explanation: The review directly supports growth hormone therapy responsiveness in PREPL deficiency.
 - name: Cystine stone prevention with hydration and diet
   description: >
     High fluid intake and dietary measures reduce cystine concentration and are
@@ -937,4 +981,31 @@ treatments:
     evidence_source: HUMAN_CLINICAL
     snippet: "She and 1 of 3 patients with HCS responded transiently to pyridostigmine during infancy."
     explanation: Response was transient and only observed in one of three HCS patients, so support is partial.
+clinical_trials:
+- name: NCT02640443
+  phase: PHASE_II
+  status: UNKNOWN
+  description: >
+    Phase 2 trial evaluating oral sulfamethoxazole for symptoms of primary PREPL
+    deficiency, including hypotonia-cystinuria syndrome and isolated PREPL deficiency.
+  target_phenotypes:
+  - preferred_term: Generalized hypotonia
+    term:
+      id: HP:0001290
+      label: Generalized hypotonia
+  - preferred_term: Ptosis
+    term:
+      id: HP:0000508
+      label: Ptosis
+  - preferred_term: Muscle weakness
+    term:
+      id: HP:0001324
+      label: Muscle weakness
+  evidence:
+  - reference: clinicaltrials:NCT02640443
+    reference_title: "Sulfamethoxazole for the Treatment of Primary PREPL Deficiency"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The investigators will evaluate whether sulfamethoxazole, a sulfamide antibiotic, improves the symptoms of primary PREPL deficiency (hypotonia-cystinuria syndrome and isolated PREPL deficiency)."
+    explanation: The ClinicalTrials.gov record directly identifies the investigational PREPL deficiency therapy and includes HCS.
 datasets:

--- a/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
+++ b/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hypotonia-cystinuria syndrome
 creation_date: "2026-05-08T16:18:38Z"
-updated_date: "2026-05-08T17:04:17Z"
+updated_date: "2026-05-19T12:30:35Z"
 synonyms:
 - HCS
 - Hypotonia-cystinuria 2p21 deletion syndrome
@@ -120,8 +120,47 @@ pathophysiology:
   downstream:
   - target: Proximal tubular cystine transport defect
     description: Loss of SLC3A1 impairs renal cystine and dibasic amino acid reabsorption.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16385448
+      reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "microdeletion of part of the SLC3A1 and PREPL genes on chromosome 2p21 was found."
+      explanation: The deleted SLC3A1 component explains the type A cystinuria transport defect.
   - target: PREPL-related neuromuscular transmission defect
     description: Loss of PREPL contributes to congenital hypotonia, weakness, ptosis, and feeding problems.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16385448
+      reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "the extended phenotype can be attributed to the deletion of PREPL."
+      explanation: The founding paper attributes the non-cystinuria syndromic phenotype to PREPL loss.
+  - target: PREPL-related growth and appetite dysregulation
+    description: PREPL loss contributes to growth hormone deficiency, early poor growth, and later hyperphagia or obesity.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - growth hormone deficiency
+    - neonatal feeding difficulty
+    evidence:
+    - reference: PMID:28726805
+      reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PREPL deficiency causes neonatal hypotonia, ptosis, neonatal feeding difficulties, childhood obesity, xerostomia, and growth hormone deficiency."
+      explanation: PREPL deficiency directly supports a growth, feeding, obesity, and xerostomia branch in HCS.
+  - target: Variable developmental and dysmorphic involvement
+    description: The contiguous deletion presentation includes variable developmental, neurobehavioral, and dysmorphic features.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22796000
+      reference_title: Two novel deletions in hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical features include cystinuria, neonatal hypotonia with spontaneous improvement, poor feeding in neonates, hyperphagia in childhood, growth hormone deficiency, and variable cognitive problems."
+      explanation: HCS case literature supports variable neurodevelopmental involvement beyond the renal and neuromuscular branches.
 - name: Proximal tubular cystine transport defect
   description: >
     Loss of the SLC3A1-encoded rBAT heavy subunit disrupts proximal tubular and
@@ -138,11 +177,43 @@ pathophysiology:
       id: CL:0002306
       label: epithelial cell of proximal tubule
   biological_processes:
+  - preferred_term: L-cystine transport
+    modifier: DECREASED
+    term:
+      id: GO:0015811
+      label: L-cystine transport
   - preferred_term: cystine and dibasic amino acid transmembrane transport
     modifier: DECREASED
     term:
       id: GO:0003333
       label: amino acid transmembrane transport
+  molecular_functions:
+  - preferred_term: amino acid transmembrane transporter activity
+    modifier: DECREASED
+    term:
+      id: GO:0015171
+      label: amino acid transmembrane transporter activity
+  chemical_entities:
+  - preferred_term: cystine
+    term:
+      id: CHEBI:17376
+      label: cystine
+    modifier: INCREASED
+  - preferred_term: L-lysine
+    term:
+      id: CHEBI:18019
+      label: L-lysine
+    modifier: INCREASED
+  - preferred_term: L-arginine
+    term:
+      id: CHEBI:16467
+      label: L-arginine
+    modifier: INCREASED
+  - preferred_term: ornithine
+    term:
+      id: CHEBI:18257
+      label: ornithine
+    modifier: INCREASED
   evidence:
   - reference: PMID:22480232
     reference_title: "Cystinuria: an inborn cause of urolithiasis."
@@ -159,10 +230,44 @@ pathophysiology:
   downstream:
   - target: Urinary cystine supersaturation
     description: High urinary cystine concentration promotes crystallization and nephrolithiasis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Such transporters deficiency leads to an accumulation of cystine in the urinary tract and to subsequent recurrent stones production, which can eventually lead to end stage renal disease."
+      explanation: The HCS case report directly links transporter deficiency to urinary cystine accumulation and stone formation.
+  - target: Cystinuria
+    description: Defective cystine and dibasic amino-acid reabsorption produces the diagnostic cystinuria phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22796000
+      reference_title: Two novel deletions in hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical features include cystinuria, neonatal hypotonia with spontaneous improvement, poor feeding in neonates, hyperphagia in childhood, growth hormone deficiency, and variable cognitive problems."
+      explanation: This HCS report lists cystinuria as a core clinical feature of the transporter-deletion syndrome.
+  - target: Elevated urinary cystine
+    description: Urinary amino-acid testing detects increased cystine from failed proximal tubular reabsorption.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The diagnosis of cystinuria was confirmed by urinary amino acid examination (cystine/creatinine 676 mMol/mol, normal value 4–15)."
+      explanation: The biochemical assay documents elevated urinary cystine downstream of the transporter defect.
 - name: Urinary cystine supersaturation
   description: >
     Increased urinary cystine concentration can exceed solubility, forming
     cystine crystals and stones that may obstruct the urinary tract.
+  chemical_entities:
+  - preferred_term: cystine
+    term:
+      id: CHEBI:17376
+      label: cystine
+    modifier: INCREASED
   evidence:
   - reference: PMID:31024870
     reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
@@ -173,6 +278,14 @@ pathophysiology:
   downstream:
   - target: Cystine nephrolithiasis
     description: Cystine stones produce renal and urinary tract morbidity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Such transporters deficiency leads to an accumulation of cystine in the urinary tract and to subsequent recurrent stones production, which can eventually lead to end stage renal disease."
+      explanation: The HCS case report connects urinary cystine accumulation with recurrent stone production.
 - name: PREPL-related neuromuscular transmission defect
   description: >
     PREPL loss causes a congenital myasthenic syndrome with impaired
@@ -194,6 +307,11 @@ pathophysiology:
     term:
       id: GO:0016079
       label: synaptic vesicle exocytosis
+  - preferred_term: chemical synaptic transmission
+    modifier: DECREASED
+    term:
+      id: GO:0007268
+      label: chemical synaptic transmission
   evidence:
   - reference: PMID:24610330
     reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
@@ -210,10 +328,54 @@ pathophysiology:
   downstream:
   - target: Generalized hypotonia
     description: Neuromuscular transmission impairment produces early generalized hypotonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24610330
+      reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Isolated PREPL deficiency is a novel monogenic disorder that causes a congenital myasthenic syndrome with pre- and postsynaptic features and growth hormone deficiency."
+      explanation: PREPL-related myasthenic transmission defects explain the hypotonia component.
   - target: Feeding difficulties
     description: Bulbar or generalized weakness can impair neonatal feeding.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24610330
+      reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major clinical features of HCS are type A cystinuria, growth hormone deficiency, muscle weakness, ptosis, and feeding problems."
+      explanation: Feeding problems are listed among the major PREPL/HCS clinical features.
+  - target: Muscle weakness
+    description: PREPL-related myasthenic transmission impairment produces muscle weakness.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24610330
+      reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major clinical features of HCS are type A cystinuria, growth hormone deficiency, muscle weakness, ptosis, and feeding problems."
+      explanation: The PREPL deficiency paper directly lists muscle weakness as a major HCS feature.
+  - target: Ptosis
+    description: Ocular muscle involvement in the PREPL-related myasthenic syndrome produces ptosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24610330
+      reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major clinical features of HCS are type A cystinuria, growth hormone deficiency, muscle weakness, ptosis, and feeding problems."
+      explanation: Ptosis is listed among the major PREPL/HCS clinical features.
   - target: Growth hormone deficiency
     description: PREPL deficiency is associated with growth hormone deficiency in HCS and isolated PREPL deficiency.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24610330
+      reference_title: PREPL deficiency with or without cystinuria causes a novel myasthenic syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The major clinical features of HCS are type A cystinuria, growth hormone deficiency, muscle weakness, ptosis, and feeding problems."
+      explanation: Growth hormone deficiency is a major clinical feature of HCS/PREPL deficiency, although the intermediate mechanism is not resolved.
 - name: Cystine nephrolithiasis
   description: >
     Cystine stones may occur later than the initial hypotonia presentation, so
@@ -225,6 +387,142 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: "The diagnosis of HCS can be difficult because neurological signs are aspecific and kidney stones are commonly absent during the first months of life."
     explanation: This explains why renal stone disease may not be present early despite the underlying cystinuria.
+  downstream:
+  - target: Nephrolithiasis
+    description: Clinically apparent cystine stones manifest as nephrolithiasis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "After 3 months, a percutaneous nephrolithotripsy was performed to treat the staghorn stone"
+      explanation: This HCS case documents clinically significant nephrolithiasis requiring intervention.
+- name: PREPL-related growth and appetite dysregulation
+  description: >
+    PREPL deficiency contributes to growth hormone deficiency, neonatal feeding
+    problems, early failure to thrive, and later appetite or weight-gain
+    abnormalities including hyperphagia and childhood obesity.
+  genes:
+  - preferred_term: PREPL
+    term:
+      id: hgnc:30228
+      label: PREPL
+  evidence:
+  - reference: PMID:28726805
+    reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PREPL deficiency causes neonatal hypotonia, ptosis, neonatal feeding difficulties, childhood obesity, xerostomia, and growth hormone deficiency."
+    explanation: The PREPL deficiency delineation paper directly supports the growth, obesity, feeding, xerostomia, and endocrine branch.
+  - reference: PMID:16385448
+    reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "and failure to thrive, followed by hyperphagia and rapid weight gain in late childhood."
+    explanation: The founding HCS report supports the temporal pattern from early failure to thrive to later hyperphagia and rapid weight gain.
+  downstream:
+  - target: Failure to thrive
+    description: Early feeding and growth impairment manifests as failure to thrive.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16385448
+      reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "and failure to thrive, followed by hyperphagia and rapid weight gain in late childhood."
+      explanation: The HCS report directly supports early failure to thrive in this growth/appetite trajectory.
+  - target: Growth hormone deficiency
+    description: PREPL deficiency is associated with growth hormone deficiency.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28726805
+      reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PREPL deficiency causes neonatal hypotonia, ptosis, neonatal feeding difficulties, childhood obesity, xerostomia, and growth hormone deficiency."
+      explanation: The PREPL deficiency delineation paper lists growth hormone deficiency as part of the phenotype.
+  - target: Short stature
+    description: Growth retardation and growth hormone deficiency contribute to short stature.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - growth hormone deficiency
+    evidence:
+    - reference: PMID:22766003
+      reference_title: 2p21 Deletions in hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "patients homozygous for these deletions suffer from a general neonatal hypotonia and growth retardation in addition to cystinuria."
+      explanation: HCS deletion cases have growth retardation in addition to hypotonia and cystinuria.
+  - target: Hyperphagia
+    description: Later childhood hyperphagia follows the early poor-feeding period in some HCS patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:22796000
+      reference_title: Two novel deletions in hypotonia-cystinuria syndrome.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical features include cystinuria, neonatal hypotonia with spontaneous improvement, poor feeding in neonates, hyperphagia in childhood, growth hormone deficiency, and variable cognitive problems."
+      explanation: HCS clinical features include childhood hyperphagia after neonatal poor feeding.
+  - target: Childhood obesity
+    description: PREPL deficiency can produce childhood obesity after the early feeding/growth phase.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:28726805
+      reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PREPL deficiency causes neonatal hypotonia, ptosis, neonatal feeding difficulties, childhood obesity, xerostomia, and growth hormone deficiency."
+      explanation: The PREPL deficiency paper directly lists childhood obesity.
+  - target: Xerostomia
+    description: Xerostomia is part of the broader PREPL deficiency phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:28726805
+      reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PREPL deficiency causes neonatal hypotonia, ptosis, neonatal feeding difficulties, childhood obesity, xerostomia, and growth hormone deficiency."
+      explanation: The PREPL deficiency paper directly lists xerostomia.
+- name: Variable developmental and dysmorphic involvement
+  description: >
+    HCS has variable developmental, cognitive or neurobehavioral involvement,
+    and minor dysmorphic features, but the intermediate mechanisms connecting
+    the 2p21 deletion to these features remain unresolved.
+  evidence:
+  - reference: PMID:22796000
+    reference_title: Two novel deletions in hypotonia-cystinuria syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinical features include cystinuria, neonatal hypotonia with spontaneous improvement, poor feeding in neonates, hyperphagia in childhood, growth hormone deficiency, and variable cognitive problems."
+    explanation: This supports variable cognitive involvement in HCS.
+  - reference: PMID:16385448
+    reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patients present with generalized hypotonia at birth, nephrolithiasis, growth hormone deficiency, minor facial dysmorphism, and failure to thrive"
+    explanation: The founding paper lists minor facial dysmorphism among presenting features.
+  downstream:
+  - target: Global developmental delay
+    description: Variable neurodevelopmental involvement can include global developmental delay.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A global developmental delay of all the motor and social skills and of the speech was also evident."
+      explanation: This HCS case directly documents global developmental delay.
+  - target: Minor facial dysmorphism
+    description: Minor facial dysmorphism is a reported HCS feature without a resolved intermediate mechanism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:16385448
+      reference_title: Deletion of PREPL, a gene encoding a putative serine oligopeptidase, in patients with hypotonia-cystinuria syndrome.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients present with generalized hypotonia at birth, nephrolithiasis, growth hormone deficiency, minor facial dysmorphism, and failure to thrive"
+      explanation: The founding paper reports minor facial dysmorphism; the causal intermediate remains unresolved.
 phenotypes:
 - category: Neurologic
   name: Generalized hypotonia
@@ -457,6 +755,36 @@ biochemical:
 - name: Elevated urinary cystine
   presence: INCREASED
   context: Urinary cystine is increased due to impaired proximal tubular reabsorption.
+  biomarker_term:
+    preferred_term: cystine
+    term:
+      id: CHEBI:17376
+      label: cystine
+  readouts:
+  - target: Proximal tubular cystine transport defect
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary cystine reports failed proximal tubular cystine reabsorption.
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The diagnosis of cystinuria was confirmed by urinary amino acid examination (cystine/creatinine 676 mMol/mol, normal value 4–15)."
+      explanation: The urinary amino-acid result provides a diagnostic readout of the SLC3A1 transport defect.
+  - target: Urinary cystine supersaturation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Markedly elevated urinary cystine is the biochemical basis for cystine supersaturation and stone risk.
+    evidence:
+    - reference: PMID:31024870
+      reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Such transporters deficiency leads to an accumulation of cystine in the urinary tract and to subsequent recurrent stones production, which can eventually lead to end stage renal disease."
+      explanation: The report links cystine accumulation in the urinary tract to recurrent stone production.
   evidence:
   - reference: PMID:31024870
     reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.

--- a/references_cache/PMID_21222627.md
+++ b/references_cache/PMID_21222627.md
@@ -1,0 +1,70 @@
+---
+reference_id: "PMID:21222627"
+title: "PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients."
+authors:
+- Boonen K
+- Régal L
+- Jaeken J
+- Creemers JW
+journal: CNS Neurol Disord Drug Targets
+year: '2011'
+doi: 10.2174/187152711794653760
+keywords:
+- "Chromosomes, Human, Pair 2"
+- "Cystinuria/genetics, physiopathology"
+- "Failure to Thrive/genetics, physiopathology"
+- Gene Deletion
+- Humans
+- Molecular Targeted Therapy
+- "Muscle Hypotonia/genetics, physiopathology"
+- Phenotype
+- Prolyl Oligopeptidases
+- "Protein Structure, Tertiary/genetics, physiology"
+- "Serine Endopeptidases/chemistry, deficiency, genetics"
+content_type: abstract_only
+---
+
+# PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients.
+**Authors:** Boonen K, Régal L, Jaeken J, Creemers JW
+**Journal:** CNS Neurol Disord Drug Targets (2011)
+**DOI:** [10.2174/187152711794653760](https://doi.org/10.2174/187152711794653760)
+
+## Content
+
+1. CNS Neurol Disord Drug Targets. 2011 May;10(3):355-60. doi:
+10.2174/187152711794653760.
+
+PREPL, a prolyl endopeptidase-like enzyme by name only?--Lessons from patients.
+
+Boonen K(1), Régal L, Jaeken J, Creemers JW.
+
+Author information:
+(1)Laboratory for Biochemical Neuroendocrinology, Center for Human Genetics,
+University of Leuven, Belgium.
+
+Deletion of the Prolyl Endopeptidase-like (PREPL) gene has been described in
+three contiguous gene deletion syndromes at the 2p21 locus and current
+developments in high resolution microarrays and whole genome sequencing will no
+doubt soon result in the identification of isolated PREPL deficiency. But by
+comparing the differences in phenotypes with the number of genes deleted, the
+contribution of PREPL deficiency can already be deduced. Homozygous or compound
+heterozygous loss of PREPL is predicted to cause neonatal hypotonia and severe
+feeding problems. Failure to thrive usually persists for several years, followed
+by a period of hyperphagia and excessive weight gain. Growth retardation is
+usually observed, which responds well to growth hormone therapy. In addition,
+minor facial dysmorphism, nasal speech, viscous saliva, hypergonadotropic
+hypogonadism and learning problems are frequently observed. How PREPL deficiency
+causes these clinical manifestations remains unknown. PREPL is highly expressed
+in brain and based on gene coexpression network architecture it has been placed
+in a group enriched with markers of neurons and synaptic proteins. PREPL is
+predicted to be a serine oligopeptidase based on its homology with prolyl
+endopeptidase (PREP) and the presence of an active catalytic triad. However,
+until now no substrates have been found. Recent observations that PREP has
+non-catalytic functions in the cytoplasm through interactions with its amino-
+terminal propeller domain, suggests that of PREPL may also have biological
+functions independent of its predicted peptidase activity. This raises the
+possibility that PREP and PREPL are homologous, not just by name but also by
+nature.
+
+DOI: 10.2174/187152711794653760
+PMID: 21222627 [Indexed for MEDLINE]

--- a/references_cache/clinicaltrials_NCT02640443.md
+++ b/references_cache/clinicaltrials_NCT02640443.md
@@ -1,0 +1,11 @@
+---
+reference_id: "clinicaltrials:NCT02640443"
+title: "Sulfamethoxazole for the Treatment of Primary PREPL Deficiency (In Dutch: Sulfamethoxazole Ter Behandeling Van Primaire PREPL deficiëntie)"
+content_type: summary
+---
+
+# Sulfamethoxazole for the Treatment of Primary PREPL Deficiency (In Dutch: Sulfamethoxazole Ter Behandeling Van Primaire PREPL deficiëntie)
+
+## Content
+
+The investigators will evaluate whether sulfamethoxazole, a sulfamide antibiotic, improves the symptoms of primary PREPL deficiency (hypotonia-cystinuria syndrome and isolated PREPL deficiency).


### PR DESCRIPTION
## Summary

Connects the hypotonia-cystinuria syndrome pathograph across the renal amino-acid transport, cystine supersaturation/stone, PREPL neuromuscular, PREPL growth/appetite, and variable developmental/dysmorphic branches.

Key changes:
- Added L-cystine transport, amino-acid transporter activity, cystine/dibasic amino-acid chemical entities, and explicit downstream edges from the SLC3A1/PREPL deletion branch.
- Added cystine chemical annotation and causal evidence on the urinary cystine supersaturation to nephrolithiasis branch.
- Added PREPL-related growth/appetite and developmental/dysmorphic pathophysiology nodes to explain currently orphaned phenotypes.
- Added readout links and a CHEBI cystine biomarker term for elevated urinary cystine.
- No new reference cache files were needed; existing cached snippets were reused.

## Connectivity After Patch

- Phenotypes reached: 14/14
- Biochemical readouts reached: 1/1
- Pathophysiology nodes: 7
- Downstream edges: 22
- GO biological processes: 4
- GO molecular functions: 1
- Chemical annotations: 5

## Validation

- `just validate kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml`
- Manual snippet audit: `total=63 exact=15 normalized=48 missing=0 no_cache=0`
- `just check-reference-cache-frontmatter`
- `git diff --check`

Unrelated reference-cache normalization churn was restored before commit.
