### PR TITLE
[codex] Wire ALAD porphyria biochemical readouts

### DIFF
--- a/kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml
+++ b/kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Porphyria due to ALA Dehydratase Deficiency
 category: Mendelian
 creation_date: '2026-05-05T09:35:36Z'
-updated_date: '2026-05-19T08:38:41Z'
+updated_date: '2026-05-21T06:40:48Z'
 description: >
   Porphyria due to ALA dehydratase deficiency, also called ALAD porphyria or
   porphyria of Doss, is an ultra-rare autosomal recessive acute hepatic
@@ -891,6 +891,21 @@ biochemical:
   context: >
     Urinary ALA is markedly increased because the ALAD block prevents efficient
     conversion of ALA to PBG.
+  readouts:
+  - target: Hepatic and erythroid ALA accumulation without PBG overproduction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary ALA reports the ALA-accumulation branch downstream of the ALAD enzymatic block.
+    evidence:
+    - reference: PMID:9516683
+      reference_title: "ALAD porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        Because of an almost complete lack of ALAD activity, patients excrete a
+        large amount of ALA, but not PBG, into urine.
+      explanation: The ADP review directly supports urinary ALA as the diagnostic readout of ALA accumulation without PBG overproduction.
   evidence:
   - reference: PMID:9516683
     reference_title: "ALAD porphyria."
@@ -905,6 +920,23 @@ biochemical:
   context: >
     Unlike most other acute hepatic porphyrias, ADP does not cause PBG
     overproduction because the enzymatic block is upstream of PBG formation.
+  readouts:
+  - target: ALAD block in heme biosynthesis
+    relationship: READOUT_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: Lack of urinary PBG overproduction reports that the heme-biosynthesis block lies upstream of PBG formation, distinguishing ADP from AIP.
+    evidence:
+    - reference: PMID:9516683
+      reference_title: "ALAD porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        The symptoms in this disease are similar to those seen in AIP, but ALAD
+        porphyria can be differentiated from AIP by its autosomal recessive,
+        rather than dominant, inheritance, by the lack of PBG overproduction, and
+        by markedly decreased ALAD activity.
+      explanation: This review identifies absent PBG overproduction as a diagnostic discriminator of the ALAD block.
   evidence:
   - reference: PMID:9516683
     reference_title: "ALAD porphyria."
@@ -919,6 +951,23 @@ biochemical:
   context: >
     Erythrocyte ALAD activity is profoundly reduced in documented genetic ADP
     cases and can help confirm the diagnosis.
+  readouts:
+  - target: ALAD block in heme biosynthesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Markedly reduced erythrocyte ALAD activity directly reports the deficient porphobilinogen synthase step in heme biosynthesis.
+    evidence:
+    - reference: PMID:10706561
+      reference_title: "Novel molecular defects of the delta-aminolevulinate dehydratase gene in a patient with inherited acute hepatic porphyria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        These data thus demonstrate that the proband was associated with 2 novel
+        molecular defects of the ALAD gene, 1 in each allele, and account for the
+        extremely low ALAD activity in his erythrocytes ( approximately 1% of
+        normal).
+      explanation: Patient molecular and enzyme data support erythrocyte ALAD activity as a direct readout of the heme-biosynthesis block.
   evidence:
   - reference: PMID:10706561
     reference_title: "Novel molecular defects of the delta-aminolevulinate dehydratase gene in a patient with inherited acute hepatic porphyria."
@@ -935,6 +984,22 @@ biochemical:
   context: >
     Urinary coproporphyrin isomers are elevated in ADP and can overlap with the
     biochemical pattern of acquired ALAD inhibition from lead intoxication.
+  readouts:
+  - target: Hepatic and erythroid ALA accumulation without PBG overproduction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary coproporphyrins report the abnormal porphyrin-intermediate profile downstream of ALAD deficiency.
+    evidence:
+    - reference: PMID:10211628
+      reference_title: "Investigations on the formation of urinary coproporphyrin isomers I-IV in 5-aminolevulinic acid dehydratase deficiency porphyria, acute lead intoxication and after oral 5-aminolevulinic acid loading."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >
+        The concentration of total coproporphyrins was about 30-fold increased in
+        patients with ALAD deficiency porphyria and acute lead intoxication as
+        compared with controls.
+      explanation: Patient biochemical data support urinary coproporphyrins as a readout of the abnormal porphyrin profile in ADP.
   evidence:
   - reference: PMID:10211628
     reference_title: "Investigations on the formation of urinary coproporphyrin isomers I-IV in 5-aminolevulinic acid dehydratase deficiency porphyria, acute lead intoxication and after oral 5-aminolevulinic acid loading."


### PR DESCRIPTION
## Summary
- Add diagnostic readout links for urinary ALA, urinary PBG, erythrocyte ALAD activity, and urinary coproporphyrins.
- Link those markers to the existing ALAD heme-biosynthesis block and ALA-accumulation pathophysiology nodes.
- Keep the PR scoped to `kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml`; no reference cache edits are included.

## Validation
- `just validate kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml`
- `just validate-terms kb/disorders/Porphyria_due_to_ALA_Dehydratase_Deficiency.yaml`
- normalized snippet audit: `checked=87 missing=0`
- local coverage audit: `phenotypes_explained_by_downstream=11/11`, `biochemical_readouts=4/4`, `readout_targets_missing=0`
- `git diff --check`

## Notes
- `just validate` produced the known unrelated cache churn in `PMID_24904092` and `PMID_31292197`; both were restored before commit.
