### PR TITLE
Curate MCAD deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/MCAD_Deficiency.yaml
+++ b/kb/disorders/MCAD_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Medium Chain Acyl-CoA Dehydrogenase Deficiency
 creation_date: '2026-02-06T03:39:54Z'
-updated_date: '2026-05-19T21:23:48Z'
+updated_date: '2026-05-21T00:54:43Z'
 category: Genetic
 synonyms:
 - MCAD deficiency
@@ -314,6 +314,24 @@ pathophysiology:
         Metabolic decompensation during these episodes can result in elevated
         liver transaminases and hyperammonemia.
       explanation: GeneReviews directly links metabolic decompensation episodes to hyperammonemia.
+  - target: Hepatomegaly
+    description: >
+      Acute MCAD decompensation can include hepatomegaly as part of the hepatic
+      crisis phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - acute hepatic energy failure during fasting or illness
+    evidence:
+    - reference: PMID:11263545
+      reference_title: "Medium chain acyl-CoA dehydrogenase deficiency human genome epidemiology review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Clinical data on the probability of clinical disease indicates that
+        MCADD patients are at risk for the following outcomes: hypoglycemia,
+        vomiting, lethargy, encephalopathy, respiratory arrest, hepatomegaly,
+        seizures, apnea, cardiac arrest, coma, and sudden and unexpected death.
+      explanation: Human clinical data list hepatomegaly among MCAD deficiency outcomes.
   - target: Chronic myopathy
     description: Uncontrolled metabolic decompensation can leave chronic skeletal-muscle sequelae.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -404,6 +422,21 @@ pathophysiology:
         seizures, apnea, cardiac arrest, coma, and sudden and unexpected death.
       explanation: >-
         Human clinical data identify coma as an MCAD deficiency outcome.
+  - target: Reye-like syndrome
+    description: >
+      Acute MCAD decompensation may resemble Reye syndrome, historically leading
+      to diagnostic confusion with Reye's syndrome or sudden infant death.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:3054550
+      reference_title: "Medium-chain acyl-CoA dehydrogenase deficiency. Diagnosis by stable-isotope dilution measurement of urinary n-hexanoylglycine and 3-phenylpropionylglycine."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Medium-chain acyl-CoA dehydrogenase (MCAD) deficiency, one of the most
+        common inherited metabolic disorders, is often mistaken for the sudden
+        infant death syndrome or Reye's syndrome.
+      explanation: The clinical diagnostic paper documents Reye syndrome as a historical MCAD deficiency mimic.
   - target: Sudden unexpected death
     description: Untreated acute metabolic crises can be fatal.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -591,6 +624,71 @@ pathophysiology:
     explanation: >-
       Supports destabilization of respiratory-chain complexes and
       supercomplexes downstream of MCAD loss.
+  downstream:
+  - target: Global developmental delay
+    description: >
+      Developmental disability is reported as a long-term outcome in MCAD
+      deficiency, but the disease-specific route from acute energy failure,
+      secondary OXPHOS dysfunction, or other modifiers to developmental delay is
+      not fully resolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:11263545
+      reference_title: "Medium chain acyl-CoA dehydrogenase deficiency human genome epidemiology review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Long-term outcomes include developmental and behavioral disability,
+        chronic muscle weakness, failure to thrive, cerebral palsy, and
+        attention deficit disorder (ADD).
+      explanation: Human epidemiology review lists developmental disability among long-term MCAD outcomes.
+    - reference: PMID:20301597
+      reference_title: "Medium-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Standard treatment for developmental delay / aphasia,
+        attention-deficit/hyperactivity disorder, and muscle weakness.
+      explanation: GeneReviews lists developmental delay among MCAD-associated manifestations requiring standard treatment.
+  - target: Expressive language delay
+    description: >
+      Aphasia or language involvement is listed among manifestations requiring
+      standard treatment in MCAD deficiency; the causal path is modeled
+      conservatively because the specific intermediary mechanism is unresolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:20301597
+      reference_title: "Medium-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Standard treatment for developmental delay / aphasia,
+        attention-deficit/hyperactivity disorder, and muscle weakness.
+      explanation: GeneReviews lists aphasia among MCAD-associated manifestations requiring standard treatment.
+  - target: Attention deficit hyperactivity disorder
+    description: >
+      Attention-deficit/hyperactivity disorder is a reported long-term
+      neurobehavioral association in MCAD deficiency, but the mechanism is not
+      resolved.
+    causal_link_type: UNKNOWN
+    evidence:
+    - reference: PMID:11263545
+      reference_title: "Medium chain acyl-CoA dehydrogenase deficiency human genome epidemiology review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Long-term outcomes include developmental and behavioral disability,
+        chronic muscle weakness, failure to thrive, cerebral palsy, and
+        attention deficit disorder (ADD).
+      explanation: Human epidemiology review lists attention deficit disorder among long-term MCAD outcomes.
+    - reference: PMID:20301597
+      reference_title: "Medium-Chain Acyl-Coenzyme A Dehydrogenase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Standard treatment for developmental delay / aphasia,
+        attention-deficit/hyperactivity disorder, and muscle weakness.
+      explanation: GeneReviews lists ADHD among MCAD-associated manifestations requiring standard treatment.
 phenotypes:
 - name: Hypoketotic hypoglycemia
   frequency: FREQUENT


### PR DESCRIPTION
## Summary
- Connect MCAD deficiency phenotype downstream coverage from 10/15 to 15/15.
- Add downstream support for hepatomegaly and Reye-like syndrome as acute decompensation/hepatic crisis manifestations.
- Add conservative `UNKNOWN` downstream links for developmental delay, expressive language delay, and ADHD as long-term neurodevelopmental/neurobehavioral associations with unresolved intermediates.
- Keep existing biochemical biomarker coverage intact; no cache files intentionally changed.

## Validation
- `just validate kb/disorders/MCAD_Deficiency.yaml` passed.
- `just validate-terms kb/disorders/MCAD_Deficiency.yaml` passed.
- `uv run python -m dismech.graph --validate kb/disorders/MCAD_Deficiency.yaml` passed.
- `git diff --check` passed.
- Explicit snippet audit: `evidence_with_snippets=84 exact=19 normalized=65 missing=0 no_cache=0`.
- Phenotype downstream audit: `15/15 linked`; unlinked: none.

## Scope
- Only `kb/disorders/MCAD_Deficiency.yaml` is intentionally changed.
- Restored unrelated validation cache churn before commit.
