### PR TITLE
Connect Citrullinemia Type I readouts

### DIFF
--- a/kb/disorders/Citrullinemia_Type_I.yaml
+++ b/kb/disorders/Citrullinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Citrullinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T16:30:43Z'
+updated_date: '2026-05-19T15:46:27Z'
 synonyms:
 - Classic citrullinemia
 - CTLN1
@@ -193,6 +193,25 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: 'the patient exhibited significantly elevated blood ammonia levels (655 μmol/L; normal reference: 10-30 μmol/L)'
       explanation: The same quantitative case data directly support hyperammonemia as the clinical expression of ammonia accumulation.
+  - target: Respiratory alkalosis
+    description: >-
+      Severe hyperammonemia in neonatal urea-cycle emergencies can cause
+      tachypnea and respiratory alkalosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ammonia-associated central respiratory stimulation with hypocapnia
+    evidence:
+    - reference: PMID:33113778
+      reference_title: "Irritability, Poor Feeding and Respiratory Alkalosis in Newborns: Think about Metabolic Emergencies. A Brief Summary of Hyperammonemia Management."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: |-
+        Their first gas analysis revealed respiratory alkalosis.
+        Hyperammonemia was confirmed, and three different enzymatic blocks in the urea
+        cycle were diagnosed.
+      explanation: >-
+        Newborn urea-cycle disorder cases support respiratory alkalosis as an
+        acute hyperammonemic presentation.
   - target: Hyperammonemic neurotoxicity via astrocyte glutamine-osmotic injury
     description: Ammonia accumulation from impaired ureagenesis drives CNS glutamine osmotic injury.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -285,6 +304,36 @@ pathophysiology:
       evidence_source: OTHER
       snippet: Shortly thereafter, they develop hyperammonemia and become progressively lethargic, feed poorly, often vomit, and may develop signs of increased intracranial pressure (ICP).
       explanation: GeneReviews describes the clinical encephalopathy sequence after neonatal hyperammonemia develops.
+  - target: Lethargy
+    description: Early hyperammonemic encephalopathy manifests as progressive lethargy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301631
+      reference_title: "Citrullinemia Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "become progressively lethargic, feed poorly"
+      explanation: GeneReviews directly lists progressive lethargy during neonatal hyperammonemic decompensation.
+  - target: Poor feeding
+    description: Acute hyperammonemic encephalopathy causes poor feeding in neonatal crises.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301631
+      reference_title: "Citrullinemia Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "become progressively lethargic, feed poorly"
+      explanation: GeneReviews directly lists poor feeding during neonatal hyperammonemic decompensation.
+  - target: Vomiting
+    description: Vomiting occurs as part of the neonatal hyperammonemic encephalopathy syndrome.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301631
+      reference_title: "Citrullinemia Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "often vomit"
+      explanation: GeneReviews directly lists vomiting during neonatal hyperammonemic decompensation.
   - target: Seizures
     description: Severe hyperammonemic CNS injury can produce seizures.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -789,6 +838,17 @@ biochemical:
   context: 'Markedly elevated plasma citrulline is the defining biochemical hallmark of CTLN1. In classic disease, citrulline can reach 2000-5000 umol/L (normal less than 60 umol/L). This is the primary marker on newborn screening.
 
     '
+  readouts:
+  - target: Impaired hepatic ureagenesis due to ASS1 deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Markedly elevated citrulline reports the blocked ASS1 step upstream of argininosuccinate formation.
+  biomarker_term:
+    preferred_term: citrulline
+    term:
+      id: CHEBI:18211
+      label: citrulline
   evidence:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
@@ -807,6 +867,17 @@ biochemical:
   context: 'Elevated blood ammonia results from impaired ureagenesis. During acute crises, ammonia can exceed 500-1000 umol/L. Diagnostic ammonia levels are a key prognostic marker; deceased UCD patients had median ammonia of 1058 umol/L versus 294 umol/L in survivors.
 
     '
+  readouts:
+  - target: Impaired hepatic ureagenesis due to ASS1 deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated ammonia reports failed hepatic nitrogen disposal through the urea cycle.
+  biomarker_term:
+    preferred_term: ammonia
+    term:
+      id: CHEBI:16134
+      label: ammonia
   evidence:
   - reference: PMID:39649700
     reference_title: "Visualization of argininosuccinate synthetase by in silico analysis: novel insights into citrullinemia type I disorders."
