### PR TITLE
Strengthen GSD IV tissue pathograph connectivity

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
@@ -1,7 +1,7 @@
 name: Glycogen Storage Disease Type IV
 category: Mendelian
 creation_date: "2026-05-08T02:54:48Z"
-updated_date: "2026-05-08T03:17:35Z"
+updated_date: "2026-05-21T08:44:13Z"
 synonyms:
 - Andersen disease
 - Amylopectinosis
@@ -252,6 +252,18 @@ pathophysiology:
     description: >
       Reduced branching enzyme activity impairs glycogen branching and leads to
       poorly branched polyglucosan accumulation.
+    evidence:
+    - reference: PMID:36796138
+      reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Consequently, glycogen synthesis is impaired and leads to accumulation of
+        poorly branched glycogen known as polyglucosan.
+      explanation: >
+        The clinical practice resource directly places polyglucosan accumulation
+        downstream of impaired glycogen synthesis caused by deficient branching
+        enzyme activity.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -290,25 +302,84 @@ pathophysiology:
     description: >
       Polyglucosan is abnormal glycogen material and is captured clinically as
       abnormal muscle glycogen content.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012269 | Abnormal muscle glycogen content | Very frequent (99-80%)"
+      explanation: >
+        Orphanet records abnormal muscle glycogen content as a very frequent
+        GSD IV phenotype, supporting this pathologic storage readout downstream
+        of polyglucosan accumulation.
   - target: Hepatic polyglucosan storage and liver injury
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >
       Liver polyglucosan storage drives hepatic enlargement and dysfunction.
+    evidence:
+    - reference: PMID:30228975
+      reference_title: "Analysis of GBE1 mutations via protein expression studies in glycogen storage disease type IV: A report on a non-progressive form with a literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by the accumulation of an amylopectin-like glycogen
+        (polyglucosan) in multiple organs, such as the liver, muscle, heart, and
+        the central and peripheral nervous systems
+      explanation: >
+        Human clinical review evidence identifies liver as one of the organs
+        affected by polyglucosan accumulation in GSD IV.
   - target: Cardiomyocyte glycogen storage and cardiomyopathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >
       Cardiac polyglucosan storage contributes to cardiomyocyte abnormality and
       cardiomyopathy.
+    evidence:
+    - reference: PMID:30228975
+      reference_title: "Analysis of GBE1 mutations via protein expression studies in glycogen storage disease type IV: A report on a non-progressive form with a literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        It is characterized by the accumulation of an amylopectin-like glycogen
+        (polyglucosan) in multiple organs, such as the liver, muscle, heart, and
+        the central and peripheral nervous systems
+      explanation: >
+        This review places heart among the organs affected by polyglucosan
+        storage, supporting the cardiac storage branch upstream of
+        cardiomyopathy.
   - target: Neuromuscular polyglucosan storage
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: >
       Skeletal muscle, peripheral nerve, and central nervous system storage
       contribute to neuromuscular manifestations across the GSD IV continuum.
+    evidence:
+    - reference: PMID:33141444
+      reference_title: "GBE1-related disorders: Adult polyglucosan body disease and its neuromuscular phenotypes."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        deficiency of glycogen-branching enzyme and secondary storage of glycogen
+        in the form of polyglucosan bodies, involving the skeletal muscle,
+        diaphragm, peripheral nerve (including autonomic fibers), brain white
+        matter, spinal cord, nerve roots, cerebellum, brainstem
+      explanation: >
+        The APBD/GSD IV review directly supports skeletal-muscle, peripheral
+        nerve, and central nervous system polyglucosan storage as the
+        neuromuscular disease branch.
   - target: Generalized abnormality of skin
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: >
       Orphanet records a generalized skin abnormality in GSD IV; the
       intermediate mechanism from systemic polyglucosan storage is unresolved.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0011354 | Generalized abnormality of skin | Very frequent (99-80%)"
+      explanation: >
+        Orphanet supports generalized skin abnormality as a frequent GSD IV
+        phenotype, but the specific intermediate mechanism from systemic
+        storage remains unresolved.
   evidence:
   - reference: PMID:36796138
     reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
@@ -331,39 +402,168 @@ pathophysiology:
   description: >
     Hepatic storage of abnormal glycogen produces hepatomegaly, liver
     dysfunction, and in progressive hepatic disease, cirrhosis and liver failure.
