### PR TITLE
Improve CPS1 pathograph connectivity

### DIFF
--- a/kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml
+++ b/kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carbamoyl Phosphate Synthetase I Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T02:28:08Z'
+updated_date: '2026-05-21T02:02:57Z'
 synonyms:
 - CPS1 deficiency
 - CPS1D
@@ -274,6 +274,16 @@ pathophysiology:
       evidence_source: OTHER
       snippet: When presenting in the neonatal period, typically after a variable symptom-free interval, UCDs are characterized by overwhelming illness that rapidly progresses from poor feeding, vomiting, lethargy and/or irritability to coma and/or death
       explanation: UCD review supports lethargy as part of neonatal hyperammonemic deterioration.
+  - target: Hypotonia
+    description: Hyperammonemic metabolic crises can manifest with reduced muscle tone as part of acute neonatal neurologic decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:25875215
+      reference_title: "The phenotypic spectrum of organic acidurias and urea cycle disorders. Part 1: the initial presentation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: vomiting and/or muscular hypotonia. Neonatal onset of symptoms was most frequent in argininosuccinic synthetase and lyase deficiency and carbamylphosphate 1 synthetase deficiency
+      explanation: The E-IMD patient registry reports muscular hypotonia during acute OAD/UCD metabolic crises and identifies carbamylphosphate 1 synthetase deficiency among disorders with frequent neonatal onset.
   - target: Vomiting
     description: Vomiting is part of the acute systemic presentation of neonatal urea-cycle decompensation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -497,11 +507,18 @@ phenotypes:
     term:
       id: HP:0001252
       label: Hypotonia
+  evidence:
+  - reference: PMID:25875215
+    reference_title: "The phenotypic spectrum of organic acidurias and urea cycle disorders. Part 1: the initial presentation."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: vomiting and/or muscular hypotonia. Neonatal onset of symptoms was most frequent in argininosuccinic synthetase and lyase deficiency and carbamylphosphate 1 synthetase deficiency
+    explanation: Human registry data list muscular hypotonia during acute OAD/UCD metabolic crises and name carbamylphosphate 1 synthetase deficiency among disorders with frequent neonatal onset.
   notes: >
-    Hypotonia is retained as a neonatal neurologic sign for CPS1D/urea-cycle
-    crisis curation. The locally cached CPS1D abstracts support neonatal
-    hyperammonemic neurologic deterioration, but do not contain an exact
-    quotable sentence naming hypotonia.
+    The disease-specific CPS1D abstracts support neonatal hyperammonemic
+    neurologic deterioration, while the broader E-IMD OAD/UCD registry abstract
+    provides the exact quotable support for muscular hypotonia during acute
+    metabolic crises.
 - name: Vomiting
   description: 'Recurrent vomiting occurs during metabolic decompensation episodes, often triggered by catabolic stress such as infection or dehydration.
 

