### PR TITLE
Connect GM3 synthase biochemical readouts

### DIFF
--- a/kb/disorders/GM3_Synthase_Deficiency.yaml
+++ b/kb/disorders/GM3_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: GM3 synthase deficiency
 category: Mendelian
 creation_date: '2026-05-04T13:48:31Z'
-updated_date: '2026-05-19T10:12:46Z'
+updated_date: '2026-05-20T04:46:10Z'
 synonyms:
 - ST3GAL5-CDG
 - Amish infantile epilepsy syndrome
@@ -204,6 +204,16 @@ pathophysiology:
     snippet: "revealed a complete loss of enzyme activity."
     explanation: Transfected-cell enzyme assays show complete loss of GM3 synthase activity for pathogenic variants.
   downstream:
+  - target: Reduced GM3 synthase activity
+    description: Pathogenic ST3GAL5 variants abolish or markedly reduce GM3 synthase enzyme activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30576498
+      reference_title: Total loss of GM3 synthase activity by a normally processed enzyme in a novel variant and in all ST3GAL5 variants reported to cause a distinct congenital disorder of glycosylation.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "revealed a complete loss of enzyme activity."
+      explanation: Transfected-cell GM3 synthase assays directly support loss of enzymatic activity for pathogenic ST3GAL5 variants.
   - target: GM3 and downstream ganglioside depletion
     description: Loss of GM3 synthase activity depletes GM3 and biosynthetic derivatives.
     causal_link_type: DIRECT
@@ -261,6 +271,26 @@ pathophysiology:
     snippet: "GM3-derived gangliosides were undetectable"
     explanation: Patient-derived iPSC and neural crest models confirm undetectable GM3-derived gangliosides.
   downstream:
+  - target: GM3 ganglioside depletion
+    description: Loss of GM3 synthase causes absent or markedly reduced GM3 ganglioside in affected individuals.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15502825
+      reference_title: Infantile-onset symptomatic epilepsy syndrome caused by a homozygous loss-of-function mutation of GM3 synthase.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "complete lack of GM3 ganglioside and its biosynthetic derivatives"
+      explanation: Plasma glycosphingolipid analysis directly supports absent GM3 ganglioside in affected individuals.
+  - target: Complex ganglioside depletion
+    description: Because GM3 is upstream of most complex gangliosides, downstream ganglioside species are depleted.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30209782
+      reference_title: Oral Ganglioside Supplement Improves Growth and Development in Patients with Ganglioside GM3 Synthase Deficiency.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "GM3 synthase deficiency (GM3D) causes an absence of GM3 and all downstream biosynthetic derivatives."
+      explanation: Clinical supplementation study background directly supports absence of downstream GM3 biosynthetic derivatives.
   - target: Glycosphingolipid remodeling
     description: Ganglioside depletion shifts glycosphingolipid composition and glycosylation programs.
     causal_link_type: DIRECT
@@ -314,6 +344,16 @@ pathophysiology:
     snippet: "Altered GSL profiles in GM3SD cells"
     explanation: Patient-derived neural lineage cells show altered GSL profiles and downstream cellular changes.
   downstream:
+  - target: Altered glycosphingolipid profile
+    description: Loss of GM3-derived gangliosides produces a measurable abnormal glycosphingolipid profile in patient-derived cells.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:37676252
+      reference_title: Neural-specific alterations in glycosphingolipid biosynthesis and cell signaling associated with two human ganglioside GM3 synthase deficiency variants.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Altered GSL profiles in GM3SD cells"
+      explanation: Patient-derived neural lineage cells show altered glycosphingolipid profiles downstream of GM3 synthase deficiency.
   - target: Neural cell signaling vulnerability
     description: Altered glycosphingolipid profiles perturb membrane and receptor signaling states.
     causal_link_type: DIRECT
@@ -924,6 +964,100 @@ phenotypes:
     evidence_source: OTHER
     snippet: "progressive microcephaly, intellectual"
     explanation: The review summarizes progressive microcephaly among human patient features.
