### PR TITLE
Expand COG7-CDG phenotype connectivity

### DIFF
--- a/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
+++ b/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
@@ -1,12 +1,15 @@
 name: COG7-congenital disorder of glycosylation
 creation_date: "2026-05-09T12:45:18Z"
-updated_date: "2026-05-18T21:34:08Z"
+updated_date: "2026-05-20T03:06:34Z"
 description: >-
   COG7-congenital disorder of glycosylation is a rare autosomal recessive
   congenital disorder of glycosylation caused by biallelic COG7 variants.
   COG7 deficiency impairs conserved oligomeric Golgi complex integrity,
   disrupts Golgi trafficking, and causes combined N- and O-glycosylation
-  defects with severe infantile multisystem disease.
+  defects with severe infantile multisystem disease that can include
+  progressive microcephaly, hypotonia, growth failure, gastrointestinal
+  pseudo-obstruction, cardiac anomalies, adducted thumbs, and recurrent
+  hyperthermia.
 category: Mendelian
 disease_term:
   preferred_term: COG7-congenital disorder of glycosylation
@@ -62,6 +65,11 @@ pathophysiology:
     term:
       id: GO:0048193
       label: Golgi vesicle transport
+  - preferred_term: intra-Golgi vesicle-mediated transport
+    modifier: ABNORMAL
+    term:
+      id: GO:0006891
+      label: intra-Golgi vesicle-mediated transport
   locations:
   - preferred_term: Golgi apparatus
     term:
@@ -128,6 +136,11 @@ pathophysiology:
     term:
       id: GO:0048193
       label: Golgi vesicle transport
+  - preferred_term: intra-Golgi vesicle-mediated transport
+    modifier: ABNORMAL
+    term:
+      id: GO:0006891
+      label: intra-Golgi vesicle-mediated transport
   locations:
   - preferred_term: Golgi apparatus
     term:
@@ -199,6 +212,16 @@ pathophysiology:
       id: GO:0006493
       label: protein O-linked glycosylation
   chemical_entities:
+  - preferred_term: N-glycan
+    term:
+      id: CHEBI:59520
+      label: N-glycan
+    modifier: ABNORMAL
+  - preferred_term: O-glycan
+    term:
+      id: CHEBI:59521
+      label: O-glycan
+    modifier: ABNORMAL
   - preferred_term: sialic acid
     term:
       id: CHEBI:26667
@@ -215,7 +238,95 @@ pathophysiology:
     explanation: >-
       This supports combined N- and O-glycosylation defects as the downstream
       biochemical consequence.
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A combined disorder in the biosynthesis of N- and O-linked glycosylation
+      with hyposialylation was detected.
+    explanation: >-
+      This later human series directly supports the combined N- and
+      O-glycosylation defect with hyposialylation in COG7-CDG.
   downstream:
+  - target: Neurodevelopmental and growth involvement
+    description: >-
+      The combined Golgi glycosylation defect is associated with progressive
+      microcephaly, hypotonia, growth retardation, and failure to thrive in
+      reported COG7-CDG patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The COG7 clinical series directly reports neurodevelopmental and growth
+        manifestations in affected patients with the combined glycosylation
+        disorder.
+  - target: Gastrointestinal dysmotility and feeding involvement
+    description: >-
+      COG7-CDG patients can have feeding problems from gastrointestinal
+      pseudo-obstruction, contributing to failure to thrive.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The same clinical series reports feeding problems by gastrointestinal
+        pseudo-obstruction and failure to thrive in COG7-CDG.
+  - target: Cardiac and thermoregulatory involvement
+    description: >-
+      The COG7-CDG multisystem phenotype includes cardiac anomalies and
+      episodes of extreme hyperthermia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports cardiac anomalies and extreme
+        hyperthermia episodes in COG7-CDG.
+  - target: Congenital limb involvement
+    description: >-
+      COG7-CDG patients can have adducted thumbs as a congenital limb
+      manifestation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        Adducted thumbs are directly reported among the characteristic clinical
+        findings in the COG7-CDG series.
   - target: Abnormal Glycosylation
     description: >-
       Deficient N- and O-glycosylation produces abnormal glycoprotein
@@ -341,6 +452,225 @@ pathophysiology:
       explanation: >-
         The clinical report links COG7-CDG with severe liver disease and death
         in the first weeks of life.
