### PR TITLE
Wire Sialidosis type 1 biochemical readouts

### DIFF
--- a/kb/disorders/Sialidosis_Type_1.yaml
+++ b/kb/disorders/Sialidosis_Type_1.yaml
@@ -1,7 +1,7 @@
 name: Sialidosis type 1
 category: Mendelian
 creation_date: "2026-05-04T18:28:00Z"
-updated_date: "2026-05-10T09:33:04Z"
+updated_date: "2026-05-21T06:02:38Z"
 synonyms:
 - Cherry-red spot-myoclonus syndrome
 - Lipomucopolysaccharidosis
@@ -704,6 +704,19 @@ biochemical:
     evidence_source: IN_VITRO
     snippet: "a sialidase activity assay. Cherry-red spots were more prevalent in the"
     explanation: Functional activity testing supports variant-specific sialidase deficiency.
+  readouts:
+  - target: NEU1 lysosomal neuraminidase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced lysosomal neuraminidase activity is the diagnostic enzymatic readout of deficient NEU1 function.
+    evidence:
+    - reference: PMID:28138907
+      reference_title: Sialidosis Type 1 with a Novel Mutation in the Neuraminidase-1 (NEU1) Gene.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "deficiency of neuraminidase. Genetic analysis identified novel homozygous"
+      explanation: Patient enzyme and molecular testing support reduced neuraminidase activity as the biochemical readout of NEU1 deficiency.
 - name: Urinary sialylated oligosaccharides
   presence: Elevated
   context: Diagnostic urinary storage biomarker
@@ -723,6 +736,19 @@ biochemical:
     evidence_source: IN_VITRO
     snippet: "accumulation of sialylated metabolites in tissues and body fluids."
     explanation: The study supports sialylated metabolite accumulation as the biochemical storage signature.
+  readouts:
+  - target: Sialylated metabolite lysosomal storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated urinary sialylated oligosaccharides report systemic accumulation of sialylated storage metabolites.
+    evidence:
+    - reference: PMID:32453490
+      reference_title: Genetic and clinical characterization of mainland Chinese patients with sialidosis type 1.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "leading to abnormal tissue accumulation as well as urinary excretion of sialylated oligosaccharides"
+      explanation: The type 1 cohort review links the storage mechanism to urinary sialylated oligosaccharide excretion.
 - name: Urinary O-linked sialopeptides
   presence: Elevated
   context: Diagnostic urinary storage biomarker
@@ -736,6 +762,19 @@ biochemical:
     evidence_source: OTHER
     snippet: "HP:0003461 | Increased urinary O-linked sialopeptides | Very frequent (99-80%)"
     explanation: Orphanet records this urinary glycopeptide abnormality as very frequent.
+  readouts:
+  - target: Sialylated metabolite lysosomal storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary O-linked sialopeptides are a diagnostic readout of sialylated lysosomal storage in Sialidosis type 1.
+    evidence:
+    - reference: ORPHA:812
+      reference_title: "Sialidosis type 1 (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003461 | Increased urinary O-linked sialopeptides | Very frequent (99-80%)"
+      explanation: Orphanet records increased urinary O-linked sialopeptides as a very frequent biochemical manifestation, supporting this urinary marker as a readout of the storage node.
 diagnosis:
 - name: NEU1 genetic testing
   description: >


### PR DESCRIPTION
## Summary
- add readout links for all three Sialidosis type 1 biochemical markers
- connect reduced neuraminidase activity to the NEU1 deficiency node
- connect urinary sialylated oligosaccharides and O-linked sialopeptides to the sialylated-storage node

## Validation
- `just validate kb/disorders/Sialidosis_Type_1.yaml` passed
- `just validate-terms kb/disorders/Sialidosis_Type_1.yaml` passed
- normalized snippet audit with Unicode dash/space normalization: 105 checked, 0 missing
- coverage audit: phenotypes explained 20/20; biochemical readouts 3/3; total readout links 3; readout targets missing 0
- `git diff --check` passed
- restored generated cache churn; branch diff is scoped to `kb/disorders/Sialidosis_Type_1.yaml` only