+  cell_types:
+  - preferred_term: hepatocyte
+    term:
+      id: CL:0000182
+      label: hepatocyte
+  biological_processes:
+  - preferred_term: glycogen metabolic process
+    term:
+      id: GO:0005977
+      label: glycogen metabolic process
+    modifier: ABNORMAL
   downstream:
   - target: Hepatomegaly
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "rapidly develop failure to thrive; hepatomegaly, liver dysfunction"
+      explanation: >
+        GeneReviews lists hepatomegaly with liver dysfunction in progressive
+        hepatic GSD IV, supporting hepatomegaly downstream of hepatic storage
+        disease.
   - target: Decreased liver function
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hepatomegaly, liver dysfunction, and progressive liver cirrhosis"
+      explanation: >
+        The progressive hepatic subtype directly includes liver dysfunction,
+        supporting decreased liver function downstream of hepatic injury.
   - target: Elevated circulating hepatic transaminase concentration
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30228975
+      reference_title: "Analysis of GBE1 mutations via protein expression studies in glycogen storage disease type IV: A report on a non-progressive form with a literature review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Laboratory data indicated an elevation of serum transaminases"
+      explanation: >
+        A human GSD IV case documents elevated transaminases, supporting this
+        laboratory readout of hepatic involvement.
   - target: Hypoalbuminemia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0003073 | Hypoalbuminemia | Frequent (79-30%)"
+      explanation: >
+        Orphanet records hypoalbuminemia as a frequent GSD IV phenotype,
+        partially supporting it as part of the hepatic dysfunction branch.
   - target: Cirrhosis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "progressive liver cirrhosis"
+      explanation: >
+        GeneReviews explicitly identifies progressive liver cirrhosis in the
+        hepatic subtype.
   - target: Hepatic failure
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Without liver transplantation, death from liver failure usually occurs by age five years."
+      explanation: >
+        GeneReviews supports liver failure as the severe downstream endpoint of
+        progressive hepatic GSD IV.
   - target: Portal hypertension
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001409 | Portal hypertension | Occasional (29-5%)"
+      explanation: >
+        Orphanet records portal hypertension in GSD IV, partially supporting it
+        as a complication of the hepatic disease branch.
   - target: Hepatosplenomegaly
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Hepatic storage disease can produce combined liver and spleen enlargement.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001433 | Hepatosplenomegaly | Occasional (29-5%)"
+      explanation: >
+        Orphanet records hepatosplenomegaly in GSD IV, partially supporting
+        combined liver-spleen enlargement in the hepatic branch.
   - target: Failure to thrive
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Progressive hepatic GSD IV causes infantile failure to thrive together with hepatomegaly and liver dysfunction.
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "rapidly develop failure to thrive; hepatomegaly"
+      explanation: >
+        GeneReviews lists failure to thrive with hepatomegaly in progressive
+        hepatic GSD IV.
   - target: Prolonged prothrombin time
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Hepatic dysfunction can impair coagulation factor synthesis and prolong prothrombin time.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0008151 | Prolonged prothrombin time | Occasional (29-5%)"
+      explanation: >
+        Orphanet records prolonged prothrombin time in GSD IV, partially
+        supporting coagulation abnormalities in the hepatic disease branch.
   - target: Prolonged partial thromboplastin time
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Hepatic dysfunction can produce broader coagulation abnormalities, including prolonged partial thromboplastin time.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0003645 | Prolonged partial thromboplastin time | Occasional (29-5%)"
+      explanation: >
+        Orphanet records prolonged partial thromboplastin time in GSD IV,
+        partially supporting broader coagulation abnormalities.
   - target: Ascites
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Portal-hypertension and liver-failure complications can include ascites.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001541 | Ascites | Occasional (29-5%)"
+      explanation: >
+        Orphanet records ascites in GSD IV, partially supporting ascites as a
+        complication of the hepatic disease branch.
   - target: Esophageal varix
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Portal-hypertension complications can include esophageal varices.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0002040 | Esophageal varix | Occasional (29-5%)"
+      explanation: >
+        Orphanet records esophageal varix in GSD IV, partially supporting this
+        portal-hypertension complication.
   evidence:
   - reference: PMID:23285490
     reference_title: Glycogen Storage Disease Type IV.
@@ -385,13 +585,51 @@ pathophysiology:
   description: >
     Cardiac involvement in GSD IV includes abnormal cardiomyocyte morphology,
     dilated cardiomyopathy, and occasionally congestive heart failure.
+  cell_types:
+  - preferred_term: cardiomyocyte
+    term:
+      id: CL:0000746
+      label: cardiac muscle cell
+  biological_processes:
+  - preferred_term: glycogen metabolic process
+    term:
+      id: GO:0005977
+      label: glycogen metabolic process
+    modifier: ABNORMAL
   downstream:
   - target: Abnormal cardiomyocyte morphology
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0031331 | Abnormal cardiomyocyte morphology | Very frequent (99-80%)"
+      explanation: >
+        Orphanet records abnormal cardiomyocyte morphology as a very frequent
+        GSD IV phenotype, partially supporting the cardiac storage branch.
   - target: Dilated cardiomyopathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "profound hypotonia, respiratory distress, and dilated cardiomyopathy."
