### PR TITLE
Clear malformed references-block findings in Angiosarcoma (#1118)

### DIFF
--- a/kb/disorders/Angiosarcoma.yaml
+++ b/kb/disorders/Angiosarcoma.yaml
@@ -802,30 +802,22 @@ references:
   title: 'Primary hepatic angiosarcoma: report of a case involving environmental arsenic exposure.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: Tsai MH(1), Chien RN, Hsieh SY, Hung CF, Chen TC, Sheen IS.
-    supporting_text: Tsai MH(1), Chien RN, Hsieh SY, Hung CF, Chen TC, Sheen IS.
+  findings: []
 - reference: PMID:16689662
   title: IFN-alpha1,8 inhibits tumor-induced angiogenesis in murine angiosarcomas.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2006 May;26(5):353-61. doi: 10.1089/jir.2006.26.353.'
-    supporting_text: '2006 May;26(5):353-61. doi: 10.1089/jir.2006.26.353.'
+  findings: []
 - reference: PMID:19433291
   title: 'Angiosarcoma of the breast: a clinicopathologic analysis of cases from the last 10 years.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2009 Jun;13(3):147-50. doi: 10.1016/j.anndiagpath.2009.02.001.'
-    supporting_text: '2009 Jun;13(3):147-50. doi: 10.1016/j.anndiagpath.2009.02.001.'
+  findings: []
 - reference: PMID:20949568
   title: Consistent MYC and FLT4 gene amplification in radiation-induced angiosarcoma but not in other radiation-associated atypical vascular lesions.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2011 Jan;50(1):25-33. doi: 10.1002/gcc.20827.'
-    supporting_text: '2011 Jan;50(1):25-33. doi: 10.1002/gcc.20827.'
+  findings: []
 - reference: PMID:21062482
   title: Gene expression profiling identifies inflammation and angiogenesis as distinguishing features of canine hemangiosarcoma.
   found_in:
@@ -844,30 +836,22 @@ references:
   title: The miR-17-92 cluster and its target THBS1 are differentially expressed in angiosarcomas dependent on MYC amplification.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2012 Jun;51(6):569-78. doi: 10.1002/gcc.21943.'
-    supporting_text: '2012 Jun;51(6):569-78. doi: 10.1002/gcc.21943.'
+  findings: []
 - reference: PMID:22431921
   title: Efficacy of Tie2 receptor antagonism in angiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2012 Feb;14(2):131-40. doi: 10.1593/neo.111770.'
-    supporting_text: '2012 Feb;14(2):131-40. doi: 10.1593/neo.111770.'
+  findings: []
 - reference: PMID:22532251
   title: A transcriptome signature of endothelial lymphatic cells coexists with the chronic oxidative stress signature in radiation-induced post-radiotherapy breast angiosarcomas.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2012 Jul;33(7):1399-405. doi: 10.1093/carcin/bgs155.'
-    supporting_text: '2012 Jul;33(7):1399-405. doi: 10.1093/carcin/bgs155.'
+  findings: []
 - reference: PMID:22934846
   title: ROCK1 & 2 perform overlapping and unique roles in angiogenesis and angiosarcoma tumor progression.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2013 Jan;13(1):205-19. doi: 10.2174/1566524011307010205.'
-    supporting_text: '2013 Jan;13(1):205-19. doi: 10.2174/1566524011307010205.'
+  findings: []
 - reference: PMID:23522954
   title: Establishment of a novel experimental model of human angiosarcoma and a VEGF-targeting therapeutic experiment.
   found_in:
@@ -879,44 +863,32 @@ references:
   title: A novel monoclonal antibody to secreted frizzled-related protein 2 inhibits tumor growth.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2013 May;12(5):685-95. doi: 10.1158/1535-7163.MCT-12-1066.'
-    supporting_text: '2013 May;12(5):685-95. doi: 10.1158/1535-7163.MCT-12-1066.'
+  findings: []
 - reference: PMID:23938603
   title: Vascular tumors have increased p70 S6-kinase activation and are inhibited by topical rapamycin.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2013 Oct;93(10):1115-27. doi: 10.1038/labinvest.2013.98.'
-    supporting_text: '2013 Oct;93(10):1115-27. doi: 10.1038/labinvest.2013.98.'
+  findings: []
 - reference: PMID:24457083
   title: Diagnostic utility of MYC amplification and anti-MYC immunohistochemistry in atypical vascular lesions, primary or radiation-induced mammary angiosarcomas, and primary angiosarcomas of other sites.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2014 Apr;45(4):709-16. doi: 10.1016/j.humpath.2013.11.002.'
-    supporting_text: '2014 Apr;45(4):709-16. doi: 10.1016/j.humpath.2013.11.002.'
+  findings: []
 - reference: PMID:25863565
   title: Can c-myc amplification reliably discriminate postradiation from primary angiosarcoma of the breast?
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2015 May;19(3):168-74. doi: 10.1016/j.canrad.2015.01.001.'
-    supporting_text: '2015 May;19(3):168-74. doi: 10.1016/j.canrad.2015.01.001.'
+  findings: []
 - reference: PMID:25955301
   title: Combined inhibition of MEK and mTOR has a synergic effect on angiosarcoma tumorgrafts.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2015 Jul;47(1):71-80. doi: 10.3892/ijo.2015.2989.'
-    supporting_text: '2015 Jul;47(1):71-80. doi: 10.3892/ijo.2015.2989.'
+  findings: []
 - reference: PMID:26617830
   title: 'Angiosarcoma (Stewart-Treves syndrome) in postmastectomy patients: report of 10 cases and review of literature.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: 2015 Sep 1;8(9):11108-15. eCollection 2015.
-    supporting_text: 2015 Sep 1;8(9):11108-15. eCollection 2015.
+  findings: []
 - reference: PMID:28716069
   title: Angiosarcoma treated successfully with anti-PD-1 therapy - a case report.
   found_in:
@@ -928,51 +900,37 @@ references:
   title: 'Clinical and diagnostic features of angiosarcoma with pulmonary metastases: A retrospective observational study.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2017 Sep;96(36):e8033. doi: 10.1097/MD.0000000000008033.'
-    supporting_text: '2017 Sep;96(36):e8033. doi: 10.1097/MD.0000000000008033.'
+  findings: []
 - reference: PMID:31243333
   title: Genomic and transcriptomic comparison of post-radiation versus sporadic sarcomas.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2019 Dec;32(12):1786-1794. doi: 10.1038/s41379-019-0300-2.'
-    supporting_text: '2019 Dec;32(12):1786-1794. doi: 10.1038/s41379-019-0300-2.'
+  findings: []
 - reference: PMID:32123305
   title: Primary mammary angiosarcomas harbor frequent mutations in KDR and PIK3CA and show evidence of distinct pathogenesis.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2020 Aug;33(8):1518-1526. doi: 10.1038/s41379-020-0511-6.'
-    supporting_text: '2020 Aug;33(8):1518-1526. doi: 10.1038/s41379-020-0511-6.'
+  findings: []
 - reference: PMID:32210430
   title: Molecular subtypes in canine hemangiosarcoma reveal similarities with human angiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2020 Mar 25;15(3):e0229728. doi: 10.1371/journal.pone.0229728. eCollection 2020.'
-    supporting_text: '2020 Mar 25;15(3):e0229728. doi: 10.1371/journal.pone.0229728. eCollection 2020.'
+  findings: []
 - reference: PMID:32777673
   title: 'Frequent expression of conventional endothelial markers in pleural mesothelioma: usefulness of claudin-5 as well as combined traditional markers to distinguish mesothelioma from angiosarcoma.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2020 Oct;148:20-27. doi: 10.1016/j.lungcan.2020.07.029.'
-    supporting_text: '2020 Oct;148:20-27. doi: 10.1016/j.lungcan.2020.07.029.'
+  findings: []
 - reference: PMID:34392127
   title: Clinicopathologic and immunohistochemical study of breast angiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2021 Oct;54:151795. doi: 10.1016/j.anndiagpath.2021.151795.'
-    supporting_text: '2021 Oct;54:151795. doi: 10.1016/j.anndiagpath.2021.151795.'
+  findings: []
 - reference: PMID:35478727
   title: Outcomes of Interventions for Angiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2022 Apr 11;9:819099. doi: 10.3389/fsurg.2022.819099. eCollection 2022.'
-    supporting_text: '2022 Apr 11;9:819099. doi: 10.3389/fsurg.2022.819099. eCollection 2022.'
+  findings: []
 - reference: PMID:36387164
   title: Whole exome sequencing identified a novel POT1 variant as a candidate pathogenic allele underlying a Li-Fraumeni-like family.
   found_in:
@@ -984,44 +942,32 @@ references:
   title: Shared hotspot mutations in oncogenes position dogs as an unparalleled comparative model for precision therapeutics.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2023 Jul 6;13(1):10935. doi: 10.1038/s41598-023-37505-2.'
-    supporting_text: '2023 Jul 6;13(1):10935. doi: 10.1038/s41598-023-37505-2.'
+  findings: []
 - reference: PMID:37725702
   title: 'Secondary Breast Angiosarcoma After a Primary Diagnosis of Breast Cancer: A Retrospective Analysis of the Surveillance, Epidemiology, and End Results (SEER) Database.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2023 Dec 1;46(12):567-571. doi: 10.1097/COC.0000000000001045.'
-    supporting_text: '2023 Dec 1;46(12):567-571. doi: 10.1097/COC.0000000000001045.'
+  findings: []
 - reference: PMID:38391320
   title: 'Angiosarcoma of the head and neck: A clinicopathologic study with special emphasis on diagnostic pitfalls.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2024 Jul 1;67(3):559-563. doi: 10.4103/ijpm.ijpm_655_22.'
-    supporting_text: '2024 Jul 1;67(3):559-563. doi: 10.4103/ijpm.ijpm_655_22.'
+  findings: []
 - reference: PMID:38457179
   title: Incidence of Nonkeratinocyte Skin Cancer After Breast Cancer Radiation Therapy.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2024 Mar 4;7(3):e241632. doi: 10.1001/jamanetworkopen.2024.1632.'
-    supporting_text: '2024 Mar 4;7(3):e241632. doi: 10.1001/jamanetworkopen.2024.1632.'
+  findings: []
 - reference: PMID:38791996
   title: Clinical Characteristics, Patterns of Care, and Treatment Outcomes of Radiation-Associated Sarcomas.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2024 May 18;16(10):1918. doi: 10.3390/cancers16101918.'
-    supporting_text: '2024 May 18;16(10):1918. doi: 10.3390/cancers16101918.'
+  findings: []
 - reference: PMID:39221877
   title: Synchronous multiple primary malignancies or transdifferentiation?-A diagnostic challenge in a case of Xeroderma pigmentosum.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Jul 1;68(3):616-619. doi: 10.4103/ijpm.ijpm_324_24.'
-    supporting_text: '2025 Jul 1;68(3):616-619. doi: 10.4103/ijpm.ijpm_324_24.'
+  findings: []
 - reference: PMID:39676119
   title: 'Demographics, Prognostic Factors, and Survival Outcomes in Hepatic Angiosarcoma: A Retrospective Analysis.'
   found_in:
@@ -1033,23 +979,17 @@ references:
   title: 'New Germline TP53 Variant Detected After Radiotherapy-Induced Angiosarcoma of the Chest Wall in a Previously Treated Breast Cancer Patient: A Case Report and Review of Li-Fraumeni Syndrome and Radiotherapy-Induced Sarcoma.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2024 Dec 19;2024:6640468. doi: 10.1155/crom/6640468. eCollection 2024.'
-    supporting_text: '2024 Dec 19;2024:6640468. doi: 10.1155/crom/6640468. eCollection 2024.'
+  findings: []
 - reference: PMID:40056281
   title: 'Angiosarcoma: Role of Immunotherapy.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Apr;26(4):242-250. doi: 10.1007/s11864-025-01307-7.'
-    supporting_text: '2025 Apr;26(4):242-250. doi: 10.1007/s11864-025-01307-7.'
+  findings: []
 - reference: PMID:40364848
   title: 'Case Report: A novel chemotherapy-free regimen combined with photodynamic therapy, target therapy, and immunotherapy in a geriatric male with huge recurrent scalp and facial angiosarcoma: a report of an extremely rare case and literature review.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Apr 29;16:1556493. doi: 10.3389/fimmu.2025.1556493. eCollection 2025.'
-    supporting_text: '2025 Apr 29;16:1556493. doi: 10.3389/fimmu.2025.1556493. eCollection 2025.'
+  findings: []
 - reference: PMID:40474296
   title: 'Dissecting the tumor microenvironment in primary breast angiosarcoma: insights from single-cell RNA sequencing.'
   found_in:
@@ -1075,16 +1015,12 @@ references:
   title: 'Cemiplimab in Locally Advanced or Metastatic Secondary Angiosarcomas (CEMangio): A Phase II Clinical Trial and Biomarker Analyses.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Sep 2;31(17):3678-3691. doi: 10.1158/1078-0432.CCR-25-0311.'
-    supporting_text: '2025 Sep 2;31(17):3678-3691. doi: 10.1158/1078-0432.CCR-25-0311.'
+  findings: []
 - reference: PMID:40712262
   title: 'Clinicopathological features and prognostic insights of cutaneous versus non-cutaneous angiosarcoma: A retrospective single-center cohort study.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Sep;273:156139. doi: 10.1016/j.prp.2025.156139.'
-    supporting_text: '2025 Sep;273:156139. doi: 10.1016/j.prp.2025.156139.'
+  findings: []
 - reference: PMID:40914676
   title: Comparison of clinical features between patients with bone and soft tissue angiosarcomas.
   found_in:
@@ -1103,16 +1039,12 @@ references:
   title: Vaccination Against Extracellular Vimentin Plus Doxorubicin for Canine Hemangiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Sep 18;26(18):9096. doi: 10.3390/ijms26189096.'
-    supporting_text: '2025 Sep 18;26(18):9096. doi: 10.3390/ijms26189096.'
+  findings: []
 - reference: PMID:41177756
   title: 'Ravulizumab as an alternative for gemcitabine related trombotic microangiopathy: A case report.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025 Nov;45(9):501356. doi: 10.1016/j.nefroe.2025.501356.'
-    supporting_text: '2025 Nov;45(9):501356. doi: 10.1016/j.nefroe.2025.501356.'
+  findings: []
 - reference: PMID:41246336
   title: Multi-omics analysis revealed potential use of immunotherapy and CDK4/6 inhibitors in intimal sarcoma.
   found_in:
@@ -1124,9 +1056,7 @@ references:
   title: Cardiac Angiosarcoma.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2025;66(6):1025-1028. doi: 10.1536/ihj.25-303.'
-    supporting_text: '2025;66(6):1025-1028. doi: 10.1536/ihj.25-303.'
+  findings: []
 - reference: PMID:41394772
   title: Aristolochic Acid and Alternative Lengthening of Telomeres Mechanisms Underlie Liver Angiosarcoma Pathogenesis.
   found_in:
@@ -1138,16 +1068,12 @@ references:
   title: 'Multimodal treatment of radiation-associated laryngeal angiosarcoma: A case report and literature review.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2026 Jan 2;105(1):e46746. doi: 10.1097/MD.0000000000046746.'
-    supporting_text: '2026 Jan 2;105(1):e46746. doi: 10.1097/MD.0000000000046746.'
+  findings: []
 - reference: PMID:41693531
   title: 'Postradiation angiosarcoma of the breast: a 25-year single-institution analysis of clinicopathological characteristics and immunohistochemical biomarker study.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2026 Apr;101(3):173-183. doi: 10.1080/10520295.2026.2626268.'
-    supporting_text: '2026 Apr;101(3):173-183. doi: 10.1080/10520295.2026.2626268.'
+  findings: []
 - reference: PMID:41742582
   title: Frequency, distribution, and prognostic impact of metastatic site in dogs with splenic hemangiosarcoma.
   found_in:
@@ -1159,23 +1085,17 @@ references:
   title: 'A rare pulmonary epithelioid angiosarcoma with ALK rearrangement: a case report and literature review.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '2026 Feb 26;16:1780353. doi: 10.3389/fonc.2026.1780353. eCollection 2026.'
-    supporting_text: '2026 Feb 26;16:1780353. doi: 10.3389/fonc.2026.1780353. eCollection 2026.'
+  findings: []
 - reference: PMID:7199426
   title: 'Epidemiology of hepatic angiosarcoma in the United States: 1964-1974.'
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: '1981 Oct;41:107-13. doi: 10.1289/ehp.8141107.'
-    supporting_text: '1981 Oct;41:107-13. doi: 10.1289/ehp.8141107.'
+  findings: []
 - reference: PMID:9010458
   title: Sporadic and Thorotrast-induced angiosarcomas of the liver manifest frequent and multiple point mutations in K-ras-2.
   found_in:
   - Angiosarcoma-deep-research-openscientist.md
-  findings:
-  - statement: Przygodzki RM(1), Finkelstein SD, Keohavong P, Zhu D, Bakker A, Swalsky PA, Soini Y, Ishak KG, Bennett WP.
-    supporting_text: Przygodzki RM(1), Finkelstein SD, Keohavong P, Zhu D, Bakker A, Swalsky PA, Soini Y, Ishak KG, Bennett WP.
+  findings: []
 - reference: PMID:37106027
   title: Spatial transcriptomics reveal topological immune landscapes of Asian head and neck angiosarcoma.
   found_in:


### PR DESCRIPTION
Refs #1118

## Summary

Fixes a systemic data-quality defect in the `references` bibliography block of `kb/disorders/Angiosarcoma.yaml`.

40 of the 63 `references[].findings[]` entries had `statement` / `supporting_text` values that are **bibliographic artifacts**, not extracted claims:
- journal volume/issue/page/DOI citation strings — e.g. `'2012 Jul;33(7):1399-405. doi: 10.1093/carcin/bgs155.'`
- PubMed author lists — e.g. `Tsai MH(1), Chien RN, Hsieh SY, Hung CF, Chen TC, Sheen IS.`

These were erroneously scraped by a deep-research tool (`found_in: Angiosarcoma-deep-research-openscientist.md`), which grabbed the wrong line of the PubMed record.

This PR sets those 40 findings to `findings: []`, matching the existing in-file convention already used by `PMID:37106027` and `PMID:38722225`. The reference entries themselves — `reference`, `title`, `found_in` — are fully preserved, so the bibliography is intact; only the non-claim "finding" content is removed.

## What was intentionally NOT changed

- The 23 findings with genuine abstract-derived statements (e.g. `PMID:23522954`, `PMID:36387164`, `PMID:40914676`) are untouched.
- The entry's curated scientific content (pathophysiology, histopathology, phenotypes, genetic, treatments) — all already well-sourced and validating — is untouched.
- Two findings have a milder issue (`statement` is the paper title rather than a claim: `DOI:10.1038/s41591-019-0749-z`, `DOI:10.7759/cureus.41947`); `PMID:41246336` has `statement` = title but a valid `supporting_text`. These were left alone to keep this PR's rule crisp (remove only non-claim citation/author artifacts). They can be addressed in a follow-up.
- No new references or evidence were added; `references_cache/` is unchanged.

## Validation

```
just validate kb/disorders/Angiosarcoma.yaml            # schema + terms: passed
just validate-references kb/disorders/Angiosarcoma.yaml  # passed
```

Compliance: **65.4% → 83.4%**. The "OK" item count is unchanged (121); the prior score was depressed purely by 40 broken `Finding` nodes, which are now removed rather than counted as incomplete.

## Note for reviewers

This is a data-quality cleanup, not a curation-content change. The deep-research scrape pattern that produced these artifacts likely affects other entries with `*-deep-research-openscientist.md` reference blocks — a repo-wide audit/script would be a worthwhile follow-up (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)