### PR TITLE
Connect catecholamine synthesis phenotypes

### DIFF
--- a/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
+++ b/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
@@ -407,6 +407,8 @@ pathophysiology:
   - target: Hyperphenylalaninemia
     description: DNAJC12-related monoamine synthesis disease can present with mild hyperphenylalaninemia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - DNAJC12 co-chaperone dysfunction
     evidence:
     - reference: DOI:10.1002/mds.29677
       supports: SUPPORT
@@ -421,6 +423,8 @@ pathophysiology:
   - target: Dystonia
     description: DNAJC12-related monoamine synthesis disease can include infantile dystonia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Combined Monoamine Deficiency
     evidence:
     - reference: DOI:10.1002/mds.29677
       supports: SUPPORT
@@ -435,6 +439,8 @@ pathophysiology:
   - target: Parkinsonism
     description: DNAJC12-related monoamine synthesis disease can include young-onset parkinsonism.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Combined Monoamine Deficiency
     evidence:
     - reference: DOI:10.1002/mds.29677
       supports: SUPPORT

--- a/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
+++ b/kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
@@ -1,6 +1,6 @@
 name: Disorder of Catecholamine Synthesis
 creation_date: "2026-05-08T13:18:01Z"
-updated_date: "2026-05-20T02:21:59Z"
+updated_date: "2026-05-20T23:49:25Z"
 category: Genetic
 parents:
 - Inborn Disorder of Neurotransmitter Metabolism and Transport
@@ -338,6 +338,17 @@ pathophysiology:
   downstream:
   - target: Combined Monoamine Deficiency
     causal_link_type: DIRECT
+  - target: Hyperphenylalaninemia
+    description: BH4-pathway defects produce non-PAH hyperphenylalaninemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: DOI:10.1002/mgg3.2294
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The subsequent systemic hyperphenylalaninemia and monoamine
+        neurotransmitter deficiency lead to neurological consequences.
+      explanation: Supports hyperphenylalaninemia as a direct systemic consequence of BH4-pathway defects.
   - target: Elevated blood phenylalanine
     description: BH4 biosynthesis and recycling defects produce non-PAH hyperphenylalaninemia.
     causal_link_type: DIRECT
@@ -378,7 +389,63 @@ pathophysiology:
       label: DNAJC12
   downstream:
   - target: Combined Monoamine Deficiency
+    description: DNAJC12 pathogenic variants affect a monoamine-synthesis co-chaperone.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired monoamine synthesis enzyme chaperoning
+    evidence:
+    - reference: DOI:10.1002/mds.29677
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Recent studies show that pathogenic variants in
+                    DNAJC12
+                    , a co‐chaperone for monoamine synthesis, may cause mild
+        hyperphenylalaninemia with infantile dystonia, young‐onset parkinsonism,
+        developmental delay and cognitive deficits.
+      explanation: Supports DNAJC12 pathogenic variants as impairing monoamine synthesis through a co-chaperone mechanism.
+  - target: Hyperphenylalaninemia
+    description: DNAJC12-related monoamine synthesis disease can present with mild hyperphenylalaninemia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/mds.29677
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Recent studies show that pathogenic variants in
+                    DNAJC12
+                    , a co‐chaperone for monoamine synthesis, may cause mild
+        hyperphenylalaninemia with infantile dystonia, young‐onset parkinsonism,
+        developmental delay and cognitive deficits.
+      explanation: Supports hyperphenylalaninemia in DNAJC12-related disease.
+  - target: Dystonia
+    description: DNAJC12-related monoamine synthesis disease can include infantile dystonia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/mds.29677
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Recent studies show that pathogenic variants in
+                    DNAJC12
+                    , a co‐chaperone for monoamine synthesis, may cause mild
+        hyperphenylalaninemia with infantile dystonia, young‐onset parkinsonism,
+        developmental delay and cognitive deficits.
+      explanation: Supports infantile dystonia in DNAJC12-related disease.
+  - target: Parkinsonism
+    description: DNAJC12-related monoamine synthesis disease can include young-onset parkinsonism.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/mds.29677
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Recent studies show that pathogenic variants in
+                    DNAJC12
+                    , a co‐chaperone for monoamine synthesis, may cause mild
+        hyperphenylalaninemia with infantile dystonia, young‐onset parkinsonism,
+        developmental delay and cognitive deficits.
+      explanation: Supports young-onset parkinsonism in DNAJC12-related disease.
   evidence:
   - reference: DOI:10.1002/mds.29677
     supports: SUPPORT
