### PR TITLE
[codex] Strengthen Lafora pathograph connectivity

### DIFF
--- a/kb/disorders/Lafora_Disease.yaml
+++ b/kb/disorders/Lafora_Disease.yaml
@@ -1,6 +1,6 @@
 name: Lafora_Disease
 creation_date: '2026-03-08T00:00:00Z'
-updated_date: '2026-05-20T05:03:05Z'
+updated_date: '2026-05-21T11:02:37Z'
 category: Mendelian
 description: >
   Lafora disease is a rare, fatal form of progressive myoclonus epilepsy (PME type 2)
@@ -216,11 +216,29 @@ pathophysiology:
       Without laforin's phosphatase activity, glycogen accumulates phosphate
       groups and develops abnormal chain length patterns, driving precipitation
       into polyglucosans.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - loss of glycogen phosphatase activity
+    evidence:
+    - reference: PMID:30143794
+      reference_title: "Lafora disease - from pathogenesis to treatment strategies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The absence of either protein results in poorly branched, hyperphosphorylated glycogen, which precipitates, aggregates and accumulates into Lafora bodies."
+      explanation: Loss of laforin or malin produces the abnormal glycogen species modeled by this downstream node.
   - target: Loss of laforin-malin complex regulation of glycogen synthesis
     description: >
       Because laforin is the carbohydrate-binding subunit that targets malin
       to glycogen, loss of laforin disengages malin from its glycogen substrate
       and disrupts ubiquitin-mediated regulation of glycogen synthesis machinery.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36511140
+      reference_title: "Laforin targets malin to glycogen in Lafora progressive myoclonus epilepsy."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "malin localizes to glycogen, laforin and malin indeed interact, at glycogen, and malin's presence at glycogen depends on laforin."
+      explanation: Laforin directly recruits malin to glycogen, so laforin loss disrupts the laforin-malin regulatory complex.
   evidence:
   - reference: PMID:30143794
     reference_title: "Lafora disease - from pathogenesis to treatment strategies."
@@ -294,10 +312,28 @@ pathophysiology:
       Without malin-mediated ubiquitination, PTG (PPP1R3C) and glycogen synthase
       are not appropriately restrained, leading to increased glycogen synthesis
       with overlong chains.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - loss of malin-mediated ubiquitination
+    evidence:
+    - reference: PMID:12958597
+      reference_title: "Mutations in NHLRC1 cause progressive myoclonus epilepsy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "NHLRC1 (also called EPM2B), which encodes malin, a putative E3 ubiquitin ligase with a RING finger domain and six NHL motifs. Laforin and malin colocalize to the ER, suggesting they operate in a related pathway protecting against polyglucosan accumulation and epilepsy."
+      explanation: Malin is an E3 ubiquitin ligase operating with laforin to protect against polyglucosan accumulation and epilepsy.
   - target: Aberrant glycogen chain length and hyperphosphorylation
     description: >
       Loss of malin-laforin complex function permits accumulation of glycogen
       with abnormal chain length and elevated phosphate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Laforin and malin interact to regulate glycogen phosphorylation and chain length pattern, the latter critical to glycogen's solubility."
+      explanation: The review directly connects laforin-malin complex function to glycogen phosphorylation and chain-length regulation.
   evidence:
   - reference: PMID:12958597
     reference_title: "Mutations in NHLRC1 cause progressive myoclonus epilepsy."
@@ -428,6 +464,38 @@ pathophysiology:
       Insoluble, hyperphosphorylated, poorly branched glucan chains aggregate
       into intracellular Lafora bodies, predominantly in astrocytes and
       neurons of the cerebral and cerebellar cortex.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30143794
