### PR TITLE
Wire LIPT1 biochemical readouts

### DIFF
--- a/kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
+++ b/kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Lipoyl Transferase 1 Deficiency
 creation_date: '2026-02-13T00:59:22Z'
-updated_date: '2026-05-07T14:41:31Z'
+updated_date: '2026-05-21T04:25:34Z'
 category: Mendelian
 description: >
   Lipoyl transferase 1 deficiency (OMIM 616299) is a rare autosomal recessive
@@ -242,6 +242,12 @@ pathophysiology:
     term:
       id: GO:0006099
       label: tricarboxylic acid cycle
+  molecular_functions:
+  - preferred_term: pyruvate dehydrogenase (acetyl-transferring) activity
+    modifier: DECREASED
+    term:
+      id: GO:0004739
+      label: pyruvate dehydrogenase (acetyl-transferring) activity
   cellular_components:
   - preferred_term: Pyruvate dehydrogenase complex
     term:
@@ -574,6 +580,22 @@ biochemical:
   context: >
     LIPT1 deficiency reduces lipoylation of pyruvate dehydrogenase and
     alpha-ketoglutarate dehydrogenase E2 subunits in patient-derived cells.
+  readouts:
+  - target: Defective lipoyl relay via LIPT1 deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced lipoylated dehydrogenase E2 subunits directly report the proximal LIPT1 lipoyl-transfer defect.
+    evidence:
+    - reference: PMID:39199267
+      reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        A Western blot analysis revealed a reduced expression of LIPT1 and
+        absent expression of lipoylated pyruvate dehydrogenase E2 (PDH E2) and
+        alpha-ketoglutarate dehydrogenase E2 (α-KGDH E2) subunits.
+      explanation: Patient-derived cellular models directly show absent lipoylated PDH E2 and alpha-KGDH E2 downstream of reduced LIPT1 expression.
   evidence:
   - reference: PMID:24256811
     reference_title: "Mutations in the lipoyltransferase LIPT1 gene cause a fatal disease associated with a specific lipoylation defect of the 2-ketoacid dehydrogenase complexes."
@@ -601,6 +623,22 @@ biochemical:
   context: >
     Reduced lipoylation lowers PDH and alpha-KGDH enzymatic activity, limiting
     pyruvate entry into the TCA cycle and TCA-cycle flux.
+  readouts:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency with spared glycine cleavage
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced PDH and alpha-KGDH activity reports the combined alpha-ketoacid dehydrogenase-deficiency branch.
+    evidence:
+    - reference: PMID:39199267
+      reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Accordingly, activities of PDH and α-KGDH were markedly reduced,
+        associated with cell bioenergetics failure, iron accumulation, and
+        lipid peroxidation.
+      explanation: Patient-derived cellular models directly document reduced PDH and alpha-KGDH activities.
   evidence:
   - reference: PMID:39199267
     reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
@@ -619,6 +657,23 @@ biochemical:
     Glycine elevation is absent because GCSH lipoylation and glycine cleavage
     remain intact, distinguishing LIPT1 deficiency from LIAS and LIPT2
     deficiency.
+  readouts:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency with spared glycine cleavage
+    relationship: READOUT_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: Normal glycine reports the spared glycine-cleavage component that distinguishes LIPT1 deficiency from upstream lipoate biosynthesis defects.
+    evidence:
+    - reference: PMID:24256811
+      reference_title: "Mutations in the lipoyltransferase LIPT1 gene cause a fatal disease associated with a specific lipoylation defect of the 2-ketoacid dehydrogenase complexes."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        However, the absence of glycine elevation, the normal activity of the
+        glycine cleavage system and the normal lipoylation of the H protein
+        suggested a defect of lipoic acid transfer to particular proteins rather
+        than a general impairment of lipoic acid biosynthesis
+      explanation: Patient biochemical testing supports normal glycine as the readout of preserved glycine cleavage in LIPT1 deficiency.
   evidence:
   - reference: PMID:24256811
     reference_title: "Mutations in the lipoyltransferase LIPT1 gene cause a fatal disease associated with a specific lipoylation defect of the 2-ketoacid dehydrogenase complexes."
@@ -637,6 +692,20 @@ biochemical:
   context: >
     Urinary lactate, ketoglutarate, and 2-oxoacid accumulation reflects the
     downstream metabolic block from deficient 2-ketoacid dehydrogenase activity.
+  readouts:
+  - target: Combined alpha-ketoacid dehydrogenase deficiency with spared glycine cleavage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urine lactate, ketoglutarate, and 2-oxoacids report the downstream metabolite accumulation caused by combined dehydrogenase deficiency.
+    evidence:
+    - reference: PMID:39199267
+      reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        increased urine lactate, ketoglutarate, and 2-oxoacid levels.
+      explanation: The clinical summary directly identifies this urinary metabolite pattern in LIPT1 deficiency.
   evidence:
   - reference: PMID:39199267
     reference_title: "A Multi-Target Pharmacological Correction of a Lipoyltransferase LIPT1 Gene Mutation in Patient-Derived Cellular Models."


### PR DESCRIPTION
## Summary
- add pyruvate dehydrogenase molecular-function annotation to the combined dehydrogenase-deficiency node
- connect all four LIPT1 biochemical markers to existing pathograph readout targets
- keep the PR scoped to `Lipoyl_Transferase_1_Deficiency.yaml` only

## Validation
- just validate kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
- just validate-terms kb/disorders/Lipoyl_Transferase_1_Deficiency.yaml
- normalized snippet audit: 50 checked, 0 missing
- graph coverage: phenotypes 5/5; biochemical readouts 4/4

Note: validation transiently rewrote unrelated term/reference caches; those were restored before commit.