### PR TITLE
Wire HHH biochemical readouts

### DIFF
--- a/kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
+++ b/kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome
 creation_date: "2026-05-11T07:39:50Z"
-updated_date: "2026-05-18T04:30:01Z"
+updated_date: "2026-05-21T04:16:09Z"
 category: Mendelian
 synonyms:
 - HHH syndrome
@@ -1421,6 +1421,19 @@ biochemical:
     term:
       id: CHEBI:18257
       label: ornithine
+  readouts:
+  - target: Mitochondrial Ornithine Transport Defect
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated ornithine reports failed mitochondrial ornithine uptake due to ORC1/ORNT1 transport deficiency.
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Ornithine carrier 1 deficiency causes HHH syndrome, characterized by failure of mitochondrial ornithine uptake, hyperammonemia, and accumulation of ornithine and lysine in the cytoplasm."
+      explanation: Human cohort evidence directly connects failed mitochondrial ornithine uptake to ornithine accumulation.
   evidence:
   - reference: PMID:39597062
     reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
@@ -1439,6 +1452,19 @@ biochemical:
     term:
       id: CHEBI:16134
       label: ammonia
+  readouts:
+  - target: Urea Cycle Flux Impairment
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated ammonia reports impaired hepatic urea-cycle nitrogen disposal.
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Three out of four cases presented with hyperammonemia, elevated transaminases, and uraciluria."
+      explanation: Human cohort data support hyperammonemia as a biochemical readout of the impaired urea-cycle branch.
   evidence:
   - reference: PMID:39597062
     reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
@@ -1456,6 +1482,19 @@ biochemical:
     term:
       id: CHEBI:17443
       label: L-homocitrulline
+  readouts:
+  - target: Carbamoyl Phosphate Diversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary homocitrulline reports carbamoyl-phosphate diversion when ornithine-dependent urea-cycle flux is impaired.
+    evidence:
+    - reference: PMID:25874378
+      reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The diagnosis relies on clinical signs and the peculiar metabolic triad of hyperammonemia, hyperornithinemia, and urinary excretion of homocitrulline."
+      explanation: The diagnostic triad supports urinary homocitrulline as a readout of the diverted urea-cycle intermediate state.
   evidence:
   - reference: PMID:25874378
     reference_title: "The hyperornithinemia-hyperammonemia-homocitrullinuria syndrome."
@@ -1474,6 +1513,19 @@ biochemical:
     term:
       id: CHEBI:16742
       label: orotic acid
+  readouts:
+  - target: Carbamoyl Phosphate Diversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Oroticaciduria reports diversion of excess carbamoyl phosphate into pyrimidine-pathway products.
+    evidence:
+    - reference: ORPHA:415
+      reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003218 | Oroticaciduria | Frequent (79-30%)"
+      explanation: Orphanet supports oroticaciduria as a frequent biochemical manifestation of the carbamoyl-phosphate diversion branch.
   evidence:
   - reference: ORPHA:415
     reference_title: "Hyperornithinemia-hyperammonemia-homocitrullinuria syndrome (Orphanet structured-database record)"
@@ -1487,6 +1539,19 @@ biochemical:
   context: >-
     Elevated hepatic transaminases accompany liver dysfunction during acute or
     chronic HHH syndrome presentations.
+  readouts:
+  - target: Liver Dysfunction and Coagulation Abnormality
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Elevated hepatic transaminases report the liver-dysfunction branch of HHH syndrome.
+    evidence:
+    - reference: PMID:39597062
+      reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Three out of four cases presented with hyperammonemia, elevated transaminases, and uraciluria."
+      explanation: Human cohort data directly document elevated transaminases accompanying HHH presentations.
   evidence:
   - reference: PMID:39597062
     reference_title: "Hyperornithinemia-Hyperammonemia-Homocitrullinuria Syndrome in Vietnamese Patients."


### PR DESCRIPTION
## Summary
- connect all five HHH biochemical markers to existing pathograph readout targets
- preserve existing 40/40 phenotype graph coverage and 5/5 biochemical downstream coverage
- update the curation timestamp

## Validation
- just validate kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
- just validate-terms kb/disorders/Hyperornithinemia_Hyperammonemia_Homocitrullinuria_Syndrome.yaml
- normalized snippet audit: 143 checked, 0 missing
- graph coverage: phenotypes 40/40; biochemical readouts 5/5

Note: validation transiently rewrote unrelated PMID_24904092 and PMID_31292197 frontmatter; those were restored before commit.