+      reference_title: "Lafora disease - from pathogenesis to treatment strategies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The absence of either protein results in poorly branched, hyperphosphorylated glycogen, which precipitates, aggregates and accumulates into Lafora bodies."
+      explanation: Abnormal glycogen precipitation and aggregation directly produces Lafora bodies.
+  - target: Poorly branched hyperphosphorylated glycogen
+    description: >
+      Aberrant glycogen architecture is directly measured as poorly branched,
+      hyperphosphorylated glycogen.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30143794
+      reference_title: "Lafora disease - from pathogenesis to treatment strategies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The absence of either protein results in poorly branched, hyperphosphorylated glycogen, which precipitates, aggregates and accumulates into Lafora bodies."
+      explanation: This biochemical readout is the abnormal glycogen species described in the mechanism.
+  - target: Polyglucosan chain length abnormality
+    description: >
+      Overlong glycogen chains are the measurable chain-length component of
+      the aberrant polyglucosan architecture.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39806098
+      reference_title: "Glycogen synthase GYS1 overactivation contributes to glycogen insolubility and malto-oligoglucan-associated neurodegenerative disease."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Polyglucosans are glycogen molecules with overlong chains, which are hyperphosphorylated in the neurodegenerative Lafora disease (LD)."
+      explanation: This directly supports chain-length abnormality as a readout of the aberrant glycogen node.
   evidence:
   - reference: PMID:30143794
     reference_title: "Lafora disease - from pathogenesis to treatment strategies."
@@ -527,6 +595,30 @@ pathophysiology:
       evidence_source: MODEL_ORGANISM
       snippet: "Evidence from Lafora disease genetic mouse models indicates that these intracellular inclusions are a principal driver of neurodegeneration and neurological disease."
       explanation: Direct attribution of neurodegeneration to Lafora body inclusions in genetic mouse models.
+  - target: Lafora body glycogen storage burden
+    description: >
+      Lafora body accumulation is measured clinically and experimentally as an
+      increased storage burden of insoluble glycogen-like inclusions.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29489177
+      reference_title: "Lafora Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The presence of the pathognomic Lafora bodies in a tissue biopsy is diagnostic of Lafora disease."
+      explanation: Tissue detection of Lafora bodies directly reports Lafora body storage burden.
+  - target: Brain glycogen accumulation
+    description: >
+      Brain Lafora body accumulation tracks the brain glycogen storage burden
+      quantified in disease models.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33277363
+      reference_title: "An inducible glycogen synthase-1 knockout halts but does not reverse Lafora disease progression in mice."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Hallmarks of LD are glycogen accumulation and formation of LBs, which are insoluble, glycogen-like particles, characterized by reduced branching and long chains (25)."
+      explanation: Glycogen accumulation and Lafora body formation are paired storage-burden readouts in the mouse model.
   evidence:
   - reference: PMID:36899857
     reference_title: "Role of Astrocytes in the Pathophysiology of Lafora Disease and Other Glycogen Storage Disorders."
@@ -581,15 +673,44 @@ pathophysiology:
     description: >
       Sustained glia-derived TNF/IL-6 signaling and infiltrating
       T-lymphocytes accelerate neuronal injury and loss.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - TNF and IL6/JAK2 signaling
+    - T-lymphocyte infiltration
+    evidence:
+    - reference: PMID:36526090
+      reference_title: "TNF and IL6/Jak2 signaling pathways are the main contributors of the glia-derived neuroinflammation present in Lafora disease, a fatal form of progressive myoclonus epilepsy."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "we define an upregulation of the expression of mediators of the TNF and IL6/JAK2 signaling pathways in LD. In addition, we describe the activation of the non-canonical form of the inflammasome. Furthermore, we describe the infiltration of peripheral immune cells in the brain parenchyma, which could aggravate glia-derived neuroinflammation."
+      explanation: The inflammatory pathways and infiltrating immune cells provide intermediates linking neuroinflammation to neuronal injury.
   - target: Synaptic dysfunction and cortical hyperexcitability
     description: >
       Reactive astrocytes lose normal synaptic support functions and release
       cytokines that shift cortical excitation/inhibition balance toward
       hyperexcitability.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:37971656
+      reference_title: "Beneficial Effect of Fingolimod in a Lafora Disease Mouse Model by Preventing Reactive Astrogliosis-Derived Neuroinflammation and Brain Infiltration of T-lymphocytes."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Our results indicate a beneficial effect of fingolimod in reducing reactive astrogliosis-derived neuroinflammation and T-lymphocyte infiltration, which correlated with the improved behavioral performance of the treated Epm2b-/- mice."
+      explanation: Reducing reactive astrogliosis-derived neuroinflammation improves behavior in the mouse model, supporting its contribution to downstream network dysfunction.
   - target: Oxidative stress and proteostasis impairment
     description: >
       Inflammatory signaling and reactive glia generate reactive oxygen
       species and disrupt proteostasis pathways.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - inflammatory signaling