+      explanation: >
+        GeneReviews lists dilated cardiomyopathy in congenital neuromuscular GSD
+        IV, supporting cardiomyopathy downstream of cardiac involvement.
   - target: Congestive heart failure
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001635 | Congestive heart failure | Occasional (29-5%)"
+      explanation: >
+        Orphanet records congestive heart failure in GSD IV, partially
+        supporting it as a severe cardiac endpoint.
   evidence:
   - reference: PMID:23285490
     reference_title: Glycogen Storage Disease Type IV.
@@ -413,43 +651,204 @@ pathophysiology:
     Neuromuscular and nervous system storage produces hypotonia, myopathy,
     motor delay, perinatal motor impairment, respiratory compromise, and in APBD
     neurogenic bladder, spastic paraparesis, and peripheral neuropathy.
+  cell_types:
+  - preferred_term: skeletal muscle cell
+    term:
+      id: CL:0000188
+      label: cell of skeletal muscle
+  - preferred_term: neuron
+    term:
+      id: CL:0000540
+      label: neuron
+  biological_processes:
+  - preferred_term: glycogen metabolic process
+    term:
+      id: GO:0005977
+      label: glycogen metabolic process
+    modifier: ABNORMAL
   downstream:
   - target: Generalized hypotonia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "profound hypotonia, respiratory distress, and dilated cardiomyopathy."
+      explanation: >
+        GeneReviews directly lists profound hypotonia in the congenital
+        neuromuscular subtype.
   - target: Myopathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Children with the non-progressive hepatic subtype tend to present with
+        hepatomegaly, liver dysfunction, myopathy, and hypotonia
+      explanation: >
+        GeneReviews supports myopathy as part of the GSD IV clinical continuum.
   - target: Motor delay
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001270 | Motor delay | Frequent (79-30%)"
+      explanation: >
+        Orphanet records motor delay as a frequent GSD IV phenotype, partially
+        supporting it as a neuromuscular consequence.
   - target: Respiratory distress
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "profound hypotonia, respiratory distress, and dilated cardiomyopathy."
+      explanation: >
+        GeneReviews directly lists respiratory distress in the congenital
+        neuromuscular subtype.
   - target: Respiratory insufficiency
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0002093 | Respiratory insufficiency | Occasional (29-5%)"
+      explanation: >
+        Orphanet records respiratory insufficiency in GSD IV, partially
+        supporting respiratory compromise in the neuromuscular branch.
   - target: Fetal akinesia sequence
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "presents in utero with fetal akinesia deformation sequence"
+      explanation: >
+        GeneReviews directly supports fetal akinesia deformation sequence in the
+        fatal perinatal neuromuscular subtype.
   - target: Abnormal neuron branching
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0500032 | Abnormal neuron branching | Very frequent (99-80%)"
+      explanation: >
+        Orphanet records abnormal neuron branching as a very frequent GSD IV
+        phenotype, partially supporting the nervous-system branch while leaving
+        intermediate mechanisms unresolved.
   - target: Neurogenic bladder
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36796138
+      reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The adult-onset form of GSD IV, referred to as adult polyglucosan body
+        disease (APBD), is a neurodegenerative disease characterized by
+        neurogenic bladder, spastic paraparesis, and peripheral neuropathy.
+      explanation: >
+        The clinical practice resource directly lists neurogenic bladder in the
+        adult polyglucosan body disease branch.
   - target: Peripheral neuropathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36796138
+      reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The adult-onset form of GSD IV, referred to as adult polyglucosan body
+        disease (APBD), is a neurodegenerative disease characterized by
+        neurogenic bladder, spastic paraparesis, and peripheral neuropathy.
+      explanation: >
+        The clinical practice resource directly lists peripheral neuropathy in
+        adult polyglucosan body disease.
   - target: Severe muscular hypotonia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Severe neuromuscular involvement can manifest as severe muscular hypotonia.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0006829 | Severe muscular hypotonia | Occasional (29-5%)"
+      explanation: >
+        Orphanet records severe muscular hypotonia in GSD IV, partially
+        supporting this severe neuromuscular endpoint.
   - target: Skeletal muscle atrophy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Chronic skeletal-muscle polyglucosan storage can manifest with skeletal muscle atrophy.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0003202 | Skeletal muscle atrophy | Occasional (29-5%)"
