### PR TITLE
Connect LIAS deficiency biomarkers

### DIFF
--- a/kb/disorders/Lipoic_Acid_Synthetase_Deficiency.yaml
+++ b/kb/disorders/Lipoic_Acid_Synthetase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Lipoic Acid Synthetase Deficiency
 creation_date: '2026-02-13T00:59:22Z'
-updated_date: "2026-05-04T23:47:37Z"
+updated_date: "2026-05-19T16:21:31Z"
 category: Mendelian
 description: >
   Lipoic acid synthetase deficiency (OMIM 614462), also known as hyperglycinemia
@@ -125,6 +125,12 @@ pathophysiology:
     term:
       id: GO:0009249
       label: protein lipoylation
+  chemical_entities:
+  - preferred_term: lipoic acid
+    modifier: DECREASED
+    term:
+      id: CHEBI:16494
+      label: lipoic acid
   cellular_components:
   - preferred_term: mitochondrion
     term:
@@ -194,11 +200,32 @@ pathophysiology:
     term:
       id: GO:0006099
       label: tricarboxylic acid cycle
+  - preferred_term: pyruvate decarboxylation to acetyl-CoA
+    modifier: DECREASED
+    term:
+      id: GO:0006086
+      label: pyruvate decarboxylation to acetyl-CoA
+  - preferred_term: branched-chain amino acid catabolic process
+    modifier: DECREASED
+    term:
+      id: GO:0009083
+      label: branched-chain amino acid catabolic process
   cellular_components:
   - preferred_term: Pyruvate dehydrogenase complex
     term:
       id: GO:0045254
       label: pyruvate dehydrogenase complex
+  chemical_entities:
+  - preferred_term: pyruvate
+    modifier: INCREASED
+    term:
+      id: CHEBI:15361
+      label: pyruvate
+  - preferred_term: lactate
+    modifier: INCREASED
+    term:
+      id: CHEBI:24996
+      label: lactate
   evidence:
   - reference: PMID:22152680
     reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
@@ -241,6 +268,20 @@ pathophysiology:
     intermediate_mechanisms:
     - citric acid cycle dysfunction
     - severe respiratory deficiency
+  - target: Failure to thrive
+    description: Severe respiratory deficiency, extreme muscle weakness, and impaired energy metabolism contribute to poor growth and failure to thrive in severe neonatal LIAS disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - citric acid cycle dysfunction
+    - severe respiratory deficiency
+    - extreme muscle weakness
+    evidence:
+    - reference: PMID:32508887
+      reference_title: "Progress in the Enzymology of the Mitochondrial Diseases of Lipoic Acid Requiring Enzymes."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Hence patients defective in either of these genes have undetectable or severely decreased levels of all lipoylated proteins and undergo the severe respiratory deficiency and extreme muscle weakness due to citric acid cycle disfunction plus the neurological impairments caused by glycine accumulation in the brain"
+      explanation: The review directly links LIAS/LIPT2 lipoylation defects to respiratory deficiency, extreme muscle weakness, and neurologic impairment, supporting failure to thrive as a downstream systemic consequence.
 - name: Glycine cleavage system dysfunction
   description: >
     LIAS deficiency also reduces lipoylation of the glycine cleavage system H
@@ -253,6 +294,12 @@ pathophysiology:
     term:
       id: GO:0006546
       label: glycine catabolic process
+  chemical_entities:
+  - preferred_term: glycine
+    modifier: INCREASED
+    term:
+      id: CHEBI:15428
+      label: glycine
   cellular_components:
   - preferred_term: Glycine cleavage complex
     term:
@@ -310,6 +357,12 @@ pathophysiology:
     term:
       id: UBERON:0000955
       label: brain
+  biological_processes:
+  - preferred_term: brain development
+    modifier: ABNORMAL
+    term:
+      id: GO:0007420
+      label: brain development
   evidence:
   - reference: PMID:32508887
     reference_title: "Progress in the Enzymology of the Mitochondrial Diseases of Lipoic Acid Requiring Enzymes."
@@ -333,6 +386,26 @@ pathophysiology:
     intermediate_mechanisms:
     - encephalopathy
     - neurodegeneration
+  - target: Cerebral atrophy
+    description: Elevated brain glycine can drive neurodegeneration and encephalopathy; reported LIAS cases include cortical involvement, providing the structural CNS branch for cerebral atrophy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - elevated brain glycine
+    - neurodegeneration
+    - cortical involvement
+    evidence:
+    - reference: PMID:32508887
+      reference_title: "Progress in the Enzymology of the Mitochondrial Diseases of Lipoic Acid Requiring Enzymes."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Lack of glycine cleavage activity additionally results in elevated brain glycine levels which can result in a host of neurological disorders, including neurodegeneration, encephalopathy, and neonatal-onset epilepsy"
+      explanation: The review links glycine cleavage failure to elevated brain glycine, neurodegeneration, and encephalopathy.
+    - reference: PMID:24334290
+      reference_title: "Variant non ketotic hyperglycinemia is caused by mutations in LIAS, BOLA3 and the novel gene GLRX5."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with lipoate synthase-deficient variant nonketotic hyperglycinemia varied in severity from mild static encephalopathy to Leigh disease and cortical involvement."
+      explanation: Human LIAS cases include cortical involvement, supporting the structural brain-injury branch but not proving cerebral atrophy by itself.
 phenotypes:
 - name: Seizures
   description: >