+    evidence:
+    - reference: PMID:36674605
+      reference_title: "Age-Related microRNA Overexpression in Lafora Disease Male Mice Provides Links between Neuroinflammation and Oxidative Stress."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Oxidative stress, alterations in proteostasis, and deregulation of inflammatory signals are some of the molecular alterations underlying this condition in both KO animal models."
+      explanation: The mouse study connects inflammatory-signal deregulation with oxidative stress and proteostasis alterations in Lafora models.
   evidence:
   - reference: PMID:31808062
     reference_title: "Reactive Glia-Derived Neuroinflammation: a Novel Hallmark in Lafora Progressive Myoclonus Epilepsy That Progresses with Age."
@@ -636,6 +757,14 @@ pathophysiology:
     description: >
       Sustained oxidative damage and proteostasis failure compound
       neuroinflammatory injury and contribute to neuronal loss.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36674605
+      reference_title: "Age-Related microRNA Overexpression in Lafora Disease Male Mice Provides Links between Neuroinflammation and Oxidative Stress."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Oxidative stress, alterations in proteostasis, and deregulation of inflammatory signals are some of the molecular alterations underlying this condition in both KO animal models."
+      explanation: Oxidative stress and proteostasis alterations are molecular disease features that contribute to downstream neuronal injury.
   evidence:
   - reference: PMID:36674605
     reference_title: "Age-Related microRNA Overexpression in Lafora Disease Male Mice Provides Links between Neuroinflammation and Oxidative Stress."
@@ -675,6 +804,14 @@ pathophysiology:
     description: >
       Defective autophagic clearance of damaged organelles and aggregates
       contributes to chronic neuronal injury.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24452334
+      reference_title: "Glycogen accumulation underlies neurodegeneration and autophagy impairment in Lafora disease."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Our findings reveal that glycogen accumulation accounts for the neurodegeneration and functional consequences seen in the malin knockout model, as well as the impaired autophagy."
+      explanation: Genetic rescue evidence links glycogen-driven autophagy impairment with neurodegeneration and functional consequences.
   evidence:
   - reference: PMID:24452334
     reference_title: "Glycogen accumulation underlies neurodegeneration and autophagy impairment in Lafora disease."
@@ -750,23 +887,75 @@ pathophysiology:
     description: >
       Cortical hyperexcitability supports generalization to bilateral
       tonic-clonic seizures.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Soon thereafter myoclonus appears and a generalized tonic-clonic seizure."
+      explanation: Generalized tonic-clonic seizures are part of the hyperexcitable epilepsy phenotype in Lafora disease.
   - target: Absence seizures
     description: >
       Aberrant cortico-thalamic synchronization yields atypical and
       myoclonic absence seizures that become near-continuous as the
       disease progresses.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Atypical and myoclonic absences set in and then become so constant that the young patient’s every thought and sentence are constantly interrupted and incomplete."
+      explanation: Absence seizures are part of the progressive Lafora epilepsy phenotype downstream of network hyperexcitability.
   - target: Visual hallucinations
     description: >
       Occipital cortical hyperexcitability produces photosensitive epileptic
       visual hallucinations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:11483392
+      reference_title: "Lafora's disease: towards a clinical, pathologic, and molecular synthesis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Characteristic seizures include myoclonic and occipital lobe seizures with visual hallucinations, scotomata, and photoconvulsions."
+      explanation: Occipital-lobe seizures with visual hallucinations directly support this hyperexcitability edge.
   - target: Photosensitive seizures
     description: >
       Cortical hyperexcitability with impaired inhibition produces
       photoparoxysmal/photosensitive seizure responses.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29489177
+      reference_title: "Lafora Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Characteristic features of Lafora disease include intractable myoclonic and photosensitive seizures, drop attacks, ataxia, apraxia, cortical blindness, rapidly progressive dementia, and neuropsychiatric symptoms."
+      explanation: Photosensitive seizures are a characteristic Lafora epilepsy manifestation.
   - target: Status epilepticus
     description: >
       Loss of inhibitory control and progressive neurodegeneration culminate
       in episodes of status epilepticus, frequently lethal.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Most patients pass away in status epilepticus or from aspiration pneumonia secondary to neurological loss of the ability to control secretions."
