### PR TITLE
[codex] Add Crohn creeping-fat fibrosis knowledge gap

### DIFF
--- a/kb/disorders/Crohn_Disease.yaml
+++ b/kb/disorders/Crohn_Disease.yaml
@@ -1,6 +1,6 @@
 name: Crohn Disease
 creation_date: '2025-12-04T16:57:31Z'
-updated_date: '2026-04-30T00:00:00Z'
+updated_date: '2026-05-21T06:08:04Z'
 description: A chronic inflammatory bowel disease that affects the lining of the digestive tract, causing a wide range of gastrointestinal and systemic symptoms.
 category: Complex
 parents:
@@ -1267,6 +1267,180 @@ treatments:
     term:
       id: MAXO:0000297
       label: immune suppressant agent therapy
+discussions:
+- discussion_id: gap_crohn_creeping_fat_stricture_causality
+  prompt: >-
+    Are creeping fat-derived CTHRC1-positive mechanosensitive fibroblasts a
+    necessary and targetable driver of Crohn strictures, or are they a
+    downstream marker of bowel-wall inflammation and established fibrosis?
+  kind: KNOWLEDGE_GAP
+  status: OPEN
+  attaches_to:
+  - pathophysiology#Fibrosis and Stricture Formation
+  - pathophysiology#Intestinal Inflammation and Epithelial Injury
+  - pathophysiology#Myeloid-Stromal Cell Crosstalk
+  rationale: >-
+    The Crohn entry captures inflammation-driven fibrosis, but recent
+    single-cell and animal-model work suggests that mesenteric creeping fat may
+    supply a mechanosensitive fibroblast population at the fat-bowel interface.
+    Testing necessity and reversibility would determine whether future
+    anti-fibrotic experiments should target bowel inflammation alone or the
+    mesenteric-fat interface as a separate disease mechanism.
+  proposed_experiments:
+  - experiment_id: exp_crohn_creeping_fat_bowel_interface_yap_taz_rescue
+    name: Patient-derived creeping-fat bowel-interface fibrosis-on-chip assay
+    description: >-
+      Construct a patient-derived Crohn bowel-wall organoid or organ-on-chip
+      that juxtaposes intestinal epithelial organoids, bowel-wall stromal cells,
+      mesenteric adipose stromal cells, and myeloid cells on tunable-stiffness
+      matrix; then deplete or inhibit CTHRC1-positive/YAP-TAZ-high fibroblasts
+      to test whether extracellular-matrix deposition and stricture-like tissue
+      contraction are prevented or reversed.
+    experiment_type:
+      preferred_term: patient-derived organ-on-chip fibrosis perturbation experiment
+    model_systems:
+    - name: Crohn creeping-fat bowel-interface organ-on-chip
+      description: >-
+        Microphysiological model of the fibrotic Crohn fat-bowel interface
+        combining intestinal epithelium, lamina propria stromal cells,
+        mesenteric adipose stromal cells, fibroblasts, and myeloid cells under
+        tunable mechanical stiffness.
+      experimental_model_type: ORGAN_ON_CHIP
+      namo_type: namo:OrganOnChip
+      organism:
+        preferred_term: human
+        term:
+          id: NCBITaxon:9606
+          label: Homo sapiens
+      tissue_term:
+        preferred_term: ileum
+        term:
+          id: UBERON:0002116
+          label: ileum
+      cell_types:
+      - preferred_term: intestinal epithelial cell
+        term:
+          id: CL:0002563
+          label: intestinal epithelial cell
+      - preferred_term: fibroblast
+        term:
+          id: CL:0000057
+          label: fibroblast
+      - preferred_term: adipocyte
+        term:
+          id: CL:0000136
+          label: adipocyte
+      - preferred_term: macrophage
+        term:
+          id: CL:0000235
+          label: macrophage
+      cell_source: resection-derived Crohn bowel wall, creeping fat, and patient-matched immune cells
+      culture_system: tunable-stiffness microfluidic matrix with epithelial-organoid and mesenteric-fat compartments
+    perturbations:
+    - name: CTHRC1-positive fibroblast depletion
+      target: pathophysiology#Fibrosis and Stricture Formation
+      description: >-
+        Genetic, antibody-based, or sorting-based removal of
+        CTHRC1-positive/YAP-TAZ-high fibroblasts from the creeping-fat
+        compartment to test necessity for fibrotic remodeling.
+      gene:
+        preferred_term: CTHRC1
+    - name: YAP/TAZ mechanotransduction inhibition
+      target: pathophysiology#Fibrosis and Stricture Formation
+      description: >-
+        Pharmacologic or genetic blockade of YAP/TAZ activity under high-stiffness
+        matrix conditions to test whether mechanosensitive signaling maintains
+        extracellular-matrix deposition.
+      genes:
+      - preferred_term: YAP1
+      - preferred_term: WWTR1
+      biological_processes:
+      - preferred_term: regulation of transcription by RNA polymerase II
+        term:
+          id: GO:0006357
+          label: regulation of transcription by RNA polymerase II
+    - name: Myeloid-stromal inflammatory challenge
+      target: pathophysiology#Myeloid-Stromal Cell Crosstalk
+      description: >-
+        Myeloid-cell cytokine challenge used to test whether creeping-fat
+        fibroblasts require inflammatory crosstalk to invade the bowel-wall
+        compartment.
+      biological_processes:
+      - preferred_term: inflammatory response
+        term:
+          id: GO:0006954
+          label: inflammatory response
+    readouts:
+    - name: Extracellular-matrix deposition and contraction
+      target: pathophysiology#Fibrosis and Stricture Formation
+      description: Collagen deposition, matrix stiffness, gel contraction, and luminal narrowing analogs.
+      biological_processes:
+      - preferred_term: extracellular matrix organization
+        term:
+          id: GO:0030198
+          label: extracellular matrix organization
+      assays:
+      - preferred_term: extracellular matrix immunostaining
+      - preferred_term: traction force microscopy
+      direction: POSITIVE
+    - name: CTHRC1-positive/YAP-TAZ fibroblast state
+      target: pathophysiology#Fibrosis and Stricture Formation
+      description: >-
+        Single-cell and spatial profiling of CTHRC1-positive fibroblasts,
+        YAP/TAZ target-gene signatures, and fat-bowel interface localization.
+      assays:
+      - preferred_term: single-cell transcriptomic profiling
+      - preferred_term: spatial transcriptomic profiling
+      direction: POSITIVE
+    - name: Epithelial barrier injury under fibrotic stiffness
+      target: pathophysiology#Intestinal Inflammation and Epithelial Injury
+      description: Barrier permeability and epithelial injury-state readouts coupled to stromal stiffness.
+      assays:
+      - preferred_term: permeability assay
+      - preferred_term: epithelial inflammatory profiling
+      direction: POSITIVE
+    controls:
+    - name: Bowel-wall organoid without creeping-fat compartment
+      description: Patient-derived intestinal organoid and stromal culture lacking mesenteric adipose cells.
+    - name: Non-stricturing Crohn comparator culture
+      description: Patient-derived culture from inflammatory, non-stricturing Crohn tissue.
+    - name: Low-stiffness matrix control
+      description: Mechanical control testing whether fibroblast activation depends on fibrotic stiffness.
+    decision_criterion: >-
+      Creeping-fat fibroblasts are supported as causal if their presence
+      increases CTHRC1/YAP-TAZ state, extracellular-matrix deposition, matrix
+      contraction, and epithelial injury, and if depletion or YAP/TAZ blockade
+      prevents or reverses these readouts despite inflammatory challenge.
+    would_support:
+    - pathophysiology#Fibrosis and Stricture Formation
+    - pathophysiology#Myeloid-Stromal Cell Crosstalk
+    would_refute:
+    - pathophysiology#Fibrosis and Stricture Formation
+    evidence:
+    - reference: PMID:40967215
+      reference_title: "Creeping fat-derived mechanosensitive fibroblasts drive intestinal fibrosis in Crohn's disease strictures."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "we identified CF-derived, CTHRC1+ fibroblasts enriched for Yes-associated protein (YAP)/transcriptional co-activator with PDZ-binding motif (TAZ) signatures and localized to a fibrotic CF-bowel wall interface within the stricture."
+      explanation: >-
+        Supports the proposed target population and its localization at the
+        creeping-fat bowel interface in human Crohn strictures.
+    - reference: PMID:40967215
+      reference_title: "Creeping fat-derived mechanosensitive fibroblasts drive intestinal fibrosis in Crohn's disease strictures."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "analogous Cthrc1+ mouse fibroblasts derive from mesenteric adipose tissue stromal cells, infiltrate fibrotic bowel, and deposit extracellular matrix in a YAP/TAZ-dependent manner"
+      explanation: >-
+        Provides causal animal-model support for testing YAP/TAZ-dependent
+        extracellular-matrix deposition in a humanized ex vivo platform.
+    - reference: PMID:40421006
+      reference_title: "Intestinal organoids in inflammatory bowel disease: advances, applications, and future directions."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Innovations in CRISPR editing, organoid-microbe co-cultures, and organ-on-a-chip systems have enhanced the physiological relevance of these models"
+      explanation: >-
+        Supports the feasibility of organoid and organ-on-chip approaches for
+        modeling complex Crohn tissue mechanisms.
 review_notes: Crohn disease is a type of inflammatory bowel disease that can affect any part of the GI tract but most commonly the terminal ileum and colon. Extraintestinal manifestations involving the joints, skin and eyes occur in a subset of patients. The disease is characterized by periods of remission interspersed with flares.
 disease_term:
   preferred_term: Crohn disease