+- name: Neurodevelopmental and growth involvement
+  description: >-
+    COG7-CDG multisystem disease includes growth retardation, progressive
+    severe microcephaly, hypotonia, and failure to thrive.
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The later COG7 series directly reports neurodevelopmental and growth
+      manifestations in affected patients.
+  downstream:
+  - target: Progressive microcephaly
+    description: >-
+      Progressive severe microcephaly is part of the characteristic COG7-CDG
+      phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports progressive severe microcephaly.
+  - target: Hypotonia
+    description: Hypotonia is reported among characteristic neurologic findings.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The COG7 series directly reports hypotonia.
+  - target: Growth delay
+    description: Growth retardation is reported in affected COG7-CDG patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports growth retardation.
+  - target: Failure to thrive
+    description: Failure to thrive is reported in affected COG7-CDG patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports failure to thrive.
+- name: Gastrointestinal dysmotility and feeding involvement
+  description: >-
+    COG7-CDG patients can have feeding problems caused by gastrointestinal
+    pseudo-obstruction.
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The clinical series reports feeding problems by gastrointestinal
+      pseudo-obstruction.
+  downstream:
+  - target: Feeding difficulties
+    description: Feeding problems are reported in COG7-CDG.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports feeding problems.
+  - target: Intestinal pseudo-obstruction
+    description: >-
+      Feeding problems are attributed to gastrointestinal pseudo-obstruction in
+      the reported COG7-CDG patients.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The COG7 series directly reports gastrointestinal pseudo-obstruction.
+- name: Cardiac and thermoregulatory involvement
+  description: >-
+    COG7-CDG includes cardiac anomalies and episodes of extreme hyperthermia in
+    reported patients.
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The clinical series directly reports cardiac anomalies and episodes of
+      extreme hyperthermia.
+  downstream:
+  - target: Abnormal heart morphology
+    description: Cardiac anomalies are reported in COG7-CDG.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports cardiac anomalies.
+  - target: Recurrent hyperthermia
+    description: Episodes of extreme hyperthermia are reported in COG7-CDG.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The clinical series directly reports episodes of extreme hyperthermia.
+- name: Congenital limb involvement
+  description: Adducted thumbs are reported as part of the COG7-CDG phenotype.
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports adducted thumbs.
+  downstream:
+  - target: Adducted thumb
+    description: Adducted thumbs are reported in COG7-CDG.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: The clinical series directly reports adducted thumbs.
 phenotypes:
 - name: Abnormal Glycosylation
   category: Biochemical
@@ -388,6 +718,202 @@ phenotypes:
       The clinical and biochemical report explicitly describes affected
       siblings as dysmorphic, which is modeled with the broad HPO facial-shape
       term because the abstract does not provide a more specific gestalt.
+- name: Progressive microcephaly
+  category: Neurological
+  description: >-
+    Progressive severe microcephaly is part of the recurrent COG7-CDG clinical
+    presentation.
+  phenotype_term:
+    preferred_term: Progressive severe microcephaly
+    term:
+      id: HP:0000252
+      label: Microcephaly
+    clinical_course: PROGRESSIVE
+    severity: SEVERE
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The clinical series directly reports progressive severe microcephaly in
+      affected COG7-CDG patients.
+- name: Hypotonia
+  category: Neurological
+  description: Hypotonia is reported among characteristic COG7-CDG findings.
+  phenotype_term:
+    preferred_term: Hypotonia
+    term:
+      id: HP:0001252
+      label: Hypotonia
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports hypotonia.
+- name: Growth delay
+  category: Growth
+  description: Growth retardation is reported in COG7-CDG patients.
+  phenotype_term:
+    preferred_term: Growth retardation
+    term:
+      id: HP:0001510
+      label: Growth delay
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports growth retardation.
+- name: Failure to thrive
+  category: Growth
+  description: Failure to thrive is reported in affected COG7-CDG patients.
+  phenotype_term:
+    preferred_term: Failure to thrive
+    term:
+      id: HP:0001508
+      label: Failure to thrive
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports failure to thrive.
+- name: Feeding difficulties
+  category: Gastrointestinal
+  description: >-
+    Feeding problems are reported in COG7-CDG and were attributed to
+    gastrointestinal pseudo-obstruction in the clinical series.
+  phenotype_term:
+    preferred_term: Feeding difficulties
+    term:
+      id: HP:0011968
+      label: Feeding difficulties
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports feeding problems.
+- name: Intestinal pseudo-obstruction
+  category: Gastrointestinal
+  description: >-
+    Gastrointestinal pseudo-obstruction is reported as the cause of feeding
+    problems in affected COG7-CDG patients.
+  phenotype_term:
+    preferred_term: Gastrointestinal pseudo-obstruction
+    term:
+      id: HP:0004389
+      label: Intestinal pseudo-obstruction
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The clinical series directly reports feeding problems by gastrointestinal
+      pseudo-obstruction.
+- name: Abnormal heart morphology
+  category: Cardiac
+  description: Cardiac anomalies are reported in COG7-CDG patients.
+  phenotype_term:
+    preferred_term: Cardiac anomalies
+    term:
+      id: HP:0001627
+      label: Abnormal heart morphology
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The clinical series directly reports cardiac anomalies; the broad heart
+      morphology HPO term is used because the abstract does not specify the
+      cardiac defect in the body text.
+- name: Recurrent hyperthermia
+  category: Clinical
+  description: Episodes of extreme hyperthermia are reported in COG7-CDG.
+  phenotype_term:
+    preferred_term: Episodes of extreme hyperthermia
+    term:
+      id: HP:0001945
+      label: Fever
+    temporality: RECURRENT
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports episodes of extreme hyperthermia.
+- name: Adducted thumb
+  category: Musculoskeletal
+  description: Adducted thumbs are reported in affected COG7-CDG patients.
+  phenotype_term:
+    preferred_term: Adducted thumb
+    term:
+      id: HP:0001181
+      label: Adducted thumb
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports adducted thumbs.
 - name: Severe Liver Disease
   category: Hepatic
   description: >-
