### PR TITLE
Wire Biotinidase biochemical readouts

### DIFF
--- a/kb/disorders/Biotinidase_Deficiency.yaml
+++ b/kb/disorders/Biotinidase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Biotinidase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-09T12:01:33Z'
+updated_date: '2026-05-21T03:52:18Z'
 synonyms:
 - BTD deficiency
 - Biotinidase deficiency, profound
@@ -142,6 +142,27 @@ pathophysiology:
     term:
       id: GO:0006552
       label: L-leucine catabolic process
+  molecular_functions:
+  - preferred_term: pyruvate carboxylase activity
+    term:
+      id: GO:0004736
+      label: pyruvate carboxylase activity
+    modifier: DECREASED
+  - preferred_term: propionyl-CoA carboxylase activity
+    term:
+      id: GO:0004658
+      label: propionyl-CoA carboxylase activity
+    modifier: DECREASED
+  - preferred_term: methylcrotonoyl-CoA carboxylase activity
+    term:
+      id: GO:0004485
+      label: methylcrotonoyl-CoA carboxylase activity
+    modifier: DECREASED
+  - preferred_term: acetyl-CoA carboxylase activity
+    term:
+      id: GO:0003989
+      label: acetyl-CoA carboxylase activity
+    modifier: DECREASED
   cell_types:
   - preferred_term: hepatocyte
     term:
@@ -154,6 +175,12 @@ pathophysiology:
     evidence_source: HUMAN_CLINICAL
     snippet: BTD deficiency may impair the activity of biotin-dependent carboxylases, and thus bring about a buildup of potentially toxic compounds in the body, primarily 3-hydroxyisovaleryl-carnitine in plasma as well as 3-hydroxyisovaleric acid in urine
     explanation: Documents the specific metabolite accumulation pattern in biotinidase deficiency.
+  - reference: PMID:9350481
+    reference_title: "Multiple carboxylase deficiency: inherited and acquired disorders of biotin metabolism."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: Acquired biotin deficiency and the two known congenital disorders of biotin metabolism, biotinidase and holocarboxylase synthetase (HCS) deficiency, all lead to deficiency of the 4 biotin-dependent carboxylases, i.e. to multiple carboxylase deficiency (MCD).
+    explanation: Review evidence directly supports secondary deficiency of all four biotin-dependent carboxylases in biotinidase deficiency.
   downstream:
   - target: Central nervous system vulnerability and white matter injury
     description: Toxic metabolite buildup and impaired carboxylase activity produce neurologic vulnerability.
@@ -991,6 +1018,19 @@ biochemical:
   context: 'Elevated C5-OH acylcarnitine is a characteristic plasma marker of impaired leucine catabolism via 3-methylcrotonyl-CoA carboxylase deficiency. Detectable on newborn screening acylcarnitine profiles.
 
     '
+  readouts:
+  - target: Disrupted intermediary metabolism and organic aciduria
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated C5-OH reports secondary multiple-carboxylase dysfunction and the leucine-catabolism branch of the metabolic block.
+    evidence:
+    - reference: PMID:33572391
+      reference_title: "Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at Tandem Mass Spectrometry Newborn Screening."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: increased levels of C5OH may be linked to 3-methylcrotonyl-CoA carboxylase activity
+      explanation: This human newborn-screening report explicitly links C5OH elevation to the 3-methylcrotonyl-CoA carboxylase branch affected by BTD deficiency.
   evidence:
   - reference: PMID:37373384
     reference_title: "Delayed Biotin Therapy in a Child with Atypical Profound Biotinidase Deficiency: Late Arrival of the Truth and a Lesson Worth Thinking."
@@ -1003,6 +1043,19 @@ biochemical:
   context: 'Elevated urinary 3-hydroxyisovaleric acid is a characteristic organic acid marker reflecting impaired leucine catabolism via 3-methylcrotonyl-CoA carboxylase.
 
     '
