### PR TITLE
Improve MMDS9B pathograph connectivity

### DIFF
--- a/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
+++ b/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
@@ -1,7 +1,7 @@
 name: Multiple Mitochondrial Dysfunctions Syndrome 9B
 category: Genetic
 creation_date: "2026-03-23T00:00:00Z"
-updated_date: "2026-05-21T02:59:15Z"
+updated_date: "2026-05-21T03:15:44Z"
 synonyms:
 - MMDS9B
 - FDXR-related mitochondriopathy
@@ -165,6 +165,18 @@ pathophysiology:
         causal_link_type: DIRECT
       - target: Impaired Mitochondrial Steroidogenesis
         causal_link_type: DIRECT
+      - target: Failure to Thrive
+        causal_link_type: UNKNOWN
+        description: >
+          Systemic mitochondrial dysfunction from FDXR deficiency is associated
+          with failure to thrive in the FDXR-related disorder spectrum.
+        evidence:
+          - reference: ORPHA:543470
+            reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+            supports: SUPPORT
+            evidence_source: OTHER
+            snippet: "HP:0001508 | Failure to thrive | Very frequent (99-80%)"
+            explanation: Orphanet records failure to thrive as a very frequent phenotype.
   - name: Impaired Mitochondrial Steroidogenesis
     description: >
       FDXR also transfers electrons to mitochondrial cytochrome P450 enzymes
@@ -355,6 +367,18 @@ pathophysiology:
             explanation: >
               Natural-history data identify developmental delay as a frequent
               finding in ferredoxin-reductase-related mitochondriopathy.
+      - target: Developmental Regression
+        causal_link_type: UNKNOWN
+        description: >
+          Developmental regression is a distinct neurodevelopmental manifestation
+          within the FDXR-related disorder spectrum.
+        evidence:
+          - reference: ORPHA:543470
+            reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+            supports: SUPPORT
+            evidence_source: OTHER
+            snippet: "HP:0002376 | Developmental regression | Frequent (79-30%)"
+            explanation: Orphanet records developmental regression as a frequent phenotype.
       - target: Movement Disorder
         causal_link_type: UNKNOWN
         description: >
@@ -745,6 +769,24 @@ phenotypes:
           Optic atrophy, movement disorder, and developmental delay were frequent findings.
         explanation: Developmental delay identified as a frequent finding in natural history study.
   - category: Neurological
+    name: Developmental Regression
+    frequency: FREQUENT
+    description: >
+      Developmental regression is a frequent neurodevelopmental manifestation
+      reported in the FDXR-related disorder spectrum.
+    phenotype_term:
+      preferred_term: Developmental regression
+      term:
+        id: HP:0002376
+        label: Developmental regression
+    evidence:
+      - reference: ORPHA:543470
+        reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+        supports: SUPPORT
+        evidence_source: OTHER
+        snippet: "HP:0002376 | Developmental regression | Frequent (79-30%)"
+        explanation: Orphanet records developmental regression as a frequent phenotype.
+  - category: Neurological
     name: Peripheral Neuropathy
     frequency: OCCASIONAL
     description: >
@@ -907,6 +949,24 @@ phenotypes:
         explanation: >
           The case description documents poor feeding in a severely affected
           infant with biallelic FDXR variants.
+  - category: Nutritional
+    name: Failure to Thrive
+    frequency: VERY_FREQUENT
+    description: >
+      Failure to thrive is very frequently reported in MMDS9B, consistent with
+      systemic metabolic disease burden.
+    phenotype_term:
+      preferred_term: Failure to thrive
+      term:
+        id: HP:0001508
+        label: Failure to thrive
+    evidence:
+      - reference: ORPHA:543470
+        reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+        supports: SUPPORT
+        evidence_source: OTHER
+        snippet: "HP:0001508 | Failure to thrive | Very frequent (99-80%)"
+        explanation: Orphanet records failure to thrive as a very frequent phenotype.
   - category: Endocrine
     name: Adrenal Insufficiency
     frequency: OCCASIONAL

--- a/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
+++ b/kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
@@ -1,7 +1,7 @@
 name: Multiple Mitochondrial Dysfunctions Syndrome 9B
 category: Genetic
 creation_date: "2026-03-23T00:00:00Z"
