### PR TITLE
Add infantile hypercalcemia chemical readouts

### DIFF
--- a/kb/disorders/Infantile_Hypercalcemia.yaml
+++ b/kb/disorders/Infantile_Hypercalcemia.yaml
@@ -1,7 +1,7 @@
 name: Infantile Hypercalcemia
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-18T17:13:44Z'
+updated_date: '2026-05-20T11:03:06Z'
 synonyms:
 - Autosomal recessive infantile hypercalcemia
 - Familial infantile hypercalcemia with suppressed intact parathyroid hormone
@@ -183,6 +183,12 @@ pathophysiology:
     term:
       id: GO:0042359
       label: vitamin D metabolic process
+  chemical_entities:
+  - preferred_term: calcitriol
+    term:
+      id: CHEBI:17823
+      label: calcitriol
+    modifier: INCREASED
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -231,6 +237,17 @@ pathophysiology:
     term:
       id: GO:0055062
       label: phosphate ion homeostasis
+  chemical_entities:
+  - preferred_term: phosphate
+    term:
+      id: CHEBI:26020
+      label: phosphate
+    modifier: DECREASED
+  - preferred_term: calcitriol
+    term:
+      id: CHEBI:17823
+      label: calcitriol
+    modifier: INCREASED
   cell_types:
   - preferred_term: epithelial cell of proximal tubule
     term:
@@ -298,6 +315,22 @@ pathophysiology:
     term:
       id: GO:0055074
       label: calcium ion homeostasis
+  chemical_entities:
+  - preferred_term: calcitriol
+    term:
+      id: CHEBI:17823
+      label: calcitriol
+    modifier: INCREASED
+  - preferred_term: calcium ion
+    term:
+      id: CHEBI:29108
+      label: calcium(2+)
+    modifier: INCREASED
+  - preferred_term: phosphate
+    term:
+      id: CHEBI:26020
+      label: phosphate
+    modifier: DECREASED
   evidence:
   - reference: ORPHA:300547
     supports: SUPPORT
@@ -432,6 +465,12 @@ pathophysiology:
     term:
       id: UBERON:0002113
       label: kidney
+  chemical_entities:
+  - preferred_term: calcium ion
+    term:
+      id: CHEBI:29108
+      label: calcium(2+)
+    modifier: INCREASED
   evidence:
   - reference: PMID:33099630
     reference_title: "Long-term outcome of the survivors of infantile hypercalcaemia with CYP24A1 and SLC34A1 mutations."
@@ -728,6 +767,11 @@ biochemical:
 - name: Elevated serum calcium
   presence: INCREASED
   context: Hypercalcemia is the central biochemical abnormality and is independent of PTH.
+  biomarker_term:
+    preferred_term: calcium ion
+    term:
+      id: CHEBI:29108
+      label: calcium(2+)
   readouts:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     relationship: READOUT_OF
@@ -755,6 +799,11 @@ biochemical:
 - name: Increased urinary calcium
   presence: INCREASED
   context: Hypercalciuria accompanies hypercalcemia and contributes to nephrocalcinosis risk.
+  biomarker_term:
+    preferred_term: calcium ion
+    term:
+      id: CHEBI:29108
+      label: calcium(2+)
   readouts:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     relationship: READOUT_OF
@@ -774,6 +823,11 @@ biochemical:
 - name: Decreased serum phosphate
   presence: DECREASED
   context: Hypophosphatemia is part of the Orphanet definition and is mechanistically central in SLC34A1-associated disease.
+  biomarker_term:
+    preferred_term: phosphate
+    term:
+      id: CHEBI:26020
+      label: phosphate
   readouts:
   - target: SLC34A1 renal phosphate transport defect
     relationship: READOUT_OF
@@ -823,6 +877,11 @@ biochemical:
     CYP24A1 variants disturb active vitamin D catabolism, while SLC34A1 variants
     increase 1,25-dihydroxyvitamin D3 generation downstream of phosphate
     wasting.
+  biomarker_term:
+    preferred_term: calcitriol
+    term:
+      id: CHEBI:17823
+      label: calcitriol
   readouts:
   - target: Active vitamin D excess and PTH-independent hypercalcemia
     relationship: READOUT_OF


### PR DESCRIPTION
## Summary
- Add calcitriol, phosphate, and calcium chemical entity annotations to the CYP24A1, SLC34A1, convergent active-vitamin-D, and renal injury mechanism nodes.
- Add CHEBI biomarker terms for elevated serum calcium, increased urinary calcium, decreased serum phosphate, and increased active vitamin D exposure.
- Keep the change scoped to pathograph chemical/readout coverage; no reference-cache files were hand-edited or committed.

## Validation
- just validate kb/disorders/Infantile_Hypercalcemia.yaml
- uv run python -m dismech.graph --validate kb/disorders/Infantile_Hypercalcemia.yaml
- just validate-terms kb/disorders/Infantile_Hypercalcemia.yaml
- just validate-references kb/disorders/Infantile_Hypercalcemia.yaml (0 checks reported by validator)
- just check-reference-cache-frontmatter
- manual snippet audit: 107 snippets, 0 missing cache, 0 no-match
- git diff --check

## Scope notes
- Restored unrelated generated reference-cache churn in PMID_24904092 and PMID_31292197.
- No cache CSV changes were needed; all added CHEBI terms were already available in the local enum cache.