### PR TITLE
Connect HIBCH deficiency biomarkers

### DIFF
--- a/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-hydroxyisobutyryl-CoA hydrolase deficiency
 creation_date: "2026-04-15T00:00:00Z"
-updated_date: "2026-05-11T01:43:24Z"
+updated_date: "2026-05-19T17:18:26Z"
 category: Mendelian
 description: >-
   3-hydroxyisobutyryl-CoA hydrolase deficiency is an inborn error of valine
@@ -54,6 +54,11 @@ pathophysiology:
       id: GO:0006574
       label: L-valine catabolic process
     modifier: DECREASED
+  locations:
+  - preferred_term: mitochondrial matrix
+    term:
+      id: GO:0005759
+      label: mitochondrial matrix
   evidence:
   - reference: PMID:24299452
     reference_title: "HIBCH mutations can cause Leigh-like disease with combined deficiency of multiple mitochondrial respiratory chain enzymes and pyruvate dehydrogenase."
@@ -77,6 +82,27 @@ pathophysiology:
   description: >-
     Loss of HIBCH activity blocks valine degradation and promotes accumulation
     of upstream toxic valine-derived intermediates.
+  biological_processes:
+  - preferred_term: valine catabolic process
+    term:
+      id: GO:0006574
+      label: L-valine catabolic process
+    modifier: DECREASED
+  - preferred_term: branched-chain amino acid catabolic process
+    term:
+      id: GO:0009083
+      label: branched-chain amino acid catabolic process
+    modifier: DECREASED
+  chemical_entities:
+  - preferred_term: L-valine
+    term:
+      id: CHEBI:16414
+      label: L-valine
+  locations:
+  - preferred_term: mitochondrial matrix
+    term:
+      id: GO:0005759
+      label: mitochondrial matrix
   evidence:
   - reference: PMID:24299452
     reference_title: "HIBCH mutations can cause Leigh-like disease with combined deficiency of multiple mitochondrial respiratory chain enzymes and pyruvate dehydrogenase."
@@ -150,6 +176,22 @@ pathophysiology:
   description: >-
     HIBCH deficiency can produce combined mitochondrial respiratory chain
     enzyme deficiency and pyruvate dehydrogenase complex dysfunction.
+  biological_processes:
+  - preferred_term: oxidative phosphorylation
+    term:
+      id: GO:0006119
+      label: oxidative phosphorylation
+    modifier: DECREASED
+  - preferred_term: pyruvate metabolic process
+    term:
+      id: GO:0006090
+      label: pyruvate metabolic process
+    modifier: DECREASED
+  locations:
+  - preferred_term: mitochondrion
+    term:
+      id: GO:0005739
+      label: mitochondrion
   evidence:
   - reference: PMID:24299452
     reference_title: "HIBCH mutations can cause Leigh-like disease with combined deficiency of multiple mitochondrial respiratory chain enzymes and pyruvate dehydrogenase."
@@ -213,6 +255,11 @@ pathophysiology:
     description: >-
       Neurodegenerative disease in infancy can impair feeding.
     causal_link_type: DIRECT
+  - target: Vomiting
+    description: >-
+      Infantile-onset HIBCH deficiency can present with vomiting during the
+      early Leigh-like neurologic disease course.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
   - target: Movement disorder
     description: >-
       Progressive HIBCH deficiency can produce a movement disorder in later
@@ -255,6 +302,19 @@ pathophysiology:
       explanation: >-
         GeneReviews supports paroxysmal dystonia within the later-onset HIBCH
         movement-disorder phenotype.
+  - target: Microcephaly
+    description: >-
+      Infantile-onset HIBCH deficiency can include microcephaly as part of the
+      neurodevelopmental disease spectrum.
+    causal_link_type: DIRECT
+  - target: Visual impairment
+    description: >-
+      Leigh-like HIBCH neurodegeneration can include visual impairment.
+    causal_link_type: DIRECT
+  - target: Cognitive impairment
+    description: >-
+      Late-onset HIBCH deficiency can include variable cognitive impairment.
+    causal_link_type: DIRECT
 phenotypes:
 - name: Global developmental delay
   category: Neurologic
@@ -352,6 +412,30 @@ phenotypes:
       hypotonia, encephalopathy, and feeding difficulties.
     explanation: >-
       This directly supports feeding difficulties as a core clinical feature.
+- name: Vomiting
+  category: Gastrointestinal
+  subtype: Infantile onset
+  description: >-
+    Vomiting is a feature of infantile-onset HIBCH deficiency, the most common
+    disease subtype.
+  phenotype_term:
+    preferred_term: Vomiting
+    term:
+      id: HP:0002013
+      label: Vomiting
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Infantile onset is the most common phenotype, presenting in the first two
+      years of life with feeding difficulties, vomiting, developmental delay
+      with regression, hypotonia, seizures, movement disorder, microcephaly,
+      vision impairment, and episodes of neurologic deterioration.
+    explanation: >-
+      GeneReviews documents vomiting as a feature of infantile-onset HIBCH
+      deficiency.
 - name: Seizure
   category: Neurologic
   description: >-
@@ -416,12 +500,90 @@ phenotypes:
       survivability.
     explanation: >-
       This directly supports dystonia as part of the late-onset HIBCH spectrum.
