### PR TITLE
[codex] Wire PDH deficiency biochemical readouts

### DIFF
--- a/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Dehydrogenase Deficiency
 creation_date: "2026-05-05T20:20:53Z"
-updated_date: "2026-05-09T18:46:08Z"
+updated_date: "2026-05-21T06:27:58Z"
 category: Mendelian
 parents:
 - mitochondrial disease
@@ -1737,6 +1737,19 @@ biochemical:
 - name: Lactate
   presence: INCREASED
   context: Blood and CSF lactate are often elevated in PDH deficiency.
+  readouts:
+  - target: Lactate and pyruvate accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated blood or CSF lactate reports the lactate arm of pyruvate-to-lactate accumulation downstream of impaired PDH flux.
+    evidence:
+    - reference: PMID:22896851
+      reference_title: "The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients who died were younger, presented clinically earlier and had higher blood lactate levels and lower residual enzyme activities than subjects who were still alive at the time of reporting."
+      explanation: The cohort review supports blood lactate as a measurable biochemical abnormality associated with PDH deficiency severity.
   evidence:
   - reference: PMID:22896851
     reference_title: "The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients."
@@ -1747,6 +1760,19 @@ biochemical:
 - name: Pyruvate
   presence: INCREASED
   context: Pyruvate accumulates when oxidative decarboxylation by the PDH complex is deficient.
+  readouts:
+  - target: Lactate and pyruvate accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated pyruvate reports impaired clearance of the glycolytic end product when oxidative decarboxylation by PDH is blocked.
+    evidence:
+    - reference: PMID:23467562
+      reference_title: Phenylbutyrate therapy for pyruvate dehydrogenase complex deficiency and lactic acidosis.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "A deficiency of any enzyme in these pathways results in inadequate removal of pyruvate and lactate from blood and tissues and causes lactic acidosis."
+      explanation: This mechanistic review supports pyruvate accumulation as a biochemical readout of impaired pyruvate oxidation.
   evidence:
   - reference: PMID:23467562
     reference_title: Phenylbutyrate therapy for pyruvate dehydrogenase complex deficiency and lactic acidosis.
@@ -1757,6 +1783,19 @@ biochemical:
 - name: PDH complex enzyme activity
   presence: DECREASED
   context: Residual enzyme activity is reduced and correlates with severity in severe presentations.
+  readouts:
+  - target: Reduced pyruvate decarboxylation to acetyl-CoA
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lower residual PDH complex activity directly reports the impaired pyruvate-to-acetyl-CoA catalytic step.
+    evidence:
+    - reference: PMID:22896851
+      reference_title: "The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "lower residual enzyme activities than subjects who were still alive at the time of reporting."
+      explanation: The clinical review supports reduced residual enzyme activity as a measurable biochemical readout of the PDH catalytic defect.
   evidence:
   - reference: PMID:22896851
     reference_title: "The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients."


### PR DESCRIPTION
## Summary
- Add diagnostic readout links for lactate and pyruvate to the existing `Lactate and pyruvate accumulation` mechanism.
- Add a diagnostic readout link for decreased residual PDH complex enzyme activity to the impaired pyruvate-to-acetyl-CoA catalytic step.
- Keep the PR scoped to `kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`; no reference cache edits are included.

## Validation
- `just validate kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`
- `just validate-terms kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml`
- normalized snippet audit: `checked=130 missing=0`
- local coverage audit: `phenotypes_explained_by_downstream=55/55`, `biochemical_readouts=3/3`, `readout_targets_missing=0`
- `git diff --check`

## Notes
- `just validate` produced the known unrelated cache churn in `PMID_24904092` and `PMID_31292197`; both were restored before commit.
