### PR TITLE
Curate ADK deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/Adenosine_Kinase_Deficiency.yaml
+++ b/kb/disorders/Adenosine_Kinase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Adenosine Kinase Deficiency
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-05-21T00:10:42Z"
+updated_date: "2026-05-21T00:19:32Z"
 category: Mendelian
 description: >-
   Adenosine kinase deficiency is a rare autosomal recessive inborn error of
@@ -197,6 +197,40 @@ pathophysiology:
       explanation: >-
         The human clinical summary lists cardiac defects among the reported
         ADK deficiency manifestations.
+  - target: Short stature
+    description: >-
+      Short stature has been documented on long-term follow-up after liver
+      transplantation in ADK deficiency, with unresolved causal intermediates.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Ten-year follow-up after LTx revealed a preserved good liver function,
+        persistent regenerative macrocytic anemia, progressive neurological
+        disease but disappearance of brain MR changes, short stature, and
+        cortisol deficiency.
+      explanation: >-
+        Long-term human follow-up documents short stature in an ADK-deficient
+        patient after liver transplantation.
+  - target: Cortisol deficiency
+    description: >-
+      Cortisol deficiency has been reported in long-term follow-up, but the
+      connection between ADK loss and adrenal steroid physiology is unresolved.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Ten-year follow-up after LTx revealed a preserved good liver function,
+        persistent regenerative macrocytic anemia, progressive neurological
+        disease but disappearance of brain MR changes, short stature, and
+        cortisol deficiency.
+      explanation: >-
+        Long-term human follow-up documents cortisol deficiency in an
+        ADK-deficient patient.
 - name: Adenosine Accumulation and AMP Depletion
   description: >-
     Excess adenosine and reduced AMP availability alter purine homeostasis,
@@ -296,6 +330,10 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
+  - preferred_term: skeletal muscle cell
+    term:
+      id: CL:0000188
+      label: cell of skeletal muscle
   biological_processes:
   - preferred_term: methionine metabolic process
     term:
@@ -498,12 +536,6 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
-  biological_processes:
-  - preferred_term: glucose homeostasis
-    term:
-      id: GO:0042593
-      label: glucose homeostasis
-    modifier: ABNORMAL
   locations:
   - preferred_term: liver
     term:
@@ -1020,6 +1052,52 @@ phenotypes:
     explanation: >-
       Directly supports delayed brain myelination in a human case with ADK
       deficiency.
+- category: Clinical
+  name: Short stature
+  description: >-
+    Short stature was reported during long-term follow-up after liver
+    transplantation in a patient later diagnosed with ADK deficiency.
+  phenotype_term:
+    preferred_term: Short stature
+    term:
+      id: HP:0004322
+      label: Short stature
+  frequency: OCCASIONAL
+  evidence:
+  - reference: PMID:36589157
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Ten-year follow-up after LTx revealed a preserved good liver function,
+      persistent regenerative macrocytic anemia, progressive neurological
+      disease but disappearance of brain MR changes, short stature, and
+      cortisol deficiency.
+    explanation: >-
+      The long-term follow-up case directly documents short stature in ADK
+      deficiency.
+- category: Clinical
+  name: Cortisol deficiency
+  description: >-
+    Cortisol deficiency was documented during long-term follow-up in a patient
+    with ADK deficiency.
+  phenotype_term:
+    preferred_term: adrenal insufficiency
+    term:
+      id: HP:0000846
+      label: Adrenal insufficiency
+  frequency: OCCASIONAL
+  evidence:
+  - reference: PMID:36589157
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Ten-year follow-up after LTx revealed a preserved good liver function,
+      persistent regenerative macrocytic anemia, progressive neurological
+      disease but disappearance of brain MR changes, short stature, and
+      cortisol deficiency.
+    explanation: >-
+      The long-term follow-up case directly documents cortisol deficiency,
+      mapped to the adrenal insufficiency HPO term.
 biochemical:
 - name: Elevated plasma methionine
   presence: INCREASED

