### PR TITLE
Connect COQ8A ubiquinone ataxia pathograph

### DIFF
--- a/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
+++ b/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Recessive Ataxia Due to Ubiquinone Deficiency
 creation_date: "2026-04-23T00:00:00Z"
-updated_date: "2026-05-19T15:16:36Z"
+updated_date: "2026-05-19T15:31:15Z"
 category: Neurological Disorder
 parents:
 - Mendelian Disorder
@@ -176,6 +176,22 @@ pathophysiology:
       explanation: >-
         The multicenter cohort documents exercise intolerance as a recurrent
         systemic feature in COQ8A disease.
+  - target: Serum lactate level
+    description: >-
+      Respiratory-chain dysfunction in COQ8A disease can be accompanied by
+      elevated circulating lactate.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired mitochondrial pyruvate oxidation with compensatory lactate production
+    evidence:
+    - reference: PMID:32743982
+      reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "His serum lactate levels were elevated, and plasma CoQ10 concentrations were decreased."
+      explanation: >-
+        Patient biochemical data support elevated serum lactate as a readout
+        associated with COQ8A-related respiratory-chain disease.
 - name: Oxidative Stress and Mitochondrial Homeostasis Defects
   description: >-
     ADCK3/COQ8A-deficient patient cells have oxidative stress, altered
@@ -413,6 +429,30 @@ pathophysiology:
       explanation: >-
         Cohort evidence supports cerebellar atrophy as the universal structural
         consequence of cerebellar disease.
+  - target: Dysarthria
+    description: Cerebellar system involvement can produce dysarthria in COQ8A disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32743982
+      reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Neurological examination revealed mild dysarthria, overt head tremor, bilateral dysmetria, and intention tremor on nose‐finger and heel‐shin tests"
+      explanation: >-
+        Clinical examination directly documents dysarthria alongside cerebellar
+        motor signs in COQ8A disease.
+  - target: Tremor
+    description: Cerebellar system involvement can include head and intention tremor.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32743982
+      reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Neurological examination revealed mild dysarthria, overt head tremor, bilateral dysmetria, and intention tremor on nose‐finger and heel‐shin tests"
+      explanation: >-
+        Clinical examination directly documents head and intention tremor with
+        dysmetria in COQ8A disease.
 phenotypes:
 - name: Ataxia
   description: >-
@@ -420,10 +460,10 @@ phenotypes:
     phenotype of this disorder.
   frequency: VERY_FREQUENT
   phenotype_term:
-    preferred_term: ataxia
+    preferred_term: progressive cerebellar ataxia
     term:
-      id: HP:0001251
-      label: Ataxia
+      id: HP:0002073
+      label: Progressive cerebellar ataxia
     clinical_course: PROGRESSIVE
     onset:
       onset_category: CHILDHOOD
@@ -437,6 +477,55 @@ phenotypes:
       cerebellar ataxia,
     explanation: >-
       Directly supports ataxia as the core and defining disease phenotype.
+- name: Dysarthria
+  description: >-
+    Dysarthria is a recurrent speech manifestation of COQ8A disease and can
+    accompany cerebellar motor findings.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: dysarthria
+    term:
+      id: HP:0001260
+      label: Dysarthria
+  evidence:
+  - reference: PMID:32743982
+    reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological examination revealed mild dysarthria, overt head tremor, bilateral dysmetria, and intention tremor on nose‐finger and heel‐shin tests"
+    explanation: >-
+      Clinical examination directly documents dysarthria in a patient with
+      COQ8A disease.
+  - reference: PMID:31621627
+    reference_title: "Dystonia-Ataxia with early handwriting deterioration in COQ8A mutation carriers: A case series and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: |-
+      clinical phenotype
+      characterized by slowly progressive or static writing difficulties, focal
+      dystonia, and speech disorder
+    explanation: >-
+      The clinical review supports speech disorder as a recurring feature in
+      COQ8A mutation carriers.
+- name: Tremor
+  description: >-
+    Head and intention tremor can occur in COQ8A disease, often with other
+    cerebellar motor signs.
+  frequency: FREQUENT
+  phenotype_term:
+    preferred_term: tremor
+    term:
+      id: HP:0001337
+      label: Tremor
+  evidence:
+  - reference: PMID:32743982
+    reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Neurological examination revealed mild dysarthria, overt head tremor, bilateral dysmetria, and intention tremor on nose‐finger and heel‐shin tests"
+    explanation: >-
+      Clinical examination directly documents overt head tremor and intention
+      tremor in COQ8A disease.
 - name: Cerebellar Atrophy
   description: >-
     Cerebellar atrophy is the characteristic structural neuroimaging
