### PR TITLE
Wire glycogen storage disease I biochemical readouts

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Glycogen Storage Disease Type I
 creation_date: '2026-03-08T12:00:00Z'
-updated_date: '2026-05-09T03:15:56Z'
+updated_date: '2026-05-21T06:12:42Z'
 category: Mendelian
 description: >
   Glycogen storage disease type I (GSD I), also known as von Gierke disease, is an
@@ -274,6 +274,16 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hyperlipidemia
+  - target: Diarrhea
+    description: Diarrhea can occur in GSD I, although the cached clinical summary does not resolve the intermediate mechanism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Xanthoma and diarrhea may be present."
+      explanation: GeneReviews supports diarrhea as a possible GSD I manifestation; the pathograph marks the causal intermediates as unresolved.
   - target: Pancreatitis
     description: Severe hypertriglyceridemia is a known intermediate for pancreatitis in untreated disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -906,21 +916,99 @@ biochemical:
 - name: Blood glucose
   presence: Decreased
   context: Fasting hypoglycemia; unable to maintain blood glucose between meals.
+  readouts:
+  - target: Impaired glucose-6-phosphate hydrolysis and fasting hypoglycemia
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased fasting blood glucose reports failure of hepatic and renal glucose release from the glucose-6-phosphatase system.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severely affected infants present in the neonatal period with severe hypoglycemia due to fasting intolerance."
+      explanation: GeneReviews identifies severe fasting hypoglycemia as the clinical biochemical consequence of the glucose-release block.
 - name: Blood lactate
   presence: Elevated
   context: Elevated due to shunting of glucose-6-phosphate through glycolysis.
+  readouts:
+  - target: Secondary metabolic derangements
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated blood lactate reports the secondary glycolytic shunting branch that produces lactic acidosis.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatomegaly, severe hypoglycemia with or without seizures, lactic acidosis, hyperuricemia, and hypertriglyceridemia."
+      explanation: The clinical summary lists lactic acidosis among the core secondary metabolic abnormalities.
 - name: Serum triglycerides
   presence: Elevated
   context: Markedly elevated due to increased de novo lipogenesis.
+  readouts:
+  - target: Secondary metabolic derangements
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated serum triglycerides report the lipid-synthesis branch of secondary metabolic derangement.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatomegaly, severe hypoglycemia with or without seizures, lactic acidosis, hyperuricemia, and hypertriglyceridemia."
+      explanation: The clinical summary lists hypertriglyceridemia among the core secondary metabolic abnormalities.
 - name: Serum uric acid
   presence: Elevated
   context: Elevated due to increased purine degradation and decreased renal clearance.
+  readouts:
+  - target: Secondary metabolic derangements
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated serum uric acid reports the purine-degradation and lactate-impaired urate-clearance branch.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatomegaly, severe hypoglycemia with or without seizures, lactic acidosis, hyperuricemia, and hypertriglyceridemia."
+      explanation: The clinical summary lists hyperuricemia among the core secondary metabolic abnormalities.
 - name: Serum cholesterol
   presence: Elevated
   context: Hypercholesterolemia due to increased lipid synthesis.
+  readouts:
+  - target: Secondary metabolic derangements
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Elevated serum cholesterol is part of the lipid-panel readout used to monitor the hyperlipidemia branch of GSD I metabolic control.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "surveillance labs to assess liver function, nutrition, and renal function including blood glucose, lactate, lipid panel, serum uric acid"
+      explanation: GeneReviews includes lipid-panel surveillance alongside blood glucose, lactate, and uric acid; serum cholesterol is interpreted as a lipid-panel component monitoring the hyperlipidemia branch.
 - name: Glucose-6-phosphatase enzyme activity
   presence: Decreased
   context: Measured in liver biopsy tissue; deficient in GSD Ia. Not directly measurable for GSD Ib without fresh tissue.
+  readouts:
+  - target: Impaired glucose-6-phosphate hydrolysis and fasting hypoglycemia
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased hepatic glucose-6-phosphatase catalytic activity directly reads out the GSD Ia enzymatic block.
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatic enzyme activity analysis is only available for glucose-6-phosphatase catalytic activity"
+      explanation: GeneReviews supports glucose-6-phosphatase catalytic activity as the measurable enzyme-activity readout for GSD Ia when molecular testing is inconclusive.
 genetic:
 - name: G6PC1
   association: Causative


### PR DESCRIPTION
## Summary
- add a downstream edge from secondary metabolic derangements to diarrhea with unknown intermediate mechanism
- add readout links for all six GSD I biochemical markers
- keep the branch scoped to `kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`

## Validation
- `just validate kb/disorders/Glycogen_Storage_Disease_Type_I.yaml` passed
- `just validate-terms kb/disorders/Glycogen_Storage_Disease_Type_I.yaml` passed
- normalized snippet audit with Unicode dash/space normalization: 86 checked, 0 missing
- coverage audit: phenotypes explained 27/27; biochemical readouts 6/6; total readout links 6; readout targets missing 0
- `git diff --check` passed
- restored generated cache churn; branch diff is scoped to `kb/disorders/Glycogen_Storage_Disease_Type_I.yaml` only
