### PR TITLE
Add alpha-mannosidosis readouts and system GO coverage

### DIFF
--- a/kb/disorders/Alpha_Mannosidosis.yaml
+++ b/kb/disorders/Alpha_Mannosidosis.yaml
@@ -1,7 +1,7 @@
 name: Alpha-mannosidosis
 category: Mendelian
 creation_date: "2026-05-04T17:13:27Z"
-updated_date: "2026-05-06T21:44:37Z"
+updated_date: "2026-05-21T09:16:35Z"
 synonyms:
 - Lysosomal alpha-D-mannosidase deficiency
 description: >
@@ -270,10 +270,40 @@ pathophysiology:
   downstream:
   - target: Mannose-rich oligosaccharide lysosomal storage
     description: Reduced lysosomal alpha-mannosidase blocks glycoprotein oligosaccharide degradation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36849760
+      reference_title: "Long-term safety and efficacy of velmanase alfa treatment in children under 6 years of age with alpha-mannosidosis: A phase 2, open label, multicenter study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "alpha-mannosidase deficiency that leads to the accumulation"
+      explanation: >
+        Pediatric clinical-trial background directly links alpha-mannosidase
+        deficiency to accumulation of storage substrate.
   - target: Reduced acid alpha-mannosidase activity
     description: MAN2B1 pathogenic variation is reflected diagnostically by reduced leukocyte or cellular acid alpha-mannosidase activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Diagnosis is made by measuring acid alpha-mannosidase activity in leukocytes or"
+      explanation: >
+        The review identifies reduced acid alpha-mannosidase activity as the
+        diagnostic enzyme readout of the MAN2B1 lysosomal enzyme defect.
   - target: Infantile form abnormal circulating enzyme concentration or activity
     description: The infantile subtype records abnormal enzyme/coenzyme activity as the enzyme-level phenotype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: "Alpha-mannosidosis, infantile form (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012379 | Abnormal enzyme/coenzyme activity | Very frequent (99-80%)"
+      explanation: >
+        Orphanet records abnormal enzyme/coenzyme activity as very frequent in
+        the infantile subtype.
 - name: Mannose-rich oligosaccharide lysosomal storage
   description: >
     Deficient lysosomal alpha-mannosidase activity causes accumulation of
@@ -306,14 +336,65 @@ pathophysiology:
   downstream:
   - target: Neurodevelopmental and motor impairment
     description: CNS storage and dysfunction contribute to cognitive, speech, hypotonia, and motor manifestations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26048034
+      reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "disabilities, hearing impairment, motor function disturbances, facial coarsening"
+      explanation: >
+        The patient cohort supports neurologic and motor manifestations in
+        alpha-mannosidosis; specific storage-to-CNS intermediates remain
+        incompletely resolved.
   - target: Immune deficiency and recurrent infections
     description: Systemic storage disease is associated with immunodeficiency and recurrent infections.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "manifested by recurrent infections, especially in the first decade of life"
+      explanation: >
+        The review supports recurrent infections as a core manifestation,
+        partially supporting the systemic storage-to-immune branch.
   - target: Skeletal and craniofacial storage manifestations
     description: Connective-tissue and skeletal involvement produces coarse facial features and skeletal dysplasia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and"
+      explanation: >
+        The review directly supports skeletal abnormalities in
+        alpha-mannosidosis, linking storage disease to the skeletal branch.
   - target: Increased urinary mannose-rich oligosaccharides
     description: Lysosomal storage is reflected by increased urinary excretion of mannose-rich oligosaccharides.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "secretion of mannose-rich oligosaccharides is suggestive, but not diagnostic."
+      explanation: >
+        The review supports urinary mannose-rich oligosaccharides as a
+        biochemical readout of the storage lesion.
   - target: Oligosacchariduria in alpha-mannosidosis subtypes
     description: Orphanet subtype records capture oligosacchariduria as a frequent storage biomarker.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: "Alpha-mannosidosis, infantile form (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0010471 | Oligosacchariduria | Very frequent (99-80%)"
+      explanation: >
+        Orphanet records oligosacchariduria as a very frequent infantile-subtype
+        phenotype, supporting it as a storage biomarker.
   - target: Hearing impairment
     description: Multisystem storage disease includes moderate-to-severe hearing impairment.
   - target: Cataract
@@ -348,6 +429,12 @@ pathophysiology:
     term:
       id: UBERON:0000955
       label: brain
+  biological_processes:
+  - preferred_term: central nervous system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0007417
+      label: central nervous system development
   evidence:
   - reference: PMID:18651971
     reference_title: Alpha-mannosidosis.
@@ -400,6 +487,12 @@ pathophysiology:
   description: >
     Immune dysfunction is a core alpha-mannosidosis manifestation and is
     clinically expressed as recurrent infections, especially during childhood.
+  biological_processes:
+  - preferred_term: innate immune response
+    modifier: DECREASED
+    term:
+      id: GO:0045087
+      label: innate immune response
   evidence:
   - reference: PMID:18651971
     reference_title: Alpha-mannosidosis.
@@ -436,6 +529,12 @@ pathophysiology:
     term:
       id: UBERON:0001434
       label: skeletal system
+  biological_processes:
+  - preferred_term: skeletal system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0001501
+      label: skeletal system development
   evidence:
   - reference: PMID:18651971
     reference_title: Alpha-mannosidosis.
@@ -534,6 +633,14 @@ biochemical:
   context: >
     Deficient acid alpha-mannosidase activity in leukocytes or other nucleated
     cells is the primary diagnostic biochemical defect.
+  readouts:
+  - target: MAN2B1 lysosomal alpha-mannosidase deficiency
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Reduced leukocyte or nucleated-cell acid alpha-mannosidase activity
+      reports the primary MAN2B1 lysosomal enzyme defect.
   evidence:
   - reference: PMID:18651971
     reference_title: Alpha-mannosidosis.
@@ -552,6 +659,15 @@ biochemical:
   context: >
     Urinary excretion of mannose-rich oligosaccharides is a suggestive storage
     biomarker, but it is not sufficient alone to establish the diagnosis.
+  readouts:
+  - target: Mannose-rich oligosaccharide lysosomal storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Increased urinary mannose-rich oligosaccharide excretion reports the
+      lysosomal oligosaccharide storage mechanism, although enzyme or molecular
+      confirmation remains required.
   evidence:
   - reference: PMID:18651971
     reference_title: Alpha-mannosidosis.


### PR DESCRIPTION
## Summary
- add GO coverage for neurodevelopmental, immune, and skeletal alpha-mannosidosis branches
- add diagnostic readouts for reduced acid alpha-mannosidase activity and urinary mannose-rich oligosaccharides
- add evidence and causal link types to proximal MAN2B1/storage/readout downstream edges

## Validation
- just validate kb/disorders/Alpha_Mannosidosis.yaml
- just validate-references kb/disorders/Alpha_Mannosidosis.yaml
- just validate-terms kb/disorders/Alpha_Mannosidosis.yaml
- normalized snippet audit: checked=134 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 no_go_or_chemical_nodes=0 no_biochemical_readouts=0
- git diff --check

Generated ontology/reference cache churn was restored before commit; only Alpha_Mannosidosis.yaml is changed.