### PR TITLE
[codex] Wire NAGS deficiency biochemical readouts

### DIFF
--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: N-Acetylglutamate Synthase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T18:29:40Z'
+updated_date: '2026-05-21T06:52:13Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -674,6 +674,19 @@ biochemical:
     term:
       id: CHEBI:28938
       label: ammonium
+  readouts:
+  - target: Systemic hyperammonemia and glutamine diversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased plasma ammonia reports failed hepatic nitrogen disposal from the proximal urea-cycle block.
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: common biochemical features include increased amounts of plasma ammonia and glutamine, reduced plasma citrulline, and normal or low levels of urinary orotic acid
+      explanation: The NAGS deficiency review identifies increased plasma ammonia as part of the shared proximal urea-cycle biochemical profile.
   evidence:
   - reference: PMID:38637895
     reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."
@@ -692,6 +705,19 @@ biochemical:
     term:
       id: CHEBI:28300
       label: glutamine
+  readouts:
+  - target: Systemic hyperammonemia and glutamine diversion
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased plasma glutamine reports diversion of excess nitrogen into glutamine during impaired ureagenesis.
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: common biochemical features include increased amounts of plasma ammonia and glutamine, reduced plasma citrulline, and normal or low levels of urinary orotic acid
+      explanation: The review directly supports increased plasma glutamine as part of the NAGS/CPS1-like proximal urea-cycle biochemical profile.
   notes: >-
     Elevated plasma glutamine is a well-established biochemical feature of proximal urea cycle defects
     (NAGS and CPS1 deficiency), reflecting ammonia diversion into glutamine synthesis. The available
@@ -715,6 +741,19 @@ biochemical:
     term:
       id: CHEBI:18211
       label: citrulline
+  readouts:
+  - target: Loss of CPS1 activation and impaired ureagenesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced plasma citrulline reports limited carbamoyl phosphate production and downstream urea-cycle flux.
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: common biochemical features include increased amounts of plasma ammonia and glutamine, reduced plasma citrulline, and normal or low levels of urinary orotic acid
+      explanation: The review identifies reduced plasma citrulline as a biochemical readout of the proximal urea-cycle block.
   evidence:
   - reference: PMID:38637895
     reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."
@@ -742,6 +781,19 @@ biochemical:
     term:
       id: CHEBI:16742
       label: orotic acid
+  readouts:
+  - target: Systemic hyperammonemia and glutamine diversion
+    relationship: READOUT_OF
+    direction: PRESENT_ABSENT
+    endpoint_context: DIAGNOSTIC
+    interpretation: Normal or low urinary orotic acid is the interpretable discriminator for a proximal NAGS/CPS1-like urea-cycle block rather than a distal OTC-like block.
+    evidence:
+    - reference: PMID:29364180
+      reference_title: "Late-Onset N-Acetylglutamate Synthase Deficiency: Report of a Paradigmatic Adult Case Presenting with Headaches and Review of the Literature."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: common biochemical features include increased amounts of plasma ammonia and glutamine, reduced plasma citrulline, and normal or low levels of urinary orotic acid
+      explanation: The review supports normal or low urinary orotic acid as part of the proximal urea-cycle biochemical profile.
   evidence:
   - reference: PMID:38637895
     reference_title: "The efficacy of Carbamylglutamate impacts the nutritional management of patients with N-Acetylglutamate synthase deficiency."

--- a/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
+++ b/kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: N-Acetylglutamate Synthase Deficiency
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-21T06:52:13Z'
+updated_date: '2026-05-21T06:59:32Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -782,7 +782,7 @@ biochemical:
       id: CHEBI:16742
       label: orotic acid
   readouts:
-  - target: Systemic hyperammonemia and glutamine diversion
+  - target: Loss of CPS1 activation and impaired ureagenesis
     relationship: READOUT_OF
     direction: PRESENT_ABSENT
     endpoint_context: DIAGNOSTIC


### PR DESCRIPTION
## Summary
- Add diagnostic readout links for plasma ammonia, plasma glutamine, plasma citrulline, and urine orotic acid.
- Keep the existing NAG readout unchanged; after this change all five biochemical entries have readout links.
- Keep the PR scoped to `kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`; no reference cache edits are included.

## Validation
- `just validate kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`
- `just validate-terms kb/disorders/N-Acetylglutamate_Synthase_Deficiency.yaml`
- normalized snippet audit: `checked=88 missing=0`
- local coverage audit: `phenotypes_explained_by_downstream=10/11`, `unexplained=["Failure to thrive"]`, `biochemical_readouts=5/5`, `readout_targets_missing=0`
- `git diff --check`

## Notes
- I intentionally did not add a pathophysiology edge for the pre-existing `Failure to thrive` phenotype because the cached snippets support poor feeding/metabolic emergency context, not that exact phenotype.
- `just validate` produced the known unrelated cache churn in `PMID_24904092` and `PMID_31292197`; both were restored before commit.
