### PR TITLE
Improve Tay-Sachs pathograph connectivity

### DIFF
--- a/kb/disorders/Tay-Sachs_Disease.yaml
+++ b/kb/disorders/Tay-Sachs_Disease.yaml
@@ -1,6 +1,6 @@
 name: Tay-Sachs Disease
 creation_date: '2026-01-06T04:44:07Z'
-updated_date: '2026-04-28T08:00:00Z'
+updated_date: '2026-05-21T02:19:10Z'
 category: Genetic
 parents:
 - Lysosomal Storage Disorder
@@ -155,7 +155,7 @@ pathophysiology:
   - reference: PMID:40710901
     reference_title: "Advances in Diagnosis, Pathological Mechanisms, Clinical Impact, and Future Therapeutic Perspectives in Tay-Sachs Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Mechanistically, TSD is caused by mutations in the HEXA gene, which encodes the alpha subunit of hexosaminidase A."
     explanation: Review states Tay-Sachs disease is caused by HEXA mutations affecting hexosaminidase A.
   - reference: PMID:15714079
@@ -244,6 +244,16 @@ pathophysiology:
   - target: GM2 Ganglioside
     description: Neuronal storage corresponds to elevated GM2 ganglioside in affected brain tissue.
     causal_link_type: DIRECT
+  - target: GM2 Ganglioside Accumulation
+    description: Neuronal lysosomal storage manifests clinically as GM2-ganglioside accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:845
+      reference_title: "Tay-Sachs disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003495 | GM2-ganglioside accumulation | Very frequent (99-80%)"
+      explanation: Orphanet lists GM2-ganglioside accumulation as a very frequent Tay-Sachs phenotype, matching the neuronal storage mechanism.
   - target: Neuroinflammation and Astrogliosis
     description: GM2 storage activates microglia and astrocytes, amplifying inflammatory neuronal injury.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -321,7 +331,7 @@ pathophysiology:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Tay-Sachs disease is characterized by acute neurodegeneration preceded by activated microglia expansion, macrophage and astrocyte activation along with inflammatory mediator production."
     explanation: Review directly links Tay-Sachs neurodegeneration to microglial expansion, astrocyte activation, and inflammatory mediator production.
   - reference: PMID:23370522
@@ -389,6 +399,19 @@ pathophysiology:
     intermediate_mechanisms:
     - retinal ganglion cell dysfunction
     - neurodegeneration
+  - target: Visual Impairment
+    description: Progressive retinal ganglion cell lipid storage and neuroretinal degeneration produce visual impairment before or short of complete blindness.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - retinal ganglion cell dysfunction
+    - neurodegeneration
+    evidence:
+    - reference: ORPHA:845
+      reference_title: "Tay-Sachs disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000505 | Visual impairment | Frequent (79-30%)"
+      explanation: Orphanet lists visual impairment as a frequent Tay-Sachs phenotype, consistent with retinal ganglion cell lipid storage.
   evidence:
   - reference: PMID:19820796
     reference_title: "'Cherry red spot' in a patient with Tay-Sachs disease: case report."
@@ -454,7 +477,7 @@ pathophysiology:
   - reference: PMID:29618308
     reference_title: "Genetics and Therapies for GM2 Gangliosidosis."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Inherited as a classical autosomal recessive disorder, this global disease of the nervous system induces developmental arrest with regression of attained milestones; neurodegeneration progresses rapidly to cause premature death in young children."
     explanation: Review describes rapid neurodegeneration in infantile GM2 gangliosidosis, consistent with neuronal loss.
 - name: Juvenile cerebellar and bulbar involvement
@@ -479,6 +502,32 @@ pathophysiology:
     intermediate_mechanisms:
     - motor pathway dysfunction
     - muscle wasting
