### PR TITLE
Add phenotype evidence for Rhabdoid Tumor (#1120)

### DIFF
--- a/kb/disorders/Rhabdoid_Tumor.yaml
+++ b/kb/disorders/Rhabdoid_Tumor.yaml
@@ -240,6 +240,13 @@ phenotypes:
     term:
       id: HP:0031500
       label: Abdominal mass
+  evidence:
+  - reference: PMID:8732342
+    reference_title: "Rhabdoid tumour of the kidney: a clinicopathological study of 22 patients from the International Society of Paediatric Oncology (SIOP) nephroblastoma file."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Clinically, they presented with an abdominal mass but four (18%) children also had hypercalcaemia"
+    explanation: SIOP clinicopathological series of 22 children with rhabdoid tumour of the kidney documents abdominal mass as the dominant presenting finding.
 - category: Genitourinary
   name: Hematuria
   subtype: RTK
@@ -251,6 +258,13 @@ phenotypes:
     term:
       id: HP:0000790
       label: Hematuria
+  evidence:
+  - reference: PMID:11216700
+    reference_title: "Clinical presentation of rhabdoid tumors of the kidney."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Either gross or microscopic hematuria was present in 84.4% (27/32) of the patients with RTK."
+    explanation: National Wilms Tumor Study Group review of 50 RTK patients shows hematuria is a near-universal presenting feature, supporting its inclusion as a characteristic phenotype of renal rhabdoid tumor.
 - category: Musculoskeletal
   name: Soft Tissue Mass
   subtype: eMRT
@@ -263,6 +277,13 @@ phenotypes:
     term:
       id: HP:0031459
       label: Soft tissue neoplasm
+  evidence:
+  - reference: PMID:36720509
+    reference_title: "Extrarenal rhabdoid tumour of axillary soft tissue: a diagnostic challenge resolved by immunohistochemistry."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "We report one such rare case in a female infant presenting as left axillary mass."
+    explanation: Case report of extrarenal rhabdoid tumour presenting as an axillary soft-tissue mass in an infant illustrates the typical eMRT presentation as a deep soft-tissue mass.
 - category: Neurological
   name: Headache
   subtype: AT/RT
@@ -274,6 +295,13 @@ phenotypes:
     term:
       id: HP:0002315
       label: Headache
+  evidence:
+  - reference: PMID:27307151
+    reference_title: "Atypical teratoid/rhabdoid tumors with multilayered rosettes in the pineal region."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patient 1, a 23-month-old girl, presented with a history of gait unsteadiness and headache"
+    explanation: Case series of two children with intracranial AT/RT in the pineal/third ventricular region documents headache as a presenting symptom consistent with intracranial mass effect.
 - category: Neurological
   name: Vomiting
   subtype: AT/RT
@@ -285,6 +313,13 @@ phenotypes:
     term:
       id: HP:0002013
       label: Vomiting
+  evidence:
+  - reference: PMID:27307151
+    reference_title: "Atypical teratoid/rhabdoid tumors with multilayered rosettes in the pineal region."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Patient 2, a 26-month-old girl, presented with headache and vomiting"
+    explanation: Same AT/RT case series documents vomiting accompanying headache, consistent with raised intracranial pressure from posterior third ventricular AT/RT.
 biochemical:
 - name: SMARCB1 (INI1/BAF47) Immunohistochemistry
   notes: >-

--- a/references_cache/PMID_11216700.md
+++ b/references_cache/PMID_11216700.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:11216700"
+title: Clinical presentation of rhabdoid tumors of the kidney.
+authors:
+- Amar AM
+- Tomlinson G
+- Green DM
+- Breslow NE
+- de Alarcon PA
+journal: J Pediatr Hematol Oncol
+year: '2001'
+doi: 10.1097/00043426-200102000-00007
+keywords:
+- Age of Onset
+- "Child, Preschool"
+- "Diagnosis, Differential"
+- Female
+- Fever/etiology
+- "Hematuria/epidemiology, etiology"
+- Humans
+- Incidence
+- Infant
+- "Infant, Newborn"
+- "Kidney Neoplasms/complications, diagnosis, epidemiology, pathology"
+- Male
+- Neoplasm Invasiveness
+- Neoplasm Staging
+- Retrospective Studies
+- "Rhabdoid Tumor/complications, diagnosis, epidemiology, pathology"
+- Wilms Tumor/diagnosis
+content_type: abstract_only
+---
+
+# Clinical presentation of rhabdoid tumors of the kidney.
+**Authors:** Amar AM, Tomlinson G, Green DM, Breslow NE, de Alarcon PA
+**Journal:** J Pediatr Hematol Oncol (2001)
+**DOI:** [10.1097/00043426-200102000-00007](https://doi.org/10.1097/00043426-200102000-00007)
+
+## Content
+
+1. J Pediatr Hematol Oncol. 2001 Feb;23(2):105-8. doi: 
+10.1097/00043426-200102000-00007.
+
+Clinical presentation of rhabdoid tumors of the kidney.
+
+Amar AM(1), Tomlinson G, Green DM, Breslow NE, de Alarcon PA.
+
+Author information:
+(1)Department of Pediatric Hematology Oncology, University of Virginia Childrens 
+Medical Center, Charlottesville, USA.
+
+PURPOSE: We designed this study to differentiate the clinical presentation, 
+particularly the incidence of hematuria, of a rhabdoid tumor of the kidney 
+(RTK), a rare but highly malignant tumor, from a Wilms tumor.
+PATIENTS AND METHODS: We reviewed patient flow charts from the National Wilms 
+Tumor Study Group and queried participating hospitals to obtain additional 
+information regarding presenting symptoms and laboratory data for fifty 
+patients. Patient ages ranged from 2 days to 3.5 years with a mean of 11 months. 
+We documented the presence of gross and microscopic hematuria, fever, and 
+hypercalcemia.
+RESULTS: Whereas 75% of children with rhabdoid tumor of the kidney (RTK) had 
+stage III (44%), IV (27%), or V (4%) tumors, 67% of children with Wilms tumors 
+had stage I (41%) or II (26%) tumors. Either gross or microscopic hematuria was 
+present in 84.4% (27/32) of the patients with RTK. Gross hematuria was present 
+in 59% (22/37) of children with RTK compared with 18% previously reported with 
+Wilms tumor. Microscopic hematuria was present in 76% (22/29) of children with 
+RTK compared with 24% previously reported with Wilms tumor. Fever was found in 
+44% (16/36) of children with RTK, compared with 22% of children previously 
+reported with Wilms tumor. Hypercalcemia was seen 26% (6/23) of children with 
+RTK.
+CONCLUSION: Although diagnosis of any renal mass still must be confirmed with 
+histopathologic features, a distinct clinical presentation with fever, 
+hematuria, a young age, and high-tumor stage at presentation suggests the 
+diagnosis of RTK.
+
+DOI: 10.1097/00043426-200102000-00007
+PMID: 11216700 [Indexed for MEDLINE]

--- a/references_cache/PMID_27307151.md
+++ b/references_cache/PMID_27307151.md
@@ -1,0 +1,78 @@
+---
+reference_id: "PMID:27307151"
+title: Atypical teratoid/rhabdoid tumors with multilayered rosettes in the pineal region.
+authors:
+- Wang J
+- Liu Z
+- Fang J
+- Du J
+- Cui Y
+- Xu L
+- Li G
+journal: Brain Tumor Pathol
+year: '2016'
+doi: 10.1007/s10014-016-0267-3
+keywords:
+- "Biomarkers, Tumor/analysis"
+- "Child, Preschool"
+- Female
+- Humans
+- Infant
+- Magnetic Resonance Imaging
+- "Neoplasms, Multiple Primary"
+- Pineal Gland/surgery
+- "Pinealoma/diagnosis, pathology, surgery"
+- "Rhabdoid Tumor/diagnosis, pathology, surgery"
+- "Teratoma/diagnosis, pathology, surgery"
+- "Tomography, X-Ray Computed"
+content_type: abstract_only
+---
+
+# Atypical teratoid/rhabdoid tumors with multilayered rosettes in the pineal region.
+**Authors:** Wang J, Liu Z, Fang J, Du J, Cui Y, Xu L, Li G
+**Journal:** Brain Tumor Pathol (2016)
+**DOI:** [10.1007/s10014-016-0267-3](https://doi.org/10.1007/s10014-016-0267-3)
+
+## Content
+
+1. Brain Tumor Pathol. 2016 Oct;33(4):261-266. doi: 10.1007/s10014-016-0267-3.
+Epub  2016 Jun 15.
+
+Atypical teratoid/rhabdoid tumors with multilayered rosettes in the pineal 
+region.
+
+Wang J(1), Liu Z(1), Fang J(1), Du J(1), Cui Y(1), Xu L(1), Li G(2).
+
+Author information:
+(1)Department of Neuropathology, Beijing Neurosurgical Institute, China National 
+Clinical Research Center for Neurological Diseases (NCRC-ND), Brain Tumor 
+Center, Beijing Institute for Brain Disorders, Beijing Key Brain Tumor 
+Laboratory, Capital Medical University, No. 6 Tiantan Xili, Dongcheng, Beijing, 
+100050, China.
+(2)Department of Neuropathology, Beijing Neurosurgical Institute, China National 
+Clinical Research Center for Neurological Diseases (NCRC-ND), Brain Tumor 
+Center, Beijing Institute for Brain Disorders, Beijing Key Brain Tumor 
+Laboratory, Capital Medical University, No. 6 Tiantan Xili, Dongcheng, Beijing, 
+100050, China. liguilin2015@sina.com.
+
+Atypical teratoid/rhabdoid tumor (AT/RT) is a rare, highly malignant tumor of 
+the central nervous system (CNS) that typically occurs during infancy. These 
+tumors exhibit morphologic heterogeneity and differentiate along multiple 
+lineages, thus posing a diagnostic challenge. Here, we present two cases of 
+AT/RT with a primitive neuroectodermal component and histological pattern 
+resembling an embryonal tumor with multilayered rosettes (ETMR), a rare but 
+distinctive embryonal entity with different therapeutic implications. Patient 1, 
+a 23-month-old girl, presented with a history of gait unsteadiness and headache; 
+cranial computed tomography (CT) identified a mass in the pineal and third 
+ventricular regions. Patient 2, a 26-month-old girl, presented with headache and 
+vomiting; CT revealed a mass in the posterior third ventricle. Both patients 
+were treated via gross total tumor resection. Although histologically, AT/RT 
+cases variably comprise primitive neuroectodermal, mesenchymal, and classic 
+rhabdoid cells, the most striking feature of both cases was the presence of 
+multilayered rosettes with a few Homer Wright rosettes and occasional primitive 
+neuroepithelial tubes in focal primitive component areas. Immunohistochemistry 
+revealed considerable heterogeneity within the tumors. We further present our 
+findings in the context of the relevant literature.
+
+DOI: 10.1007/s10014-016-0267-3
+PMID: 27307151 [Indexed for MEDLINE]

--- a/references_cache/PMID_36720509.md
+++ b/references_cache/PMID_36720509.md
@@ -1,0 +1,65 @@
+---
+reference_id: "PMID:36720509"
+title: "Extrarenal rhabdoid tumour of axillary soft tissue: a diagnostic challenge resolved by immunohistochemistry."
+authors:
+- Buch AC
+- Bhuibhar G
+- Londhe M
+- Dhaliwal S
+- Gurwale S
+journal: BMJ Case Rep
+year: '2023'
+doi: 10.1136/bcr-2022-254438
+keywords:
+- Infant
+- Child
+- Humans
+- Female
+- DNA-Binding Proteins/genetics
+- Transcription Factors/genetics
+- SMARCB1 Protein/genetics
+- "Rhabdoid Tumor/diagnosis, pathology"
+- "Chromosomal Proteins, Non-Histone/genetics"
+- Immunohistochemistry
+- Sarcoma/pathology
+- "Soft Tissue Neoplasms/diagnosis, pathology"
+content_type: abstract_only
+---
+
+# Extrarenal rhabdoid tumour of axillary soft tissue: a diagnostic challenge resolved by immunohistochemistry.
+**Authors:** Buch AC, Bhuibhar G, Londhe M, Dhaliwal S, Gurwale S
+**Journal:** BMJ Case Rep (2023)
+**DOI:** [10.1136/bcr-2022-254438](https://doi.org/10.1136/bcr-2022-254438)
+
+## Content
+
+1. BMJ Case Rep. 2023 Jan 31;16(1):e254438. doi: 10.1136/bcr-2022-254438.
+
+Extrarenal rhabdoid tumour of axillary soft tissue: a diagnostic challenge 
+resolved by immunohistochemistry.
+
+Buch AC(1), Bhuibhar G(1), Londhe M(1), Dhaliwal S(2), Gurwale S(1).
+
+Author information:
+(1)Department of Pathology, Dr D Y Patil Medical College Hospital and Research 
+Centre, Dr D Y Patil Vidyapeeth, Pune, Maharashtra, India.
+(2)Department of Pathology, Dr D Y Patil Medical College Hospital and Research 
+Centre, Dr D Y Patil Vidyapeeth, Pune, Maharashtra, India 
+sargam.dhaliwal@gmail.com.
+
+Extrarenal rhabdoid tumour of soft tissue in children is a rare tumour 
+associated with poor prognosis. It is a heterogeneous group of aggressive 
+tumours with distinct histopathological and immunohistochemistry findings. The 
+tumour is characterised by diffuse proliferation of rhabdoid cells with hyaline 
+like inclusion bodies. Defining feature is aberration of INI1/SMARCB1 gene 
+located at chromosome 22q11.2. We report one such rare case in a female infant 
+presenting as left axillary mass.
+
+© BMJ Publishing Group Limited 2023. No commercial re-use. See rights and 
+permissions. Published by BMJ.
+
+DOI: 10.1136/bcr-2022-254438
+PMCID: PMC9890742
+PMID: 36720509 [Indexed for MEDLINE]
+
+Conflict of interest statement: Competing interests: None declared.

--- a/references_cache/PMID_8732342.md
+++ b/references_cache/PMID_8732342.md
@@ -1,0 +1,75 @@
+---
+reference_id: "PMID:8732342"
+title: "Rhabdoid tumour of the kidney: a clinicopathological study of 22 patients from the International Society of Paediatric Oncology (SIOP) nephroblastoma file."
+authors:
+- Vujanić GM
+- Sandstedt B
+- Harms D
+- Boccon-Gibod L
+- Delemarre JF
+journal: Histopathology
+year: '1996'
+doi: 10.1046/j.1365-2559.1996.d01-436.x
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Aged, 80 and over"
+- Child
+- "Child, Preschool"
+- "Diagnosis, Differential"
+- Female
+- Humans
+- Infant
+- "Kidney Neoplasms/diagnosis, pathology"
+- Male
+- Registries
+- "Rhabdoid Tumor/diagnosis, pathology"
+- "Wilms Tumor/diagnosis, pathology"
+content_type: abstract_only
+---
+
+# Rhabdoid tumour of the kidney: a clinicopathological study of 22 patients from the International Society of Paediatric Oncology (SIOP) nephroblastoma file.
+**Authors:** Vujanić GM, Sandstedt B, Harms D, Boccon-Gibod L, Delemarre JF
+**Journal:** Histopathology (1996)
+**DOI:** [10.1046/j.1365-2559.1996.d01-436.x](https://doi.org/10.1046/j.1365-2559.1996.d01-436.x)
+
+## Content
+
+1. Histopathology. 1996 Apr;28(4):333-40. doi:
+10.1046/j.1365-2559.1996.d01-436.x.
+
+Rhabdoid tumour of the kidney: a clinicopathological study of 22 patients from 
+the International Society of Paediatric Oncology (SIOP) nephroblastoma file.
+
+Vujanić GM(1), Sandstedt B, Harms D, Boccon-Gibod L, Delemarre JF.
+
+Author information:
+(1)Department of Pathology, University of Wales College of Medicine, Cardiff, 
+UK.
+
+We present 22 (0.9%) cases of rhabdoid tumour of the kidney diagnosed amongst 
+2392 renal tumours in children. The patients ages ranged from 3 weeks to 94 
+months (median 7 months) and the female:male ration was 1.2:1. Clinically, they 
+presented with an abdominal mass but four (18%) children also had hypercalcaemia 
+and one (4.5%) developed a brain tumour (primitive neuroectodermal tumour). None 
+of the children presented with stage I disease, five (23%) had stage II, ten 
+(46%) stage III, and five (23%) stage IV disease. Two (9%) patients had 
+bilateral tumours. Histologically, the vast majority (20/22) of the tumours 
+exhibited a classical pattern but other histological patterns were also noted. 
+Immunohistochemical studies performed in 12 cases showed vimentin positivity in 
+all cases, CAM 5.2 in eight, epithelial membrane antigen in six, neuron specific 
+enolase in four, S-100 protein in eight, and desmin in one case. In only 12 of 
+the 22 tumours was there agreement between the reporting pathologist and the 
+panel on a diagnosis of rhabdoid tumour of the kidney. Eight tumours originally 
+diagnosed as rhabdoid tumour of the kidney were found to be other renal tumours 
+and in another ten cases the initial diagnosis was changed by the panel to 
+rhabdoid tumour. Metastases developed in 18 (82%) of the children--in eight they 
+were present at the time of diagnosis and in 10 they developed from 2 weeks to 9 
+months after initial diagnosis. Metastases were found in the lung, abdomen, 
+lymph nodes, liver, bone and brain. Of the 19 children with adequate follow-up, 
+only two (10.5%) with stage II disease are alive, while 17 (89.5%) died 2 weeks 
+to 20 months after the diagnosis.
+
+DOI: 10.1046/j.1365-2559.1996.d01-436.x
+PMID: 8732342 [Indexed for MEDLINE]


### PR DESCRIPTION
Refs #1120

## Summary

Adds verified PMID evidence to the 5 phenotypes in `kb/disorders/Rhabdoid_Tumor.yaml` that previously lacked `evidence` blocks. All snippets are exact substrings of fetched PubMed abstracts (cached via `just fetch-reference`).

| Phenotype | Subtype | PMID | Quote source |
|---|---|---|---|
| Abdominal Mass | RTK | PMID:8732342 | Vujanić et al. 1996 — SIOP clinicopathological series of 22 RTK patients |
| Hematuria | RTK | PMID:11216700 | Amar et al. 2001 — NWTSG clinical-presentation study (84.4% of RTK patients with hematuria) |
| Soft Tissue Mass | eMRT | PMID:36720509 | Buch et al. 2023 — axillary eMRT case report |
| Headache | AT/RT | PMID:27307151 | Wang et al. 2016 — pineal AT/RT case series |
| Vomiting | AT/RT | PMID:27307151 | Wang et al. 2016 — same series, second case |

## Why this enrichment

Selection rationale (automated high-effort scanner run): scanned the unassigned high-effort `curation` queue (`label:curation -label:low_effort -label:medium_effort`). `Rhabdoid_Tumor.yaml` had the lowest compliance of the cancer-batch entries (76.5% / weighted 77.6%) and its top single remediable gap was `phenotypes[].evidence: 0.0% (0/5)` — a bounded, clearly-actionable enrichment with one PMID per phenotype rather than a sprawling rewrite. Other cancer-batch enrichments merged in the last 24h (#2812, #2814, #2818, #2827), so this PR continues a productive pattern without overlapping in-flight work.

Issue #1120 was last touched 2026-05-17 and had no in-flight enrichment PR (PR #2814 closed the CDKN2A/p16 → CDK4-CCND1 gap and merged 2026-05-19).

## Compliance impact

- Global: **76.5% → 83.7%** (+7.2 percentage points)
- Weighted: **77.6% → 85.2%** (+7.6 percentage points)
- Closes the entire `phenotypes[].evidence` gap (was 0/5, now 5/5)

## Validation

```
just validate kb/disorders/Rhabdoid_Tumor.yaml      → ✅ schema + terms + references all green
just validate-references kb/disorders/Rhabdoid_Tumor.yaml → ✅
just validate-terms kb/disorders/Rhabdoid_Tumor.yaml      → ✅
just check-reference-cache-frontmatter              → ✅ cache contract holds
```

## What was intentionally NOT changed

- Did not modify `description` or `phenotype_term` for the 5 phenotypes — only added the missing `evidence` blocks.
- Did not touch the remaining compliance gaps (`biochemical[].evidence`, `pathophysiology[].downstream[].evidence`, `classifications.harrisons_chapter[].evidence`, `treatments[].target_mechanisms[].evidence`) — those are separate enrichments with different evidence sources and deserve their own bounded PRs.
- Did not normalize cosmetic `reference_id` quoting on unrelated cache files that the term-validator touched during validation — kept those out of this diff for scope hygiene.

— automated curation scanner run (claude[bot])