### PR TITLE
Wire argininosuccinic aciduria biochemical readouts

### DIFF
--- a/kb/disorders/Argininosuccinic_Aciduria.yaml
+++ b/kb/disorders/Argininosuccinic_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: Argininosuccinic Aciduria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T14:31:01Z'
+updated_date: '2026-05-21T05:37:18Z'
 synonyms:
 - Argininosuccinate lyase deficiency
 - ASLD
@@ -132,6 +132,18 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Patients with ASL deficiency present with argininosuccinic aciduria, an inherited metabolic disease with hyperammonemia
       explanation: Directly links ASL deficiency to hyperammonemia in ASA.
+  - target: Encephalopathy
+    description: Hyperammonemia from impaired ureagenesis exposes the brain to neurotoxic ammonia during acute decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neurotoxic ammonia accumulation
+    evidence:
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The urea cycle enzyme argininosuccinate lyase (ASL) enables the clearance of neurotoxic ammonia
+      explanation: Supports neurotoxic ammonia as the bridge from impaired ureagenesis and hyperammonemia to encephalopathic crises.
   - target: Ammonia
     description: Failed ureagenesis increases circulating ammonia.
     causal_link_type: DIRECT
@@ -672,6 +684,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: Patients with ASL deficiency present with argininosuccinic aciduria
     explanation: The disease name itself reflects the pathognomonic finding of elevated argininosuccinic acid.
+  readouts:
+  - target: ASL molecular function deficiency
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated plasma or urinary argininosuccinic acid is the pathognomonic biochemical readout of deficient ASL catalytic activity.
+    evidence:
+    - reference: PMID:22241104
+      reference_title: "Argininosuccinate lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The biochemical diagnosis of ASLD is typically established with elevation of plasma citrulline together with elevated argininosuccinic acid in the plasma or urine.
+      explanation: Establishes elevated argininosuccinic acid as the diagnostic biochemical readout of ASL deficiency.
 - name: Ammonia
   presence: INCREASED
   context: 'Plasma ammonia is elevated during metabolic crises due to impaired ureagenesis. Hyperammonemia severity is variable and may be less frequent than in other UCDs, but remains the major driver of acute encephalopathy risk.
@@ -684,6 +709,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: Patients with ASL deficiency present with argininosuccinic aciduria, an inherited metabolic disease with hyperammonemia
     explanation: Directly supports elevated ammonia as a feature of ASA.
+  readouts:
+  - target: Impaired ureagenesis and hyperammonemia
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased plasma ammonia reports failure of ASL-dependent urea-cycle nitrogen disposal.
+    evidence:
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patients with ASL deficiency present with argininosuccinic aciduria, an inherited metabolic disease with hyperammonemia
+      explanation: The patient summary identifies hyperammonemia as the clinical biochemical manifestation of impaired ureagenesis in ASL deficiency.
 - name: Arginine
   presence: DECREASED
   context: 'Plasma arginine is decreased due to the block in its biosynthesis from argininosuccinate. Arginine deficiency contributes to impaired NO production and is the rationale for arginine supplementation therapy.
@@ -696,6 +734,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: the current standard of care and therapeutic strategy, which aims to normalize plasma ammonia and arginine levels
     explanation: Supports arginine deficiency as a therapeutic target in ASA.
+  readouts:
+  - target: ASL molecular function deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased arginine reports loss of the ASL reaction that normally generates arginine from argininosuccinate.
+    evidence:
+    - reference: PMID:22241104
+      reference_title: "Argininosuccinate lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Argininosuccinate lyase (ASL) catalyzes the fourth reaction in this cycle, resulting in the breakdown of argininosuccinic acid to arginine and fumarate.
+      explanation: The ASL reaction produces arginine, so low arginine is interpreted as a negative readout of the deficient catalytic step.
 - name: Glutathione
   presence: DECREASED
   context: 'Hepatic and plasma glutathione is depleted in ASA patients and mouse models. Glutathione depletion is accompanied by up-regulation of cysteine metabolism and down-regulated antioxidant pathways, reflecting a redox imbalance that contributes to chronic liver disease.
@@ -708,6 +759,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: Up-regulation of cysteine metabolism contrasted with glutathione depletion and down-regulated antioxidant pathways.
     explanation: Confirms glutathione depletion alongside altered cysteine handling in ASL-deficient patients and mice.
