### PR TITLE
Connect aromatase deficiency hormone readouts

### DIFF
--- a/kb/disorders/Aromatase_Deficiency.yaml
+++ b/kb/disorders/Aromatase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Aromatase Deficiency
 creation_date: "2025-12-04T16:57:31Z"
-updated_date: "2026-05-08T08:40:13Z"
+updated_date: "2026-05-20T10:46:54Z"
 description: >-
   Aromatase deficiency is a rare autosomal recessive disorder caused by
   biallelic CYP19A1 loss-of-function variants. Deficient aromatase activity
@@ -98,6 +98,11 @@ pathophysiology:
       id: GO:0070330
       label: aromatase activity
   biological_processes:
+  - preferred_term: steroid biosynthetic process
+    modifier: ABNORMAL
+    term:
+      id: GO:0006694
+      label: steroid biosynthetic process
   - preferred_term: estrogen biosynthetic process
     modifier: DECREASED
     term:
@@ -108,6 +113,17 @@ pathophysiology:
     term:
       id: GO:0008209
       label: androgen metabolic process
+  chemical_entities:
+  - preferred_term: estradiol
+    modifier: DECREASED
+    term:
+      id: CHEBI:23965
+      label: estradiol
+  - preferred_term: testosterone
+    modifier: INCREASED
+    term:
+      id: CHEBI:17347
+      label: testosterone
   locations:
   - preferred_term: ovary
     description: Site of granulosa aromatase; ovarian development and fertility are affected.
@@ -189,6 +205,17 @@ pathophysiology:
     term:
       id: GO:0032274
       label: gonadotropin secretion
+  chemical_entities:
+  - preferred_term: estradiol
+    modifier: DECREASED
+    term:
+      id: CHEBI:23965
+      label: estradiol
+  - preferred_term: testosterone
+    modifier: INCREASED
+    term:
+      id: CHEBI:17347
+      label: testosterone
   locations:
   - preferred_term: uterus
     description: Estrogen-dependent organ; hypoplasia and poor endometrial development may occur.
@@ -219,6 +246,24 @@ pathophysiology:
     explanation: >-
       Supports the combined estrogen-deficiency and androgen-excess mechanism.
   downstream:
+  - target: Maternal Antenatal Virilization
+    description: >-
+      Failure of fetal-placental aromatization exposes the pregnant mother to
+      excess androgens, producing antenatal virilization during affected
+      pregnancies.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Excess androgens in the fetal-placental unit during pregnancy.
+    evidence:
+    - reference: PMID:40321354
+      reference_title: "Aromatase deficiency due to novel CYP19A1 mutation: a rare cause of maternal and fetal virilization."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        This enzyme protects the fetus and mother from excess androgens by converting them into estrogen.
+      explanation: >-
+        The case-report abstract directly supports maternal androgen exposure
+        when CYP19A1 aromatization is deficient.
   - target: Gonadotropin Feedback and Reproductive Development Disruption
     description: >-
       Low estrogen weakens reproductive-tissue maturation and negative feedback
@@ -511,6 +556,17 @@ pathophysiology:
     term:
       id: CL:0000136
       label: adipocyte
+  biological_processes:
+  - preferred_term: glucose homeostasis
+    modifier: ABNORMAL
+    term:
+      id: GO:0042593
+      label: glucose homeostasis
+  - preferred_term: insulin receptor signaling pathway
+    modifier: ABNORMAL
+    term:
+      id: GO:0008286
+      label: insulin receptor signaling pathway
   locations:
   - preferred_term: adipose tissue
     term:
@@ -572,6 +628,32 @@ phenotypes:
     explanation: >-
       Systematic review count supports ambiguous genitalia as very frequent in
       genetically confirmed 46,XX aromatase deficiency.
+- category: Reproductive
+  name: Maternal Antenatal Virilization
+  description: >-
+    Virilization of the pregnant mother can occur when the fetal-placental unit
+    cannot aromatize androgen precursors to estrogens, leading to excess
+    androgen exposure during affected pregnancies.
+  frequency: FREQUENT
+  notes: Maternal manifestation during pregnancy with an affected fetus.
+  evidence:
+  - reference: PMID:32623730
+    reference_title: "Aromatase deficiency: A case series of 46, XX Chinese children and a systematic review of the literature."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The main characteristics were maternal antenatal virilization (21/29), ambiguous genitalia (mainly Prader IV or III, 19/23), delayed bone age (16/17), low bone mass (5/8), markedly elevated FSH levels and ovarian cysts (13/30)."
+    explanation: >-
+      The systematic review count supports maternal antenatal virilization as a
+      frequent presentation associated with aromatase deficiency pregnancies.
+  - reference: PMID:40321354
+    reference_title: "Aromatase deficiency due to novel CYP19A1 mutation: a rare cause of maternal and fetal virilization."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A 10-day-old newborn presented with atypical genitalia and a history of maternal virilization during pregnancy.
+    explanation: >-
+      Case-report evidence documents maternal virilization during pregnancy in
+      an infant with genetically confirmed aromatase deficiency.
 - category: Reproductive
   name: Clitoromegaly
   description: Enlarged clitoris due to androgen excess in 46,XX individuals.
@@ -807,6 +889,17 @@ biochemical:
     term:
       id: CHEBI:23965
       label: estradiol
+  readouts:
+  - target: CYP19A1 Loss-of-Function and Aromatase Deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Very low or undetectable estradiol reports the aromatase enzyme block.
+  - target: Estrogen Deficiency and Androgen Excess
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low serum estradiol directly reports the estrogen-deficient endocrine state.
   evidence:
   - reference: PMID:35837780
     reference_title: "Aromatase deficiency caused by mutation of CYP19A1 gene: A case report."
@@ -825,11 +918,22 @@ biochemical:
     explanation: >-
       Review-level clinical guidance supports undetectable serum estradiol as a
       diagnostic biochemical feature.
-- name: Serum Androgens
+- name: Serum Testosterone
   presence: INCREASED
   context: >-
-    Testosterone and other androgens are normal to elevated because androgen
-    precursors are not efficiently aromatized to estrogens.
+    Testosterone is normal to elevated because androgen precursors are not
+    efficiently aromatized to estrogens.
+  biomarker_term:
+    preferred_term: testosterone
+    term:
+      id: CHEBI:17347
+      label: testosterone
+  readouts:
+  - target: Estrogen Deficiency and Androgen Excess
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Normal-to-elevated circulating testosterone reports androgen excess from failed aromatization.
   evidence:
   - reference: PMID:18448329
     reference_title: "Human models of aromatase deficiency."


### PR DESCRIPTION
## Summary
- Add steroid-biosynthesis and estradiol/testosterone chemical annotations to the initiating aromatase-deficiency mechanism.
- Add maternal antenatal virilization as a reproductive phenotype and connect it from the estrogen-deficiency/androgen-excess node with cached human clinical evidence.
- Rename the androgen biochemical marker to serum testosterone and add readout links for serum estradiol/testosterone to the relevant pathograph nodes.
- Add glucose homeostasis and insulin receptor signaling GO coverage to the metabolic branch.

## Validation
- just validate kb/disorders/Aromatase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/Aromatase_Deficiency.yaml
- just validate-terms kb/disorders/Aromatase_Deficiency.yaml
- just validate-references kb/disorders/Aromatase_Deficiency.yaml (0 checks reported by validator)
- just check-reference-cache-frontmatter
- manual snippet audit: 54 snippets, 0 missing cache, 0 no-match
- git diff --check

## Scope notes
- Restored unrelated generated reference-cache churn in PMID_24904092 and PMID_31292197.
- No references_cache files were hand-edited or committed.