### PR TITLE
Wire Barth syndrome biochemical readouts

### DIFF
--- a/kb/disorders/Barth_Syndrome.yaml
+++ b/kb/disorders/Barth_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Barth syndrome
 creation_date: '2026-04-12T00:00:00Z'
-updated_date: '2026-05-08T11:46:38Z'
+updated_date: '2026-05-21T04:58:02Z'
 category: Mendelian
 synonyms:
 - BTHS
@@ -757,6 +757,23 @@ biochemical:
     explanation: >-
       This bloodspot assay study establishes an increased MLCL:CL ratio as the
       defining Barth syndrome biomarker.
+  readouts:
+  - target: Tafazzin deficiency impairs cardiolipin remodeling
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: An increased monolysocardiolipin:cardiolipin ratio directly reports the tafazzin-dependent cardiolipin remodeling defect.
+    evidence:
+    - reference: PMID:18070816
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        All BTHS patients (n = 31) had monolysocardiolipin:cardiolipin ratios
+        >0.40 and all controls (n = 215) had monolysocardiolipin:cardiolipin
+        ratios <0.23.
+      explanation: >-
+        Patient bloodspot data support the MLCL:CL ratio as a diagnostic
+        biochemical readout of the cardiolipin remodeling defect.
 - name: Elevated urinary 3-methylglutaconic acid
   presence: INCREASED
   biomarker_term:
@@ -777,6 +794,27 @@ biochemical:
     explanation: >-
       This case series directly documents 3-methylglutaconic aciduria as a
       common biochemical abnormality in Barth syndrome.
+  readouts:
+  - target: Tafazzin deficiency impairs cardiolipin remodeling
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Urinary 3-methylglutaconic acid elevation is a classic metabolic readout associated with the tafazzin/cardiolipin-remodeling defect, although the intermediate route is unresolved.
+    evidence:
+    - reference: PMID:23409742
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        BACKGROUND: Barth syndrome (BS) is an X-linked infantile-onset
+        cardioskeletal disease characterized by cardiomyopathy, hypotonia, growth
+        delay, neutropenia and 3-methylglutaconic aciduria. It is caused by
+        mutations in the TAZ gene encoding tafazzin, a protein involved in the
+        metabolism of cardiolipin, a mitochondrial-specific phospholipid involved
+        in mitochondrial energy production.
+      explanation: >-
+        The clinical series links Barth syndrome 3-methylglutaconic aciduria to
+        TAZ/tafazzin and cardiolipin metabolism, supporting the diagnostic
+        readout link while leaving intermediate mechanisms unresolved.
 - name: Lactic acidosis
   presence: INCREASED
   biomarker_term:
@@ -797,6 +835,67 @@ biochemical:
       tested and five of them also had lactic acidosis.
     explanation: >-
       This cohort directly reports lactic acidosis in most evaluated patients.
+  readouts:
+  - target: Myocardial metabolic substrate shift
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased lactate reports the glucose-shifted, glycolytic component of Barth mitochondrial energy rewiring.
+    evidence:
+    - reference: PMID:31861102
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        We also demonstrate that TAZ517delG induces metabolic alterations in
+        pathways related to energy production as reflected by high glucose
+        uptake, an increase in glycolytic lactate production and a decrease in
+        palmitate uptake.
+      explanation: >-
+        Barth iPSC-cardiomyocytes show increased glycolytic lactate production
+        as part of the metabolic substrate shift, supporting lactate as a
+        readout of that mechanism.
+    - reference: PMID:23409742
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        CONCLUSIONS: Lactic acidosis associated with 3-methylglutaconic aciduria
+        is highly suggestive of BS, whilst the severity of the metabolic
+        decompensation at disease onset should be considered for prognostic
+        purposes.
+      explanation: >-
+        The clinical series supports lactic acidosis in diagnostic and
+        decompensation contexts, complementing the cellular lactate-production
+        mechanism.
+  - target: Mitochondrial respiratory chain dysfunction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lactic acidosis also reports the upstream mitochondrial respiratory dysfunction branch of Barth syndrome.
+    evidence:
+    - reference: PMID:23361305
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        An examination of the patients' fibroblast cultures revealed that
+        extremely low mitochondrial membrane potentials (mtΔΨ about 50 % of the
+        control value) dominated other unspecific mitochondrial changes detected
+        (respiratory chain dysfunction, abnormal ROS production and depressed
+        antioxidant defense).
+      explanation: >-
+        Patient-derived fibroblast cultures show mitochondrial membrane-potential
+        loss with respiratory-chain dysfunction, supporting the upstream
+        mitochondrial dysfunction target.
+    - reference: PMID:23361305
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Severe lactic acidosis without 3-methylglutaconic aciduria in male
+        neonates as well as asymptomatic left ventricular noncompaction at ECHO
+        record may characterise a range of natural history of Barth syndrome.
+      explanation: >-
+        The affected-sibling report documents severe neonatal lactic acidosis as
+        part of the Barth syndrome clinical spectrum, supporting lactate as the
+        clinical readout paired with the mitochondrial dysfunction evidence.
 treatments:
 - name: Heart failure pharmacotherapy
   description: >-


### PR DESCRIPTION
## Summary
- Added diagnostic readouts for all three Barth syndrome biochemical markers: MLCL:CL ratio, urinary 3-methylglutaconic acid, and lactic acidosis.
- Biochemical readout coverage is now 3/3, with targets matched to existing pathophysiology nodes.
- Confirmed all 8 phenotypes already have incoming downstream mechanism edges; no phenotype edge changes were needed.
- Restored generated cache churn after validation so the diff is scoped to `kb/disorders/Barth_Syndrome.yaml`.

## Validation
- `just validate kb/disorders/Barth_Syndrome.yaml`
- `just validate-terms kb/disorders/Barth_Syndrome.yaml`
- normalized snippet audit: 48 checked, 0 missing
- coverage audit: phenotypes explained 8/8; biochemical readouts 3/3; readout targets missing 0
- `git diff --check`