--- a/kb/disorders/Adenosine_Kinase_Deficiency.yaml
+++ b/kb/disorders/Adenosine_Kinase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Adenosine Kinase Deficiency
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-05-21T00:19:32Z"
+updated_date: "2026-05-21T00:27:23Z"
 category: Mendelian
 description: >-
   Adenosine kinase deficiency is a rare autosomal recessive inborn error of
@@ -330,10 +330,6 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
-  - preferred_term: skeletal muscle cell
-    term:
-      id: CL:0000188
-      label: cell of skeletal muscle
   biological_processes:
   - preferred_term: methionine metabolic process
     term:
@@ -477,6 +473,10 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
+  - preferred_term: skeletal muscle cell
+    term:
+      id: CL:0000188
+      label: cell of skeletal muscle
   biological_processes:
   - preferred_term: respiratory electron transport chain
     term:

--- a/kb/disorders/Adenosine_Kinase_Deficiency.yaml
+++ b/kb/disorders/Adenosine_Kinase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Adenosine Kinase Deficiency
 creation_date: "2026-04-16T00:00:00Z"
-updated_date: "2026-05-20T00:44:04Z"
+updated_date: "2026-05-21T00:10:42Z"
 category: Mendelian
 description: >-
   Adenosine kinase deficiency is a rare autosomal recessive inborn error of
@@ -135,6 +135,68 @@ pathophysiology:
         The case report explicitly associates ADK deficiency with
         cerebrovascular abnormalities and stroke, supporting a connected
         vascular branch while leaving the intermediates unspecified.
+  - target: Mitochondrial Respiratory Chain Abnormality
+    description: >-
+      ADK-deficient patients can show combined respiratory-chain complex
+      defects in liver or skeletal muscle, producing a mitochondrial-disease-like
+      energy-stress branch downstream of the primary purine and methionine
+      metabolic defect.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        As the phenotype was consistent with a mitochondrial disorder, we
+        studied liver mitochondrial respiratory chain activities in two
+        patients and revealed a combined defect of several complexes.
+      explanation: >-
+        The patient series reports combined liver respiratory-chain defects in
+        ADK deficiency, supporting a mitochondrial branch while not resolving
+        the intervening molecular steps.
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        A decrease of mitochondrial respiratory chain complex II and III
+        activity were found in the postnuclear supernatants obtained from
+        skeletal muscle biopsy.
+      explanation: >-
+        A later human case documents reduced respiratory-chain complex II and
+        III activity in skeletal muscle.
+  - target: Facial dysmorphism
+    description: >-
+      Dysmorphic facial features are part of the recurrent syndromic phenotype,
+      although the developmental intermediates connecting ADK loss to craniofacial
+      findings are not established.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Adenosine kinase (ADK) deficiency is characterized by liver disease,
+        dysmorphic features, epilepsy and developmental delay.
+      explanation: >-
+        The clinical series identifies dysmorphic features as part of the ADK
+        deficiency phenotype.
+  - target: Cardiac defects
+    description: >-
+      Cardiac abnormalities have been reported in ADK deficiency, but the
+      path from the metabolic defect to cardiac development or function remains
+      unresolved.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by developmental delay, hypotonia, epilepsy,
+        facial dysmorphism, failure to thrive, transient liver dysfunction
+        with cholestasis, recurrent hypoglycemia, and cardiac defects.
+      explanation: >-
+        The human clinical summary lists cardiac defects among the reported
+        ADK deficiency manifestations.
 - name: Adenosine Accumulation and AMP Depletion
   description: >-
     Excess adenosine and reduced AMP availability alter purine homeostasis,
@@ -350,6 +412,83 @@ pathophysiology:
       explanation: >-
         The case report biochemically confirms elevated S-adenosylhomocysteine
         in ADK deficiency.