+  - target: Muscle Weakness
+    description: Progressive motor pathway and anterior motor neuron involvement produce generalized muscle weakness across Tay-Sachs subtypes.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - motor pathway dysfunction
+    - anterior motor neuron involvement
+    evidence:
+    - reference: PMID:17015493
+      reference_title: "The natural history of juvenile or subacute GM2 gangliosidosis: 21 new cases and literature review of 134 previously reported."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Muscle wasting (10.6 +/- 7.4 years), proximal weakness (11.1 +/- 7.7 years), and incontinence of sphincters (14.6 +/- 9.7 years) appeared later in the course of the disease."
+      explanation: Juvenile GM2 gangliosidosis natural history documents proximal weakness during disease progression.
+  - target: Skeletal Muscle Atrophy
+    description: Progressive motor involvement produces muscle wasting that corresponds to skeletal muscle atrophy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - motor pathway dysfunction
+    - anterior motor neuron involvement
+    evidence:
+    - reference: PMID:17015493
+      reference_title: "The natural history of juvenile or subacute GM2 gangliosidosis: 21 new cases and literature review of 134 previously reported."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Muscle wasting (10.6 +/- 7.4 years), proximal weakness (11.1 +/- 7.7 years), and incontinence of sphincters (14.6 +/- 9.7 years) appeared later in the course of the disease."
+      explanation: The juvenile GM2 gangliosidosis natural-history cohort directly reports muscle wasting during disease progression.
   - target: Dysarthria
     description: Bulbar and motor speech pathway involvement produces dysarthria and speech deterioration.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -496,6 +545,19 @@ pathophysiology:
     intermediate_mechanisms:
     - corticospinal tract dysfunction
     - upper motor neuron involvement
+  - target: Progressive Spasticity
+    description: Progressive motor pathway involvement manifests as increasing spasm progression and progressive spasticity.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - corticospinal tract dysfunction
+    - upper motor neuron involvement
+    evidence:
+    - reference: PMID:30524313
+      reference_title: "New Approaches to Tay-Sachs Disease Therapy."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The juvenile form of the disease strikes in early childhood, usually at the age of 3–10 years. Common symptoms are ataxia, dysarthria, dysphagia development, hypotension, and spasm progression."
+      explanation: The review lists spasm progression among common juvenile Tay-Sachs symptoms, supporting progressive spasticity downstream of motor pathway involvement.
   - target: Cerebellar Atrophy
     description: Chronic cerebellar involvement produces cerebellar atrophy on brain MRI in juvenile disease.
     causal_link_type: DIRECT
@@ -509,7 +571,7 @@ pathophysiology:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "The juvenile form of the disease strikes in early childhood, usually at the age of 3–10 years. Common symptoms are ataxia, dysarthria, dysphagia development, hypotension, and spasm progression."
     explanation: Review identifies juvenile Tay-Sachs symptoms spanning cerebellar, bulbar, swallowing, tone, and motor manifestations.
 - name: Late-onset cerebellar and anterior motor neuron involvement
@@ -864,13 +926,13 @@ phenotypes:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Common neurodegenerative symptoms in infants are hypotension, inability to sit or hold their head unsupported, eye movement abnormalities, dysphagia, spasms, and hypomyelination"
     explanation: Review supports late-stage infantile motor tone/spasm manifestations downstream of neurodegeneration.
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "The juvenile form of the disease strikes in early childhood, usually at the age of 3–10 years. Common symptoms are ataxia, dysarthria, dysphagia development, hypotension, and spasm progression."
     explanation: Review supports progressive juvenile motor tone/spasm manifestations.
 - name: Dysarthria
@@ -894,7 +956,7 @@ phenotypes:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "The juvenile form of the disease strikes in early childhood, usually at the age of 3–10 years. Common symptoms are ataxia, dysarthria, dysphagia development, hypotension, and spasm progression."
     explanation: Review explicitly lists dysarthria among common juvenile Tay-Sachs symptoms.
   - reference: ORPHA:845
@@ -919,7 +981,7 @@ phenotypes:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Common neurodegenerative symptoms in infants are hypotension, inability to sit or hold their head unsupported, eye movement abnormalities, dysphagia, spasms, and hypomyelination"
     explanation: Review lists dysphagia among common infantile Tay-Sachs neurodegenerative symptoms.
   - reference: PMID:17015493
@@ -963,7 +1025,7 @@ phenotypes:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Common neurodegenerative symptoms in infants are hypotension, inability to sit or hold their head unsupported, eye movement abnormalities, dysphagia, spasms, and hypomyelination"
     explanation: Review explicitly lists hypomyelination among common neurodegenerative findings in infantile Tay-Sachs disease.
   - reference: PMID:34456134