+      explanation: >
+        Orphanet records skeletal muscle atrophy in GSD IV, partially supporting
+        muscle atrophy as part of the neuromuscular branch.
   - target: Flexion contracture
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Severe fetal or neuromuscular involvement can be accompanied by flexion contractures.
+    evidence:
+    - reference: ORPHA:367
+      reference_title: "Glycogen storage disease due to glycogen branching enzyme deficiency (Orphanet structured-database record)"
+      supports: PARTIAL
+      evidence_source: OTHER
+      snippet: "HP:0001371 | Flexion contracture | Occasional (29-5%)"
+      explanation: >
+        Orphanet records flexion contracture in GSD IV, partially supporting it
+        as a severe neuromuscular or fetal manifestation.
   - target: Spastic paraparesis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Adult polyglucosan body disease causes corticospinal and peripheral nerve involvement with spastic paraparesis.
+    evidence:
+    - reference: PMID:36796138
+      reference_title: "Diagnosis and management of glycogen storage disease type IV, including adult polyglucosan body disease: A clinical practice resource."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The adult-onset form of GSD IV, referred to as adult polyglucosan body
+        disease (APBD), is a neurodegenerative disease characterized by
+        neurogenic bladder, spastic paraparesis, and peripheral neuropathy.
+      explanation: >
+        The clinical practice resource directly lists spastic paraparesis in
+        adult polyglucosan body disease.
   - target: Polyhydramnios
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Fatal perinatal neuromuscular disease can present in utero with polyhydramnios.
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "polyhydramnios, and fetal hydrops."
+      explanation: >
+        GeneReviews directly lists polyhydramnios in the fatal perinatal
+        neuromuscular subtype.
   - target: Nonimmune hydrops fetalis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Fatal perinatal neuromuscular disease can present in utero with fetal hydrops.
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "polyhydramnios, and fetal hydrops."
+      explanation: >
+        GeneReviews directly lists fetal hydrops in the fatal perinatal
+        neuromuscular subtype.
   evidence:
   - reference: PMID:23285490
     reference_title: Glycogen Storage Disease Type IV.
@@ -1140,7 +1539,7 @@ phenotypes:
   description: >
     Spastic paraparesis is a cardinal APBD neurologic feature.
   phenotype_term:
-    preferred_term: Spastic paraplegia
+    preferred_term: Spastic paraparesis
     term:
       id: HP:0001258
       label: Spastic paraplegia
@@ -1344,6 +1743,23 @@ treatments:
     term:
       id: MAXO:0001175
       label: liver transplantation
+  target_mechanisms:
+  - target: Hepatic polyglucosan storage and liver injury
+    treatment_effect: MODULATES
+    description: >
+      Liver transplantation addresses the progressive hepatic failure branch of
+      GSD IV when liver disease becomes life-threatening.
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Liver transplantation is the only treatment option for individuals with
+        the progressive hepatic subtype of GSD IV who develop liver failure
+      explanation: >
+        GeneReviews supports liver transplantation as a treatment directed at
+        the progressive hepatic disease branch.
   target_phenotypes:
   - preferred_term: Hepatic failure
     term:
@@ -1366,6 +1782,21 @@ treatments:
     term:
       id: MAXO:0010032
       label: cardiac transplantation
+  target_mechanisms:
+  - target: Cardiomyocyte glycogen storage and cardiomyopathy
+    treatment_effect: MODULATES
+    description: >
+      Cardiac transplantation is considered for the severe cardiac-involvement
+      branch of GSD IV.
+    evidence:
+    - reference: PMID:23285490
+      reference_title: Glycogen Storage Disease Type IV.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Heart transplant may be an option in individuals with severe cardiac involvement."
+      explanation: >
+        GeneReviews supports heart transplantation for severe cardiac
+        involvement, linking the treatment to the cardiomyopathy branch.
   target_phenotypes:
   - preferred_term: Dilated cardiomyopathy
     term:


### PR DESCRIPTION
## Summary
- add tissue-level cell and glycogen-process annotations for hepatic, cardiac, and neuromuscular GSD IV branches
- add evidence-backed downstream edges from GBE1/polyglucosan storage through organ-system phenotypes
- connect liver and cardiac transplantation to the hepatic and cardiac pathophysiology branches

## Validation
- just validate kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
- just validate-references kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
- just validate-terms kb/disorders/Glycogen_Storage_Disease_Type_IV.yaml
- normalized snippet audit: checked=124 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 no_go_or_chemical_nodes=0 no_biochemical_readouts=0 downstream_edges_without_evidence=0
- git diff --check