+  readouts:
+  - target: Oxidative stress and glutathione dysregulation
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased glutathione reports the redox and antioxidant-pathway branch of ASL deficiency.
+    evidence:
+    - reference: PMID:38198573
+      reference_title: "mRNA therapy corrects defective glutathione metabolism and restores ureagenesis in preclinical argininosuccinic aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Up-regulation of cysteine metabolism contrasted with glutathione depletion and down-regulated antioxidant pathways.
+      explanation: Directly links glutathione depletion to the oxidative-stress and glutathione-dysregulation mechanism in ASL-deficient patients and mice.
 - name: Nitric oxide
   presence: DECREASED
   context: 'Tissue and systemic NO production is reduced due to impaired ASL-mediated channeling of arginine to NOS. NO deficiency drives endothelial dysfunction, BBB disruption, hypertension, and may contribute to catecholamine dysregulation and movement disorders.
@@ -720,6 +784,19 @@ biochemical:
     evidence_source: IN_VITRO
     snippet: Our results suggest that ASL-mediated NO synthesis is required for proper maintenance of brain microvascular endothelial cell functions as well as BBB integrity.
     explanation: Links NO deficiency to brain endothelial dysfunction.
+  readouts:
+  - target: Nitric oxide deficiency and endothelial dysfunction
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced nitric oxide production reports the ASL-dependent endothelial dysfunction branch.
+    evidence:
+    - reference: PMID:30075114
+      reference_title: "Argininosuccinate Lyase Deficiency Causes an Endothelial-Dependent Form of Hypertension."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: loss of ASL in endothelial cells leads to endothelial-dependent vascular dysfunction with reduced nitric oxide (NO) production, increased oxidative stress, and impaired angiogenesis
+      explanation: Supports decreased nitric oxide production as a readout of ASL-dependent endothelial dysfunction.
 - name: Alanine aminotransferase
   presence: INCREASED
   context: 'Chronic ALT elevation is a marker of hepatocellular injury in ASA. Prevalence of elevated ALT above 100 U/L on at least two occasions is 37% in ASLD, significantly associated with hyperammonemia and nitrogen-scavenger use.
@@ -732,6 +809,19 @@ biochemical:
     evidence_source: HUMAN_CLINICAL
     snippet: We demonstrate a high prevalence of elevated ALT in ASLD (37%). Hyperammonemia and use of nitrogen-scavenging agents, 2 markers of disease severity, were significantly (P < 0.001 and P = 0.001, respectively) associated with elevated ALT in ASLD.
     explanation: Quantifies ALT elevation prevalence and clinical associations.
+  readouts:
+  - target: Impaired hepatic glycogen metabolism
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Elevated ALT reports chronic hepatocellular injury accompanying the hepatic glycogen-metabolism branch of ASLD.
+    evidence:
+    - reference: PMID:31990680
+      reference_title: "Chronic liver disease and impaired hepatic glycogen metabolism in argininosuccinate lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We demonstrate a high prevalence of elevated ALT in ASLD (37%).
+      explanation: Supports ALT elevation as a monitoring readout of ASLD liver involvement.
 genetic:
 - name: ASL (argininosuccinate lyase) variants
   gene_term:
@@ -1359,6 +1449,8 @@ references:
   findings: []
 - reference: PMID:22241104
   title: Argininosuccinate lyase deficiency.
+  tags:
+  - GeneReviews
   found_in:
   - Argininosuccinic_Aciduria-deep-research-openscientist.md
   findings: []


### PR DESCRIPTION
## Summary
- add a pathophysiology edge from impaired ureagenesis/hyperammonemia to encephalopathy
- add readout links for all six Argininosuccinic Aciduria biochemical markers
- keep the branch scoped to `kb/disorders/Argininosuccinic_Aciduria.yaml`

## Validation
- `just validate kb/disorders/Argininosuccinic_Aciduria.yaml` passed
- `just validate-terms kb/disorders/Argininosuccinic_Aciduria.yaml` passed
- normalized snippet audit with Unicode dash/space normalization: 77 checked, 0 missing
- coverage audit: phenotypes explained 12/12; biochemical readouts 6/6; total readout links 6; readout targets missing 0
- `git diff --check` passed
- restored generated cache churn; branch diff is scoped to `kb/disorders/Argininosuccinic_Aciduria.yaml` only
