### PR TITLE
Connect citrin deficiency neurologic edges

### DIFF
--- a/kb/disorders/Citrin_Deficiency.yaml
+++ b/kb/disorders/Citrin_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Citrin Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-08T14:15:06Z'
+updated_date: '2026-05-21T01:51:05Z'
 synonyms:
 - SLC25A13 deficiency
 - Citrullinemia type II
@@ -267,6 +267,32 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "in adults as recurrent hyperammonemia with neuropsychiatric \nsymptoms in citrullinemia type II (CTLN2)."
       explanation: GeneReviews directly links the adult CTLN2 presentation with recurrent hyperammonemia.
+  - target: Encephalopathy
+    description: Recurrent hyperammonemia in CTLN2 produces neuropsychiatric and neurologic manifestations captured as hyperammonemic encephalopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - ammonia neurotoxicity
+    - cerebral metabolic stress
+    evidence:
+    - reference: PMID:20301360
+      reference_title: "Citrin Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Clinical manifestations include recurrent hyperammonemia with \nneuropsychiatric (aggression, irritability, restlessness, hyperactivity, \ndelusions, nocturnal delirium) and neurologic manifestations"
+      explanation: GeneReviews links recurrent hyperammonemia to neuropsychiatric and neurologic CTLN2 manifestations.
+  - target: Seizures
+    description: Severe CTLN2 hyperammonemic neurologic episodes can include convulsive seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - hyperammonemic encephalopathy
+    - lowered seizure threshold
+    evidence:
+    - reference: PMID:20301360
+      reference_title: "Citrin Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "memory loss, disorientation, drowsiness, convulsive seizures, coma"
+      explanation: GeneReviews directly lists convulsive seizures among CTLN2 neurologic manifestations.
   - target: Ammonia
     description: Impaired ureagenesis raises blood or plasma ammonia concentration.
     causal_link_type: DIRECT
@@ -764,6 +790,12 @@ biochemical:
   context: 'Elevated plasma citrulline is the hallmark biochemical marker, reflecting impaired ASS1 activity due to limited cytosolic aspartate and ATP. Citrulline elevation is used in newborn screening, though levels can be borderline or normal on dried blood spots, potentially causing false negatives.
 
     '
+  readouts:
+  - target: Impaired urea cycle and ammonia detoxification
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated citrulline reports impaired ASS1 flux from limited cytosolic aspartate in citrin deficiency.
   evidence:
   - reference: PMID:20301360
     reference_title: "Citrin Deficiency."
@@ -776,6 +808,12 @@ biochemical:
   context: 'Plasma ammonia is elevated during hyperammonemic episodes, particularly in CTLN2. A distinctive feature is that plasma glutamine is often not elevated despite hyperammonemia, reflecting impaired glutamine synthetase function.
 
     '
+  readouts:
+  - target: Impaired urea cycle and ammonia detoxification
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated ammonia reports impaired hepatic nitrogen disposal and hyperammonemic CTLN2 episodes.
   evidence:
   - reference: PMID:20301360
     reference_title: "Citrin Deficiency."
@@ -788,6 +826,12 @@ biochemical:
   context: 'Conjugated (direct) hyperbilirubinemia is a key laboratory finding in NICCD, reflecting intrahepatic cholestasis. Liver function tests are abnormal in the neonatal period.
 
     '
+  readouts:
+  - target: Neonatal cholestatic hepatopathy
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated conjugated bilirubin reports the neonatal cholestatic hepatopathy branch.
   evidence:
   - reference: PMID:17982687
     reference_title: "Six cases of citrin deficiency in Korea."
@@ -800,6 +844,12 @@ biochemical:
   context: 'A distinctive feature of citrin deficiency is that plasma glutamine is often not elevated despite hyperammonemia, in contrast to other urea cycle disorders. This reflects impaired glutamine synthetase activity due to glutamate and ATP substrate deficiency.
 
     '
+  readouts:
+  - target: Impaired urea cycle and ammonia detoxification
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low or inappropriately normal plasma glutamine reports impaired glutamine-synthetase-dependent ammonia detoxification.
   evidence:
   - reference: PMID:29651749
     reference_title: "Medium-chain triglycerides supplement therapy with a low-carbohydrate formula can supply energy and enhance ammonia detoxification in the hepatocytes of patients with adult-onset type II citrullinemia."
@@ -815,6 +865,12 @@ biochemical:
   context: 'Elevated AST and ALT are observed during the NICCD stage, reflecting hepatocellular injury from cholestatic hepatitis. Levels typically normalize after resolution of NICCD with dietary management.
 
     '
+  readouts:
+  - target: Neonatal cholestatic hepatopathy
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated transaminases report hepatocellular injury in the neonatal cholestatic hepatopathy stage.
   evidence:
   - reference: PMID:17982687
     reference_title: "Six cases of citrin deficiency in Korea."


### PR DESCRIPTION
## Summary
- connect CTLN2 neurologic phenotypes (`Encephalopathy`, `Seizures`) downstream of impaired urea-cycle/ammonia detoxification
- add diagnostic readout links for citrulline, ammonia, conjugated bilirubin, plasma glutamine, and transaminases
- keep the PR scoped to the single disorder YAML

## Validation
- `just validate kb/disorders/Citrin_Deficiency.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Citrin_Deficiency.yaml`
- `git diff --check`
- normalized local snippet audit: 75 cached snippets checked; 0 skipped
- phenotype downstream coverage: 14/14
- biochemical readouts: 5/5

## Scope
- `kb/disorders/Citrin_Deficiency.yaml` only