+  - target: Macrocytic anemia
+    description: >-
+      Macrocytic anemia has been documented with the ADK transmethylation
+      phenotype, including persistence after liver transplantation, but the
+      causal intermediates remain unresolved.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36589157
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Six-month-old patient presented with cholestatic liver disease,
+        macrocytic anemia, developmental delay, generalized hypotonia,
+        delayed brain myelination, and elevated levels of serum methionine.
+      explanation: >-
+        The case report places macrocytic anemia in the same ADK deficiency
+        presentation as elevated methionine and cholestatic liver disease.
+- name: Mitochondrial Respiratory Chain Abnormality
+  description: >-
+    ADK deficiency can secondarily reduce mitochondrial respiratory-chain
+    activity in liver or skeletal muscle, with reported combined liver complex
+    defects and reduced complex II/III activity in skeletal muscle.
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  biological_processes:
+  - preferred_term: respiratory electron transport chain
+    term:
+      id: GO:0022904
+      label: respiratory electron transport chain
+    modifier: DECREASED
+  - preferred_term: oxidative phosphorylation
+    term:
+      id: GO:0006119
+      label: oxidative phosphorylation
+    modifier: DECREASED
+  evidence:
+  - reference: PMID:33309011
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      As the phenotype was consistent with a mitochondrial disorder, we
+      studied liver mitochondrial respiratory chain activities in two
+      patients and revealed a combined defect of several complexes.
+    explanation: >-
+      Human liver tissue testing showed combined mitochondrial respiratory-chain
+      defects in ADK deficiency.
+  - reference: PMID:36589157
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      A decrease of mitochondrial respiratory chain complex II and III
+      activity were found in the postnuclear supernatants obtained from
+      skeletal muscle biopsy.
+    explanation: >-
+      A later human case supports reduced respiratory-chain complex activity in
+      skeletal muscle.
+  downstream:
+  - target: Hepatic Dysfunction and Cholestasis
+    description: >-
+      Respiratory-chain defects in liver tissue are part of the
+      mitochondrial-disease-like presentation accompanying ADK-related neonatal
+      liver disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33309011
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        We report the clinical, histological and biochemical courses of three
+        ADK children carrying two new mutations and presenting with neonatal
+        cholestasis and neurological disorders.
+      explanation: >-
+        The same case series that documents liver respiratory-chain defects
+        reports neonatal cholestasis in ADK-deficient children.
 - name: Hepatic Dysfunction and Cholestasis
   description: >-
     Patients may present with neonatal jaundice, cholestasis, transaminase
@@ -359,6 +498,12 @@ pathophysiology:
     term:
       id: CL:0000182
       label: hepatocyte
+  biological_processes:
+  - preferred_term: glucose homeostasis
+    term:
+      id: GO:0042593
+      label: glucose homeostasis
+    modifier: ABNORMAL
   locations:
   - preferred_term: liver
     term:
@@ -407,6 +552,39 @@ pathophysiology:
       explanation: >-
         The clinical summary directly links the hepatic disease component to
         cholestasis.
+  - target: Hypoglycemia
+    description: >-
+      Recurrent hypoglycemia occurs as part of the liver-centered metabolic
+      phenotype in ADK deficiency.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by developmental delay, hypotonia, epilepsy,
+        facial dysmorphism, failure to thrive, transient liver dysfunction
+        with cholestasis, recurrent hypoglycemia, and cardiac defects.
+      explanation: >-
+        The clinical summary reports recurrent hypoglycemia alongside transient
+        liver dysfunction with cholestasis in ADK deficiency.
+  - target: Failure to Thrive
+    description: >-
+      Failure to thrive is reported in the same infantile multisystem metabolic
+      presentation as hepatic dysfunction and recurrent hypoglycemia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34765398
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by developmental delay, hypotonia, epilepsy,
+        facial dysmorphism, failure to thrive, transient liver dysfunction
+        with cholestasis, recurrent hypoglycemia, and cardiac defects.
+      explanation: >-
+        The human clinical summary includes failure to thrive in the ADK
+        deficiency presentation that also includes liver dysfunction and
+        hypoglycemia.
 - name: Neurodevelopmental Impairment and Seizures
   description: >-
     ADK deficiency causes hypotonia, global developmental delay, epilepsy,
