### PR TITLE
Connect ACOX1 phenotype graph

### DIFF
--- a/kb/disorders/Peroxisomal_Acyl-CoA_Oxidase_Deficiency.yaml
+++ b/kb/disorders/Peroxisomal_Acyl-CoA_Oxidase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Peroxisomal Acyl-CoA Oxidase Deficiency
 creation_date: "2026-05-10T20:13:58Z"
-updated_date: "2026-05-11T04:05:53Z"
+updated_date: "2026-05-19T16:05:46Z"
 description: >-
   Peroxisomal acyl-CoA oxidase deficiency is a rare autosomal recessive
   peroxisomal fatty-acid oxidation disorder caused by ACOX1 deficiency. Loss of
@@ -192,6 +192,60 @@ pathophysiology:
       - target: Neurodegenerative White Matter Disease
         description: VLCFA accumulation contributes to inflammatory demyelination and progressive CNS disease.
         causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+      - target: Retinitis Pigmentosa
+        description: >-
+          The ACOX1 deficiency phenotype spectrum includes retinal degeneration
+          with retinitis pigmentosa and vision abnormalities.
+        causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+        evidence:
+          - reference: PMID:24619150
+            reference_title: "Effects of hematopoietic stem cell transplantation on acyl-CoA oxidase deficiency: a sibling comparison study."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "Retinitis pigmentosa, vision abnormalities, and hearing loss are also common manifestations"
+            explanation: >-
+              The clinical literature summary identifies retinitis pigmentosa
+              as a common manifestation in ACOX1 deficiency.
+      - target: Facial Dysmorphism
+        description: Facial dysmorphism is part of the broader reported ACOX1 deficiency phenotype spectrum.
+        causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+        evidence:
+          - reference: PMID:24619150
+            reference_title: "Effects of hematopoietic stem cell transplantation on acyl-CoA oxidase deficiency: a sibling comparison study."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "facial dysmorphism, hepatic dysfunction, and adrenal insufficiency are less frequently reported findings."
+            explanation: The literature summary reports facial dysmorphism as a less frequent finding.
+      - target: Hepatic Dysfunction
+        description: Hepatic dysfunction is part of the broader reported ACOX1 deficiency phenotype spectrum.
+        causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+        evidence:
+          - reference: PMID:24619150
+            reference_title: "Effects of hematopoietic stem cell transplantation on acyl-CoA oxidase deficiency: a sibling comparison study."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "facial dysmorphism, hepatic dysfunction, and adrenal insufficiency are less frequently reported findings."
+            explanation: The literature summary reports hepatic dysfunction as a less frequent finding.
+      - target: Adrenal Insufficiency
+        description: Adrenal insufficiency is part of the broader reported ACOX1 deficiency phenotype spectrum.
+        causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+        evidence:
+          - reference: PMID:24619150
+            reference_title: "Effects of hematopoietic stem cell transplantation on acyl-CoA oxidase deficiency: a sibling comparison study."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "facial dysmorphism, hepatic dysfunction, and adrenal insufficiency are less frequently reported findings."
+            explanation: The literature summary reports adrenal insufficiency as a less frequent finding.
+      - target: Peripheral Neuropathy
+        description: Peripheral neuropathy is reported in severe ACOX1 deficiency.
+        causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+        evidence:
+          - reference: PMID:16773508
+            reference_title: "Pitfall in metabolic screening in a patient with fatal peroxisomal beta-oxidation defect."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: "peripheral neuropathy"
+            explanation: The fatal case report explicitly lists peripheral neuropathy.
   - name: Fibroblast IL-1 Cytokine Inflammatory Response
     description: >-
       Patient fibroblast transcriptomic and PCR-array studies show IL-1 pathway


### PR DESCRIPTION
## Summary\n- Added downstream edges from the ACOX1/VLCFA pathophysiology branch to the remaining unreached phenotypes: retinitis pigmentosa, facial dysmorphism, hepatic dysfunction, adrenal insufficiency, and peripheral neuropathy.\n- Reused cached clinical evidence already supporting those phenotypes, keeping each new downstream edge single-target and evidence-backed.\n- Kept scope to kb/disorders/Peroxisomal_Acyl-CoA_Oxidase_Deficiency.yaml; restored unrelated reference-cache churn after validation.\n\n## Connectivity\n- Pathophysiology nodes: 5\n- Downstream/readout/treatment/genetic edges: 21\n- Phenotypes reached: 13/13\n- Biochemical readouts reached: 3/3\n- GO annotations: 10\n- Chemical entities/biomarkers: 4\n\n## Validation\n- just validate kb/disorders/Peroxisomal_Acyl-CoA_Oxidase_Deficiency.yaml\n- uv run python -m dismech.graph --validate kb/disorders/Peroxisomal_Acyl-CoA_Oxidase_Deficiency.yaml\n- just check-reference-cache-frontmatter\n- git diff --check\n- Manual snippet audit: total=62 exact=22 normalized=40 missing=0 no_cache=0; normalized matches are cache line-wrap-only matches already present in this file.