+  readouts:
+  - target: Disrupted intermediary metabolism and organic aciduria
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary 3-hydroxyisovaleric acid reports impaired 3-methylcrotonyl-CoA carboxylase-dependent leucine catabolism.
+    evidence:
+    - reference: PMID:37373384
+      reference_title: "Delayed Biotin Therapy in a Child with Atypical Profound Biotinidase Deficiency: Late Arrival of the Truth and a Lesson Worth Thinking."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: primarily 3-hydroxyisovaleryl-carnitine in plasma as well as 3-hydroxyisovaleric acid in urine
+      explanation: This case report directly identifies urinary 3-hydroxyisovaleric acid accumulation downstream of impaired BTD-dependent carboxylase function.
   evidence:
   - reference: PMID:37373384
     reference_title: "Delayed Biotin Therapy in a Child with Atypical Profound Biotinidase Deficiency: Late Arrival of the Truth and a Lesson Worth Thinking."
@@ -1021,7 +1074,26 @@ biochemical:
   context: 'Elevated C3-acylcarnitine reflects propionyl-CoA carboxylase dysfunction in the setting of secondary multiple carboxylase deficiency.
 
     '
+  readouts:
+  - target: Disrupted intermediary metabolism and organic aciduria
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated C3 reports the propionyl-CoA carboxylase branch of secondary multiple-carboxylase dysfunction.
+    evidence:
+    - reference: PMID:33572391
+      reference_title: "Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at Tandem Mass Spectrometry Newborn Screening."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: mildly elevated C3 levels may reflect propionyl-CoA carboxylase deficiency
+      explanation: This human newborn-screening report directly links C3 elevation to propionyl-CoA carboxylase deficiency in the BTD deficiency metabolic context.
   evidence:
+  - reference: PMID:33572391
+    reference_title: "Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at Tandem Mass Spectrometry Newborn Screening."
+    supports: PARTIAL
+    evidence_source: HUMAN_CLINICAL
+    snippet: mildly elevated C3 levels may reflect propionyl-CoA carboxylase deficiency
+    explanation: Directly supports C3 elevation as a marker of the propionyl-CoA carboxylase branch in biotinidase deficiency.
   - reference: PMID:38928282
     reference_title: "Biotin Homeostasis and Human Disorders: Recent Findings and Perspectives."
     supports: PARTIAL
@@ -1033,7 +1105,32 @@ biochemical:
   context: 'Lactic acidosis results from pyruvate carboxylase impairment. Brain lactate may be detectable by magnetic resonance spectroscopy.
 
     '
+  readouts:
+  - target: Disrupted intermediary metabolism and organic aciduria
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lactate elevation reports impaired pyruvate carboxylase-dependent intermediary metabolism and lactic-acidosis risk.
+    evidence:
+    - reference: PMID:9427142
+      reference_title: "Cerebral metabolic changes in biotinidase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Lactate, pyruvate and 3-hydroxyisovaleric acid as metabolic disease markers were measured in blood, cerebrospinal fluid and brain tissue by biochemical analyses or localized magnetic resonance proton spectroscopy.
+      explanation: Human metabolic imaging and biochemical measurements identify lactate as a disease marker in biotinidase deficiency.
   evidence:
+  - reference: PMID:9427142
+    reference_title: "Cerebral metabolic changes in biotinidase deficiency."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: Lactate, pyruvate and 3-hydroxyisovaleric acid as metabolic disease markers were measured in blood, cerebrospinal fluid and brain tissue by biochemical analyses or localized magnetic resonance proton spectroscopy.
+    explanation: Directly supports lactate as a biochemical disease marker in biotinidase deficiency.
+  - reference: PMID:3736876
+    reference_title: "Biotinidase deficiency: accumulation of lactate in the brain and response to physiologic doses of biotin."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: this disorder who had high CSF content of lactate that could have contributed to the clinical disorder
+    explanation: Classic patient report supports increased CSF lactate in biotinidase deficiency.
   - reference: PMID:37027963
     reference_title: "Biotinidase deficiency: What have we learned in forty years?"
     supports: SUPPORT
@@ -1045,6 +1142,19 @@ biochemical:
   context: 'Reduced serum biotinidase enzyme activity is the definitive diagnostic marker. Profound deficiency is defined as less than 10% of mean normal activity and partial deficiency as 10-30%.
 
     '
