### PR TITLE
Connect MLD hypotonia and peripheral myelination

### DIFF
--- a/kb/disorders/Metachromatic_Leukodystrophy.yaml
+++ b/kb/disorders/Metachromatic_Leukodystrophy.yaml
@@ -1,6 +1,6 @@
 name: Metachromatic Leukodystrophy
 creation_date: '2026-03-30T18:20:00Z'
-updated_date: '2026-05-20T04:32:29Z'
+updated_date: '2026-05-21T09:07:14Z'
 description: >
   Metachromatic leukodystrophy (MLD) is an autosomal recessive lysosomal
   storage leukodystrophy caused by arylsulfatase A deficiency, leading to
@@ -247,6 +247,12 @@ pathophysiology:
     term:
       id: CL:0002573
       label: Schwann cell
+  biological_processes:
+  - preferred_term: peripheral nervous system myelination
+    modifier: DYSREGULATED
+    term:
+      id: GO:0022011
+      label: myelination in peripheral nervous system
   downstream:
   - target: Peripheral Neuropathy
     description: Peripheral nerve demyelination produces the polyneuropathy phenotype seen in MLD.
@@ -286,6 +292,15 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "The typical clinical course of patients with the late infantile form includes a regression in motor skills with progression to dysphagia, seizures, hypotonia and death."
       explanation: This abstract directly supports seizures as a downstream neurologic consequence of progressive late-infantile disease.
+  - target: Hypotonia
+    description: Progressive late-infantile neurologic deterioration includes hypotonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30828547
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The typical clinical course of patients with the late infantile form includes a regression in motor skills with progression to dysphagia, seizures, hypotonia and death."
+      explanation: This abstract directly lists hypotonia as part of the progressive late-infantile MLD course.
   evidence:
   - reference: PMID:40577679
     supports: SUPPORT


### PR DESCRIPTION
## Summary
- add GO:0022011 peripheral nervous system myelination to the MLD demyelinating polyneuropathy branch
- connect progressive neurodegeneration to the existing Hypotonia phenotype with exact PMID:30828547 evidence
- keep broad progressive neurodegeneration unforced rather than adding an unsupported broad GO term

## Validation
- just validate kb/disorders/Metachromatic_Leukodystrophy.yaml
- just validate-references kb/disorders/Metachromatic_Leukodystrophy.yaml
- just validate-terms kb/disorders/Metachromatic_Leukodystrophy.yaml
- normalized snippet audit: checked=39 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 no_biochemical_readouts=0 downstream_edges_without_evidence=0
- git diff --check