### PR TITLE
Wire beta-mannosidosis biochemical readouts

### DIFF
--- a/kb/disorders/Beta_Mannosidosis.yaml
+++ b/kb/disorders/Beta_Mannosidosis.yaml
@@ -1,6 +1,6 @@
 name: Beta Mannosidosis
 creation_date: '2025-12-19T01:18:09Z'
-updated_date: "2026-05-04T23:26:44Z"
+updated_date: "2026-05-21T07:47:19Z"
 description: >
   A rare autosomal recessive lysosomal storage disorder caused by deficiency of
   lysosomal beta-mannosidase enzyme, leading to accumulation of mannose-containing
@@ -571,6 +571,21 @@ biochemical:
     Accumulated oligosaccharides including Man-GlcNAc disaccharide and sialylated
     derivatives are detected in urine. Modern UPLC-MS/MS allows multiplexed detection
     for glycoproteinoses.
+  readouts:
+  - target: Glycoprotein-derived oligosaccharide storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Increased urinary free oligosaccharides report overflow of incompletely
+      degraded glycoprotein-derived substrates from lysosomal storage.
+    evidence:
+    - reference: PMID:32847582
+      reference_title: "Variant c.2158-2A>G in MANBA is an important and frequent cause of hereditary hearing loss and beta-mannosidosis among the Czech and Slovak Roma population- evidence for a new ethnic-specific variant."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Biochemical diagnostics confirmed the typical disaccharides (primarily Man (beta1 → 4) GlcNac) in the urine of affected patients"
+      explanation: Patient urine testing directly supports urinary oligosaccharides as a diagnostic readout of glycoprotein-derived oligosaccharide storage.
   evidence:
   - reference: PMID:32847582
     reference_title: "Variant c.2158-2A>G in MANBA is an important and frequent cause of hereditary hearing loss and beta-mannosidosis among the Czech and Slovak Roma population- evidence for a new ethnic-specific variant."
@@ -590,6 +605,21 @@ biochemical:
   notes: >
     Affected individuals exhibit enzyme activities ranging from undetectable up to
     2-10% of normal controls. Carriers may show approximately 40% activity.
+  readouts:
+  - target: MANBA lysosomal beta-mannosidase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Decreased beta-mannosidase activity directly reports the primary MANBA
+      lysosomal enzyme deficiency.
+    evidence:
+    - reference: PMID:32847582
+      reference_title: "Variant c.2158-2A>G in MANBA is an important and frequent cause of hereditary hearing loss and beta-mannosidosis among the Czech and Slovak Roma population- evidence for a new ethnic-specific variant."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "a decreased activity of the beta-mannosidase enzyme in different cells, particularly in leukocytes"
+      explanation: Patient cell assays support reduced beta-mannosidase activity as a direct diagnostic readout of MANBA enzyme deficiency.
   evidence:
   - reference: PMID:32847582
     reference_title: "Variant c.2158-2A>G in MANBA is an important and frequent cause of hereditary hearing loss and beta-mannosidosis among the Czech and Slovak Roma population- evidence for a new ethnic-specific variant."


### PR DESCRIPTION
## Summary
- add readout links for urinary free oligosaccharides and beta-mannosidase activity
- connect both beta-mannosidosis biochemical markers to existing pathophysiology nodes using exact cached snippets
- update entry timestamp from a fresh branch off current origin/main

## Validation
- just validate kb/disorders/Beta_Mannosidosis.yaml
- just validate-references kb/disorders/Beta_Mannosidosis.yaml
- just validate-terms kb/disorders/Beta_Mannosidosis.yaml
- normalized snippet audit: checked=46 missing=0
- connectivity audit: phenotypes explained 9/9, biochemical readouts 2/2, bad readout targets=[]
- git diff --check