+biochemical:
+- name: Reduced GM3 synthase activity
+  presence: DECREASED
+  context: >
+    Direct enzyme assays show loss of GM3 synthase activity from pathogenic
+    ST3GAL5 variants.
+  readouts:
+  - target: ST3GAL5 GM3 synthase loss of function
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced GM3 synthase activity reports the proximal ST3GAL5 enzymatic defect.
+  evidence:
+  - reference: PMID:30576498
+    reference_title: Total loss of GM3 synthase activity by a normally processed enzyme in a novel variant and in all ST3GAL5 variants reported to cause a distinct congenital disorder of glycosylation.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "revealed a complete loss of enzyme activity."
+    explanation: Transfected-cell assays directly show complete loss of GM3 synthase activity for pathogenic variants.
+- name: GM3 ganglioside depletion
+  presence: ABSENT
+  context: >
+    Absent GM3 in plasma or cells is the direct chemical readout of the blocked
+    ST3GAL5 sialyltransferase step.
+  biomarker_term:
+    preferred_term: ganglioside GM3
+    term:
+      id: CHEBI:84118
+      label: ganglioside GM3
+  readouts:
+  - target: GM3 and downstream ganglioside depletion
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Absent GM3 ganglioside reports failure of the ST3GAL5-dependent biosynthetic step.
+  evidence:
+  - reference: PMID:15502825
+    reference_title: Infantile-onset symptomatic epilepsy syndrome caused by a homozygous loss-of-function mutation of GM3 synthase.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "complete lack of GM3 ganglioside and its biosynthetic derivatives"
+    explanation: Plasma glycosphingolipid analysis directly documents absent GM3 ganglioside.
+- name: Complex ganglioside depletion
+  presence: DECREASED
+  context: >
+    Downstream GM3-derived gangliosides are depleted because GM3 is the precursor
+    for most complex gangliosides in neural tissue.
+  biomarker_term:
+    preferred_term: ganglioside
+    term:
+      id: CHEBI:28892
+      label: ganglioside
+  readouts:
+  - target: GM3 and downstream ganglioside depletion
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Depletion of downstream gangliosides reports the broader biosynthetic consequence of absent GM3 synthase activity.
+  evidence:
+  - reference: PMID:30209782
+    reference_title: Oral Ganglioside Supplement Improves Growth and Development in Patients with Ganglioside GM3 Synthase Deficiency.
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "GM3 synthase deficiency (GM3D) causes an absence of GM3 and all downstream biosynthetic derivatives."
+    explanation: This clinical study background supports absence of GM3 and downstream biosynthetic derivatives.
+  - reference: PMID:37676252
+    reference_title: Neural-specific alterations in glycosphingolipid biosynthesis and cell signaling associated with two human ganglioside GM3 synthase deficiency variants.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "GM3 and GM3-derived gangliosides were undetectable in cells carrying either variant"
+    explanation: Patient-derived neural lineage cells independently show undetectable GM3-derived gangliosides.
+- name: Altered glycosphingolipid profile
+  presence: ABNORMAL
+  context: >
+    Patient-derived cells show broader glycosphingolipid remodeling beyond GM3
+    and downstream ganglioside depletion.
+  biomarker_term:
+    preferred_term: glycosphingolipid
+    term:
+      id: CHEBI:24402
+      label: glycosphingolipid
+  readouts:
+  - target: Glycosphingolipid remodeling
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Altered GSL profiles report compensatory glycosphingolipid remodeling downstream of GM3 depletion.
+  evidence:
+  - reference: PMID:37676252
+    reference_title: Neural-specific alterations in glycosphingolipid biosynthesis and cell signaling associated with two human ganglioside GM3 synthase deficiency variants.
+    supports: SUPPORT
+    evidence_source: IN_VITRO
+    snippet: "Altered GSL profiles in GM3SD cells"
+    explanation: Patient-derived neural lineage cells show altered glycosphingolipid profiles.
 diagnosis:
 - name: ST3GAL5 molecular genetic testing
   diagnosis_term:


### PR DESCRIPTION
## Summary
- add biochemical readouts for reduced GM3 synthase activity, absent GM3 ganglioside, downstream ganglioside depletion, and altered glycosphingolipid profiles
- connect the existing ST3GAL5/GM3 depletion/remodeling mechanism chain to those readout nodes
- keep the PR scoped to GM3_Synthase_Deficiency.yaml; no reference-cache files were added or hand-edited

## Validation
- just validate kb/disorders/GM3_Synthase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/GM3_Synthase_Deficiency.yaml
- just validate-terms kb/disorders/GM3_Synthase_Deficiency.yaml
- just check-reference-cache-frontmatter
- manual snippet audit: 93 total, 0 missing, 0 no_cache
- git diff --check HEAD~1 HEAD