### PR TITLE
Connect hypophosphatasia biomarkers and symptoms

### DIFF
--- a/kb/disorders/Hypophosphatasia.yaml
+++ b/kb/disorders/Hypophosphatasia.yaml
@@ -1,6 +1,6 @@
 name: Hypophosphatasia
 creation_date: '2026-02-13T00:31:42Z'
-updated_date: "2026-05-05T06:00:31Z"
+updated_date: "2026-05-21T01:39:26Z"
 category: Mendelian
 description: >
   Hypophosphatasia (HPP) is a rare inherited metabolic bone disease caused by
@@ -239,6 +239,17 @@ pathophysiology:
       snippet: >-
         PP(i) excesses cause chondrocalcinosis and sometimes arthropathy.
       explanation: Review directly links PPi excess to chondrocalcinosis and arthropathy.
+  - target: Fatigue
+    description: Chronic HPP can include fatigue as part of the broader non-skeletal adult disease burden; the biochemical-to-fatigue intermediate remains uncertain.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1007/s11914-025-00906-5
+      reference_title: "Medical Management of Hypophosphatasia: Review of Data on Asfotase Alfa"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        non-skeletal impairments, such as pain and chronic fatigue.
+      explanation: Review evidence from Global HPP Registry data supports chronic fatigue as a recognized non-skeletal HPP impairment.
 - name: Skeletal and dentoalveolar mineralization failure
   description: >
     Excess PPi inhibits hydroxyapatite crystal growth after matrix vesicle
@@ -297,6 +308,18 @@ pathophysiology:
   - target: Fractures
     description: Osteomalacia and impaired mineralization increase fracture and pseudofracture risk.
     causal_link_type: DIRECT
+  - target: Muscle Weakness
+    description: Adult and severe HPP musculoskeletal disease includes muscle weakness, though the exact intermediate between mineralization failure and weakness is not fully resolved.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:34884378
+      reference_title: "Hypophosphatasia."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        recurrent, poorly healing fractures, muscle weakness and arthropathy are
+        common in adults.
+      explanation: Review evidence supports muscle weakness as part of the adult HPP musculoskeletal phenotype.
   - target: Craniosynostosis
     description: Craniosynostosis is a severe skeletal manifestation of HPP, though the exact local mechanism is not fully resolved.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -693,6 +716,12 @@ biochemical:
   context: >
     Persistently low serum alkaline phosphatase activity is the cardinal
     diagnostic biochemical marker of HPP and reflects deficient TNAP activity.
+  readouts:
+  - target: ALPL loss of function and TNAP deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Persistently low serum ALP reports deficient TNAP enzymatic activity.
   evidence:
   - reference: PMID:34884378
     reference_title: "Hypophosphatasia."
@@ -715,6 +744,12 @@ biochemical:
   context: >
     Elevated inorganic pyrophosphate is a diagnostic TNAP substrate and the
     central inhibitor of hydroxyapatite crystal growth.
+  readouts:
+  - target: TNAP substrate accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated PPi reports impaired TNAP pyrophosphatase activity and substrate accumulation.
   evidence:
   - reference: DOI:10.1007/s00223-025-01356-y
     reference_title: "Diagnosis and Treatment of Hypophosphatasia"
@@ -738,6 +773,12 @@ biochemical:
   context: >
     Elevated plasma PLP reflects impaired TNAP-mediated vitamin B6 metabolism
     and supports the seizure branch in severe infantile disease.
+  readouts:
+  - target: TNAP substrate accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated PLP reports impaired TNAP-mediated dephosphorylation of vitamin B6 substrate.
   evidence:
   - reference: DOI:10.1007/s00223-025-01356-y
     reference_title: "Diagnosis and Treatment of Hypophosphatasia"
@@ -761,6 +802,12 @@ biochemical:
   context: >
     Urinary phosphoethanolamine is an additional ALP substrate that can be
     elevated in HPP and used as part of the diagnostic biochemical pattern.
+  readouts:
+  - target: TNAP substrate accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urine PEA reports accumulation of ALP substrates downstream of TNAP deficiency.
   evidence:
   - reference: DOI:10.1007/s00223-025-01356-y
     reference_title: "Diagnosis and Treatment of Hypophosphatasia"


### PR DESCRIPTION
## Summary
- connect the remaining unlinked hypophosphatasia phenotypes (`Muscle Weakness`, `Fatigue`) with conservative unknown-intermediate edges
- add diagnostic readout links for low serum ALP, PPi, PLP, and urine PEA
- keep the PR scoped to the single disorder YAML

## Validation
- `just validate kb/disorders/Hypophosphatasia.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Hypophosphatasia.yaml`
- `git diff --check`
- normalized local snippet audit: 60 cached snippets checked; 0 skipped
- phenotype downstream coverage: 13/13
- biochemical readouts: 4/4

## Scope
- `kb/disorders/Hypophosphatasia.yaml` only