@@ -848,6 +1026,11 @@ biochemical:
   context: >-
     Plasma methionine is a high-signal diagnostic biochemical readout of ADK
     deficiency and distinguishes it from nonspecific liver disease.
+  biomarker_term:
+    preferred_term: L-methionine
+    term:
+      id: CHEBI:16643
+      label: L-methionine
   readouts:
   - target: Transmethylation Cycle Disruption and Hypermethioninemia
     relationship: READOUT_OF
@@ -890,6 +1073,11 @@ biochemical:
   context: >-
     S-adenosylhomocysteine elevation provides a more specific
     transmethylation-cycle readout alongside hypermethioninemia.
+  biomarker_term:
+    preferred_term: S-adenosyl-L-homocysteine
+    term:
+      id: CHEBI:16680
+      label: S-adenosyl-L-homocysteine
   readouts:
   - target: Transmethylation Cycle Disruption and Hypermethioninemia
     relationship: READOUT_OF
@@ -916,6 +1104,47 @@ biochemical:
     explanation: >-
       The case report directly supports elevated S-adenosylhomocysteine in
       ADK deficiency.
+- name: Normal plasma homocysteine
+  presence: NORMAL
+  context: >-
+    Normal homocysteine paired with elevated methionine helps define the ADK
+    biochemical pattern and distinguishes it from hyperhomocysteinemic
+    methionine-cycle disorders.
+  biomarker_term:
+    preferred_term: homocysteine
+    term:
+      id: CHEBI:17230
+      label: homocysteine
+  readouts:
+  - target: Transmethylation Cycle Disruption and Hypermethioninemia
+    relationship: READOUT_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: >-
+      Normal homocysteine is part of the diagnostic biochemical signature when
+      interpreted together with elevated methionine.
+    evidence:
+    - reference: PMID:30477030
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Biochemically, methionine is elevated with normal homocysteine levels
+        and the diagnosis is confirmed through molecular analysis of the ADK
+        gene.
+      explanation: >-
+        The review explicitly states the elevated-methionine, normal-
+        homocysteine biochemical pattern.
+  evidence:
+  - reference: PMID:30477030
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: >-
+      Biochemically, methionine is elevated with normal homocysteine levels
+      and the diagnosis is confirmed through molecular analysis of the ADK
+      gene.
+    explanation: >-
+      The review confirms normal homocysteine as part of the ADK deficiency
+      biochemical profile.
 genetic:
 - name: ADK
   gene_term:


### PR DESCRIPTION
## Summary
- Connect ADK deficiency phenotype coverage from 7/12 to 14/14 downstream-supported phenotypes.
- Add a mitochondrial respiratory-chain abnormality branch with GO coverage for respiratory electron transport chain and oxidative phosphorylation.
- Connect failure to thrive, hypoglycemia, facial dysmorphism, cardiac defects, macrocytic anemia, short stature, and cortisol deficiency with conservative evidence-backed downstream edges.
- Strengthen biochemical biomarkers with CHEBI-backed methionine, S-adenosyl-L-homocysteine, and normal homocysteine readouts.
- Address Claude nonblocking suggestions by removing the physiological-level glucose-homeostasis GO term and adding skeletal muscle cell context.

## Validation
- `just validate kb/disorders/Adenosine_Kinase_Deficiency.yaml` passed.
- `just validate-terms kb/disorders/Adenosine_Kinase_Deficiency.yaml` passed.
- `uv run python -m dismech.graph --validate kb/disorders/Adenosine_Kinase_Deficiency.yaml` passed.
- `git diff --check` passed.
- Explicit snippet audit: `evidence_with_snippets=77 exact=8 normalized=69 missing=0 no_cache=0`.
- Phenotype downstream audit: `14/14 linked`; unlinked: none.

## Scope
- Only `kb/disorders/Adenosine_Kinase_Deficiency.yaml` is intentionally changed.
- Restored unrelated validation cache churn before commit.