@@ -501,6 +590,7 @@ phenotypes:
   description: >-
     Developmental regression can occur in childhood-onset COQ8A ataxia as part
     of the broader neurodevelopmental presentation.
+  frequency: FREQUENT
   phenotype_term:
     preferred_term: developmental regression
     term:
@@ -546,10 +636,10 @@ phenotypes:
     in a substantial subset of COQ8A-ataxia patients.
   frequency: FREQUENT
   phenotype_term:
-    preferred_term: abnormality of movement
+    preferred_term: hyperkinetic movements
     term:
-      id: HP:0100022
-      label: Abnormality of movement
+      id: HP:0002487
+      label: Hyperkinetic movements
   evidence:
   - reference: DOI:10.1002/ana.25751
     reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
@@ -792,6 +882,37 @@ biochemical:
     evidence_source: IN_VITRO
     snippet: "ADCK3 deficiency decreased cellular CoQ10 content."
     explanation: Patient-derived cell studies directly document decreased cellular CoQ10 content after ADCK3 deficiency.
+- name: Serum lactate level
+  presence: INCREASED
+  readouts:
+  - target: Impaired Oxidative Phosphorylation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated serum lactate reports impaired mitochondrial respiratory-chain energy metabolism.
+  context: >-
+    Elevated serum lactate is reported in COQ8A disease and provides a
+    biochemical readout of mitochondrial respiratory-chain dysfunction.
+  biomarker_term:
+    preferred_term: lactate
+    term:
+      id: CHEBI:24996
+      label: lactate
+  evidence:
+  - reference: PMID:32743982
+    reference_title: Primary coenzyme Q10 deficiency due to COQ8A gene mutations.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "His serum lactate levels were elevated, and plasma CoQ10 concentrations were decreased."
+    explanation: Patient biochemical testing directly documents elevated serum lactate.
+  - reference: PMID:37476682
+    reference_title: "Adolescence Onset Primary Coenzyme Q10 Deficiency With Rare CoQ8A Gene Mutation: A Case Report and Review of Literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: |-
+      abnormal serum
+      urea (49.4 mg/dL), lactate (7.5 mmol/L), and CoQ10 level (0.4 µg/mL)
+    explanation: An independent COQ8A case report documents elevated lactate with low CoQ10.
 clinical_trials: []
 datasets: []
 references:

--- a/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
+++ b/kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Autosomal Recessive Ataxia Due to Ubiquinone Deficiency
 creation_date: "2026-04-23T00:00:00Z"
-updated_date: "2026-05-10T05:37:16Z"
+updated_date: "2026-05-19T15:16:36Z"
 category: Neurological Disorder
 parents:
 - Mendelian Disorder
@@ -42,6 +42,12 @@ pathophysiology:
       id: GO:0006744
       label: ubiquinone biosynthetic process
     modifier: DECREASED
+  chemical_entities:
+  - preferred_term: coenzyme Q10
+    term:
+      id: CHEBI:46245
+      label: coenzyme Q10
+    modifier: DECREASED
   evidence:
   - reference: DOI:10.3390/metabo12100955
     reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
@@ -54,6 +60,16 @@ pathophysiology:
       This directly supports the upstream metabolic defect in CoQ10
       biosynthesis caused by COQ8A deficiency.
   downstream:
