### PR TITLE
Curate 3-MCCD pathograph connectivity

### DIFF
--- a/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
+++ b/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 3-Methylcrotonyl-CoA Carboxylase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-21T00:37:32Z'
+updated_date: '2026-05-21T00:45:28Z'
 synonyms:
 - 3-MCC deficiency
 - 3-MCCD
@@ -729,7 +729,7 @@ phenotypes:
   frequency: OCCASIONAL
   description: Cerebral vascular abnormalities are occasional manifestations listed by Orphanet.
   phenotype_term:
-    preferred_term: Abnormality of the cerebral vasculature
+    preferred_term: Abnormal cerebral vascular morphology
     term:
       id: HP:0100659
       label: Abnormal cerebral vascular morphology

--- a/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
+++ b/kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 3-Methylcrotonyl-CoA Carboxylase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-20T09:52:43Z'
+updated_date: '2026-05-21T00:37:32Z'
 synonyms:
 - 3-MCC deficiency
 - 3-MCCD
@@ -401,6 +401,60 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "underwent dramatic developmental regression at 11 months of age, following a respiratory tract infection."
       explanation: Case-report abstract links respiratory infection-triggered illness with developmental regression.
+  - target: Hypotonia
+    description: >
+      Hypotonia is a frequent neurologic manifestation reported for 3-MCCD, but
+      the causal route from decompensation or leucine-catabolic failure to
+      persistent tone abnormality is not resolved and may vary between patients.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001252 | Hypotonia | Very frequent (99-80%)"
+      explanation: Orphanet lists hypotonia as a very frequent 3-MCCD phenotype.
+    - reference: PMID:25356967
+      reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "nonspecific symptoms such as developmental delay, failure to thrive, hemiparesis, muscular hypotonia, and"
+      explanation: Human clinical review text includes muscular hypotonia among nonspecific symptoms historically attributed to MCCD, supporting a cautious unknown-intermediate edge.
+  - target: Failure to thrive in infancy
+    description: >
+      Failure to thrive in infancy is reported in 3-MCCD, but published data
+      emphasize variable expressivity and uncertain attribution for some
+      nonspecific growth features.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001531 | Failure to thrive in infancy | Frequent (79-30%)"
+      explanation: Orphanet lists failure to thrive in infancy as a frequent 3-MCCD phenotype.
+    - reference: PMID:25356967
+      reference_title: "Consanguinity and rare mutations outside of MCCC genes underlie nonspecific phenotypes of MCCD."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "nonspecific symptoms such as developmental delay, failure to thrive, hemiparesis, muscular hypotonia, and"
+      explanation: Clinical review text includes failure to thrive among nonspecific symptoms attributed to MCCD, supporting a conservative uncertain-attribution edge.
+  - target: Respiratory insufficiency
+    description: >
+      Respiratory insufficiency is an occasional reported manifestation in the
+      clinical spectrum of 3-MCCD metabolic crisis, but disease-specific
+      intermediates are not established.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002093 | Respiratory insufficiency | Occasional (29-5%)"
+      explanation: Orphanet lists respiratory insufficiency as an occasional 3-MCCD phenotype.
+    - reference: PMID:22642865
+      reference_title: "3-methylcrotonyl-CoA carboxylase deficiency: clinical, biochemical, enzymatic and molecular studies in 88 individuals."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "may lead to a severe clinical phenotype resembling classical organic acidurias."
+      explanation: Cohort conclusion supports severe organic-aciduria-like clinical crises in a subset of patients.
 - name: Secondary mitochondrial dysfunction and oxidative stress
   description: >
     Patient-derived MCC-deficient fibroblasts show transcriptional and
@@ -417,6 +471,10 @@ pathophysiology:
     term:
       id: GO:0006979
       label: response to oxidative stress
+  - preferred_term: oxidative phosphorylation
+    term:
+      id: GO:0006119
+      label: oxidative phosphorylation
   cell_types:
   - preferred_term: fibroblast
     term:
@@ -440,6 +498,55 @@ pathophysiology:
     evidence_source: IN_VITRO
     snippet: "genes of the glycolysis, the TCA cycle, OXPHOS, gluconeogenesis, β-oxidation and"
     explanation: Supports oxidative stress and energy pathway disruption downstream of MCC deficiency.
+  downstream:
+  - target: Abnormality of movement
+    description: >
+      Movement abnormalities are reported in 3-MCCD. Secondary mitochondrial
+      dysfunction and energy-homeostasis disruption provide a plausible cellular
+      stress branch, but the disease-specific causal path is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100022 | Abnormality of movement | Frequent (79-30%)"
+      explanation: Orphanet lists movement abnormality as a frequent 3-MCCD phenotype.
+    - reference: PMID:27417235
+      reference_title: "A 3-methylcrotonyl-CoA carboxylase deficient human skin fibroblast transcriptome reveals underlying mitochondrial dysfunction and oxidative stress."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "oxidative stress might impact adversely on the quality of life and energy levels"
+      explanation: Patient-derived fibroblast data support secondary energy stress that may contribute to neurologic vulnerability, while leaving patient-level motor intermediates unresolved.
+  - target: Spasticity
+    description: >
+      Spasticity is an occasional neurologic manifestation reported for 3-MCCD;
+      current evidence does not define a specific causal route from the MCC
+      block to pyramidal motor findings.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001257 | Spasticity | Occasional (29-5%)"
+      explanation: Orphanet lists spasticity as an occasional 3-MCCD phenotype.
+    - reference: PMID:27417235
+      reference_title: "A 3-methylcrotonyl-CoA carboxylase deficient human skin fibroblast transcriptome reveals underlying mitochondrial dysfunction and oxidative stress."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "hallmark of mitochondrial dysfunction, decreased antioxidant response and disruption of energy homeostasis"
+      explanation: Secondary mitochondrial dysfunction and energy disruption support a plausible but unresolved neurologic stress branch.
+  - target: Abnormal cerebral vascular morphology
+    description: >
+      Cerebral vascular morphology abnormalities are occasional reported
+      features in Orphanet; the relation to MCC deficiency or secondary cellular
+      stress is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: ORPHA:6
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100659 | Abnormality of the cerebral vasculature | Occasional (29-5%)"
+      explanation: Orphanet lists abnormality of the cerebral vasculature as an occasional 3-MCCD phenotype.
 phenotypes:
 - name: Hypotonia
   frequency: VERY_FREQUENT


### PR DESCRIPTION
## Summary
- Connect 3-MCCD phenotype downstream coverage from 8/14 to 14/14.
- Add conservative downstream edges for hypotonia, failure to thrive in infancy, respiratory insufficiency, movement abnormality, spasticity, and cerebral vascular morphology.
- Keep uncertain/nonspecific phenotype links marked with `UNKNOWN` causal directness where the literature warns attribution to MCC deficiency is unresolved.
- Add oxidative phosphorylation GO coverage to the secondary mitochondrial dysfunction/oxidative stress branch.

## Validation
- `just validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml` passed.
- `just validate-terms kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml` passed.
- `uv run python -m dismech.graph --validate kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml` passed.
- `git diff --check` passed.
- Explicit snippet audit: `evidence_with_snippets=77 exact=61 normalized=16 missing=0 no_cache=0`.
- Phenotype downstream audit: `14/14 linked`; unlinked: none.

## Scope
- Only `kb/disorders/3-Methylcrotonyl-CoA_Carboxylase_Deficiency.yaml` is intentionally changed.
- Restored unrelated validation cache churn before commit.
