### PR TITLE
Connect AIP pharmacodynamic readouts

### DIFF
--- a/kb/disorders/Acute_Intermittent_Porphyria.yaml
+++ b/kb/disorders/Acute_Intermittent_Porphyria.yaml
@@ -1,6 +1,6 @@
 name: Acute Intermittent Porphyria
 creation_date: '2026-04-21T04:42:02Z'
-updated_date: '2026-05-19T23:25:44Z'
+updated_date: '2026-05-20T09:37:49Z'
 category: Mendelian
 synonyms:
 - AIP
@@ -200,6 +200,12 @@ pathophysiology:
       id: GO:0003870
       label: 5-aminolevulinate synthase activity
     modifier: INCREASED
+  chemical_entities:
+  - preferred_term: 5-aminolevulinic acid
+    term:
+      id: CHEBI:17549
+      label: 5-aminolevulinic acid
+    modifier: INCREASED
   evidence:
   - reference: PMID:9516674
     reference_title: "Acute intermittent porphyria."
@@ -255,6 +261,12 @@ pathophysiology:
     Increased upstream pathway flux in the setting of partial HMBS deficiency
     causes excess production and systemic spillover of 5-aminolevulinic acid
     and porphobilinogen.
+  biological_processes:
+  - preferred_term: heme biosynthetic process
+    term:
+      id: GO:0006783
+      label: heme biosynthetic process
+    modifier: DYSREGULATED
   chemical_entities:
   - preferred_term: 5-aminolevulinic acid
     term:
@@ -679,6 +691,45 @@ biochemical:
       explanation: >-
         Human attack-monitoring data connect urinary ALA to hepatic precursor
         overproduction during active AIP attacks.
+  - target: Triggered hepatic ALAS1 induction
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    interpretation: >-
+      Lower urinary ALA after ALAS1-suppressive therapy reports reduced hepatic
+      precursor production.
+    evidence:
+    - reference: PMID:31994716
+      reference_title: "Pharmacokinetics and Pharmacodynamics of the Small Interfering Ribonucleic Acid, Givosiran, in Patients With Acute Hepatic Porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Givosiran treatment resulted in a rapid and dose-dependent reduction in
+        urinary aminolevulinic acid (ALA) and porphobilinogen (PBG) towards the
+        upper limit of normal (ULN) in AHP patients.
+      explanation: >-
+        Human phase I pharmacodynamic data support urinary ALA as a marker of
+        ALAS1-directed pathway suppression.
+  - target: Neurovisceral attack susceptibility
+    relationship: CORRELATES_WITH
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: >-
+      Higher ALA during symptoms supports an ongoing acute attack and can be
+      tracked during treatment response.
+    evidence:
+    - reference: PMID:19327613
+      reference_title: >-
+        Plasma porphobilinogen as a sensitive biomarker to monitor the clinical
+        and therapeutic course of acute intermittent porphyria attacks.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        These metabolites represent the acute phase reactants confirming an
+        ongoing attack and are used to evaluate therapeutic measures.
+      explanation: >-
+        Attack-monitoring data support ALA/PBG as biochemical correlates of
+        ongoing attack state and treatment response.
   evidence:
   - reference: PMID:19327613
     reference_title: >-
@@ -725,6 +776,45 @@ biochemical:
       explanation: >-
         Human attack-monitoring data connect urinary PBG to hepatic precursor
         overproduction during active AIP attacks.
+  - target: Triggered hepatic ALAS1 induction
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: POSITIVE
+    endpoint_context: PHARMACODYNAMIC
+    interpretation: >-
+      Lower urinary PBG after ALAS1-suppressive therapy reports reduced hepatic
+      precursor production.
+    evidence:
+    - reference: PMID:31994716
+      reference_title: "Pharmacokinetics and Pharmacodynamics of the Small Interfering Ribonucleic Acid, Givosiran, in Patients With Acute Hepatic Porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Givosiran treatment resulted in a rapid and dose-dependent reduction in
+        urinary aminolevulinic acid (ALA) and porphobilinogen (PBG) towards the
+        upper limit of normal (ULN) in AHP patients.
+      explanation: >-
+        Human phase I pharmacodynamic data support urinary PBG as a marker of
+        ALAS1-directed pathway suppression.
+  - target: Neurovisceral attack susceptibility
+    relationship: CORRELATES_WITH
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: >-
+      Higher PBG during symptoms supports an ongoing acute attack and can be
+      tracked during treatment response.
+    evidence:
+    - reference: PMID:19327613
+      reference_title: >-
+        Plasma porphobilinogen as a sensitive biomarker to monitor the clinical
+        and therapeutic course of acute intermittent porphyria attacks.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        These metabolites represent the acute phase reactants confirming an
+        ongoing attack and are used to evaluate therapeutic measures.
+      explanation: >-
+        Attack-monitoring data support ALA/PBG as biochemical correlates of
+        ongoing attack state and treatment response.
   evidence:
   - reference: PMID:19327613
     reference_title: >-


### PR DESCRIPTION
## Summary
- add ALA as the chemical product marker on the ALAS1 induction node
- mark the ALA/PBG accumulation node as dysregulated heme biosynthesis
- connect urinary ALA and PBG to ALAS1-directed pharmacodynamic response and neurovisceral attack monitoring

## Validation
- just validate kb/disorders/Acute_Intermittent_Porphyria.yaml
- uv run python -m dismech.graph --validate kb/disorders/Acute_Intermittent_Porphyria.yaml
- just validate-terms kb/disorders/Acute_Intermittent_Porphyria.yaml
- just validate-references kb/disorders/Acute_Intermittent_Porphyria.yaml (0 validator checks; followed with manual snippet audit)
- just check-reference-cache-frontmatter (then restored unrelated reference-cache normalization)
- manual snippet audit: 52 snippets checked, 0 missing, 0 no-match
- git diff --check