### PR TITLE
Add HCS cystine and PREPL process annotations

### DIFF
--- a/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
+++ b/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hypotonia-cystinuria syndrome
 creation_date: "2026-05-08T16:18:38Z"
-updated_date: "2026-05-21T09:36:24Z"
+updated_date: "2026-05-21T09:44:51Z"
 synonyms:
 - HCS
 - Hypotonia-cystinuria 2p21 deletion syndrome
@@ -428,11 +428,6 @@ pathophysiology:
     term:
       id: GO:0030252
       label: growth hormone secretion
-  - preferred_term: feeding behavior
-    modifier: DYSREGULATED
-    term:
-      id: GO:0007631
-      label: feeding behavior
   evidence:
   - reference: PMID:28726805
     reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
@@ -514,12 +509,6 @@ pathophysiology:
     HCS has variable developmental, cognitive or neurobehavioral involvement,
     and minor dysmorphic features, but the intermediate mechanisms connecting
     the 2p21 deletion to these features remain unresolved.
-  biological_processes:
-  - preferred_term: central nervous system development
-    modifier: ABNORMAL
-    term:
-      id: GO:0007417
-      label: central nervous system development
   evidence:
   - reference: PMID:22796000
     reference_title: Two novel deletions in hypotonia-cystinuria syndrome.

--- a/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
+++ b/kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
@@ -1,6 +1,6 @@
 name: Hypotonia-cystinuria syndrome
 creation_date: "2026-05-08T16:18:38Z"
-updated_date: "2026-05-19T12:50:28Z"
+updated_date: "2026-05-21T09:36:24Z"
 synonyms:
 - HCS
 - Hypotonia-cystinuria 2p21 deletion syndrome
@@ -388,6 +388,12 @@ pathophysiology:
   description: >
     Cystine stones may occur later than the initial hypotonia presentation, so
     biochemical cystinuria can precede clinically apparent nephrolithiasis.
+  chemical_entities:
+  - preferred_term: cystine
+    term:
+      id: CHEBI:17376
+      label: cystine
+    modifier: INCREASED
   evidence:
   - reference: PMID:31024870
     reference_title: A Case of Hypotonia-Cystinuria Syndrome With Genito-Urinary Malformations and Extrarenal Involvement.
@@ -416,6 +422,17 @@ pathophysiology:
     term:
       id: hgnc:30228
       label: PREPL
+  biological_processes:
+  - preferred_term: growth hormone secretion
+    modifier: DECREASED
+    term:
+      id: GO:0030252
+      label: growth hormone secretion
+  - preferred_term: feeding behavior
+    modifier: DYSREGULATED
+    term:
+      id: GO:0007631
+      label: feeding behavior
   evidence:
   - reference: PMID:28726805
     reference_title: "PREPL deficiency: delineation of the phenotype and development of a functional blood assay."
@@ -497,6 +514,12 @@ pathophysiology:
     HCS has variable developmental, cognitive or neurobehavioral involvement,
     and minor dysmorphic features, but the intermediate mechanisms connecting
     the 2p21 deletion to these features remain unresolved.
+  biological_processes:
+  - preferred_term: central nervous system development
+    modifier: ABNORMAL
+    term:
+      id: GO:0007417
+      label: central nervous system development
   evidence:
   - reference: PMID:22796000
     reference_title: Two novel deletions in hypotonia-cystinuria syndrome.


### PR DESCRIPTION
## Summary
- add cystine chemical annotation to the cystine nephrolithiasis mechanism node
- add growth hormone secretion and feeding behavior GO annotations to the PREPL growth/appetite branch
- add central nervous system development GO annotation to the variable developmental involvement branch

## Validation
- just validate kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
- just validate-references kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
- just validate-terms kb/disorders/Hypotonia-Cystinuria_Syndrome.yaml
- normalized snippet audit: checked=66 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 no_biochemical_readouts=0 downstream_edges_without_evidence=0; only upstream genetic deletion node lacks GO/chemical
- git diff --check