@@ -536,6 +609,24 @@ biochemical:
   context: >
     LIAS deficiency reduces the lipoamide prosthetic group on mitochondrial
     proteins that require lipoate for activity.
+  biomarker_term:
+    preferred_term: lipoic acid
+    term:
+      id: CHEBI:16494
+      label: lipoic acid
+  readouts:
+  - target: Defective lipoic acid synthesis via LIAS deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced lipoamide on mitochondrial proteins reports the proximal LIAS-dependent protein-lipoylation defect.
+    evidence:
+    - reference: PMID:22152680
+      reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "A pronounced reduction of the prosthetic group lipoamide was found in lipoylated proteins."
+      explanation: Patient fibroblast data directly show reduced lipoamide on lipoylated proteins downstream of LIAS deficiency.
   evidence:
   - reference: PMID:22152680
     reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
@@ -554,6 +645,19 @@ biochemical:
   context: >
     Impaired lipoylation reduces pyruvate dehydrogenase complex activity and
     limits oxidative pyruvate metabolism.
+  readouts:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced pyruvate dehydrogenase activity reports impaired lipoate-dependent alpha-ketoacid dehydrogenase function.
+    evidence:
+    - reference: PMID:22152680
+      reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Investigation of the mitochondrial energy metabolism showed reduced oxidation of pyruvate and decreased pyruvate dehydrogenase complex activity."
+      explanation: Direct patient-cell enzymology shows reduced PDH complex activity.
   evidence:
   - reference: PMID:22152680
     reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
@@ -572,6 +676,24 @@ biochemical:
   context: >
     Elevated plasma, urine, and borderline cerebrospinal-fluid glycine reflect
     impaired glycine cleavage system activity.
+  biomarker_term:
+    preferred_term: glycine
+    term:
+      id: CHEBI:15428
+      label: glycine
+  readouts:
+  - target: Glycine cleavage system dysfunction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Higher glycine reports impaired lipoate-dependent glycine cleavage activity.
+    evidence:
+    - reference: PMID:24334290
+      reference_title: "Variant non ketotic hyperglycinemia is caused by mutations in LIAS, BOLA3 and the novel gene GLRX5."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "All patients had high serum and borderline elevated cerebrospinal fluid glycine and cerebrospinal fluid:plasma glycine ratio"
+      explanation: Human LIAS/lipoate-synthase deficient cases show elevated glycine in serum and borderline-elevated CSF.
   evidence:
   - reference: PMID:22152680
     reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."
@@ -591,6 +713,24 @@ biochemical:
     Lactate can rise when PDH dysfunction causes pyruvate accumulation and
     reduction to lactate, although lactic acidosis is variable in reported LIAS
     cases.
+  biomarker_term:
+    preferred_term: lactate
+    term:
+      id: CHEBI:24996
+      label: lactate
+  readouts:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Higher lactate reports pyruvate diversion caused by impaired lipoate-dependent PDH activity.
+    evidence:
+    - reference: PMID:32508887
+      reference_title: "Progress in the Enzymology of the Mitochondrial Diseases of Lipoic Acid Requiring Enzymes."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "the presence of very high levels of lactate (resulting from reduction of the pyruvate that accumulates due to loss pyruvate dehydrogenase activity)"
+      explanation: Review evidence explains why impaired lipoate-dependent PDH activity raises lactate.
   evidence:
   - reference: PMID:22152680
     reference_title: "Lipoic acid synthetase deficiency causes neonatal-onset epilepsy, defective mitochondrial energy metabolism, and glycine elevation."


### PR DESCRIPTION
## Summary
- Added metabolic chemical entities for LIAS protein-lipoylation failure, pyruvate/lactate diversion, and glycine accumulation.
- Added `READOUT_OF` links for all LIAS biochemical entries: lipoylated mitochondrial proteins, PDH activity, glycine, and lactate.
- Added evidence-backed downstream edges to Failure to thrive and Cerebral atrophy, plus additional GO coverage for pyruvate-to-acetyl-CoA, branched-chain amino acid catabolism, and abnormal brain development.

## Scope
- Changed one disorder YAML: `kb/disorders/Lipoic_Acid_Synthetase_Deficiency.yaml`.
- No reference-cache or term-cache changes staged; validator cache churn was restored.
- Connectivity after patch: pathophysiology 4, downstream edges 11, phenotypes reached 8/10 (Apnea and Microcephaly remain unlinked due to lack of exact cached support), biochemical readouts 4/4, GO annotations 7, chemical entities 4.

## Validation
- `just validate kb/disorders/Lipoic_Acid_Synthetase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Lipoic_Acid_Synthetase_Deficiency.yaml`
- `just check-reference-cache-frontmatter`
- `git diff --check`
- Manual snippet audit: `total=50 exact=13 normalized=37 missing=0 no_cache=0`; normalized matches are cache line-wrap-only matches already present in this file.
