### PR TITLE
Connect 3-MCCD decompensation phenotypes

### DIFF
--- a/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
+++ b/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 3-Methylcrotonyl-CoA Carboxylase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-20T02:48:43Z'
+updated_date: '2026-05-20T09:52:43Z'
 synonyms:
 - 3-MCC deficiency
 - 3-MCCD
@@ -129,6 +129,13 @@ pathophysiology:
     term:
       id: GO:0004485
       label: methylcrotonoyl-CoA carboxylase activity
+    modifier: DECREASED
+  biological_processes:
+  - preferred_term: L-leucine catabolic process
+    term:
+      id: GO:0006552
+      label: L-leucine catabolic process
+    modifier: DECREASED
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -186,6 +193,8 @@ pathophysiology:
     term:
       id: CHEBI:37084
       label: 3-hydroxyisovaleric acid
+    modifier: INCREASED
+  - preferred_term: 3-methylcrotonylglycine
     modifier: INCREASED
   - preferred_term: 3-hydroxyisovalerylcarnitine
     term:
@@ -348,6 +357,38 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "metabolic acidosis, ketotic hypoglycaemia and carnitine deficiency."
       explanation: Case-report abstract directly supports hypoglycemia as part of metabolic decompensation.
+  - target: Metabolic acidosis
+    description: Metabolic decompensation in 3-MCCD can include metabolic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40639867
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency in a child with developmental regression and delay: call for early diagnosis and multidisciplinary approach."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "metabolic acidosis, ketotic hypoglycaemia and carnitine deficiency."
+      explanation: Case-report abstract directly supports metabolic acidosis as part of metabolic decompensation.
+  - target: Ketoacidosis
+    description: Specific symptomatic MCCD presentations can include ketoacidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:25356967
+      reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Specific symptoms included ketoacidosis, hypoglycemia, hyperammonemia, coma, and plasma carnitine depletion with gross elevation of hydroxyisovaleryl-carnitine."
+      explanation: Human case-series evidence identifies ketoacidosis among specific symptoms directly related to defective leucine catabolism.
+  - target: Coma
+    description: Severe symptomatic MCCD decompensation can progress to coma.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - organic-aciduria-like biochemical decompensation
+    evidence:
+    - reference: PMID:25356967
+      reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Specific symptoms included ketoacidosis, hypoglycemia, hyperammonemia, coma, and plasma carnitine depletion with gross elevation of hydroxyisovaleryl-carnitine."
+      explanation: Human case-series evidence identifies coma among specific symptoms of symptomatic MCCD.
   - target: Developmental regression
     description: Severe symptomatic 3-MCCD can present with developmental regression after infection-triggered decompensation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -432,6 +473,54 @@ phenotypes:
     evidence_source: HUMAN_CLINICAL
     snippet: "ketotic hypoglycaemia and carnitine deficiency."
     explanation: Case-report abstract links 3-MCC enzyme deficiency with ketotic hypoglycemia.
+- name: Metabolic acidosis
+  description: Metabolic acidosis can occur during symptomatic 3-MCCD decompensation.
+  phenotype_term:
+    preferred_term: Metabolic acidosis
+    term:
+      id: HP:0001942
+      label: Metabolic acidosis
+  evidence:
+  - reference: PMID:40639867
+    reference_title: "3-methylcrotonyl-CoA carboxylase deficiency in a child with developmental regression and delay: call for early diagnosis and multidisciplinary approach."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "metabolic acidosis, ketotic hypoglycaemia and carnitine deficiency."
+    explanation: Case report directly supports metabolic acidosis in symptomatic 3-MCCD.
+  - reference: PMID:27033733
+    reference_title: "Outcomes of cases with 3-methylcrotonyl-CoA carboxylase (3-MCC) deficiency - Report from the Inborn Errors of Metabolism Information System."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "traditional biochemical symptoms including acidosis, hyperammonemia or lactic acidosis"
+    explanation: Registry data support acidosis among biochemical symptoms reported in newborn-screening-identified 3-MCCD cases.
+- name: Ketoacidosis
+  description: Ketoacidosis is reported among specific biochemical symptoms in symptomatic 3-MCCD.
+  phenotype_term:
+    preferred_term: Ketoacidosis
+    term:
+      id: HP:0001993
+      label: Ketoacidosis
+  evidence:
+  - reference: PMID:25356967
+    reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Specific symptoms included ketoacidosis, hypoglycemia, hyperammonemia, coma, and plasma carnitine depletion with gross elevation of hydroxyisovaleryl-carnitine."
+    explanation: Human case-series evidence directly supports ketoacidosis in symptomatic MCCD.
+- name: Coma
+  description: Coma is a rare severe presentation reported with specific symptomatic biochemical decompensation.
+  phenotype_term:
+    preferred_term: Coma
+    term:
+      id: HP:0001259
+      label: Coma
+  evidence:
+  - reference: PMID:25356967
+    reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Specific symptoms included ketoacidosis, hypoglycemia, hyperammonemia, coma, and plasma carnitine depletion with gross elevation of hydroxyisovaleryl-carnitine."
+    explanation: Human case-series evidence directly supports coma among severe symptomatic MCCD manifestations.
 - name: Organic aciduria
   frequency: VERY_FREQUENT
   description: Organic aciduria reflects urinary excretion of 3-MCCD metabolites including 3-hydroxyisovaleric acid and 3-methylcrotonylglycine.
@@ -596,6 +685,11 @@ biochemical:
     direction: POSITIVE
     endpoint_context: DIAGNOSTIC
     interpretation: Higher urinary 3-hydroxyisovaleric acid reports impaired MCC-dependent leucine catabolism.
+  - target: Organic aciduria
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: The urinary 3-hydroxyisovaleric acid and 3-methylcrotonylglycine pattern is the measured biochemical basis of organic aciduria.
   evidence:
   - reference: PMID:36822454
     reference_title: "Newborn screening for 3-methylcrotonyl-CoA carboxylase deficiency in Zhejiang province, China."


### PR DESCRIPTION
## Summary
- annotate decreased MCC molecular function and decreased L-leucine catabolism on the initiating MCCC1/MCCC2 mechanism
- add increased 3-methylcrotonylglycine as an unbound chemical entity in the diagnostic metabolite node because local ChEBI search did not return a usable exact term
- add metabolic acidosis, ketoacidosis, and coma phenotypes, with downstream edges from stress-triggered metabolic decompensation
- connect urinary 3-hydroxyisovaleric acid / 3-methylcrotonylglycine readout to organic aciduria

## Validation
- just validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
- just validate-terms kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
- just validate-references kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml (0 validator checks; manual snippet audit used)
- just check-reference-cache-frontmatter
- manual snippet audit: 66 snippets checked, 0 missing cache, 0 no-match
- git diff --check

Restored unrelated reference cache churn for PMID_24904092 and PMID_31292197 before commit.