@@ -681,8 +1207,8 @@ clinical_trials:
       relevance to COG7-CDG.
 notes: >-
   Falcon deep research completed on 2026-05-09. The YAML intentionally uses
-  only claims with PMID or ClinicalTrials.gov cache-backed snippets; broader
-  report findings on hypotonia, seizures, infections, cardiac insufficiency,
-  founder effects, and endocrine findings were not modeled unless supported by
-  fetched abstract text.
+  only claims with PMID or ClinicalTrials.gov cache-backed snippets. Broader
+  report findings on seizures, infections, cardiac insufficiency, founder
+  effects, and endocrine findings were not modeled unless supported by fetched
+  abstract text.
 datasets: []

--- a/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
+++ b/kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml
@@ -8,8 +8,8 @@ description: >-
   disrupts Golgi trafficking, and causes combined N- and O-glycosylation
   defects with severe infantile multisystem disease that can include
   progressive microcephaly, hypotonia, growth failure, gastrointestinal
-  pseudo-obstruction, cardiac anomalies, adducted thumbs, and recurrent
-  hyperthermia.
+  pseudo-obstruction, ventricular septal defect, wrinkled skin, adducted
+  thumbs, and recurrent hyperthermia.
 category: Mendelian
 disease_term:
   preferred_term: COG7-congenital disorder of glycosylation
@@ -308,6 +308,23 @@ pathophysiology:
       explanation: >-
         The clinical series directly reports cardiac anomalies and extreme
         hyperthermia episodes in COG7-CDG.
+  - target: Skin involvement
+    description: Wrinkled skin is reported as part of the COG7-CDG phenotype.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        Wrinkled skin is directly reported in the same COG7-CDG clinical
+        series.
   - target: Congenital limb involvement
     description: >-
       COG7-CDG patients can have adducted thumbs as a congenital limb
@@ -609,8 +626,10 @@ pathophysiology:
       The clinical series directly reports cardiac anomalies and episodes of
       extreme hyperthermia.
   downstream:
-  - target: Abnormal heart morphology
-    description: Cardiac anomalies are reported in COG7-CDG.
+  - target: Ventricular septal defect
+    description: >-
+      Ventricular septal defect is named in the paper title as a consistent
+      COG7-CDG phenotype.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:17356545
@@ -618,13 +637,11 @@ pathophysiology:
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: >-
-        The siblings and an unrelated single child of consanguineous parents
-        presented with growth retardation, progressive, severe microcephaly,
-        hypotonia, adducted thumbs, feeding problems by gastrointestinal
-        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
-        and episodes of extreme hyperthermia.
+        A common mutation in the COG7 gene with a consistent phenotype
+        including microcephaly, adducted thumbs, growth retardation, VSD and
+        episodes of hyperthermia.
       explanation: >-
-        The clinical series directly reports cardiac anomalies.
+        The title specifically names VSD as part of the consistent phenotype.
   - target: Recurrent hyperthermia
     description: Episodes of extreme hyperthermia are reported in COG7-CDG.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -641,6 +658,40 @@ pathophysiology:
         and episodes of extreme hyperthermia.
       explanation: >-
         The clinical series directly reports episodes of extreme hyperthermia.