-updated_date: "2026-05-17T19:54:26Z"
+updated_date: "2026-05-21T02:59:15Z"
 synonyms:
 - MMDS9B
 - FDXR-related mitochondriopathy
@@ -420,6 +420,51 @@ pathophysiology:
             explanation: >
               This cohort expansion supports Leigh syndrome as a severe-end
               manifestation of FDXR deficiency.
+      - target: Spasticity
+        causal_link_type: UNKNOWN
+        description: >
+          Spasticity occurs within the FDXR neurodegenerative mitochondriopathy
+          spectrum.
+        evidence:
+          - reference: PMID:29040572
+            reference_title: "Biallelic mutations in the ferredoxin reductase gene cause novel mitochondriopathy with optic atrophy."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: >
+              Other less common features included spasticity and respiratory failure.
+            explanation: >
+              The original FDXR cohort reports spasticity among additional
+              neurologic manifestations.
+      - target: Microcephaly
+        causal_link_type: UNKNOWN
+        description: >
+          Microcephaly is part of the reported FDXR-related neurodevelopmental
+          phenotype spectrum.
+        evidence:
+          - reference: ORPHA:543470
+            reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+            supports: SUPPORT
+            evidence_source: OTHER
+            snippet: "Additional common manifestations include global developmental delay with or without regression, neuropathy, spasticity, and microcephaly"
+            explanation: >
+              Orphanet lists microcephaly among additional manifestations of the
+              FDXR-related disorder.
+      - target: Feeding Difficulty
+        causal_link_type: UNKNOWN
+        description: >
+          Severe infantile FDXR-related disease can include impaired feeding in
+          the setting of broader neurologic and systemic involvement.
+        evidence:
+          - reference: PMID:30250212
+            reference_title: "Biallelic mutations in FDXR cause neurodegeneration associated with inflammation."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: >
+              She then spent 2.5 months in neonatal intensive care unit for poor feeding,
+              abdominal distension, and initial respiratory distress syndrome.
+            explanation: >
+              The case description supports feeding difficulty as a severe
+              clinical manifestation in an FDXR patient.
   - name: Neuroinflammation
     description: >
       FDXR-related neurodegeneration is accompanied by reactive gliosis with increased
@@ -510,6 +555,40 @@ pathophysiology:
             explanation: >
               The ocular cohort directly supports retinal dystrophy as part of
               the FDXR-associated ocular phenotype.
+      - target: Nystagmus
+        causal_link_type: UNKNOWN
+        description: >
+          Nystagmus is an ocular manifestation reported with FDXR-related optic
+          atrophy and retinal disease.
+        evidence:
+          - reference: PMID:39746537
+            reference_title: "Ocular and neurological manifestations of the FDXR-related disorder."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: >
+              Our review of the existing literature reveals other common ocular findings
+              of myopia, nystagmus, strabismus, retinal dystrophy, attenuation of
+              retinal vessels, and cataracts.
+            explanation: >
+              This ophthalmology review places nystagmus among common ocular
+              manifestations of FDXR-related disorder.
+      - target: Strabismus
+        causal_link_type: UNKNOWN
+        description: >
+          Strabismus is another ocular manifestation reported in the FDXR-related
+          ocular phenotype spectrum.
+        evidence:
+          - reference: PMID:39746537
+            reference_title: "Ocular and neurological manifestations of the FDXR-related disorder."
+            supports: SUPPORT
+            evidence_source: HUMAN_CLINICAL
+            snippet: >
+              Our review of the existing literature reveals other common ocular findings
+              of myopia, nystagmus, strabismus, retinal dystrophy, attenuation of
+              retinal vessels, and cataracts.
+            explanation: >
+              This ophthalmology review places strabismus among common ocular
+              manifestations of FDXR-related disorder.
   - name: Peripheral Neuropathy and Demyelination
     description: >
       Sensorimotor peripheral neuropathy with demyelination of sciatic and other peripheral
@@ -688,11 +767,21 @@ phenotypes:
   - category: Neurological
     name: Nystagmus
     frequency: OCCASIONAL
+    description: >
+      Nystagmus is reported among ocular manifestations of the FDXR-related
+      disorder.
     phenotype_term:
       preferred_term: Nystagmus
       term:
         id: HP:0000639
         label: Nystagmus