+  - target: Coenzyme Q10 level
+    description: COQ8A deficiency lowers cellular CoQ10 content.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26866375
+      reference_title: "AarF Domain Containing Kinase 3 (ADCK3) Mutant Cells Display Signs of Oxidative Stress, Defects in Mitochondrial Homeostasis and Lysosomal Accumulation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "ADCK3 deficiency decreased cellular CoQ10 content."
+      explanation: Patient-cell studies directly support reduced CoQ10 content downstream of ADCK3/COQ8A deficiency.
   - target: Impaired Oxidative Phosphorylation
     description: Reduced CoQ10 availability compromises mitochondrial energy transfer.
     causal_link_type: DIRECT
@@ -109,6 +125,241 @@ pathophysiology:
       explanation: >-
         Review supports progressive cerebellar ataxia and cerebellar atrophy as
         downstream manifestations of COQ8A-related respiratory-chain disease.
+  - target: Oxidative Stress and Mitochondrial Homeostasis Defects
+    description: >-
+      ADCK3-deficient patient cells show oxidative stress and disordered
+      mitochondrial homeostasis downstream of impaired CoQ10-dependent
+      mitochondrial function.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - reduced CoQ10-dependent respiratory-chain electron transfer
+    evidence:
+    - reference: PMID:26866375
+      reference_title: "AarF Domain Containing Kinase 3 (ADCK3) Mutant Cells Display Signs of Oxidative Stress, Defects in Mitochondrial Homeostasis and Lysosomal Accumulation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: |-
+        lines derived from ARCA-2 patients display signs of oxidative stress, defects in
+        mitochondrial homeostasis and increases in lysosomal content.
+      explanation: >-
+        Patient-derived cell data support oxidative-stress and mitochondrial
+        homeostasis abnormalities as downstream cellular consequences.
+  - target: COQ8A-Related Multisystem Brain Disease
+    description: >-
+      Respiratory-chain dysfunction in COQ8A disease manifests as a progressive
+      multisystem neurologic syndrome rather than isolated cerebellar ataxia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neuronal energy failure from impaired mitochondrial respiratory-chain function
+    evidence:
+    - reference: PMID:31621627
+      reference_title: "Dystonia-Ataxia with early handwriting deterioration in COQ8A mutation carriers: A case series and literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "history is characterized by a progression to a multisystem brain disease"
+      explanation: >-
+        Clinical review supports progression beyond isolated ataxia to
+        multisystem brain disease.
+  - target: Systemic Mitochondrial Energy Limitation
+    description: >-
+      CoQ10-dependent respiratory-chain dysfunction can extend beyond the
+      cerebellum and limit systemic exercise tolerance.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - reduced mitochondrial ATP production during exertion
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "to exercise intolerance (25%)"
+      explanation: >-
+        The multicenter cohort documents exercise intolerance as a recurrent
+        systemic feature in COQ8A disease.
+- name: Oxidative Stress and Mitochondrial Homeostasis Defects
+  description: >-
+    ADCK3/COQ8A-deficient patient cells have oxidative stress, altered
+    mitochondrial homeostasis, and lysosomal accumulation, providing a cellular
+    stress pathway between CoQ10-dependent respiratory-chain dysfunction and
+    neural vulnerability.
+  biological_processes:
+  - preferred_term: response to oxidative stress
+    term:
+      id: GO:0006979
+      label: response to oxidative stress
+    modifier: INCREASED
+  evidence:
+  - reference: PMID:26866375
+    reference_title: "AarF Domain Containing Kinase 3 (ADCK3) Mutant Cells Display Signs of Oxidative Stress, Defects in Mitochondrial Homeostasis and Lysosomal Accumulation."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: |-
+      lines derived from ARCA-2 patients display signs of oxidative stress, defects in
+      mitochondrial homeostasis and increases in lysosomal content.
+    explanation: >-
+      Patient-derived cell studies support oxidative stress as a cellular
+      consequence of ADCK3/COQ8A deficiency.
+  downstream:
+  - target: Progressive Cerebellar Neurodegeneration
+    description: >-
+      Oxidative and mitochondrial homeostasis stress provide a plausible
+      cellular route to selective cerebellar injury in COQ8A disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27499294
+      reference_title: Cerebellar Ataxia and Coenzyme Q Deficiency through Loss of Unorthodox Kinase Activity.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: |-
+        mice lacking COQ8A develop a slowly progressive cerebellar ataxia linked to
+        Purkinje cell dysfunction and mild exercise intolerance, recapitulating ARCA2.
+      explanation: >-
+        Mouse data support cerebellar Purkinje-cell vulnerability downstream of
+        COQ8A loss, consistent with a cellular-stress route to cerebellar
+        degeneration.
+- name: COQ8A-Related Multisystem Brain Disease
+  description: >-
+    COQ8A disease can progress to a multisystem brain syndrome that includes
+    epilepsy, cognitive impairment, developmental regression, and hyperkinetic
+    movement disorders in addition to cerebellar ataxia.
+  evidence:
+  - reference: PMID:31621627
+    reference_title: "Dystonia-Ataxia with early handwriting deterioration in COQ8A mutation carriers: A case series and literature review."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "history is characterized by a progression to a multisystem brain disease"
+    explanation: >-
+      Clinical review characterizes COQ8A disease as progressive multisystem
+      brain involvement.
+  downstream:
+  - target: Seizure
+    description: Multisystem brain involvement in COQ8A disease includes epilepsy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - mitochondrial neuronal energy failure and network hyperexcitability
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "with complicating features ranging from epilepsy (32%)"
+      explanation: The cohort directly reports epilepsy as a complicating feature.
+  - target: Cognitive Impairment
+    description: Multisystem brain involvement commonly includes cognitive impairment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - chronic mitochondrial neuronal dysfunction
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "cognitive impairment (49%)"
+      explanation: The cohort directly reports cognitive impairment in nearly half of patients.
+  - target: Developmental Regression
+    description: Childhood-onset COQ8A disease can include developmental regression.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - early-life mitochondrial neuronal dysfunction
+    evidence:
+    - reference: DOI:10.3390/metabo12100955
+      reference_title: COQ8A-Ataxia as a Manifestation of Primary Coenzyme Q Deficiency
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The disease is usually present as childhood-onset progressive ataxia
+        with developmental regression and cerebellar atrophy.
+      explanation: The review explicitly includes developmental regression in the usual presentation.
+  - target: COQ8A-Related Hyperkinetic Motor Circuit Dysfunction
+    description: >-
+      Multisystem brain involvement includes hyperkinetic movement disorders,
+      especially dystonia and myoclonus.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - motor network dysfunction in COQ8A-related multisystem brain disease
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        hyperkinetic movement disorders (41%), including dystonia and myoclonus
+        as presenting symptoms
+      explanation: The cohort identifies hyperkinetic movement disorders, dystonia, and myoclonus as COQ8A features.
+- name: COQ8A-Related Hyperkinetic Motor Circuit Dysfunction
+  description: >-
+    COQ8A disease can involve motor circuits beyond the cerebellum, producing
+    hyperkinetic movement disorders such as dystonia and myoclonus.
+  evidence:
+  - reference: DOI:10.1002/ana.25751
+    reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      hyperkinetic movement disorders (41%), including dystonia and myoclonus
+      as presenting symptoms
+    explanation: The cohort directly supports hyperkinetic movement disorder involvement.
+  downstream:
+  - target: Hyperkinetic Movement Disorder
+    description: Motor-circuit involvement manifests as hyperkinetic movement disorder.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hyperkinetic movement disorders (41%)"
+      explanation: The cohort directly reports hyperkinetic movement disorders.
+  - target: Dystonia
+    description: Dystonia is a specific hyperkinetic manifestation of COQ8A disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        including dystonia and myoclonus as presenting symptoms
+      explanation: The cohort directly names dystonia as a presenting symptom.
+  - target: Myoclonus
+    description: Myoclonus is a specific hyperkinetic manifestation of COQ8A disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        including dystonia and myoclonus as presenting symptoms
+      explanation: The cohort directly names myoclonus as a presenting symptom.
+- name: Systemic Mitochondrial Energy Limitation
+  description: >-
+    CoQ10-dependent respiratory-chain dysfunction can impair energy production
+    during exertion, producing exercise intolerance in a subset of patients.
+  biological_processes:
+  - preferred_term: oxidative phosphorylation
+    term:
+      id: GO:0006119
+      label: oxidative phosphorylation
+    modifier: DECREASED
+  evidence:
+  - reference: DOI:10.1002/ana.25751
+    reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "to exercise intolerance (25%)"
+    explanation: The multicenter cohort documents exercise intolerance as a recurrent non-cerebellar feature.
+  downstream:
+  - target: Exercise Intolerance
+    description: Systemic mitochondrial energy limitation manifests clinically as exercise intolerance.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/ana.25751
+      reference_title: "Clinico‐Genetic, Imaging and Molecular Delineation of <scp><i>COQ8A</i></scp>‐Ataxia: A Multicenter Study of 59 Patients"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "to exercise intolerance (25%)"
+      explanation: The cohort directly reports exercise intolerance.
 - name: Progressive Cerebellar Neurodegeneration
   description: >-
     COQ8A-related ubiquinone deficiency preferentially injures cerebellar
