### PR TITLE
Wire PRPS1 Superactivity biochemical readouts

### DIFF
--- a/kb/disorders/PRPS1_Superactivity.yaml
+++ b/kb/disorders/PRPS1_Superactivity.yaml
@@ -1,6 +1,6 @@
 name: PRPS1 Superactivity
 creation_date: "2026-04-04T00:00:00Z"
-updated_date: "2026-05-05T03:40:31Z"
+updated_date: "2026-05-21T04:37:25Z"
 description: >-
   Phosphoribosylpyrophosphate synthetase (PRS-I) superactivity is an
   X-linked disorder of purine metabolism caused either by PRPS1
@@ -618,6 +618,20 @@ biochemical:
     Enzyme testing can show high PRS-I activity or lack of allosteric
     regulation; the severe variant mechanism impairs purine nucleotide
     feedback inhibition.
+  readouts:
+  - target: PRS-I allosteric gain of function
+    relationship: READOUT_OF
+    direction: THRESHOLD_DEPENDENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased PRS-I activity or abnormal allosteric regulation reports the proximal PRS-I superactivity mechanism.
+    evidence:
+    - reference: PMID:20301734
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        detection of high activity or lack of allosteric regulation of the
+        PRS-I enzyme (PRS-I enzyme assay) establishes the diagnosis.
+      explanation: GeneReviews identifies high PRS-I activity or loss of allosteric regulation as the diagnostic enzyme readout.
   evidence:
   - reference: PMID:20301734
     supports: SUPPORT
@@ -650,6 +664,23 @@ biochemical:
   context: >-
     Patient cells can show increased PRPP and purine nucleotide synthesis,
     reflecting enhanced entry of ribose into purine biosynthesis.
+  readouts:
+  - target: PRPP and purine nucleotide overproduction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased PRPP and purine nucleotide synthesis directly report the purine-overproduction node downstream of PRS-I superactivity.
+    evidence:
+    - reference: PMID:10066814
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        modulated relative increases in PRS activities at suboptimal Pi
+        concentration and in rates of PRPP and purine nucleotide synthesis in
+        intact patient fibroblasts indicate that despite an intact allosteric
+        mechanism of regulation of PRS activity, PRPS1 transcription is a
+        major determinant of PRPP and purine synthesis.
+      explanation: Patient fibroblast data directly support increased PRPP and purine synthesis as the readout of purine-overproduction biology.
   evidence:
   - reference: PMID:10066814
     supports: SUPPORT
@@ -673,6 +704,21 @@ biochemical:
   context: >-
     Serum urate is elevated from uric acid overproduction and is monitored
     as a treatment target.
+  readouts:
+  - target: Urate overproduction and crystal disease
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Elevated serum urate reports the urate-overproduction branch and is used to monitor crystal-disease risk.
+    evidence:
+    - reference: PMID:30423175
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Clinical findings in previously reported females with PRPS1
+        superactivity showed a high clinical penetrance of this disorder with
+        a mean serum urate level of 8.5 (4.1) mg/dl
+      explanation: Human case synthesis directly supports elevated serum urate as a clinical readout of PRPS1 superactivity.
   evidence:
   - reference: PMID:30423175
     supports: SUPPORT
@@ -693,6 +739,21 @@ biochemical:
   context: >-
     Urinary uric acid excretion is increased and is used for screening and
     treatment surveillance.
+  readouts:
+  - target: Urate overproduction and crystal disease
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Increased urinary uric acid excretion reports urate overproduction and the urinary crystal/stone-risk branch.
+    evidence:
+    - reference: PMID:20301734
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        In male relatives at risk: measurement of serum urate concentration
+        and 24-hour urinary uric acid excretion or spot urinary
+        urate-to-creatinine ratio.
+      explanation: GeneReviews identifies urinary uric acid excretion as a measured biochemical readout for PRS-I superactivity risk assessment.
   evidence:
   - reference: PMID:20301734
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- connect all four PRPS1 Superactivity biochemical markers to existing pathograph readout targets
- use diagnostic context for PRS-I/PRPP readouts and monitoring context for serum/urine urate readouts
- keep the PR scoped to `PRPS1_Superactivity.yaml` only

## Validation
- just validate kb/disorders/PRPS1_Superactivity.yaml
- just validate-terms kb/disorders/PRPS1_Superactivity.yaml
- normalized snippet audit: 50 checked, 0 missing
- graph coverage: phenotypes 10/10; biochemical readouts 4/4

Note: validation transiently rewrote unrelated PMID_24904092 and PMID_31292197 frontmatter; those were restored before commit.