### PR TITLE
Connect arginase deficiency phenotype edges

### DIFF
--- a/kb/disorders/Arginase_Deficiency.yaml
+++ b/kb/disorders/Arginase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Arginase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-19T19:15:02Z'
+updated_date: '2026-05-21T01:27:40Z'
 synonyms:
 - Argininemia
 - Hyperargininemia
@@ -231,6 +231,30 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: infrequent episodes of hyperammonemia
       explanation: Supports hyperammonemia as a downstream phenotype, while preserving its lower frequency in ARG1-D.
+  - target: Encephalopathy
+    description: In severe ARG1-D, intermittent hyperammonemia can progress to acute hyperammonemic coma, captured clinically as encephalopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired ureagenesis
+    - hyperammonemia
+    - hyperammonemic coma
+    evidence:
+    - reference: PMID:41684183
+      reference_title: "Cluster of Severe Arginase 1 Deficiency in the Comoros: Clinical, Neuroimaging, and Molecular Features in 17 Patients From Mayotte Compared With 10 From Paris."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The main clinical features at diagnosis included hyperammonemic coma (with or without liver failure) and neurodevelopmental delay with spastic diplegia.
+      explanation: Severe human ARG1-D cohort evidence supports acute hyperammonemic coma as a downstream manifestation of impaired nitrogen disposal.
+  - target: Growth retardation
+    description: Persistent hyperargininemia in ARG1-D is associated with chronic growth failure in the core clinical syndrome.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26467175
+      reference_title: "Arginase-1 deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: ARG1-deficient patients exhibit hyperargininemia with spastic paraparesis, progressive neurological and intellectual impairment, persistent growth retardation, and infrequent episodes of hyperammonemia
+      explanation: Review of human ARG1-deficient patients links hyperargininemia with persistent growth retardation as part of the characteristic clinical pattern.
   - target: Neurotoxicity from guanidino compound accumulation
     description: Chronic arginine, ammonia, and guanidino-compound accumulation acts as neurotoxic exposure.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES


### PR DESCRIPTION
## Summary
- connect the remaining unlinked Arginase Deficiency phenotypes to the impaired ureagenesis/hyperargininemia mechanism
- add an encephalopathy edge through intermittent hyperammonemia/hyperammonemic coma using severe cohort evidence
- add a growth-retardation edge using existing human ARG1-D review evidence

## Validation
- `just validate kb/disorders/Arginase_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Arginase_Deficiency.yaml`
- `git diff --check`
- normalized local snippet audit: 78 cached snippets checked; 0 skipped
- phenotype downstream coverage: 12/12

## Scope
- `kb/disorders/Arginase_Deficiency.yaml` only
