### PR TITLE
Wire fucosidosis biochemical readouts

### DIFF
--- a/kb/disorders/Fucosidosis.yaml
+++ b/kb/disorders/Fucosidosis.yaml
@@ -1,7 +1,7 @@
 name: Fucosidosis
 category: Mendelian
 creation_date: "2026-05-04T15:41:26Z"
-updated_date: "2026-05-10T23:15:11Z"
+updated_date: "2026-05-21T07:31:07Z"
 synonyms:
 - Alpha-L-fucosidase deficiency
 description: >
@@ -1480,6 +1480,21 @@ biochemical:
   notes: >
     Affected individuals have deficient alpha-L-fucosidase activity in
     leukocytes, fibroblasts, or other assayed cells.
+  readouts:
+  - target: FUCA1 alpha-L-fucosidase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Reduced alpha-L-fucosidase activity directly reports the primary FUCA1
+      lysosomal hydrolase deficiency.
+    evidence:
+    - reference: PMID:1873910
+      reference_title: Defective expression of alpha-L-fucosidase by lymphoid cells of a fucosidosis patient.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "negligible catalytic activity as compared with the mean of 19 control cultures."
+      explanation: Patient lymphoid-cell assays directly support low alpha-L-fucosidase catalytic activity as a readout of the root enzyme deficiency.
   evidence:
   - reference: PMID:1873910
     reference_title: Defective expression of alpha-L-fucosidase by lymphoid cells of a fucosidosis patient.
@@ -1493,6 +1508,22 @@ biochemical:
   notes: >
     Urine may show excess fucosylated glycopeptides, glycoasparagines, and
     oligosaccharides.
+  readouts:
+  - target: Fucose-rich glycoconjugate lysosomal storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Increased urinary fucose-rich oligosaccharides and glycopeptides report
+      the fucosylated glycoconjugate storage burden caused by alpha-L-fucosidase
+      deficiency.
+    evidence:
+    - reference: PMID:33266441
+      reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients affected with fucosidosis excrete a large amount of glycopeptide in the urine"
+      explanation: The review supports urinary fucosylated glycopeptide excretion as a diagnostic readout of fucose-rich glycoconjugate storage.
   evidence:
   - reference: PMID:33266441
     reference_title: Fucosidosis-Clinical Manifestation, Long-Term Outcomes, and Genetic Profile-Review and Case Series.


### PR DESCRIPTION
## Summary
- add readout links for alpha-L-fucosidase enzyme activity and urinary fucose-rich oligosaccharide/glycopeptide abnormalities
- connect both biochemical markers to existing Fucosidosis pathophysiology nodes using exact cached snippets
- update Fucosidosis entry timestamp

## Validation
- just validate kb/disorders/Fucosidosis.yaml
- just validate-references kb/disorders/Fucosidosis.yaml
- just validate-terms kb/disorders/Fucosidosis.yaml
- normalized snippet audit: checked=131 missing=0
- connectivity audit: phenotypes explained 32/32, biochemical readouts 2/2, bad readout targets=[]
- git diff --check