@@ -838,6 +909,11 @@ biochemical:
       evidence_source: OTHER
       snippet: Plasma amino acids analysis demonstrating elevated citrulline, absent argininosuccinate, with low-to-normal arginine and ornithine levels
       explanation: Full GeneReviews diagnostic text supports low-to-normal arginine as a biochemical readout of the ASS1 urea-cycle block.
+  biomarker_term:
+    preferred_term: L-arginine
+    term:
+      id: CHEBI:16467
+      label: L-arginine
   evidence:
   - reference: 'url:https://www.ncbi.nlm.nih.gov/books/NBK1458/?report=printable'
     reference_title: "Citrullinemia Type I - GeneReviews® - NCBI Bookshelf"
@@ -850,6 +926,17 @@ biochemical:
   context: 'Absent or markedly reduced argininosuccinate is the immediate biochemical consequence of the ASS1 block, since argininosuccinate synthase normally condenses citrulline and aspartate to form argininosuccinate.
 
     '
+  readouts:
+  - target: Impaired hepatic ureagenesis due to ASS1 deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Absent argininosuccinate directly reports failure of ASS1-mediated citrulline-aspartate condensation.
+  biomarker_term:
+    preferred_term: argininosuccinate
+    term:
+      id: CHEBI:15682
+      label: (N(omega)-L-arginino)succinic acid
   evidence:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."
@@ -875,6 +962,11 @@ biochemical:
       evidence_source: OTHER
       snippet: Possibly normal urine organic analysis, although orotic acid may be detected as part of urinary organic acid analysis by gas chromatography/mass spectrometry, especially during metabolic crises.
       explanation: Full GeneReviews diagnostic text supports urinary orotic acid as a crisis-associated readout.
+  biomarker_term:
+    preferred_term: orotic acid
+    term:
+      id: CHEBI:16742
+      label: orotic acid
   evidence:
   - reference: 'url:https://www.ncbi.nlm.nih.gov/books/NBK1458/?report=printable'
     reference_title: "Citrullinemia Type I - GeneReviews® - NCBI Bookshelf"
@@ -887,6 +979,17 @@ biochemical:
   context: 'Elevated plasma and brain glutamine reflects astrocytic ammonia detoxification. Glutamine accumulation in astrocytes is the direct driver of osmotic swelling and cerebral edema during hyperammonemic crises.
 
     '
+  readouts:
+  - target: Hyperammonemic neurotoxicity via astrocyte glutamine-osmotic injury
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated glutamine reports ammonia detoxification and the osmotic neurotoxicity branch during hyperammonemic crises.
+  biomarker_term:
+    preferred_term: glutamine
+    term:
+      id: CHEBI:28300
+      label: glutamine
   evidence:
   - reference: PMID:20301631
     reference_title: "Citrullinemia Type I."


### PR DESCRIPTION
## Summary\n- Added pathophysiology downstream edges so the CTLN1 graph now reaches lethargy, poor feeding, vomiting, and respiratory alkalosis from the hyperammonemic crisis mechanism.\n- Added READOUT_OF relationships and CHEBI biomarker terms for citrulline, ammonia, arginine, argininosuccinate, orotic acid, and glutamine.\n- Kept scope to kb/disorders/Citrullinemia_Type_I.yaml; restored unrelated reference-cache churn after validation.\n\n## Connectivity\n- Pathophysiology nodes: 5\n- Downstream/readout/treatment/genetic edges: 30\n- Phenotypes reached: 13/13\n- Biochemical readouts reached: 6/6\n- GO annotations: 8\n- Chemical entities/biomarkers: 13\n\n## Validation\n- just validate kb/disorders/Citrullinemia_Type_I.yaml\n- uv run python -m dismech.graph --validate kb/disorders/Citrullinemia_Type_I.yaml\n- just check-reference-cache-frontmatter\n- git diff --check\n- Manual snippet audit: total=96 exact=14 normalized=82 missing=0 no_cache=0; the normalized matches are cache line-wrap-only matches already present in this file, and the newly added evidence snippets are exact cached substrings.