@@ -432,6 +499,76 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
   - target: Autonomic Dysfunction
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+  - target: Hypotonia
+    description: Combined monoamine deficiency in AADC deficiency includes early hypotonia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.3390/genes15010134
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Onset is early and the key signs are hypotonia, movement disorders
+        (oculogyric crises, dystonia and hypokinesia), developmental delay and
+        autonomic dysfunction.
+      explanation: Supports hypotonia as a clinical consequence in AADC-related monoamine deficiency.
+  - target: Oculogyric Crisis
+    description: AADC-related monoamine deficiency includes oculogyric crises within its movement-disorder spectrum.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.3390/genes15010134
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Onset is early and the key signs are hypotonia, movement disorders
+        (oculogyric crises, dystonia and hypokinesia), developmental delay and
+        autonomic dysfunction.
+      explanation: Supports oculogyric crises downstream of AADC-related monoamine deficiency.
+  - target: Dystonia
+    description: Catecholamine and monoamine deficiency can manifest as dystonia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.3390/genes15010134
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Onset is early and the key signs are hypotonia, movement disorders
+        (oculogyric crises, dystonia and hypokinesia), developmental delay and
+        autonomic dysfunction.
+      explanation: Supports dystonia as part of the AADC-related monoamine-deficiency movement disorder.
+    - reference: DOI:10.1002/mdc3.14157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Three phenotypes were outlined: (1) early‐infantile encephalopathic
+        phenotype with profound disability (24 of 45 patients), (2)
+        dystonia‐parkinsonism phenotype with infantile/early‐childhood onset of
+        developmental stagnation/regression preceding the emergence of movement
+        disorder (7 of 45), and (3) late‐onset DRD phenotype (14 of 45).
+      explanation: Supports dystonia-parkinsonism in recessive GCH1/BH4 cofactor deficiency.
+  - target: Parkinsonism
+    description: Recessive GCH1/BH4 cofactor deficiency and DNAJC12-related disease can manifest as parkinsonism.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1002/mdc3.14157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Three phenotypes were outlined: (1) early‐infantile encephalopathic
+        phenotype with profound disability (24 of 45 patients), (2)
+        dystonia‐parkinsonism phenotype with infantile/early‐childhood onset of
+        developmental stagnation/regression preceding the emergence of movement
+        disorder (7 of 45), and (3) late‐onset DRD phenotype (14 of 45).
+      explanation: Supports parkinsonism in the dystonia-parkinsonism subgroup of recessive GCH1 deficiency.
+    - reference: DOI:10.1002/mds.29677
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Recent studies show that pathogenic variants in
+                    DNAJC12
+                    , a co‐chaperone for monoamine synthesis, may cause mild
+        hyperphenylalaninemia with infantile dystonia, young‐onset parkinsonism,
+        developmental delay and cognitive deficits.
+      explanation: Supports young-onset parkinsonism in DNAJC12-related monoamine synthesis disease.
   evidence:
   - reference: DOI:10.1002/jimd.12697
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- Add evidence-backed downstream edges from BH4 and DNAJC12 mechanisms to hyperphenylalaninemia and from monoamine deficiency to hypotonia, oculogyric crisis, dystonia, and parkinsonism.
- Strengthen the DNAJC12-to-monoamine-deficiency edge with an explicit intermediate mechanism and human clinical evidence.
- Bring phenotype downstream coverage from 3/8 to 8/8 without adding new references or cache files.

## Validation
- just validate kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
- just validate-terms kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Disorder_of_Catecholamine_Synthesis.yaml
- explicit snippet audit: exact=54 normalized=24 missing=0 no_cache=0
- phenotype downstream audit: 8/8 linked
- git diff --check
- restored recurring unrelated PMID_24904092 / PMID_31292197 cache quote-normalization churn