### PR TITLE
Wire transaldolase biochemical readouts

### DIFF
--- a/kb/disorders/Transaldolase_Deficiency.yaml
+++ b/kb/disorders/Transaldolase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Transaldolase Deficiency
 creation_date: "2026-05-05T07:40:18Z"
-updated_date: "2026-05-10T22:41:17Z"
+updated_date: "2026-05-21T07:21:36Z"
 category: Mendelian
 synonyms:
 - TALDO deficiency
@@ -582,6 +582,21 @@ biochemical:
     Patient-derived fibroblast and lymphoblast studies and recombinant protein
     assays show loss of transaldolase enzymatic activity in disease-associated
     TALDO1 variants.
+  readouts:
+  - target: TALDO1 transaldolase activity deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Reduced transaldolase enzyme activity directly reports the primary TALDO1
+      catalytic-function defect.
+    evidence:
+    - reference: PMID:15115436
+      reference_title: "Deletion of Ser-171 causes inactivation, proteasome-mediated degradation and complete deficiency of human transaldolase."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "no expression of the TALDeltaS171 protein or enzyme activity was detected"
+      explanation: Patient-cell experiments show absent transaldolase protein/enzyme activity, supporting enzyme activity as a direct readout of the root mechanism.
   evidence:
   - reference: PMID:15115436
     reference_title: "Deletion of Ser-171 causes inactivation, proteasome-mediated degradation and complete deficiency of human transaldolase."
@@ -595,6 +610,21 @@ biochemical:
     Urine testing shows increased erythritol, ribitol, arabitol, sedoheptitol,
     perseitol, sedoheptulose, and sedoheptulose-7-phosphate, supporting the
     biochemical diagnosis.
+  readouts:
+  - target: Pentose phosphate pathway metabolite imbalance
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Increased urinary polyols and seven-carbon sugars report the downstream
+      pentose-phosphate metabolite imbalance caused by transaldolase deficiency.
+    evidence:
+    - reference: PMID:24497183
+      reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Elevated excretion of erythritol, ribitol, arabitol, sedoheptitol, perseitol, sedoheptulose and sedoheptulose-7P in the urine"
+      explanation: Human urine testing directly supports the metabolite panel as a diagnostic readout of the pentose-phosphate metabolite imbalance.
   evidence:
   - reference: PMID:24497183
     reference_title: "Clinical and molecular characteristics of two transaldolase-deficient patients."


### PR DESCRIPTION
## Summary
- add readout links for reduced transaldolase activity and urinary polyol/seven-carbon sugar abnormalities
- connect both biochemical markers to the relevant pathophysiology nodes with exact cached evidence snippets
- update Transaldolase Deficiency entry timestamp

## Validation
- just validate kb/disorders/Transaldolase_Deficiency.yaml
- just validate-references kb/disorders/Transaldolase_Deficiency.yaml
- just validate-terms kb/disorders/Transaldolase_Deficiency.yaml
- normalized snippet audit: checked=93 missing=0
- connectivity audit: phenotypes explained 19/19, biochemical readouts 2/2, bad readout targets=[]
- git diff --check