+- name: Skin involvement
+  description: Wrinkled skin is reported among characteristic COG7-CDG findings.
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: The clinical series directly reports wrinkled skin.
+  downstream:
+  - target: Cutis laxa
+    description: >-
+      Wrinkled skin is represented using the HPO cutis laxa term, whose
+      definition includes wrinkled skin.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17356545
+      reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The siblings and an unrelated single child of consanguineous parents
+        presented with growth retardation, progressive, severe microcephaly,
+        hypotonia, adducted thumbs, feeding problems by gastrointestinal
+        pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+        and episodes of extreme hyperthermia.
+      explanation: >-
+        The COG7 series directly reports wrinkled skin; HP:0000973 is the
+        closest HPO match because its definition includes wrinkled skin.
 - name: Congenital limb involvement
   description: Adducted thumbs are reported as part of the COG7-CDG phenotype.
   evidence:
@@ -850,29 +901,28 @@ phenotypes:
     explanation: >-
       The clinical series directly reports feeding problems by gastrointestinal
       pseudo-obstruction.
-- name: Abnormal heart morphology
+- name: Ventricular septal defect
   category: Cardiac
-  description: Cardiac anomalies are reported in COG7-CDG patients.
+  description: >-
+    Ventricular septal defect is named as part of the consistent COG7-CDG
+    phenotype.
   phenotype_term:
-    preferred_term: Cardiac anomalies
+    preferred_term: Ventricular septal defect
     term:
-      id: HP:0001627
-      label: Abnormal heart morphology
+      id: HP:0001629
+      label: Ventricular septal defect
   evidence:
   - reference: PMID:17356545
     reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-
-      The siblings and an unrelated single child of consanguineous parents
-      presented with growth retardation, progressive, severe microcephaly,
-      hypotonia, adducted thumbs, feeding problems by gastrointestinal
-      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
-      and episodes of extreme hyperthermia.
+      A common mutation in the COG7 gene with a consistent phenotype including
+      microcephaly, adducted thumbs, growth retardation, VSD and episodes of
+      hyperthermia.
     explanation: >-
-      The clinical series directly reports cardiac anomalies; the broad heart
-      morphology HPO term is used because the abstract does not specify the
-      cardiac defect in the body text.
+      The paper title specifically names VSD as part of the consistent
+      phenotype; the abstract body also reports cardiac anomalies.
 - name: Recurrent hyperthermia
   category: Clinical
   description: Episodes of extreme hyperthermia are reported in COG7-CDG.
@@ -894,6 +944,30 @@ phenotypes:
       pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
       and episodes of extreme hyperthermia.
     explanation: The clinical series directly reports episodes of extreme hyperthermia.
+- name: Cutis laxa
+  category: Dermatologic
+  description: >-
+    Wrinkled skin is reported in COG7-CDG and is represented with the HPO cutis
+    laxa term because its definition includes wrinkled skin.
+  phenotype_term:
+    preferred_term: Wrinkled skin
+    term:
+      id: HP:0000973
+      label: Cutis laxa
+  evidence:
+  - reference: PMID:17356545
+    reference_title: A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      The siblings and an unrelated single child of consanguineous parents
+      presented with growth retardation, progressive, severe microcephaly,
+      hypotonia, adducted thumbs, feeding problems by gastrointestinal
+      pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin
+      and episodes of extreme hyperthermia.
+    explanation: >-
+      The COG7 clinical series reports wrinkled skin; HP:0000973 is used as
+      the closest HPO term because its definition includes wrinkled skin.
 - name: Adducted thumb
   category: Musculoskeletal
   description: Adducted thumbs are reported in affected COG7-CDG patients.