@@ -1023,9 +1085,49 @@ biochemical:
 - name: Hexosaminidase A Activity
   presence: Decreased
   context: Absent or severely reduced in leukocytes or fibroblasts
+  readouts:
+  - target: Hexosaminidase A deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced or absent Hexosaminidase A activity is the diagnostic enzyme readout of the core Tay-Sachs enzyme deficiency.
+    evidence:
+    - reference: PMID:40710901
+      reference_title: "Advances in Diagnosis, Pathological Mechanisms, Clinical Impact, and Future Therapeutic Perspectives in Tay-Sachs Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Diagnosis is based on enzymatic testing showing reduced or absent hexosaminidase A activity, confirmed by genetic testing."
+      explanation: Review states that reduced or absent Hexosaminidase A activity is the enzymatic diagnostic basis for Tay-Sachs disease.
+  evidence:
+  - reference: PMID:40710901
+    reference_title: "Advances in Diagnosis, Pathological Mechanisms, Clinical Impact, and Future Therapeutic Perspectives in Tay-Sachs Disease."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "Diagnosis is based on enzymatic testing showing reduced or absent hexosaminidase A activity, confirmed by genetic testing."
+    explanation: Supports reduced Hexosaminidase A activity as the diagnostic biochemical abnormality.
 - name: GM2 Ganglioside
   presence: Elevated
   context: Accumulates in brain tissue
+  readouts:
+  - target: GM2 ganglioside accumulation in neurons
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased GM2 ganglioside reports lysosomal ganglioside storage in affected neural tissue.
+    evidence:
+    - reference: PMID:22025593
+      reference_title: "Natural history of infantile G(M2) gangliosidosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "G(M2) gangliosidoses are caused by an inherited deficiency of lysosomal β-hexosaminidase and result in ganglioside accumulation in the brain."
+      explanation: Natural-history data link beta-hexosaminidase deficiency to ganglioside accumulation in the brain.
+  evidence:
+  - reference: PMID:22025593
+    reference_title: "Natural history of infantile G(M2) gangliosidosis."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "G(M2) gangliosidoses are caused by an inherited deficiency of lysosomal β-hexosaminidase and result in ganglioside accumulation in the brain."
+    explanation: Supports elevated GM2/ganglioside storage in affected brain tissue.
 genetic:
 - name: HEXA
   gene_term:
@@ -1062,7 +1164,7 @@ genetic:
   - reference: PMID:40710901
     reference_title: "Advances in Diagnosis, Pathological Mechanisms, Clinical Impact, and Future Therapeutic Perspectives in Tay-Sachs Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "Mechanistically, TSD is caused by mutations in the HEXA gene, which encodes the alpha subunit of hexosaminidase A."
     explanation: Review supports HEXA as the causative gene for Tay-Sachs disease.
   - reference: PMID:15714079
@@ -1122,7 +1224,7 @@ treatments:
   - reference: PMID:30524313
     reference_title: "New Approaches to Tay-Sachs Disease Therapy."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "There are also clinical reports of substrate reduction therapy using miglustat and bone marrow or hematopoietic stem cell transplantation."
     explanation: Review documents miglustat-based substrate reduction therapy as an investigational/off-label option in Tay-Sachs disease.
 - name: Pharmacological Chaperone Therapy


### PR DESCRIPTION
## Summary
- Connect the remaining generic Tay-Sachs phenotypes: GM2-ganglioside accumulation, visual impairment, muscle weakness, skeletal muscle atrophy, and progressive spasticity.
- Add diagnostic biochemical readouts for reduced Hexosaminidase A activity and elevated GM2/ganglioside storage.
- Reclassify existing review-article evidence items for PMID:40710901, PMID:30524313, and PMID:29618308 from HUMAN_CLINICAL to OTHER.

## Validation
- `just validate kb/disorders/Tay-Sachs_Disease.yaml`
- `git diff --check`
- normalized snippet audit: 87 cached snippets checked, 2 skipped without local cache mapping
- graph coverage check: phenotype downstream coverage 21/21; biochemical readouts present for both biomarkers

## Notes
- `just validate-references kb/disorders/Tay-Sachs_Disease.yaml` reported Total checks: 0 in this checkout, so I used the explicit normalized snippet audit.
- Restored unrelated validator churn in enum cache and PMID_24904092/PMID_31292197 before commit.