+- name: Microcephaly
+  category: Neurologic
+  subtype: Infantile onset
+  description: >-
+    Microcephaly is reported in infantile-onset HIBCH deficiency.
+  phenotype_term:
+    preferred_term: Microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Infantile onset is the most common phenotype, presenting in the first two
+      years of life with feeding difficulties, vomiting, developmental delay
+      with regression, hypotonia, seizures, movement disorder, microcephaly,
+      vision impairment, and episodes of neurologic deterioration.
+    explanation: >-
+      GeneReviews documents microcephaly as a feature of infantile-onset HIBCH
+      deficiency.
+- name: Visual impairment
+  category: Ophthalmologic
+  subtype: Infantile onset
+  description: >-
+    Visual impairment is reported in infantile-onset HIBCH deficiency and is
+    managed with ophthalmology assessment and low vision services.
+  phenotype_term:
+    preferred_term: Visual impairment
+    term:
+      id: HP:0000505
+      label: Visual impairment
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Infantile onset is the most common phenotype, presenting in the first two
+      years of life with feeding difficulties, vomiting, developmental delay
+      with regression, hypotonia, seizures, movement disorder, microcephaly,
+      vision impairment, and episodes of neurologic deterioration.
+    explanation: >-
+      GeneReviews documents vision impairment as a feature of infantile-onset
+      HIBCH deficiency.
+- name: Cognitive impairment
+  category: Neurologic
+  subtype: Late onset
+  description: >-
+    Variable cognitive impairment can occur in the late-onset HIBCH phenotype.
+  phenotype_term:
+    preferred_term: Cognitive impairment
+    term:
+      id: HP:0100543
+      label: Cognitive impairment
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Late onset is the second most common phenotype, presenting in childhood as
+      a slowly progressive disease with significant movement disorder with or
+      without paroxysmal dystonia, variable cognitive impairment, and high
+      survivability.
+    explanation: >-
+      GeneReviews documents variable cognitive impairment in late-onset HIBCH
+      deficiency.
 biochemical:
 - name: C4-OH acylcarnitine
   presence: INCREASED
   context: >-
     Elevation of hydroxy-C4-carnitine in dried blood spots is a useful
     biochemical clue in HIBCH deficiency.
+  readouts:
+  - target: Valine catabolic block
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >-
+      Elevated C4-OH acylcarnitine reports disturbed valine catabolism
+      downstream of impaired HIBCH activity.
   evidence:
   - reference: PMID:33762937
     reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
@@ -438,6 +600,14 @@ biochemical:
   context: >-
     Urinary 2,3-dihydroxy-2-methylbutyrate is an elevated organic acid marker
     in HIBCH deficiency.
+  readouts:
+  - target: Valine catabolic block
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >-
+      Elevated urinary 2,3-dihydroxy-2-methylbutyrate reports accumulation of
+      valine-derived intermediates from the HIBCH catabolic block.
   evidence:
   - reference: PMID:33762937
     reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
@@ -455,6 +625,14 @@ biochemical:
   context: >-
     Urinary S-(2-carboxypropyl)cysteamine is another disease-associated
     metabolite in HIBCH deficiency.
+  readouts:
+  - target: Valine catabolic block
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >-
+      Elevated urinary S-(2-carboxypropyl)cysteamine reports toxic
+      valine-derived intermediate buildup in HIBCH deficiency.
   evidence:
   - reference: PMID:33762937
     reference_title: "Cinical, Metabolic, and Genetic Analysis and Follow-Up of Eight Patients With HIBCH Mutations Presenting With Leigh/Leigh-Like Syndrome."
@@ -676,6 +854,39 @@ treatments:
     explanation: >-
       This supports the use of non-curative supportive metabolic management,
       although the paper does not specify a standardized regimen.
+- name: Agents and diets to avoid
+  description: >-
+    Due to secondary mitochondrial abnormalities in HIBCH deficiency, sodium
+    valproate should be avoided when possible and ketogenic or modified Atkins
+    diets should be avoided because of potential side effects.
+  notes: >-
+    GeneReviews also advises careful anesthesia use, avoiding prolonged propofol,
+    preventing catabolism, avoiding neuromuscular blockers in those with muscle
+    disease, avoiding lactate-containing agents, and avoiding triheptanoin and
+    dichloroacetate.
+  treatment_term:
+    preferred_term: supportive care
+    term:
+      id: MAXO:0000950
+      label: supportive care
+  evidence:
+  - reference: PMID:41264763
+    reference_title: 3-Hydroxyisobutyryl-CoA Hydrolase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Agents/circumstances to avoid: Due to secondary mitochondrial
+      abnormalities it may be beneficial to avoid sodium valproate if possible;
+      consider anesthesia use carefully; avoid prolonged propofol use; prevent
+      catabolism; avoid neuromuscular blocking agents in those with muscle
+      disease; avoid lactate-containing agents, including dialysate containing
+      lactate; ketogenic / modified Atkins diets should be avoided due to
+      potential side effects; triheptanoin is contraindicated due to the
+      potential increase in propionyl-CoA; dichloroacetate, as there is no
+      published evidence to support its use in HIBCH deficiency.
+    explanation: >-
+      GeneReviews explicitly lists valproate and ketogenic or modified Atkins
+      diets among agents and circumstances to avoid in HIBCH deficiency.
 clinical_trials: []
 datasets: []
 references:


### PR DESCRIPTION
## Summary
- add GO/location coverage to the HIBCH valine-catabolism and mitochondrial dysfunction mechanisms
- add a safe L-valine chemical participant to the valine catabolic block
- connect all three biochemical markers as diagnostic readouts of the valine catabolic block
- add GeneReviews infantile-onset phenotypes: vomiting, microcephaly, and visual impairment
- add late-onset cognitive impairment and GeneReviews agents/diets-to-avoid guidance

## Validation
- just validate kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/3-Hydroxyisobutyryl-CoA_Hydrolase_Deficiency.yaml
- just check-reference-cache-frontmatter
- git diff --check
- manual snippet audit: 36 total, 4 exact, 32 normalized, 0 missing, 0 no-cache