+      explanation: Status epilepticus is a frequent terminal manifestation of the progressive hyperexcitable epilepsy syndrome.
+  - target: Atonic (drop) attacks
+    description: >
+      Cortical network hyperexcitability also manifests as atonic and drop
+      attacks that drive loss of ambulation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Within a few years the patient is out of school and is unable to walk mainly because of frequent myoclonic and atonic attacks."
+      explanation: Atonic attacks are a disabling seizure manifestation in the Lafora epilepsy phenotype.
   evidence:
   - reference: PMID:15623692
     reference_title: "Sensorimotor cortex excitability in Unverricht-Lundborg disease and Lafora body disease."
@@ -818,28 +1007,132 @@ pathophysiology:
     description: >
       Cortical and hippocampal neuron loss produces relentless cognitive
       deterioration ending in profound dementia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:11483392
+      reference_title: "Lafora's disease: towards a clinical, pathologic, and molecular synthesis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The course of the disease consists of worsening seizures and an inexorable decline in mental and other neurologic functions that result in dementia and death within 10 years of onset."
+      explanation: Progressive neurologic decline in Lafora disease culminates in dementia.
   - target: Ataxia
     description: >
       Cerebellar neurodegeneration, including Purkinje cell involvement,
       contributes to ataxia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29489177
+      reference_title: "Lafora Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Characteristic features of Lafora disease include intractable myoclonic and photosensitive seizures, drop attacks, ataxia, apraxia, cortical blindness, rapidly progressive dementia, and neuropsychiatric symptoms."
+      explanation: Ataxia is a characteristic neurologic manifestation of progressive Lafora disease.
   - target: Progressive neurologic deterioration
     description: >
       Cumulative cortical and subcortical neuron loss underlies the
       relentless progression to a vegetative state.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "patients undergo first insidious then rapid progressive myoclonus epilepsy toward a vegetative state and death within a decade."
+      explanation: The clinical course documents relentless neurologic deterioration to end-stage disease.
   - target: Cerebral atrophy
     description: >
       Cortical neuronal loss yields cerebral atrophy on neuroimaging in
       later disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30143794
+      reference_title: "Lafora disease - from pathogenesis to treatment strategies."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Evidence from Lafora disease genetic mouse models indicates that these intracellular inclusions are a principal driver of neurodegeneration and neurological disease."
+      explanation: Lafora body-driven neurodegeneration provides the mechanistic basis for cerebral atrophy.
   - target: Cerebellar atrophy
     description: >
       Cerebellar neurodegeneration produces cerebellar atrophy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30143794
+      reference_title: "Lafora disease - from pathogenesis to treatment strategies."
+      supports: PARTIAL
+      evidence_source: MODEL_ORGANISM
+      snippet: "Evidence from Lafora disease genetic mouse models indicates that these intracellular inclusions are a principal driver of neurodegeneration and neurological disease."
+      explanation: General Lafora body-driven neurodegeneration indirectly supports cerebellar atrophy as a regional manifestation.
   - target: Dysarthria
     description: >
       Cortical and cerebellar neurodegeneration disrupts motor speech
       coordination.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301563
+      reference_title: "Progressive Myoclonus Epilepsy, Lafora Type."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dysarthria and ataxia appear early, while spasticity appears late."
+      explanation: Dysarthria is a neurologic manifestation occurring with ataxia in Lafora disease.
   - target: Apraxia
     description: >
       Cortical neurodegeneration produces apraxia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29489177