--- a/references_cache/PMID_40421006.md
+++ b/references_cache/PMID_40421006.md
@@ -1,0 +1,58 @@
+---
+reference_id: "PMID:40421006"
+title: "Intestinal organoids in inflammatory bowel disease: advances, applications, and future directions."
+authors:
+- Ren J
+- Huang S
+journal: Front Cell Dev Biol
+year: '2025'
+doi: 10.3389/fcell.2025.1517121
+content_type: abstract_only
+---
+
+# Intestinal organoids in inflammatory bowel disease: advances, applications, and future directions.
+**Authors:** Ren J, Huang S
+**Journal:** Front Cell Dev Biol (2025)
+**DOI:** [10.3389/fcell.2025.1517121](https://doi.org/10.3389/fcell.2025.1517121)
+
+## Content
+
+1. Front Cell Dev Biol. 2025 May 12;13:1517121. doi: 10.3389/fcell.2025.1517121.
+eCollection 2025.
+
+Intestinal organoids in inflammatory bowel disease: advances, applications, and
+future directions.
+
+Ren J(1), Huang S(1).
+
+Author information:
+(1)Department of Gastroenterology, South China Hospital, Medical School,
+Shenzhen University, Shenzhen, China.
+
+Inflammatory bowel disease (IBD), characterized by chronic gastrointestinal
+inflammation, is a significant global health challenge. Traditional models often
+fail to accurately reflect human pathophysiology, leading to suboptimal
+treatments. This review provides an overview of recent advancements in
+intestinal organoid technology and its role in IBD research. Organoids, derived
+from patient-specific or pluripotent stem cells, retain the genetic, epigenetic,
+and structural characteristics of the native gut, allowing for precise modeling
+of key aspects of IBD. Innovations in CRISPR editing, organoid-microbe
+co-cultures, and organ-on-a-chip systems have enhanced the physiological
+relevance of these models, facilitating drug discovery and personalized therapy
+screening. However, challenges such as vascularization deficits and the need for
+standardized protocols remain. This review underscores the need for
+interdisciplinary efforts to bridge the gap between models and the complex
+reality of IBD. Future directions include the development of scalable
+vascularized models and robust regulatory frameworks to accelerate therapeutic
+translation. Organoids hold promise for unraveling IBD heterogeneity and
+transforming disease management.
+
+Copyright © 2025 Ren and Huang.
+
+DOI: 10.3389/fcell.2025.1517121
+PMCID: PMC12104276
+PMID: 40421006
+
+Conflict of interest statement: The authors declare that the research was
+conducted in the absence of any commercial or financial relationships that could
+be construed as a potential conflict of interest.

--- a/references_cache/PMID_40967215.md
+++ b/references_cache/PMID_40967215.md
@@ -1,0 +1,118 @@
+---
+reference_id: "PMID:40967215"
+title: "Creeping fat-derived mechanosensitive fibroblasts drive intestinal fibrosis in Crohn's disease strictures."
+authors:
+- Bauer-Rowe KE
+- Pham B
+- Griffin M
+- Liang NE
+- Kim A
+- Lu JM
+- Januszyk M
+- Guo JL
+- De Santis S
+- Xing Y
+- Prystupa A
+- Sidhu I
+- Suh EJ
+- Foster DS
+- Korah M
+- Goyal A
+- Wan DC
+- Norton JA
+- Delitto D
+- Pizarro TT
+- Naik SL
+- Hyun JS
+- Longaker MT
+journal: Cell
+year: '2025'
+doi: 10.1016/j.cell.2025.08.029
+keywords:
+- Fibroblasts
+- Humans
+- "Crohn Disease/metabolism, pathology"
+- "Intestines/metabolism, pathology"
+- Animals
+- Mice
+- "Disease Models, Animal"
+- "Adipose Tissue/metabolism, pathology"
+- Extracellular Matrix Proteins/metabolism
+- "Transcription, Genetic"
+- Gene Regulatory Networks
+- Signal Transduction
+- Male
+- Female
+- "Mice, Inbred C57BL"
+content_type: abstract_only
+---
+
+# Creeping fat-derived mechanosensitive fibroblasts drive intestinal fibrosis in Crohn's disease strictures.
+**Authors:** Bauer-Rowe KE, Pham B, Griffin M, Liang NE, Kim A, Lu JM, Januszyk M, Guo JL, De Santis S, Xing Y, Prystupa A, Sidhu I, Suh EJ, Foster DS, Korah M, Goyal A, Wan DC, Norton JA, Delitto D, Pizarro TT, Naik SL, Hyun JS, Longaker MT
+**Journal:** Cell (2025)
+**DOI:** [10.1016/j.cell.2025.08.029](https://doi.org/10.1016/j.cell.2025.08.029)
+
+## Content
+
+1. Cell. 2025 Nov 13;188(23):6536-6553.e26. doi: 10.1016/j.cell.2025.08.029. Epub
+ 2025 Sep 17.
+
+Creeping fat-derived mechanosensitive fibroblasts drive intestinal fibrosis in
+Crohn's disease strictures.
+
+Bauer-Rowe KE(1), Pham B(2), Griffin M(2), Liang NE(2), Kim A(2), Lu JM(1),
+Januszyk M(2), Guo JL(2), De Santis S(3), Xing Y(4), Prystupa A(4), Sidhu I(4),
+Suh EJ(2), Foster DS(2), Korah M(1), Goyal A(5), Wan DC(2), Norton JA(2),
+Delitto D(2), Pizarro TT(3), Naik SL(4), Hyun JS(6), Longaker MT(7).
+
+Author information:
+(1)Hagey Laboratory for Pediatric Regenerative Medicine, Division of Plastic and
+Reconstructive Surgery, Stanford University School of Medicine, Stanford, CA
+94305, USA; Department of Surgery, Stanford University School of Medicine,
+Stanford, CA 94305, USA; Institute for Stem Cell Biology and Regenerative
+Medicine, Stanford University School of Medicine, Stanford, CA 94305, USA.
+(2)Hagey Laboratory for Pediatric Regenerative Medicine, Division of Plastic and
+Reconstructive Surgery, Stanford University School of Medicine, Stanford, CA
+94305, USA; Department of Surgery, Stanford University School of Medicine,
+Stanford, CA 94305, USA.
+(3)Department of Pathology, Case Western Reserve University School of Medicine,
+Cleveland, OH 44106, USA.
+(4)Department of Immunology and Immunotherapy, Department of Dermatology, Icahn
+School of Medicine, Mt. Sinai, New York, NY, USA.
+(5)Department of Pediatrics, Stanford University School of Medicine, Stanford,
+CA 94305, USA.
+(6)Hagey Laboratory for Pediatric Regenerative Medicine, Division of Plastic and
+Reconstructive Surgery, Stanford University School of Medicine, Stanford, CA
+94305, USA; Department of Surgery, Stanford University School of Medicine,
+Stanford, CA 94305, USA. Electronic address: jhyun1@stanford.edu.
+(7)Hagey Laboratory for Pediatric Regenerative Medicine, Division of Plastic and
+Reconstructive Surgery, Stanford University School of Medicine, Stanford, CA
+94305, USA; Department of Surgery, Stanford University School of Medicine,
+Stanford, CA 94305, USA; Institute for Stem Cell Biology and Regenerative
+Medicine, Stanford University School of Medicine, Stanford, CA 94305, USA.
+Electronic address: longaker@stanford.edu.
+
+A significant complication of Crohn's disease (CD) is intestinal fibrosis, which
+narrows the bowel lumen to form a stricture. Creeping fat (CF) is the wrapping
+of mesenteric adipose tissue around diseased bowel, of which the role in CD
+stricture progression is unclear. By constructing a human single-cell CD
+fibroblast atlas, we identified CF-derived, CTHRC1+ fibroblasts enriched for
+Yes-associated protein (YAP)/transcriptional co-activator with PDZ-binding motif
+(TAZ) signatures and localized to a fibrotic CF-bowel wall interface within the
+stricture. We further showed that analogous Cthrc1+ mouse fibroblasts derive
+from mesenteric adipose tissue stromal cells, infiltrate fibrotic bowel, and
+deposit extracellular matrix in a YAP/TAZ-dependent manner in a mouse model of
+intestinal fibrosis. Our findings identify CF as a key source of pro-fibrotic
+fibroblasts and raise the possibility of improving future clinical management of
+stricture progression by targeting not only the bowel but also CF.
+
+Copyright © 2025 Elsevier Inc. All rights reserved.
+
+DOI: 10.1016/j.cell.2025.08.029
+PMCID: PMC12453597
+PMID: 40967215 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of interests S.L.N. is on the SAB of
+Seed Inc. and is a co-founder of Stara Biosciences. Stanford Provisional patent:
+“YAP Inhibition for Intestinal Fibrosis,” serial number 63/818,707 (M.T.L.,
+J.S.H., A.K., B.P., N.E.L., and K.E.B.-R.).


### PR DESCRIPTION
## Summary
- Adds a `KNOWLEDGE_GAP` discussion to Crohn Disease for whether creeping fat-derived fibroblasts are causal drivers of stricture fibrosis.
- Adds a proposed patient-derived creeping-fat bowel-interface fibrosis-on-chip experiment with Description-pattern model system, perturbation, and readout fields.
- Adds regenerated PubMed reference caches for PMID:40967215 and PMID:40421006.

## Validation
- `just validate kb/disorders/Crohn_Disease.yaml`
- `uv run pytest tests/test_render_discussions.py -q`
- Rendered `/tmp/Crohn_Disease.html` and confirmed the Discussions and Knowledge Gaps section plus the proposed experiment title.
- `git diff HEAD~1..HEAD --check`