### PR TITLE
[codex] Wire HFI transaminase readout

### DIFF
--- a/kb/disorders/Hereditary_Fructose_Intolerance.yaml
+++ b/kb/disorders/Hereditary_Fructose_Intolerance.yaml
@@ -1,6 +1,6 @@
 name: Hereditary Fructose Intolerance
 creation_date: '2026-04-21T04:43:27Z'
-updated_date: '2026-05-20T12:57:46Z'
+updated_date: '2026-05-21T07:09:24Z'
 category: Genetic
 synonyms:
 - HFI
@@ -630,6 +630,19 @@ biochemical:
   context: >
     Liver injury in HFI may present with asymptomatic transaminase elevation,
     especially around diagnosis or when dietary control is imperfect.
+  readouts:
+  - target: Chronic hepatic lipid storage and inflammatory dysregulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: MONITORING
+    interpretation: Elevated transaminases report hepatic injury associated with chronic liver involvement in HFI.
+    evidence:
+    - reference: PMID:36052111
+      reference_title: "Hereditary fructose intolerance: A comprehensive review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Liver manifestations include an asymptomatic increase of transaminases, steatohepatitis and rarely liver failure."
+      explanation: The review supports transaminase elevation as a liver manifestation that can monitor hepatic involvement in HFI.
   evidence:
   - reference: PMID:36052111
     reference_title: "Hereditary fructose intolerance: A comprehensive review."


### PR DESCRIPTION
## Summary
- Add a monitoring readout link for increased transaminases to the existing chronic hepatic lipid storage/inflammatory dysregulation node.
- Keep existing fructose-1-phosphate, ATP, and blood glucose readouts unchanged; after this change all four biochemical entries have readout links.
- Keep the PR scoped to `kb/disorders/Hereditary_Fructose_Intolerance.yaml`; no reference cache edits are included.

## Validation
- `just validate kb/disorders/Hereditary_Fructose_Intolerance.yaml`
- `just validate-terms kb/disorders/Hereditary_Fructose_Intolerance.yaml`
- normalized snippet audit: `checked=58 missing=0`
- local coverage audit: `phenotypes_explained_by_downstream=10/10`, `biochemical_readouts=5 total links across 4/4 markers`, `readout_targets_missing=0`
- `git diff --check`

## Notes
- `just validate` produced the known unrelated cache churn in `PMID_24904092` and `PMID_31292197`; both were restored before commit.