--- a/references_cache/PMID_25875215.md
+++ b/references_cache/PMID_25875215.md
@@ -1,0 +1,215 @@
+---
+reference_id: "PMID:25875215"
+title: "The phenotypic spectrum of organic acidurias and urea cycle disorders. Part 1: the initial presentation."
+authors:
+- Kölker S
+- Garcia-Cazorla A
+- Valayannopoulos V
+- Lund AM
+- Burlina AB
+- Sykut-Cegielska J
+- Wijburg FA
+- Teles EL
+- Zeman J
+- Dionisi-Vici C
+- Barić I
+- Karall D
+- Augoustides-Savvopoulou P
+- Aksglaede L
+- Arnoux JB
+- Avram P
+- Baumgartner MR
+- Blasco-Alonso J
+- Chabrol B
+- Chakrapani A
+- Chapman K
+- I Saladelafont EC
+- Couce ML
+- de Meirleir L
+- Dobbelaere D
+- Dvorakova V
+- Furlan F
+- Gleich F
+- Gradowska W
+- Grünewald S
+- Jalan A
+- Häberle J
+- Haege G
+- Lachmann R
+- Laemmle A
+- Langereis E
+- de Lonlay P
+- Martinelli D
+- Matsumoto S
+- Mühlhausen C
+- de Baulny HO
+- Ortez C
+- Peña-Quintana L
+- Ramadža DP
+- Rodrigues E
+- Scholl-Bürgi S
+- Sokal E
+- Staufner C
+- Summar ML
+- Thompson N
+- Vara R
+- Pinera IV
+- Walter JH
+- Williams M
+- Burgard P
+journal: J Inherit Metab Dis
+year: '2015'
+doi: 10.1007/s10545-015-9839-3
+keywords:
+- Adolescent
+- Adult
+- Aged
+- "Amino Acid Metabolism, Inborn Errors/diagnosis"
+- "Brain Diseases, Metabolic/diagnosis"
+- Child
+- "Child, Preschool"
+- Europe
+- Female
+- Glutaryl-CoA Dehydrogenase/deficiency
+- Humans
+- Hyperammonemia/diagnosis
+- Infant
+- "Infant, Newborn"
+- Intellectual Disability
+- Male
+- Middle Aged
+- Ornithine Carbamoyltransferase Deficiency Disease/diagnosis
+- Registries
+- "Urea Cycle Disorders, Inborn/diagnosis"
+- Vomiting
+- Young Adult
+content_type: abstract_only
+---
+
+# The phenotypic spectrum of organic acidurias and urea cycle disorders. Part 1: the initial presentation.
+**Authors:** Kölker S, Garcia-Cazorla A, Valayannopoulos V, Lund AM, Burlina AB, Sykut-Cegielska J, Wijburg FA, Teles EL, Zeman J, Dionisi-Vici C, Barić I, Karall D, Augoustides-Savvopoulou P, Aksglaede L, Arnoux JB, Avram P, Baumgartner MR, Blasco-Alonso J, Chabrol B, Chakrapani A, Chapman K, I Saladelafont EC, Couce ML, de Meirleir L, Dobbelaere D, Dvorakova V, Furlan F, Gleich F, Gradowska W, Grünewald S, Jalan A, Häberle J, Haege G, Lachmann R, Laemmle A, Langereis E, de Lonlay P, Martinelli D, Matsumoto S, Mühlhausen C, de Baulny HO, Ortez C, Peña-Quintana L, Ramadža DP, Rodrigues E, Scholl-Bürgi S, Sokal E, Staufner C, Summar ML, Thompson N, Vara R, Pinera IV, Walter JH, Williams M, Burgard P
+**Journal:** J Inherit Metab Dis (2015)
+**DOI:** [10.1007/s10545-015-9839-3](https://doi.org/10.1007/s10545-015-9839-3)
+
+## Content
+
+1. J Inherit Metab Dis. 2015 Nov;38(6):1041-57. doi: 10.1007/s10545-015-9839-3.
+Epub 2015 Apr 15.
+
+The phenotypic spectrum of organic acidurias and urea cycle disorders. Part 1:
+the initial presentation.
+
+Kölker S(1), Garcia-Cazorla A(2), Valayannopoulos V(3), Lund AM(4), Burlina
+AB(5), Sykut-Cegielska J(6), Wijburg FA(7), Teles EL(8), Zeman J(9),
+Dionisi-Vici C(10), Barić I(11), Karall D(12), Augoustides-Savvopoulou P(13),
+Aksglaede L(4), Arnoux JB(3), Avram P(14), Baumgartner MR(15), Blasco-Alonso
+J(16), Chabrol B(17), Chakrapani A(18), Chapman K(19), I Saladelafont EC(2),
+Couce ML(20), de Meirleir L(21), Dobbelaere D(22), Dvorakova V(9), Furlan F(5),
+Gleich F(23), Gradowska W(24), Grünewald S(25), Jalan A(26), Häberle J(15),
+Haege G(23), Lachmann R(27), Laemmle A(15), Langereis E(7), de Lonlay P(3),
+Martinelli D(10), Matsumoto S(28), Mühlhausen C(29), de Baulny HO(30), Ortez
+C(2), Peña-Quintana L(31), Ramadža DP(32), Rodrigues E(8), Scholl-Bürgi S(12),
+Sokal E(33), Staufner C(23), Summar ML(19), Thompson N(25), Vara R(34), Pinera
+IV(35), Walter JH(36), Williams M(37), Burgard P(23).
+
+Author information:
+(1)Department of General Pediatrics, Division of Inherited Metabolic Diseases,
+University Children's Hospital Heidelberg, Im Neuenheimer Feld 430, D-69120,
+Heidelberg, Germany. Stefan.Koelker@med.uni-heidelberg.de.
+(2)Servicio de Neurologia and CIBERER, ISCIII, Hospital San Joan de Deu,
+Barcelona, Spain.
+(3)Hôpital Necker-Enfants Malades, Assistance Publique-Hôpitaux de Paris,
+Reference Center for Inherited Metabolic Disease, Necker-Enfants Malades
+University Hospital and IMAGINE Institute, Paris, France.
+(4)Centre for Inherited Metabolic Diseases, Department of Clinical Genetics,
+Copenhagen University Hospital, Rigshospitalet, Copenhagen, Denmark.
+(5)U.O.C. Malattie Metaboliche Ereditarie, Azienda Ospedaliera di Padova,
+Padova, Italy.
+(6)Screening Department, Institute of Mother and Child, Warsaw, Poland.
+(7)Department of Pediatrics, Academisch Medisch Centrum, Amsterdam, Netherlands.
+(8)Unidade de Doenças Metabólicas, Serviço de Pediatria, Hospital de S. João,
+EPE, Porto, Portugal.
+(9)First Faculty of Medicine, Charles University and General University of
+Prague, Prague, Czech Republic.
+(10)U.O.C. Patologia Metabolica, Ospedale Pediatrico Bambino Gésu, Rome, Italy.
+(11)School of Medicine, University Hospital Center Zagreb and University of
+Zagreb, Zagreb, Croatia.
+(12)Clinic for Pediatrics I, Inherited Metabolic Disorders, Medical University
+of Innsbruck, Innsbruck, Austria.
+(13)1st Pediatric Department, Metabolic Laboratory, General Hospital of
+Thessaloniki 'Hippocration', Thessaloniki, Greece.
+(14)Institute of Mother and Child Care "Alfred Rusescu", Bucharest, Romania.
+(15)Division of Metabolism and Children's Research Centre, University Children's
+Hospital Zurich, Steinwiesstraße 75, CH-8032, Zurich, Switzerland.
+(16)Hospital Materno-Infantil (HRU Carlos Haya), Málaga, Spain.
+(17)Centre de Référence des Maladies Héréditaires du Métabolisme, Service de
+Neurologie, Hôpital d'Enfants, CHU Timone, Marseilles, France.
+(18)Birmingham Children's Hospital NHS Foundation Trust, Steelhouse Lane,
+Birmingham, B4 6NH, UK.
+(19)Children's National Medical Center, 111 Michigan Avenue, N.W., Washington,
+DC, 20010, USA.
+(20)Metabolic Unit, Department of Pediatrics, Hospital Clinico Universitario de
+Santiago de Compostela, Santiago de Compostela, Spain.
+(21)University Hospital Vrije Universiteit Brussel, Bruxelles, Belgium.
+(22)Centre de Référence des Maladies Héréditaires du Métabolisme de l'Enfant et
+de l'Adulte, Hôpital Jeanne de Flandre, Lille, France.
+(23)Department of General Pediatrics, Division of Inherited Metabolic Diseases,
+University Children's Hospital Heidelberg, Im Neuenheimer Feld 430, D-69120,
+Heidelberg, Germany.
+(24)Department of Laboratory Diagnostics, The Children's Memorial Health
+Institute, Warsaw, Poland.
+(25)Metabolic Unit Great Ormond Street Hospital and Institute for Child Health,
+University College London, London, UK.
+(26)N.I.R.M.A.N., Om Rachna Society, Vashi, Navi Mumbai, Mumbai, India.
+(27)Charles Dent Metabolic Unit, National Hospital for Neurology and
+Neurosurgery, London, UK.
+(28)Department of Pediatrics, Kumamoto University Hospital, Kumamoto City,
+Japan.
+(29)Klinik für Kinder- und Jugendmedizin, Universitätsklinikum
+Hamburg-Eppendorf, Hamburg, Germany.
+(30)Hôpital Robert Debré, Université de Paris, Paris, France.
+(31)Hospital Universitario Materno-Infantil de Canarias, Unit of Pediatric
+Gastroenterology, Hepatology and Nutrition, University of Las Palmas de Gran
+Canaria, Las Palmas de Gran Canaria, Spain.
+(32)University Hospital Center Zagreb, Zagreb, Croatia.
+(33)Service Gastroentérologie and Hépatologie Pédiatrique, Cliniques
+Universitaires St Luc, Université Catholique de Louvain, Bruxelles, Belgium.
+(34)Evelina Children's Hospital, St Thomas' Hospital, London, UK.
+(35)Inborn Metabolic Disease Unit, Hospital Virgen de la Arrixaca de Murcia, El
+Palmar, Spain.
+(36)Manchester Academic Health Science Centre, Willink Biochemical Genetics
+Unit, Genetic Medicine, University of Manchester, Manchester, UK.
+(37)Erasmus MC-Sophia Kinderziekenhuis, Erasmus Universiteit Rotterdam,
+Rotterdam, Netherlands.
+
+Erratum in
+    J Inherit Metab Dis. 2015 Nov;38(6):1155-6. doi: 10.1007/s10545-015-9867-z..
+Cazorla, Angeles Garcia [corrected to Garcia-Cazorla, Angeles].
+
+BACKGROUND: The clinical presentation of patients with organic acidurias (OAD)
+and urea cycle disorders (UCD) is variable; symptoms are often non-specific.
+AIMS/METHODS: To improve the knowledge about OAD and UCD the E-IMD consortium
+established a web-based patient registry.
+RESULTS: We registered 795 patients with OAD (n = 452) and UCD (n = 343), with
+ornithine transcarbamylase (OTC) deficiency (n = 196), glutaric aciduria type 1
+(GA1; n = 150) and methylmalonic aciduria (MMA; n = 149) being the most frequent
+diseases. Overall, 548 patients (69 %) were symptomatic. The majority of them
+(n = 463) presented with acute metabolic crisis during (n = 220) or after the
+newborn period (n = 243) frequently demonstrating impaired consciousness,
+vomiting and/or muscular hypotonia. Neonatal onset of symptoms was most frequent
+in argininosuccinic synthetase and lyase deficiency and carbamylphosphate 1
+synthetase deficiency, unexpectedly low in male OTC deficiency, and least
+frequently in GA1 and female OTC deficiency. For patients with MMA, propionic
+aciduria (PA) and OTC deficiency (male and female), hyperammonemia was more
+severe in metabolic crises during than after the newborn period, whereas
+metabolic acidosis tended to be more severe in MMA and PA patients with late
+onset of symptoms. Symptomatic patients without metabolic crises (n = 94) often
+presented with a movement disorder, mental retardation, epilepsy and psychiatric
+disorders (the latter in UCD only).
+CONCLUSIONS: The initial presentation varies widely in OAD and UCD patients.
+This is a challenge for rapid diagnosis and early start of treatment. Patients
+with a sepsis-like neonatal crisis and those with late-onset of symptoms are
+both at risk of delayed or missed diagnosis.
+
+DOI: 10.1007/s10545-015-9839-3
+PMID: 25875215 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Connect Hypotonia downstream of Hyperammonemia-driven neurotoxicity in CPS1 deficiency.
- Add human E-IMD registry support from PMID:25875215 for muscular hypotonia during acute OAD/UCD metabolic crises and frequent neonatal onset in carbamylphosphate 1 synthetase deficiency.
- Add the generated reference cache for PMID:25875215.

## Validation
- `just validate kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml`
- `just validate-references kb/disorders/Carbamoyl_Phosphate_Synthetase_I_Deficiency.yaml`
- `git diff --check`
- normalized snippet audit: 72 cached snippets checked, 0 skipped
- graph coverage check: phenotype downstream coverage 13/13; biochemical readouts present for all 5 biomarkers

## Notes
- Restored unrelated validator cache churn in PMID_24904092 and PMID_31292197 before commit.
- `just validate-references` reported Total checks: 0 in this checkout, so I also ran the explicit normalized snippet audit.