+    evidence:
+      - reference: ORPHA:543470
+        reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+        supports: SUPPORT
+        evidence_source: OTHER
+        snippet: "HP:0000639 | Nystagmus | Occasional (29-5%)"
+        explanation: Orphanet records nystagmus as an occasional phenotype.
   - category: Ophthalmologic
     name: Retinal Dystrophy
     frequency: FREQUENT
@@ -744,38 +833,80 @@ phenotypes:
         label: Abnormal basal ganglia morphology
   - category: Ophthalmologic
     name: Strabismus
-    frequency: OCCASIONAL
+    description: >
+      Strabismus is reported among ocular findings in the FDXR-related disorder.
     phenotype_term:
       preferred_term: Strabismus
       term:
         id: HP:0000486
         label: Strabismus
+    evidence:
+      - reference: PMID:39746537
+        reference_title: "Ocular and neurological manifestations of the FDXR-related disorder."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: >
+          Our review of the existing literature reveals other common ocular findings
+          of myopia, nystagmus, strabismus, retinal dystrophy, attenuation of retinal
+          vessels, and cataracts.
+        explanation: The review reports strabismus among ocular manifestations of FDXR-related disorder.
   - category: Neurological
     name: Spasticity
-    frequency: OCCASIONAL
+    frequency: FREQUENT
+    description: >
+      Spasticity is a recurrent neurologic manifestation in FDXR-related
+      mitochondriopathy.
     phenotype_term:
       preferred_term: Spasticity
       term:
         id: HP:0001257
         label: Spasticity
+    evidence:
+      - reference: ORPHA:543470
+        reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+        supports: SUPPORT
+        evidence_source: OTHER
+        snippet: "HP:0001257 | Spasticity | Frequent (79-30%)"
+        explanation: Orphanet records spasticity as a frequent phenotype.
   - category: Neurological
     name: Microcephaly
     frequency: OCCASIONAL
+    description: >
+      Microcephaly is reported in a subset of patients with FDXR-related
+      neurodevelopmental disease.
     phenotype_term:
       preferred_term: Microcephaly
       term:
         id: HP:0000252
         label: Microcephaly
+    evidence:
+      - reference: ORPHA:543470
+        reference_title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Orphanet structured-database record)"
+        supports: SUPPORT
+        evidence_source: OTHER
+        snippet: "HP:0000252 | Microcephaly | Occasional (29-5%)"
+        explanation: Orphanet records microcephaly as an occasional phenotype.
   - category: Neurological
-    name: Dysphagia
-    frequency: OCCASIONAL
+    name: Feeding Difficulty
     description: >
-      Swallowing difficulty in severe cases, with aspiration risk in severe hypotonia.
+      Severe infantile FDXR-related disease can include poor feeding, broadening
+      the clinical spectrum beyond optic atrophy and neuropathy.
     phenotype_term:
-      preferred_term: Dysphagia
+      preferred_term: Feeding difficulties
       term:
-        id: HP:0002015
-        label: Dysphagia
+        id: HP:0011968
+        label: Feeding difficulties
+    evidence:
+      - reference: PMID:30250212
+        reference_title: "Biallelic mutations in FDXR cause neurodegeneration associated with inflammation."
+        supports: SUPPORT
+        evidence_source: HUMAN_CLINICAL
+        snippet: >
+          She then spent 2.5 months in neonatal intensive care unit for poor feeding,
+          abdominal distension, and initial respiratory distress syndrome.
+        explanation: >
+          The case description documents poor feeding in a severely affected
+          infant with biallelic FDXR variants.
   - category: Endocrine
     name: Adrenal Insufficiency
     frequency: OCCASIONAL
@@ -836,6 +967,14 @@ biochemical:
         explanation: >
           In vitro fibroblast assays documented increased ROS in patient cells.
   - name: Mitochondrial Iron Overload
+    readouts:
+      - target: Mitochondrial Iron Overload
+        relationship: READOUT_OF
+        direction: POSITIVE
+        endpoint_context: DIAGNOSTIC
+        interpretation: >
+          Increased mitochondrial iron concentration directly reports loss of
+          mitochondrial iron homeostasis downstream of impaired FDXR function.
     notes: >
       Accumulation of iron in mitochondria due to impaired iron-sulfur cluster synthesis.
     evidence:

--- a/references_cache/ORPHA_543470.md
+++ b/references_cache/ORPHA_543470.md
@@ -1,0 +1,96 @@
+---
+reference_id: "ORPHA:543470"
+title: "Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome"
+database: "Orphanet"
+content_type: "structured_record"
+---
+
+# ORPHA:543470  Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome
+
+**ORPHA:543470** — Optic atrophy-ataxia-peripheral neuropathy-global developmental delay syndrome (Disease, Disorder)
+
+## Definition
+
+A rare mitochondrial disease characterized by a variable clinical phenotype with the core features of optic atrophy, ataxia, and hypotonia. Additional common manifestations include global developmental delay with or without regression, neuropathy, spasticity, and microcephaly, less frequently seizures, movement disorder, hearing loss, and respiratory failure. Brain imaging may show abnormalities of the corpus callosum, basal ganglia, and midbrain, cerebral or cerebellar atrophy, or white matter abnormalities. The condition is frequently fatal at an early age.
+
+## Inheritance
+
+- Autosomal recessive
+
+## Natural history
+
+- Age of onset: Adolescent
+- Age of onset: Childhood
+- Age of onset: Infancy
+
+## Epidemiology
+
+| Class | Region | Type | Source |
+|---|---|---|---|
+| - | Worldwide | Cases/families | PMID:29040572 |
+| <1 / 1 000 000 | Worldwide | Point prevalence | PMID:29040572 |
+
+## Genes
+
+| Symbol | Name | HGNC | Association |
+|---|---|---|---|
+| FDXR | ferredoxin reductase | hgnc:3642 | Disease-causing germline mutation(s) in |
+
+## Phenotypes
+
+| HPO ID | Phenotype | Frequency |
+|---|---|---|
+| HP:0000062 | Ambiguous genitalia | Occasional (29-5%) |
+| HP:0000252 | Microcephaly | Occasional (29-5%) |
+| HP:0000505 | Visual impairment | Frequent (79-30%) |
+| HP:0000518 | Cataract | Occasional (29-5%) |
+| HP:0000603 | Central scotoma | Occasional (29-5%) |
+| HP:0000618 | Blindness | Occasional (29-5%) |
+| HP:0000639 | Nystagmus | Occasional (29-5%) |
+| HP:0000648 | Optic atrophy | Very frequent (99-80%) |
+| HP:0000750 | Delayed speech and language development | Very frequent (99-80%) |
+| HP:0001250 | Seizure | Occasional (29-5%) |
+| HP:0001251 | Ataxia | Frequent (79-30%) |
+| HP:0001252 | Hypotonia | Frequent (79-30%) |
+| HP:0001257 | Spasticity | Frequent (79-30%) |
+| HP:0001263 | Global developmental delay | Very frequent (99-80%) |
+| HP:0001272 | Cerebellar atrophy | Occasional (29-5%) |
+| HP:0001273 | Abnormal corpus callosum morphology | Occasional (29-5%) |
+| HP:0001276 | Hypertonia | Occasional (29-5%) |
+| HP:0001320 | Cerebellar vermis hypoplasia | Occasional (29-5%) |
+| HP:0001508 | Failure to thrive | Very frequent (99-80%) |
+| HP:0001622 | Premature birth | Occasional (29-5%) |
+| HP:0002066 | Gait ataxia | Occasional (29-5%) |
+| HP:0002079 | Hypoplasia of the corpus callosum | Occasional (29-5%) |
+| HP:0002134 | Abnormality of the basal ganglia | Occasional (29-5%) |
+| HP:0002194 | Delayed gross motor development | Very frequent (99-80%) |
+| HP:0002353 | EEG abnormality | Occasional (29-5%) |
+| HP:0002376 | Developmental regression | Frequent (79-30%) |
+| HP:0002465 | Poor speech | Frequent (79-30%) |
+| HP:0002506 | Diffuse cerebral atrophy | Occasional (29-5%) |
+| HP:0007333 | Hypoplasia of the frontal lobes | Occasional (29-5%) |
+| HP:0008665 | Clitoral hypertrophy | Occasional (29-5%) |
+| HP:0008936 | Axial hypotonia | Occasional (29-5%) |
+| HP:0010862 | Delayed fine motor development | Very frequent (99-80%) |
+| HP:0012087 | Abnormal mitochondrial shape | Frequent (79-30%) |
+| HP:0012430 | Cerebral white matter hypoplasia | Occasional (29-5%) |
+| HP:0012448 | Delayed myelination | Occasional (29-5%) |
+| HP:0012697 | Small basal ganglia | Occasional (29-5%) |
+| HP:0012794 | Periventricular white matter hypodensities | Occasional (29-5%) |
+| HP:0100022 | Abnormality of movement | Occasional (29-5%) |
+| HP:0100602 | Preeclampsia | Occasional (29-5%) |
+
+## Cross-references
+
+| Reference | Mapping |
+|---|---|
+| ICD-10:E88.8 | Narrower |
+| MONDO:0034092 | Exact |
+| OMIM:620887 | Exact |
+| UMLS:C5681321 | Exact |
+
+## Source
+
+Orphadata snapshot **2025-12-09** (`en_product1+4+6+9_prev+9_ages`). Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+[Orpha.net entry](http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=543470)

