### PR TITLE
Improve APRT renal GO coverage

### DIFF
--- a/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
+++ b/kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: Adenine Phosphoribosyltransferase Deficiency
 category: Mendelian
 creation_date: "2026-05-10T09:34:20Z"
-updated_date: "2026-05-18T22:44:37Z"
+updated_date: "2026-05-21T08:27:02Z"
 synonyms:
 - APRT deficiency
 - 2,8-dihydroxyadenine urolithiasis
@@ -470,6 +470,17 @@ pathophysiology:
       id: CHEBI:183641
       label: 2,8-dihydroxyadenine
     modifier: INCREASED
+  cell_types:
+  - preferred_term: renal tubular epithelial cell
+    term:
+      id: CL:0002518
+      label: kidney epithelial cell
+  biological_processes:
+  - preferred_term: endocytosis
+    term:
+      id: GO:0006897
+      label: endocytosis
+    modifier: INCREASED
   evidence:
   - reference: PMID:32086278
     reference_title: "Cellular and Molecular Mechanisms of Kidney Injury in 2,8-Dihydroxyadenine Nephropathy."
@@ -549,6 +560,12 @@ pathophysiology:
     Ongoing crystal nephropathy manifests clinically as recurrent
     nephrolithiasis, acute obstructive kidney injury, chronic kidney disease,
     and kidney failure in a subset of untreated or late-treated individuals.
+  biological_processes:
+  - preferred_term: glomerular filtration
+    term:
+      id: GO:0003094
+      label: glomerular filtration
+    modifier: DECREASED
   evidence:
   - reference: PMID:22934314
     reference_title: "Adenine Phosphoribosyltransferase Deficiency."


### PR DESCRIPTION
## Summary
- add renal tubular epithelial cell and endocytosis grounding to the 2,8-DHA tubular crystal-deposition node
- add decreased glomerular filtration to the progressive DHA crystal nephropathy and renal dysfunction node
- keep the PR scoped to kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml

## Validation
- just validate kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
- just validate-references kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
- just validate-terms kb/disorders/Adenine_Phosphoribosyltransferase_Deficiency.yaml
- normalized snippet audit: checked=108 missing=0
- git diff --check