### PR TITLE
Wire SLOS sterol readouts

### DIFF
--- a/kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
+++ b/kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
@@ -1,6 +1,6 @@
 name: Smith-Lemli-Opitz syndrome
 creation_date: '2026-04-13T01:17:48Z'
-updated_date: '2026-05-19T01:56:25Z'
+updated_date: '2026-05-21T07:38:48Z'
 category: Mendelian
 synonyms:
 - SLOS
@@ -617,6 +617,26 @@ biochemical:
 - name: Serum 7-dehydrocholesterol
   presence: INCREASED
   context: Diagnostic sterol abnormality detected in serum and other tissues.
+  biomarker_term:
+    preferred_term: 7-dehydrocholesterol
+    term:
+      id: CHEBI:17759
+      label: cholesta-5,7-dien-3beta-ol
+  readouts:
+  - target: 7-Dehydrocholesterol Accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Elevated serum or tissue 7-dehydrocholesterol reports accumulation of
+      the DHCR7 substrate upstream of toxic oxysterol generation.
+    evidence:
+    - reference: PMID:23059950
+      reference_title: "Smith-Lemli-Opitz syndrome: phenotype, natural history, and epidemiology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The clinical diagnosis of SLOS is confirmed by demonstrating an abnormally elevated concentration of the cholesterol precursor, 7DHC, in serum or other tissues, or by the presence of two DHCR7 mutations."
+      explanation: The clinical review supports elevated 7DHC as a diagnostic readout of the accumulated precursor pool.
   evidence:
   - reference: PMID:23059950
     reference_title: "Smith-Lemli-Opitz syndrome: phenotype, natural history, and epidemiology."
@@ -633,6 +653,26 @@ biochemical:
 - name: Plasma cholesterol
   presence: DECREASED
   context: Characteristically low, especially in more severely affected individuals.
+  biomarker_term:
+    preferred_term: cholesterol
+    term:
+      id: CHEBI:16113
+      label: cholesterol
+  readouts:
+  - target: Relative Cholesterol Deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Low plasma cholesterol reports the cholesterol-deficiency branch of the
+      terminal DHCR7 sterol-biosynthesis block.
+    evidence:
+    - reference: PMID:7706951
+      reference_title: "Markedly increased tissue concentrations of 7-dehydrocholesterol combined with low levels of cholesterol are characteristic of the Smith-Lemli-Opitz syndrome."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "It is characterized biochemically by low plasma cholesterol and greatly elevated levels of two dehydrocholesterols, one of which is the cholesterol precursor 7-dehydrocholesterol."
+      explanation: Human sterol measurements support low plasma cholesterol as a diagnostic readout of relative cholesterol deficiency.
   evidence:
   - reference: PMID:7706951
     reference_title: "Markedly increased tissue concentrations of 7-dehydrocholesterol combined with low levels of cholesterol are characteristic of the Smith-Lemli-Opitz syndrome."


### PR DESCRIPTION
## Summary
- add CHEBI biomarker bindings for serum 7-dehydrocholesterol and plasma cholesterol
- connect both sterol biomarkers to existing SLOS pathophysiology nodes with readout links
- update Smith-Lemli-Opitz syndrome entry timestamp

## Validation
- just validate kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
- just validate-references kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
- just validate-terms kb/disorders/Smith-Lemli-Opitz_syndrome.yaml
- normalized snippet audit: checked=68 missing=0
- connectivity audit: phenotypes explained 8/8, biochemical readouts 2/2, bad readout targets=[]
- git diff --check