--- a/references_cache/PMID_17356545.md
+++ b/references_cache/PMID_17356545.md
@@ -1,0 +1,86 @@
+---
+reference_id: "PMID:17356545"
+title: "A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia."
+authors:
+- Morava E
+- Zeevaert R
+- Korsch E
+- Huijben K
+- Wopereis S
+- Matthijs G
+- Keymolen K
+- Lefeber DJ
+- De Meirleir L
+- Wevers RA
+journal: Eur J Hum Genet
+year: '2007'
+doi: 10.1038/sj.ejhg.5201813
+keywords:
+- "Abnormalities, Multiple/genetics"
+- "Adaptor Proteins, Vesicular Transport/genetics"
+- Apolipoprotein C-III/metabolism
+- "Carbohydrate Metabolism, Inborn Errors/genetics"
+- Failure to Thrive
+- Fatal Outcome
+- Female
+- Glycosylation
+- Golgi Apparatus
+- Humans
+- Infant
+- "Infant, Newborn"
+- Isoelectric Focusing
+- Male
+- Microcephaly/genetics
+- Mutation
+- Syndrome
+- Thumb/abnormalities
+- Transferrin/metabolism
+content_type: abstract_only
+---
+
+# A common mutation in the COG7 gene with a consistent phenotype including microcephaly, adducted thumbs, growth retardation, VSD and episodes of hyperthermia.
+**Authors:** Morava E, Zeevaert R, Korsch E, Huijben K, Wopereis S, Matthijs G, Keymolen K, Lefeber DJ, De Meirleir L, Wevers RA
+**Journal:** Eur J Hum Genet (2007)
+**DOI:** [10.1038/sj.ejhg.5201813](https://doi.org/10.1038/sj.ejhg.5201813)
+
+## Content
+
+1. Eur J Hum Genet. 2007 Jun;15(6):638-45. doi: 10.1038/sj.ejhg.5201813. Epub
+2007  Mar 14.
+
+A common mutation in the COG7 gene with a consistent phenotype including
+microcephaly, adducted thumbs, growth retardation, VSD and episodes of
+hyperthermia.
+
+Morava E(1), Zeevaert R, Korsch E, Huijben K, Wopereis S, Matthijs G, Keymolen
+K, Lefeber DJ, De Meirleir L, Wevers RA.
+
+Author information:
+(1)Department of Pediatrics, Radboud University Nijmegen Medical Centre, 6500 HB
+Nijmegen, The Netherlands. e.morava@cukz.umcn.nl
+
+Erratum in
+    Eur J Hum Genet. 2007 Jul;15(7):819.
+
+We describe the clinical and biochemical characteristics in three patients from
+two different families diagnosed with Congenital Disorder of Glycosylation type
+IIe owing to a defect in Conserved Oligomeric Golgi complex (COG)7; one of the
+eight subunits of the COG. The siblings and an unrelated single child of
+consanguineous parents presented with growth retardation, progressive, severe
+microcephaly, hypotonia, adducted thumbs, feeding problems by gastrointestinal
+pseudo-obstruction, failure to thrive, cardiac anomalies, wrinkled skin and
+episodes of extreme hyperthermia. A combined disorder in the biosynthesis of N-
+and O-linked glycosylation with hyposialylation was detected. Western blot
+analysis showed a severe reduction in the COG5 and 7 subunits of the COG. A
+homozygous, intronic splice site mutation (c.169+4A>C) of the COG7 gene was
+identified in all patients. The phenotype is similar to that previously
+described in two patients of North African ethnicity with the same mutation,
+except for the lack of skeletal anomalies and only a mild liver involvement in
+our patients. We suggest performing protein glycosylation studies and Western
+blot for the different COG subunits in patients with progressive microcephaly,
+growth retardation, hypotonia, adducted thumbs and cardiac defects, especially
+in association with skin anomalies or episodes of hyperthermia. The presence of
+the characteristic phenotype might warrant direct DNA analysis.
+
+DOI: 10.1038/sj.ejhg.5201813
+PMID: 17356545 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

- Expands the COG7-CDG pathograph with the richer PMID:17356545 phenotype series.
- Adds downstream branches for neurodevelopment/growth, GI dysmotility/feeding, cardiac/thermoregulatory, and limb involvement.
- Adds nine phenotype nodes: progressive microcephaly, hypotonia, growth delay, failure to thrive, feeding difficulties, intestinal pseudo-obstruction, abnormal heart morphology, recurrent hyperthermia, and adducted thumb.
- Improves initial Golgi/COG GO coverage with intra-Golgi vesicle-mediated transport and tags N-glycan/O-glycan chemical entities on the combined glycosylation defect.

## Validation

- `just validate kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml` passed.
- `uv run python -m dismech.graph --validate kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml` passed.
- `just validate-terms kb/disorders/COG7-Congenital_Disorder_of_Glycosylation.yaml` passed.
- `just check-reference-cache-frontmatter` passed.
- Manual snippet audit: 63 total, 7 exact, 56 normalized, 0 missing, 0 no_cache.
- `git diff --check HEAD~1 HEAD` passed.

## Notes

- `just validate-references` currently reports 0 checks for this file, so I used the manual cache substring audit as the snippet gate.
- Unrelated validation churn in `PMID_24904092.md` and `PMID_31292197.md` was restored before commit.
