### PR TITLE
Wire CACT biochemical readouts

### DIFF
--- a/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
+++ b/kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Carnitine-acylcarnitine Translocase Deficiency
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-18T18:45:28Z'
+updated_date: '2026-05-21T04:48:31Z'
 synonyms:
 - CACT deficiency
 - CACTD
@@ -862,6 +862,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: The acylcarnitine profiles from 15 patients were classified into three categories using C12, C14, C16, C18, C16:1, C18:1, and C18:2 as the primary diagnostic markers.
     explanation: Newborn screening study confirms long-chain acylcarnitines as primary diagnostic markers in genetically confirmed cases.
+  readouts:
+  - target: Toxic acylcarnitine accumulation and secondary carnitine depletion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated C16, C18, and C18:1 acylcarnitines report the long-chain acylcarnitine accumulation caused by defective CACT-mediated transport.
+    evidence:
+    - reference: PMID:37305732
+      reference_title: "Increased acylcarnitine ratio indices in newborn screening for carnitine-acylcarnitine translocase deficiency shows increased sensitivity and reduced false-positivity."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The acylcarnitine profiles from 15 patients were classified into three categories using C12, C14, C16, C18, C16:1, C18:1, and C18:2 as the primary diagnostic markers.
+      explanation: Patient newborn-screening profiles support C16, C18, C16:1, and C18:1 as primary diagnostic markers that report the long-chain acylcarnitine accumulation state.
 - name: Free carnitine (C0)
   presence: DECREASED
   context: 'Secondary free carnitine depletion results from sequestration in long-chain acylcarnitine esters that cannot be transported into mitochondria. Low free carnitine is a characteristic biochemical finding.
@@ -874,6 +887,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: The second category for patients P7 and P8 showed a significant decrease in the C0 level and a normal concentration of long-chain acylcarnitines.
     explanation: Directly demonstrates decreased free carnitine (C0) in confirmed CACT-deficient patients.
+  readouts:
+  - target: Toxic acylcarnitine accumulation and secondary carnitine depletion
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low free carnitine reports the secondary carnitine-depletion component of the CACT acylcarnitine trapping mechanism.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Free carnitine is low in blood, with marked elevations of C16, C18, and C18:1 carnitine species.
+      explanation: The review directly links low free carnitine with the marked long-chain acylcarnitine elevation pattern in CACT deficiency.
 - name: Acylcarnitine ratio indices
   presence: INCREASED
   context: 'Acylcarnitine ratio indices including (C16+C18:1)/C2, C16/C2, C16:1/C3, and C16:1-OH/C3 improve diagnostic sensitivity and reduce false-positive rates in newborn screening compared with single acylcarnitine markers alone. False-positive rates with ratios were 0.02-0.08% versus 0.16-0.88% for single acylcarnitine indices.
@@ -911,6 +937,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: Urine organic acids may show dicarboxylic aciduria.
     explanation: Review evidence supports dicarboxylic aciduria as a urinary biochemical finding in CACT deficiency.
+  readouts:
+  - target: Impaired mitochondrial long-chain fatty acid oxidation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Dicarboxylic aciduria is a urinary organic-acid readout of impaired mitochondrial long-chain fatty acid oxidation and compensatory omega-oxidation.
+    evidence:
+    - reference: PMID:29502916
+      reference_title: "Inborn Errors of Metabolism with Myopathy: Defects of Fatty Acid Oxidation and the Carnitine Shuttle System."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Urine organic acids may show dicarboxylic aciduria.
+      explanation: The review supports dicarboxylic aciduria as an organic-acid finding in CACT deficiency, reflecting the long-chain FAO block.
 histopathology:
 - name: Multi-organ microvesicular steatosis
   finding_term:


### PR DESCRIPTION
## Summary
- Added diagnostic readouts for the remaining CACT biochemical markers: long-chain acylcarnitines, free carnitine, and dicarboxylic aciduria.
- Biochemical readout coverage is now 4/4, with targets matched to existing pathophysiology nodes.
- Confirmed all 15 phenotypes already have incoming downstream mechanism edges; no phenotype edge changes were needed.
- Restored generated cache churn after validation so the diff is scoped to `kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml`.

## Validation
- `just validate kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml`
- `just validate-terms kb/disorders/Carnitine-Acylcarnitine_Translocase_Deficiency.yaml`
- normalized snippet audit: 97 checked, 0 missing
- coverage audit: phenotypes explained 15/15; biochemical readouts 4/4; readout targets missing 0
- `git diff --check`