+      reference_title: "Lafora Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Characteristic features of Lafora disease include intractable myoclonic and photosensitive seizures, drop attacks, ataxia, apraxia, cortical blindness, rapidly progressive dementia, and neuropsychiatric symptoms."
+      explanation: Apraxia is a characteristic manifestation of Lafora disease.
+  - target: Cortical visual impairment
+    description: >
+      Occipital and association-cortex degeneration can progress from visual
+      seizures and hallucinations to cortical visual loss.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:29489177
+      reference_title: "Lafora Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Characteristic features of Lafora disease include intractable myoclonic and photosensitive seizures, drop attacks, ataxia, apraxia, cortical blindness, rapidly progressive dementia, and neuropsychiatric symptoms."
+      explanation: Cortical blindness is a characteristic late neurologic feature of Lafora disease.
+  - target: Dysphagia
+    description: >
+      Advanced neurologic deterioration impairs swallowing and secretion
+      control, increasing aspiration risk.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301563
+      reference_title: "Progressive Myoclonus Epilepsy, Lafora Type."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Gastrostomy feedings can decrease the risk of aspiration pneumonia when the disease is advanced."
+      explanation: Advanced disease requires gastrostomy to reduce aspiration risk, supporting dysphagia as a late neurologic consequence.
+  - target: Vegetative state
+    description: >
+      End-stage cortical and subcortical neurodegeneration culminates in a
+      vegetative state.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "patients undergo first insidious then rapid progressive myoclonus epilepsy toward a vegetative state and death within a decade."
+      explanation: The clinical natural history directly documents progression to vegetative state.
+  - target: Neuropsychiatric symptoms
+    description: >
+      Cortical dysfunction and progressive dementia produce behavioral and
+      neuropsychiatric manifestations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30336494
+      reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Behavioral abnormalities emerge, commonly in the realm of a disinhibited dementia."
+      explanation: Behavioral abnormalities are part of the progressive dementia phenotype.
   evidence:
   - reference: PMID:30143794
     reference_title: "Lafora disease - from pathogenesis to treatment strategies."
@@ -1099,7 +1392,7 @@ phenotypes:
     reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Atypical and myoclonic absences set in and then become so constant that the young patient's every thought and sentence are constantly interrupted and incomplete."
+    snippet: "Atypical and myoclonic absences set in and then become so constant that the young patient’s every thought and sentence are constantly interrupted and incomplete."
     explanation: Describes the progression of absence seizures becoming constant and severely disabling.
 - category: Neurological
   name: Visual hallucinations
@@ -1442,7 +1735,7 @@ diagnosis:
     reference_title: "Lafora Disease: A Review of Molecular Mechanisms and Pathology."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "successive electroencephalographs (EEG's) show, unlike in JME, a slowing background and spike-wave discharges"
+    snippet: "successive electroencephalographs (EEG’s) show, unlike in JME, a slowing background and spike-wave discharges"
     explanation: Describes the characteristic EEG findings distinguishing Lafora disease from JME.
 genetic:
 - name: EPM2A

--- a/kb/disorders/Lafora_Disease.yaml
+++ b/kb/disorders/Lafora_Disease.yaml
@@ -1,6 +1,6 @@
 name: Lafora_Disease
 creation_date: '2026-03-08T00:00:00Z'
-updated_date: '2026-05-21T11:02:37Z'
+updated_date: '2026-05-21T11:18:18Z'
 category: Mendelian
 description: >
   Lafora disease is a rare, fatal form of progressive myoclonus epilepsy (PME type 2)
@@ -13,6 +13,12 @@ description: >
   epileptic seizures (generalized tonic-clonic, absence, and occipital), visual
   hallucinations, and relentless cognitive decline leading to dementia and death within
   approximately 10 years of onset. There is currently no disease-modifying therapy.
+references:
+- reference: PMID:20301563
+  title: Progressive Myoclonus Epilepsy, Lafora Type.
+  tags:
+  - GeneReviews
+  findings: []
 disease_term:
   preferred_term: Lafora disease
   term:


### PR DESCRIPTION
## Summary
- Added evidence-backed downstream edges connecting Lafora glycogen dysregulation to Lafora bodies, neuroinflammation, oxidative/proteostasis stress, neurodegeneration, seizures, neurologic phenotypes, and biochemical readouts.
- Added missing edge evidence for previously unsupported pathograph links and connected all phenotype and biochemical readout nodes through downstream mechanisms.
- Kept scope to `kb/disorders/Lafora_Disease.yaml`; restored validator-induced reference-cache churn.

## Validation
- `just validate kb/disorders/Lafora_Disease.yaml`
- `just validate-terms kb/disorders/Lafora_Disease.yaml`
- `just validate-references kb/disorders/Lafora_Disease.yaml` (stock validator reports 0 checks for this file)
- Normalized snippet audit: `checked=138 missing=0 no_cache=0`
- Graph audit: `pathophysiology=10 phenotypes=19 biochemical=4 treatments=7 edges=38`; unexplained phenotypes `0`; biochemical readouts not downstream `0`; edges without evidence `0`
- `git diff --check`