--- a/references_cache/PMID_39746537.md
+++ b/references_cache/PMID_39746537.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:39746537"
+title: Ocular and neurological manifestations of the FDXR-related disorder.
+authors:
+- Kaler A
+- Couser N
+journal: J AAPOS
+year: '2025'
+doi: 10.1016/j.jaapos.2024.104102
+keywords:
+- Female
+- Humans
+- Cataract/genetics
+- Eye Diseases/genetics
+- "Hearing Loss, Sensorineural/genetics"
+- Mutation
+- "Nystagmus, Pathologic/genetics"
+- Young Adult
+content_type: abstract_only
+---
+
+# Ocular and neurological manifestations of the FDXR-related disorder.
+**Authors:** Kaler A, Couser N
+**Journal:** J AAPOS (2025)
+**DOI:** [10.1016/j.jaapos.2024.104102](https://doi.org/10.1016/j.jaapos.2024.104102)
+
+## Content
+
+1. J AAPOS. 2025 Feb;29(1):104102. doi: 10.1016/j.jaapos.2024.104102. Epub 2024
+Dec  31.
+
+Ocular and neurological manifestations of the FDXR-related disorder.
+
+Kaler A(1), Couser N(2).
+
+Author information:
+(1)Virginia Commonwealth University School of Medicine, Virginia, Richmond.
+(2)Department of Ophthalmology, Virginia Commonwealth University School of
+Medicine, Richmond, Virginia; Department of Human and Molecular Genetics,
+Virginia Commonwealth University School of Medicine, Richmond, Virginia;
+Department of Pediatrics, Virginia Commonwealth University School of Medicine,
+Children's Hospital of Richmond at Virginia Commonwealth University, Richmond,
+Virginia. Electronic address: cousernl@gmail.com.
+
+The FDXR-related disorder is caused by pathogenic variants in the FDXR gene.
+Including our case, a total of 47 patients have been reported. The most common
+genotypes are the homozygous c.1174C>T (p.R392W) variant and homozygous c.916C>T
+(p.R306C) variant. Optic atrophy is the most common feature (89%), but many
+other ocular manifestations have not previously been characterized. Our review
+of the existing literature reveals other common ocular findings of myopia,
+nystagmus, strabismus, retinal dystrophy, attenuation of retinal vessels, and
+cataracts. Common neurological symptoms include movement disorder, sensorineural
+hearing loss, developmental delay/regression, and hypotonia.
+
+Copyright © 2025 American Association for Pediatric Ophthalmology and
+Strabismus. Published by Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.jaapos.2024.104102
+PMID: 39746537 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Connect all previously unlinked MMDS9B phenotypes through evidence-backed downstream edges.
- Add ORPHA:543470 and PMID:39746537 cached evidence for microcephaly, spasticity, nystagmus, and strabismus.
- Replace weak dysphagia wording with cached-evidence-backed feeding difficulty and add a mitochondrial iron overload readout.

## Validation
- just validate kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
- just validate-terms kb/disorders/Multiple_Mitochondrial_Dysfunctions_Syndrome_9B.yaml
- normalized snippet audit: 73 cached snippets checked, 0 skipped
- graph phenotype coverage: 16/16
- biochemical readout coverage: 6/6

## Notes
- validate-references currently reports Total checks: 0 in this repo, so I also ran the explicit normalized snippet audit against local caches.
- The two known validator cache churn files were restored before push.