@@ -517,6 +768,30 @@ treatments:
     explanation: >-
       This provides cohort-level evidence that CoQ10 supplementation can
       improve clinical outcomes in a sizable subset of patients.
+biochemical:
+- name: Coenzyme Q10 level
+  presence: DECREASED
+  readouts:
+  - target: COQ8A-Dependent Coenzyme Q10 Deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lower cellular or tissue CoQ10 reports the primary COQ8A-dependent biosynthetic defect.
+  context: >-
+    COQ8A/ADCK3 deficiency reduces CoQ10 content, which can be used as a
+    biochemical readout of the primary coenzyme Q deficiency state.
+  biomarker_term:
+    preferred_term: coenzyme Q10
+    term:
+      id: CHEBI:46245
+      label: coenzyme Q10
+  evidence:
+  - reference: PMID:26866375
+    reference_title: "AarF Domain Containing Kinase 3 (ADCK3) Mutant Cells Display Signs of Oxidative Stress, Defects in Mitochondrial Homeostasis and Lysosomal Accumulation."
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "ADCK3 deficiency decreased cellular CoQ10 content."
+    explanation: Patient-derived cell studies directly document decreased cellular CoQ10 content after ADCK3 deficiency.
 clinical_trials: []
 datasets: []
 references:


### PR DESCRIPTION
## Summary
- Strengthened the COQ8A/ADCK3 loss-of-function chain from impaired coenzyme Q10 biosynthesis through respiratory-chain dysfunction, oxidative stress/homeostasis defects, multisystem brain disease, motor-circuit dysfunction, and systemic energy limitation.
- Added CoQ10 chemical annotation on the upstream metabolic node and a decreased CoQ10 biochemical readout linked back to the primary deficiency.
- Added downstream edges so the graph now explains all existing seizure, cognitive, developmental regression, exercise intolerance, hyperkinetic movement disorder, dystonia, and myoclonus phenotypes.

## Connectivity
- Pathophysiology nodes: 7
- Downstream/readout/treatment/genetic edges: 20
- Phenotypes reached: 9/9
- Biochemical readouts reached: 1/1
- GO annotations on pathophysiology nodes: 5
- Chemical entities on pathophysiology nodes: 1

## Validation
- `just validate kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Autosomal_Recessive_Ataxia_Due_to_Ubiquinone_Deficiency.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --check`
- Manual snippet audit: total=44, exact=44, normalized=0, missing=0, no_cache=0

## Scope
- Disorder YAML only.
- No reference-cache or ontology-cache changes were needed; unrelated reference-cache churn from validation was restored.
