### PR TITLE
Wire pyruvate carboxylase biochemical readouts

### DIFF
--- a/kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
+++ b/kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Carboxylase Deficiency Disease
 creation_date: "2026-04-23T00:00:00Z"
-updated_date: "2026-05-10T22:23:11Z"
+updated_date: "2026-05-21T05:22:02Z"
 description: >-
   Pyruvate carboxylase deficiency disease is a rare autosomal recessive
   mitochondrial neurometabolic disorder caused by biallelic PC variants. The
@@ -973,6 +973,27 @@ biochemical:
     explanation: >-
       This directly supports lactic acidosis/elevated lactate as a core
       biochemical disease finding.
+  readouts:
+  - target: Lactate Accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased lactate reports the lactate-accumulation branch created by impaired pyruvate-to-oxaloacetate flux.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        The patient cohort identifies lactic acidosis as a core biochemical and
+        clinical finding, supporting lactate as the readout of lactate
+        accumulation.
 - name: Ketonuria
   presence: PRESENT
   context: >-
@@ -992,6 +1013,27 @@ biochemical:
     explanation: >-
       This directly supports ketonuria as a characteristic biochemical
       abnormality.
+  readouts:
+  - target: Mitochondrial Energy Deficit
+    relationship: READOUT_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: The presence of ketonuria is a biochemical readout of metabolic decompensation accompanying the mitochondrial energy deficit in pyruvate carboxylase deficiency.
+    evidence:
+    - reference: PMID:37207470
+      reference_title: >-
+        Clinical, biochemical and molecular characterization of 12 patients
+        with pyruvate carboxylase deficiency treated with triheptanoin.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The main biochemical and clinical findings in PC deficiency (PCD)
+        include lactic acidosis, ketonuria, failure to thrive, and
+        neurological dysfunction.
+      explanation: >-
+        The cohort lists ketonuria with lactic acidosis, failure to thrive, and
+        neurologic dysfunction, supporting it as a diagnostic biochemical
+        readout of the systemic energy-deficit branch.
 - name: Hypercitrullinemia
   presence: INCREASED
   subtype: Type B
@@ -1010,6 +1052,24 @@ biochemical:
     explanation: >-
       This directly supports hypercitrullinemia as a severe neonatal
       biochemical abnormality.
+  readouts:
+  - target: Urea Cycle Perturbation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated citrulline reports the secondary nitrogen-disposal and urea-cycle perturbation seen in severe neonatal pyruvate carboxylase deficiency.
+    evidence:
+    - reference: PMID:16278852
+      reference_title: "Pyruvate carboxylase deficiency: metabolic characteristics and new neurological aspects."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Hypoglycemia, lactic acidosis, and hypercitrullinemia were invariably
+        found.
+      explanation: >-
+        The severe neonatal series reports invariant hypercitrullinemia,
+        supporting elevated citrulline as the biochemical readout of the
+        urea-cycle perturbation branch.
 genetic:
 - name: PC
   association: Causal biallelic variant


### PR DESCRIPTION
## Summary
- Added diagnostic readouts for all three pyruvate carboxylase deficiency biochemical markers: lactate, ketonuria, and hypercitrullinemia.
- Biochemical readout coverage is now 3/3, with targets matched to existing pathophysiology nodes.
- Confirmed all 13 phenotypes already have incoming downstream mechanism edges; no phenotype edge changes were needed.
- Restored generated cache churn after validation so the diff is scoped to `kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml`.

## Validation
- `just validate kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml`
- `just validate-terms kb/disorders/Pyruvate_Carboxylase_Deficiency_Disease.yaml`
- normalized snippet audit with Unicode dash/space normalization: 63 checked, 0 missing
- coverage audit: phenotypes explained 13/13; biochemical readouts 3/3; total readout links 3; readout targets missing 0
- `git diff --check`