+  readouts:
+  - target: Impaired biotin recycling and secondary multiple carboxylase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced biotinidase activity directly reports the proximal BTD enzyme defect that impairs biotin recycling.
+    evidence:
+    - reference: PMID:38141137
+      reference_title: "Evaluation of clinical, laboratory, and molecular genetic features of patients with biotinidase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Complete enzyme deficiency was identified in 19.8%, partial enzyme deficiency in 55.1%, and heterogenous enzyme deficiency in 9.7%
+      explanation: Cohort enzyme-activity data support reduced biotinidase activity as the diagnostic readout of the proximal mechanism.
   evidence:
   - reference: PMID:40190376
     reference_title: "Biotinidase Deficiency Induced Optic Neuropathy: A Case Report and Literature Review."

--- a/references_cache/PMID_33572391.md
+++ b/references_cache/PMID_33572391.md
@@ -1,0 +1,107 @@
+---
+reference_id: "PMID:33572391"
+title: Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at Tandem Mass Spectrometry Newborn Screening.
+authors:
+- Cicalini I
+- Pieragostino D
+- Rizzo C
+- Verrocchio S
+- Semeraro D
+- Zucchelli M
+- Di Michele S
+- Dionisi-Vici C
+- Stuppia L
+- De Laurenzi V
+- Bucci I
+- Rossi C
+journal: Int J Environ Res Public Health
+year: '2021'
+doi: 10.3390/ijerph18041659
+keywords:
+- Biotinidase/genetics
+- Biotinidase Deficiency/diagnosis
+- "Carnitine/analogs & derivatives"
+- Female
+- Humans
+- Infant
+- "Infant, Newborn"
+- Neonatal Screening
+- Tandem Mass Spectrometry
+content_type: full_text_xml
+---
+
+# Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at Tandem Mass Spectrometry Newborn Screening.
+**Authors:** Cicalini I, Pieragostino D, Rizzo C, Verrocchio S, Semeraro D, Zucchelli M, Di Michele S, Dionisi-Vici C, Stuppia L, De Laurenzi V, Bucci I, Rossi C
+**Journal:** Int J Environ Res Public Health (2021)
+**DOI:** [10.3390/ijerph18041659](https://doi.org/10.3390/ijerph18041659)
+
+## Content
+
+1. Int J Environ Res Public Health. 2021 Feb 9;18(4):1659. doi:
+10.3390/ijerph18041659.
+
+Partial Biotinidase Deficiency Revealed Imbalances in Acylcarnitines Profile at
+Tandem Mass Spectrometry Newborn Screening.
+
+Cicalini I(1)(2), Pieragostino D(1)(3), Rizzo C(4), Verrocchio S(1)(2), Semeraro
+D(1)(2), Zucchelli M(1)(3), Di Michele S(5), Dionisi-Vici C(4), Stuppia L(1)(6),
+De Laurenzi V(1)(3), Bucci I(1)(2), Rossi C(1)(6).
+
+Author information:
+(1)Center for Advanced Studies and Technology (CAST), University "G. d'Annunzio"
+of Chieti-Pescara, 66100 Chieti, Italy.
+(2)Department of Medicine and Aging Science, University "G. d'Annunzio" of
+Chieti-Pescara, 66100 Chieti, Italy.
+(3)Department of Innovative Technologies in Medicine & Dentistry, University
+''G. d'Annunzio'' of Chieti-Pescara, 66100 Chieti, Italy.
+(4)Metabolic Diseases Unit, Bambino Gesù Children Hospital and Research
+Institute, 00165 Rome, Italy.
+(5)Department of Pediatrics, "Spirito Santo" Hospital, 65100 Pescara, Italy.
+(6)Department of Psychological, Health and Territory Sciences, School of
+Medicine and Health Sciences, "G. d'Annunzio" University, 66100 Chieti, Italy.
+
+Biotinidase (BTD) deficiency is an autosomal recessive inherited neurocutaneous
+disorder. BTD recycles the vitamin biotin, a coenzyme essential for the function
+of four biotin-dependent carboxylases, including propionyl-CoA carboxylase,
+3-methylcrotonyl-CoA carboxylase, pyruvate carboxylase, and acetyl-CoA
+carboxylase. Due to deficient activities of the carboxylases, BTD deficiency is
+also recognized as late-onset multiple carboxylase deficiency and is associated
+with secondary alterations in the metabolism of amino acids, carbohydrates, and
+fatty acids. BTD deficiency can be classified as "profound", with less than 10%
+of mean normal activity, and as "partial" with 10-30% of mean normal activity.
+Newborn screening (NBS) of BTD deficiency is performed in most countries and is
+able to detect both variants. Moreover, mild metabolic alterations related to
+carboxylase deficiency in profound BTD deficiency could result and possibly be
+revealed in the metabolic profile by tandem mass spectrometry (MS/MS) NBS. Here,
+we report the case of a newborn female infant with an initial suspected BTD
+deficiency at the NBS test, finally confirmed as a partial variant by molecular
+testing. Although BTD deficiency was partial, interestingly her metabolic
+profile at birth and during the follow-up tests revealed, for the first time,
+alterations in specific acylcarnitines as a possible result of the deficient
+activity of biotin-dependent carboxylases.
+
+DOI: 10.3390/ijerph18041659
+PMCID: PMC7916230
+PMID: 33572391 [Indexed for MEDLINE]
+
+Conflict of interest statement: The authors declare no conflict of interest.
+
+Biotinidase (BTD) deficiency is an autosomal recessive inherited disorder of biotin recycling and it is associated with neurologic and cutaneous consequences if untreated [1,2]. The BTD enzyme is encoded by a single gene (BTD) located on chromosome 3p25. Over 150 mutations in the BTD gene have been identified and reported to cause BTD deficiency [1,3,4]. The BTD enzyme, a 70–80 kDa glycoprotein, has a dual function: on the one hand, it separates the water-soluble vitamin biotin from the biocytin, allowing the recirculation of free biotin, also releasing lysine; on the other hand, BTD also recovers biotin from food sources, by breaking down its bond with other proteins [5], as shown in Figure 1.
+
+In particular, biotin in the free form acts as a coenzyme, essential for the function of four carboxylases: propionyl-CoA carboxylase and 3-methylcrotonyl-CoA carboxylase in protein catabolism, pyruvate carboxylase necessary for gluconeogenesis, and acetyl-CoA carboxylase in the first step of fatty acid synthesis [4,6,7]. Therefore, an inherited disorder of biotin recycling because of a deficiency of BTD is also known as late-onset multiple carboxylase deficiency and is associated with secondary imbalances in the metabolism of amino acids, carbohydrates, and fatty acids [8]. Depending on the residual enzymatic activity, BTD deficiency variants are functionally described as “profound” with less than 10% of mean normal activity, and “partial” with 10 to 30% of mean normal activity [1,4,5]. Worldwide, the incidence of BTD deficiency varies from 1:40,000 to 1:60,000 births, being even higher in countries with high consanguinity rates [5]. Interestingly, a higher incidence of 1:6300 (cumulative for complete or partial) has been recently reported in Italy [9]. The initial clinical symptoms in untreated children might appear between two and five months of age, even if they may not be evident until several years later [1]. Untreated infants with profound BTD deficiency can exhibit a variety of neurological and clinical manifestations, including hypotonia, seizures, feeding problems, ataxia, developmental delay, hearing loss, alopecia, eczema, and skin rash [1,4,5]. Biochemically, most untreated patients may present lactic acidosis, ketoacidosis, and eventually hyperammonaemia [1,4]. Other metabolic alterations may include the elevation of lactic acid and alanine due to deficient activity of pyruvate carboxylase, accumulation of propionate, 3-hydroxypropionate, and methyl citrate because of deficient activity of propionyl-CoA carboxylase, and increased excretion levels of 3-hydroxyvaleric acid and 3-methylcrotonylglycine as a result of 3-methylcrotonyl-CoA carboxylase deficiency [1,5,10,11]. Consequently, sometimes in profound BTD deficiency mildly elevated 3-hydroxyvalerylcarnitine (C5OH) and propionylcarnitine (C3) may be revealed [1] by tandem mass spectrometry (MS/MS) analysis as a newborn screening (NBS) test for other inborn errors of metabolism (IEMs) through amino acids and acylcarnitines determination. The over described metabolic alterations as a consequence of multiple carboxylase deficiency have been already reported and confirmed in mice with profound BTD deficiency [12,13,14]. Most patients with partial BTD deficiency are asymptomatic but can develop hypotonia or skin rash under stressful conditions such as fever or starvation. Since symptoms of this metabolic disorder can be prevented and easily treated with success by supplementation with oral biotin in the free form, and an affordable and reliable screening test is available, newborns are screened for BTD deficiency in most countries [1,4]. In Italy, BTD deficiency is one of the disorders incorporated in the nationwide screening program that also includes testing for disorders of amino acid metabolism, urea cycle metabolism, organic acid metabolism, and for defects of fatty acid oxidation, galactosemia, cystic fibrosis, and congenital hypothyroidism. Nowadays, it is well known that metabolic findings and imbalances revealed at NBS may be influenced not only by the genome, but also by other factors such as partial enzyme deficiencies, treatments, nutritional deficiency, prematurity, and maternal defects [15,16,17]. In fact, in screening newborns for BTD deficiency, both profound and partial variants can be detected [1,18]. Sometimes, the profound defects have been associated with metabolic alterations at MS/MS NBS linked to the multiple blocks of carboxylases [1,19].
+
+Here, we describe the case of a newborn female infant who, after the initial detection of BTD deficient activity at NBS, was finally diagnosed with partial BTD deficiency in a compound heterozygous variant. More importantly, we report the first description of alterations in the levels of C3 and C5OH by MS/MS NBS possibly linked to the multiple blocks of carboxylases in a neonatal case of a partial BTD deficiency variant. In fact, even though the deficiency variant identified was partial, MS/MS metabolic profile at birth and during the follow-up tests unexpectedly revealed alterations in specific acylcarnitines, probably related to the deficient function of some of the carboxylases which use biotin as a coenzyme.
+
+The patient, a newborn female infant, was the first child of Caucasian non-consanguineous parents. She was born at 40 weeks of gestation by vaginal delivery, the birth weight was adequate for the gestational age (3600 kg). Neonatal parameters were unremarkable, she presented normal red reflex examination and oto-acoustic emission screening tests. The family history was positive only for maternal thyroid disease. The newborn tested positive at the NBS performed on the second day of life for reduced BTD activity (50.1 U/dL, cut-off > 85 U/dL). The newborn was re-called and the new test confirmed the reduced enzymatic activity. Subsequent follow-up BTD activity determination and BTD gene molecular analysis confirmed a partial BTD deficit. At the initial clinical evaluation, no signs or symptoms consistent with BTD deficiency were observed. Treatment with biotin was recommended only during stress conditions and regular clinical and biochemical follow-ups were scheduled [20]. At subsequent clinical checks, the absence of signs and symptoms and normal psychomotor development were documented. During the COVID-19 pandemic, a family screening was also performed. The father, a 33-year-old, completely asymptomatic adult, also showed a reduced BTD activity associated with an alteration of the acylcarnitine panel, as detailed in the following paragraphs.
+
+BTD enzyme activity was screened by a fluorescence-based assay (GSP Neonatal Biotinidase, Wallac Oy PerkinElmer) on a dried blood spot (DBS) sample collected at 48 h of life. The newborn screened positive, having BTD activity equal to 50.1 U/dL below the laboratory 85 U/dL cut-off. Based on BTD activity distribution in the laboratory population, the newborn’s value at first DBS was consistent with partial BTD deficiency. The newborn was re-called at 7 and 10 days of life for re-determination of BTD activity. Low BTD activity was confirmed in the repeated DBS: 45.4 U/dL and 74.4 U/dL, respectively, and the newborn was referred to clinical evaluation and genetic analysis. The biochemical phenotype was confirmed at the time of the fourth and fifth DBS collection (Figure 2, Panel A). All DBS samples of the newborn were also analyzed by MS/MS for the simultaneous quantification of amino acids and acylcarnitines. As shown by the histograms in Figure 2B, C several numerous alterations were observed in the acylcarnitine panel. In particular, after 482 days of life of the newborn, the screening of amino acids and acylcarnitines showed an increase in the values of methylmalonyl-3-hyroxy-isovalerylcarnitine C4DC-C5OH = 0.65 μM (cut-off > 0.57 μM), accompanied by an important alteration of its ratio with short and medium-chain acylcarnitines: C4DC-C5OH/C2 = 0.10 (cut-off > 0.04), C4DC-C5OH/C8 = 50.2 (cut-off > 16), and C4DC-C5OH/C10 = 40.75 (cut-off > 11), as reported in Figure 2, Panel B. While screening analyses in MS/MS showed an alteration of proprionylcarnitine (C3), already in the first sample at 2 days of life (Figure 2, Panel C). The alteration of acylcarnitine C3 (sampling after 2 days of life) and the alteration of the ratios C3/C2 and C3/C16 (after 482 days of life) required a further second-level analysis for the quantification of homocysteine (HCY), acid methyl citric acid (MCA) and methylmalonic acid (MMA), showing, in both cases, values below the reference limit for all the three monitored metabolites. Table 1 shows in detail all the information relating to the first and second-level analyses of all the samples collected from the newborn. Methodological details are reported in the supplementary materials and in Table S1.
+
+In order to emphasize the metabolic alterations observed in the present neonatal case of partial BTD deficiency, we show in Figure 3 the comparison with the other two newborns with a partial defect of BTD, at different time points (Figure 3, Panel A). Interestingly, histograms in Panel C highlight no alteration in the levels of C4DC-C5OH and its ratios for the two newborns (NB2 and NB3) involved in the comparison. In addition, in Figure S1 we also report the comparison between the newborn discussed in the present case report and a few of the negative neonatal samples in terms of BTD activity and levels of acylcarnitine C4DC-C5OH and its ratios, as examples of normal ranges in the neonatal population.
+
+The BTD deficiency DBS screening test was also performed on the newborn’s parents. As shown in Figure 4, Panel A, the father, a 33-year-old adult, completely asymptomatic, showed a reduced BTD activity of 49.9 U/dL, (cut-off > 85 U/dL), while the BTD activity measured in the mother’s sample was found to be fully normal. Interestingly, at MS/MS analyses, the father’s sample showed an evident increase in the levels of acylcarnitine C4DC-C5OH = 0.70 μM (cut-off > 0.57 μM) and of its ratio with short and medium-chain acylcarnitines: C4DC-C5OH/C2 = 0.07 (cut-off > 0.04), C4DC-C5OH/C8 = 31.0 (cut-off > 16), and C4DC-C5OH/C10 = 26.74 (cut-off > 11), as reported in Figure 4, Panel B. On the other hand, no alterations in the levels of acylcarnitine C3 and in its ratios were found (Figure 4, Panel C). The mother’s MS/MS profile was unremarkable.
+
+Genomic DNA from peripheral blood and sequence analysis of the BTD gene was performed by Next Generation Sequencing (NGS) (NovaSeq6000, Illumina, San Diego, CA, USA) using NimbleGen SeqCap Target Enrichment (Roche, Basel, Switzerland). According to the sequence analysis results of the BTD gene, including exon-intron boundaries, the BTD deficiency was finally confirmed as compound heterozygous. The mutations found were p.(Val62Met) and p.(Asp444His) corresponding to the following genotypes: c.184G > A and c.1330G > C. To date, the segregation has not yet been confirmed in the parents. Molecular testing results together with the percentage of residual enzymatic activity measured by fluorescence-based BTD assays at NBS allowed us to confirm the partial BTD deficiency variant.
+
+BTD deficiency screening allows the estimation of enzyme activity and identification of newborns requiring diagnostic confirmation. Newborns affected with profound BTD deficiency have less than 10% of mean normal enzyme activity, while 10–30% of mean normal enzyme activity is observed in the partial form [4]. In this case, we report the story of a female full-term infant from non-consanguineous parents, in which suspected BTD deficiency at NBS was confirmed as a partial form at the genetic analysis. As already described and reported in Figure 1, this enzyme recycles the vitamin biotin, a coenzyme essential for the function of four biotin-dependent carboxylases, including propionyl-CoA carboxylase, 3-methylcrotonyl-CoA carboxylase, pyruvate carboxylase, and acetyl-CoA carboxylase [1,4]. In Italy, the expanded NBS program includes, in addition to the measurement of BTD activity through fluorescence-based assays, the measurement of total galactose and a large panel of amino acids and acylcarnitines in DBS samples thanks to the use of high-throughput technologies such as MS/MS [21]. Importantly, the entire metabolites panel allows appreciating possible alterations related to propionyl-CoA carboxylase and 3-methylcrotonyl-CoA carboxylase activity, as biotine-depended enzymes. In particular, mildly elevated C3 levels may reflect propionyl-CoA carboxylase deficiency. As well, increased levels of C5OH may be linked to 3-methylcrotonyl-CoA carboxylase activity. Rai-Hseng Hsu et al. have already described cases of neonates diagnosed with BTD deficiency, who simultaneously presented alterations of C5OH and elevation of urinary levels of 3-hydroxyisovalerate, 3-methylcrotonylglycine, lactate, and pyruvate [19]. However, these described cases are always related to a profound deficit in BTD activity. Here, we report, for the first time, some slight alterations in the levels of C3 and C5OH at MS/MS NBS in a neonatal case of partial BTD deficiency. The MS/MS analyses carried out in our laboratory showed an alteration of the C3, already in the first sample (2 days of life). Then, during the last follow-up (after 482 days of life), increased ratios of C3/C2 and C3/C16 were detected. These metabolic alterations at MS/MS NBS required second-tier tests by LC-MS/MS for the quantification of methyl citric acid (MCA), as a direct product of propionyl-CoA carboxylase activity. MCA levels, normally undetectable, were quantified only in the last LC-MS/MS analysis after 482 days of life (MCA = 0.8 μM, cut-off < 1 μM), highlighting a slight accumulation of MCA, probably linked to a deficiency in the disposal of propionyl-CoA through propionyl-CoA carboxylase activity [22]. Furthermore, the levels of C4DC-C5OH and its ratios with short and medium-chain acylcarnitines were found to be within the reference limits in the first four samples between 2 and 22 days of life. Instead, it is interesting to note that NBS analyses carried out on the last sampling (after 482 days of life) revealed alterations of C4DC-C5OH and its ratios. These data might be suggestive of deficient 3-methylcrotonyl-CoA carboxylase activity, considering the strong inverse correlation between C5OH levels and residual enzymatic activity [23,24]. Surprisingly, her father, who showed approximately the same residual BTD activity, also presented similar alterations in his metabolic profile. More specifically, C4DC-C5OH and its ratios versus C2, C8, and C10 were found to be increased after MS/MS analysis of the father’s DBS sample.
+
+The present neonatal case highlights the importance of an expanded NBS test in detecting partial enzyme deficiencies, also allowing for subclassifications of the disorders. Moreover, the expanded NBS approach also allows revealing patients with late-onset forms of diseases, which may never require treatment or only in adulthood. As already discussed, BTD deficiency could be secondarily accompanied by acidosis and a characteristic organic acidemia due to multiple carboxylase deficiency [9]. For this reason, even in countries where an NBS test for BTD deficiency is not performed, we highly recommend that newborns with specific abnormalities in acylcarnitine profile following MS/MS NBS be considered for suspicion of BTD deficiency. In addition, plasma acylcarnitines by Liquid Chromatography coupled to tandem Mass Spectrometry (LC-MS/MS) and urinary organic acid profiles by Gas Chromatography-Mass Spectrometry (GC-MS) should be performed to check for the altered results at the NBS test. Finally, the present case points out the significance of the follow-up, mainly in asymptomatic patients. In fact, follow-up analyses of the patient allow appreciating any further alterations as indices of the metabolic status.

--- a/references_cache/PMID_3736876.md
+++ b/references_cache/PMID_3736876.md
@@ -1,0 +1,48 @@
+---
+reference_id: "PMID:3736876"
+title: "Biotinidase deficiency: accumulation of lactate in the brain and response to physiologic doses of biotin."
+authors:
+- Diamantopoulos N
+- Painter MJ
+- Wolf B
+- Heard GS
+- Roe C
+journal: Neurology
+year: '1986'
+doi: 10.1212/wnl.36.8.1107
+keywords:
+- Amidohydrolases/deficiency
+- Biotin/therapeutic use
+- Biotinidase
+- Brain/metabolism
+- Child
+- Humans
+- Lactates/metabolism
+- Male
+- Metabolic Diseases/drug therapy
+content_type: abstract_only
+---
+
+# Biotinidase deficiency: accumulation of lactate in the brain and response to physiologic doses of biotin.
+**Authors:** Diamantopoulos N, Painter MJ, Wolf B, Heard GS, Roe C
+**Journal:** Neurology (1986)
+**DOI:** [10.1212/wnl.36.8.1107](https://doi.org/10.1212/wnl.36.8.1107)
+
+## Content
+
+1. Neurology. 1986 Aug;36(8):1107-9. doi: 10.1212/wnl.36.8.1107.
+
+Biotinidase deficiency: accumulation of lactate in the brain and response to
+physiologic doses of biotin.
+
+Diamantopoulos N, Painter MJ, Wolf B, Heard GS, Roe C.
+
+Biotinidase deficiency is the most common cause of late onset, biotin-responsive
+multiple carboxylase deficiency (MCD). We studied the two oldest known boys with
+this disorder who had high CSF content of lactate that could have contributed to
+the clinical disorder. The symptoms of these patients implied that near
+physiologic, rather than pharmacologic, doses of biotin may be sufficient for
+treatment.
+
+DOI: 10.1212/wnl.36.8.1107
+PMID: 3736876 [Indexed for MEDLINE]

--- a/references_cache/PMID_9427142.md
+++ b/references_cache/PMID_9427142.md
@@ -1,0 +1,59 @@
+---
+reference_id: "PMID:9427142"
+title: Cerebral metabolic changes in biotinidase deficiency.
+authors:
+- Schürmann M
+- Engelbrecht V
+- Lohmeier K
+- Lenard HG
+- Wendel U
+- Gärtner J
+journal: J Inherit Metab Dis
+year: '1997'
+doi: "10.1023/a:1005307415289"
+keywords:
+- Amidohydrolases/deficiency
+- Biotin/therapeutic use
+- Biotinidase
+- "Brain/pathology, physiopathology"
+- Electroencephalography
+- Humans
+- Infant
+- "Lactic Acid/blood, cerebrospinal fluid, metabolism"
+- Magnetic Resonance Imaging
+- Male
+- "Pyruvic Acid/blood, cerebrospinal fluid, metabolism"
+- Seizures/etiology
+- "Valerates/blood, cerebrospinal fluid, metabolism"
+content_type: abstract_only
+---
+
+# Cerebral metabolic changes in biotinidase deficiency.
+**Authors:** Schürmann M, Engelbrecht V, Lohmeier K, Lenard HG, Wendel U, Gärtner J
+**Journal:** J Inherit Metab Dis (1997)
+**DOI:** [10.1023/a:1005307415289](https://doi.org/10.1023/a:1005307415289)
+
+## Content
+
+1. J Inherit Metab Dis. 1997 Nov;20(6):755-60. doi: 10.1023/a:1005307415289.
+
+Cerebral metabolic changes in biotinidase deficiency.
+
+Schürmann M(1), Engelbrecht V, Lohmeier K, Lenard HG, Wendel U, Gärtner J.
+
+Author information:
+(1)Department of Paediatrics, Heinrich-Heine-University, Düsseldorf, Germany.
+
+Clinical and metabolic changes in the central nervous system are described in a
+patient with biotinidase deficiency before and after biotin treatment. Lactate,
+pyruvate and 3-hydroxyisovaleric acid as metabolic disease markers were measured
+in blood, cerebrospinal fluid and brain tissue by biochemical analyses or
+localized magnetic resonance proton spectroscopy. The patient improved markedly
+with biotin treatment. Nevertheless, neurological sequelae and abnormal
+intracerebral lactate concentrations persisted despite normalized metabolic
+disease markers in extracerebral fluids. Therefore, localized in vivo
+measurements of intracerebral metabolites may be a valuable tool for elucidating
+the pathogenesis of biotinidase deficiency.
+
+DOI: 10.1023/a:1005307415289
+PMID: 9427142 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- add molecular-function annotations for the four biotin-dependent carboxylase activities in the Biotinidase metabolic node
- connect all five biochemical markers to pathograph readout targets
- add fetched PMID caches supporting C3/C5OH acylcarnitine and lactate readouts

## Validation
- just validate kb/disorders/Biotinidase_Deficiency.yaml
- just validate-terms kb/disorders/Biotinidase_Deficiency.yaml
- normalized snippet audit: 123 checked, 0 missing
- reference cache frontmatter check passed
- graph coverage: phenotypes 25/25; biochemical readouts 5/5

Note: validation/frontmatter checks transiently rewrote unrelated PMID_24904092 and PMID_31292197 frontmatter; those were restored before commit.