### PR TITLE
[codex] Add evidence to Isovaleric Acidemia downstream edges

### DIFF
--- a/kb/disorders/Isovaleric_Acidemia.yaml
+++ b/kb/disorders/Isovaleric_Acidemia.yaml
@@ -1,7 +1,7 @@
 name: Isovaleric Acidemia
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-19T16:40:11Z'
+updated_date: '2026-05-21T11:29:12Z'
 classifications:
   harrisons_chapter:
   - classification_value: hereditary disease
@@ -65,6 +65,12 @@ pathophysiology:
   - target: Deficient leucine catabolic flux
     description: Reduced IVD activity blocks isovaleryl-CoA oxidation in leucine catabolism.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The review identifies IVA as an inherited leucine-metabolism disorder caused by IVD deficiency, supporting the direct block in leucine catabolic flux.
 - name: Deficient leucine catabolic flux
   description: 'IVD deficiency blocks leucine degradation at the mitochondrial isovaleryl-CoA to 3-methylcrotonyl-CoA step, causing upstream accumulation of isovaleryl-CoA, isovaleric acid, and characteristic secondary metabolites.
 
@@ -89,6 +95,12 @@ pathophysiology:
   - target: Toxic isovaleryl-CoA and organic acid accumulation
     description: Blocked IVD flux causes upstream isovaleryl-CoA and derivative organic acids to accumulate.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The review directly connects IVD deficiency to accumulation of the characteristic organic acids and conjugates.
 - name: Toxic isovaleryl-CoA and organic acid accumulation
   description: 'Blocked isovaleryl-CoA oxidation causes accumulation of isovaleryl-CoA, isovaleric acid, 3-hydroxyisovaleric acid, isovalerylcarnitine, and isovalerylglycine. This toxic organic acid burden drives the characteristic odor, secondary detoxification through carnitine and glycine conjugation, and downstream acute metabolic decompensation, hyperammonemia, mitochondrial stress, and direct neurotoxicity.
 
@@ -160,51 +172,111 @@ pathophysiology:
   - target: Isovaleric acid
     description: IVD deficiency causes free isovaleric acid accumulation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The cited review lists isovaleric acid among the metabolites that accumulate downstream of IVD deficiency.
   - target: 3-Hydroxyisovaleric acid
     description: Alternative metabolism of accumulated isovaleryl-CoA produces elevated 3-hydroxyisovaleric acid.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - alternate oxidation of accumulated isovaleryl-CoA derivatives
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The cited review lists 3-hydroxyisovaleric acid as a derivative accumulated in IVA.
   - target: Isovalerylcarnitine (C5)
     description: Carnitine conjugation of accumulated isovaleryl-CoA produces elevated C5 isovalerylcarnitine.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - carnitine conjugation of accumulated isovaleryl-CoA
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The cited review lists isovaleryl (C5)-carnitine as a characteristic accumulated conjugate in IVA.
   - target: Isovalerylglycine
     description: Glycine conjugation of accumulated isovaleryl-CoA produces elevated urinary isovalerylglycine.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - glycine conjugation of accumulated isovaleryl-CoA
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Isovaleric acidemia (IVA, OMIM 243500) is an inherited disorder of leucine \nmetabolism caused by a deficiency of isovaleryl-CoA dehydrogenase (IVD), leading \nto an accumulation of isovaleric acid and its derivates 3-hydroxyisovaleric \nacid, isovaleryl (C5)-carnitine and isovalerylglycine in body fluids."
+      explanation: The cited review lists isovalerylglycine as a characteristic accumulated conjugate in IVA.
   - target: Free carnitine
     description: Formation and urinary excretion of isovalerylcarnitine depletes the free carnitine pool.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - isovalerylcarnitine formation and urinary excretion
+    evidence:
+    - reference: PMID:6549017
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Isovaleric acidemia, resulting from isovaleryl-coenzyme A dehydrogenase\ndeficiency, is associated with marked reduction of free carnitine in both plasma\nand urine."
+      explanation: The human treatment study directly supports depletion of free carnitine in IVA.
   - target: Catabolic acute metabolic decompensation
     description: Toxic metabolite load worsens during fasting, illness, and protein intake, producing acute crises.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - fasting, febrile illness, gastroenteritis, or increased protein intake
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Acute metabolic decompensations are typically\ntriggered by fasting, (febrile) illness (especially gastroenteritis), or\nincreased protein intake."
+      explanation: GeneReviews supports catabolic and protein-load triggers for acute IVA decompensation.
   - target: Secondary urea cycle impairment and hyperammonemia
     description: Accumulated isovaleryl-CoA impairs N-acetylglutamate synthesis and urea-cycle activation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - N-acetylglutamate synthase inhibition and acetyl-CoA depletion
+    evidence:
+    - reference: PMID:41133704
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The \nclinical presentation is highly variable, ranging from life-threatening \nmetabolic crises with metabolic acidosis and hyperammonemia to a clinically \nasymptomatic only biochemical phenotype."
+      explanation: The IVA review directly supports hyperammonemia as part of life-threatening metabolic crises.
   - target: Mitochondrial energy depletion and oxidative stress
     description: Accumulated organic acids decrease mitochondrial energy production and increase oxidative stress.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - TCA-cycle inhibition and secondary oxidative stress
+    evidence:
+    - reference: PMID:36817957
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "The increase in these metabolites decreases mitochondrial energy \nproduction and increases oxidative stress."
+      explanation: This mechanistic paper links accumulated IVA metabolites to decreased mitochondrial energy production and oxidative stress.
   - target: Neuronal membrane dysfunction via Na+,K+-ATPase inhibition
     description: Free isovaleric acid inhibits cerebral cortical Na+,K+-ATPase in model systems.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - isovaleric acid exposure in brain tissue
+    evidence:
+    - reference: PMID:19210957
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "IVA injection significantly inhibited \nNa(+),K(+)-ATPase activity (25%) in cerebral cortex of rats 2 or 24 h after IVA \nadministration, while pre-treatment of rats with creatine completely prevented \nthe inhibitory effects of IVA on Na(+),K(+)-ATPase."
+      explanation: Rat cerebral cortex data directly support isovaleric-acid-induced Na+,K+-ATPase inhibition.
   - target: Characteristic sweaty feet odor
     description: Volatile isovaleric acid buildup produces the characteristic sweaty-feet odor.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - buildup of volatile isovaleric acid
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Classic IVA is characterized by acute metabolic\ndecompensations (vomiting, poor feeding, lethargy, hypotonia, seizures, and a\ndistinct odor of sweaty feet)."
+      explanation: GeneReviews lists the sweaty-feet odor among classic IVA decompensation features.
 - name: Catabolic acute metabolic decompensation
   description: 'Fasting, febrile illness, gastroenteritis, and increased protein intake increase leucine flux and toxic organic-acid burden, triggering acute metabolic decompensation with vomiting, encephalopathy, metabolic acidosis, ketosis, hyperammonemia, and neurologic deterioration.
 
@@ -245,50 +317,128 @@ pathophysiology:
   - target: Metabolic acidosis
     description: Acute organic-acid accumulation produces metabolic acidosis during crises.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38344522
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Laboratory results showed acidosis (81%), \nhyperammonemia (71.4%), and hypoglycemia (14.3%)."
+      explanation: The IVA cohort documents metabolic acidosis during clinical presentation.
   - target: Hyperammonemia
     description: Acute decompensation in IVA commonly includes secondary hyperammonemia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - secondary urea-cycle impairment
+    evidence:
+    - reference: PMID:38344522
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Laboratory results showed acidosis (81%), \nhyperammonemia (71.4%), and hypoglycemia (14.3%)."
+      explanation: The IVA cohort documents hyperammonemia during clinical presentation.
   - target: Vomiting
     description: Vomiting is a common acute decompensation symptom.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38344522
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Vomiting was the most prevalent symptom (57.1%), and \nencephalopathy occurred in 33.3%."
+      explanation: The IVA cohort documents vomiting as the most prevalent symptom.
   - target: Feeding difficulties
     description: Poor feeding is a core manifestation of acute metabolic decompensation in classic IVA.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Classic IVA is characterized by acute metabolic\ndecompensations (vomiting, poor feeding, lethargy, hypotonia, seizures, and a\ndistinct odor of sweaty feet)."
+      explanation: GeneReviews lists poor feeding among classic IVA decompensation manifestations.
   - target: Encephalopathy
     description: Acute decompensation produces encephalopathy through hyperammonemia and organic-acid neurotoxicity.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - hyperammonemia, mitochondrial dysfunction, and Na+,K+-ATPase inhibition
+    evidence:
+    - reference: PMID:38344522
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Vomiting was the most prevalent symptom (57.1%), and \nencephalopathy occurred in 33.3%."
+      explanation: The IVA cohort documents encephalopathy during acute clinical presentation.
   - target: Lethargy
     description: Acute crises commonly cause reduced alertness.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Classic IVA is characterized by acute metabolic\ndecompensations (vomiting, poor feeding, lethargy, hypotonia, seizures, and a\ndistinct odor of sweaty feet)."
+      explanation: GeneReviews lists lethargy among classic IVA decompensation manifestations.
   - target: Hypotonia
     description: Hypotonia is listed among acute decompensation manifestations in classic IVA.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Classic IVA is characterized by acute metabolic\ndecompensations (vomiting, poor feeding, lethargy, hypotonia, seizures, and a\ndistinct odor of sweaty feet)."
+      explanation: GeneReviews lists hypotonia among classic IVA decompensation manifestations.
   - target: Hypoglycemia
     description: Hypoglycemia occurs in a subset of acute IVA presentations.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38344522
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Laboratory results showed acidosis (81%), \nhyperammonemia (71.4%), and hypoglycemia (14.3%)."
+      explanation: The IVA cohort documents hypoglycemia during clinical presentation.
   - target: Seizures
     description: Acute metabolic decompensation can present with seizures.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - hyperammonemia and organic-acid neurotoxicity
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Classic IVA is characterized by acute metabolic\ndecompensations (vomiting, poor feeding, lethargy, hypotonia, seizures, and a\ndistinct odor of sweaty feet)."
+      explanation: GeneReviews lists seizures among classic IVA decompensation manifestations.
   - target: Movement disorder
     description: Recurrent or severe IVA decompensation can contribute to movement disorders through metabolic brain injury and organic-acid neurotoxicity.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - hyperammonemia, mitochondrial dysfunction, and organic-acid neurotoxicity
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Additional manifestations of classic IVA include developmental\ndelay, intellectual disability and/or impaired cognition, epilepsy, and movement\ndisorder (tremor, dysmetria, extrapyramidal movements)."
+      explanation: GeneReviews lists movement disorder among additional classic IVA manifestations.
   - target: Pancytopenia
     description: Severe infection-triggered decompensation can present with pancytopenia.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:2124776
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A case of isovaleric acidemia appearing as diabetic ketoacidosis with acute\nencephalopathy and pancytopenia was reported."
+      explanation: A human IVA case report documents pancytopenia during acute encephalopathic presentation.
   - target: Global developmental delay
     description: Recurrent or severe IVA decompensation contributes to developmental delay risk.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:38484105
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Additional manifestations of classic IVA include developmental\ndelay, intellectual disability and/or impaired cognition, epilepsy, and movement\ndisorder (tremor, dysmetria, extrapyramidal movements)."
+      explanation: GeneReviews lists developmental delay among additional classic IVA manifestations.
   - target: Failure to thrive
     description: Chronic intermittent IVA can present with failure to thrive.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30547004
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The chronic intermittent form with onset in infancy or childhood presents with developmental delays and/or failure to thrive.
+      explanation: A human follow-up report states that chronic intermittent IVA can present with failure to thrive.
 - name: Secondary urea cycle impairment and hyperammonemia
   description: 'Isovaleryl-CoA inhibits N-acetylglutamate synthase (NAGS), reducing N-acetylglutamate availability and impairing activation of carbamoyl phosphate synthetase 1 (CPS1), the rate-limiting entry enzyme of the urea cycle. Combined with acetyl-CoA depletion, this produces secondary hyperammonemia that contributes to encephalopathy and neurological complications.
 
@@ -331,24 +481,54 @@ pathophysiology:
   - target: Ammonia
     description: Urea-cycle impairment increases circulating ammonia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30522498
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Treatment with N-carbamyl-L-glutamate can rapidly normalise \nammonia levels by stimulating the first step of the urea cycle."
+      explanation: The review links urea-cycle activation to normalization of ammonia levels, supporting ammonia as the readout of impaired urea-cycle entry.
   - target: Hyperammonemia
     description: Impaired urea-cycle entry produces the hyperammonemia phenotype.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30522498
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This is frequently accompanied by severe \nhyperammonaemia and constitutes a metabolic emergency"
+      explanation: The organic-acidemia review supports severe hyperammonemia as a frequent accompaniment of decompensation.
   - target: Encephalopathy
     description: Severe hyperammonemia during organic-acidemia crises contributes to life-threatening neurologic dysfunction.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - increased ammonia levels and accumulating toxic metabolites
+    evidence:
+    - reference: PMID:30522498
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "increased ammonia \nlevels and accumulating toxic metabolites are associated with life-threatening \nneurological complications."
+      explanation: The review supports hyperammonemia and toxic metabolites as drivers of severe neurologic complications.
   - target: Intellectual disability
     description: Repeated hyperammonemia and metabolic decompensation can lead to intellectual disability.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - repeated hyperammonemic metabolic decompensations
+    evidence:
+    - reference: PMID:30522498
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Repeated and frequent episodes of hyperammonaemia \n(alongside metabolic decompensations) can result in impaired growth and \nintellectual disability, the severity of which increase with longer duration of \nhyperammonaemia."
+      explanation: The review directly links repeated hyperammonemia and metabolic decompensation to intellectual disability.
   - target: Failure to thrive
     description: Repeated hyperammonemia and metabolic decompensation can impair growth.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - repeated hyperammonemic metabolic decompensations
+    evidence:
+    - reference: PMID:30522498
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Repeated and frequent episodes of hyperammonaemia \n(alongside metabolic decompensations) can result in impaired growth and \nintellectual disability, the severity of which increase with longer duration of \nhyperammonaemia."
+      explanation: The review links repeated hyperammonemia and metabolic decompensation to impaired growth.
 - name: Mitochondrial energy depletion and oxidative stress
   description: 'Accumulated isovaleryl-CoA and isovaleric acid impair tricarboxylic acid cycle function, with evidence for inhibition of citrate synthase and reduced CO2 production from acetate in brain tissue. Chronic metabolite accumulation also increases oxidative stress, contributing to neurological morbidity. Oxidative stress from chronic persistent buildup of isovaleric acid may be more neurologically detrimental than acute buildup.
 
@@ -391,9 +571,21 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - impaired TCA-cycle activity in cerebral cortex
+    evidence:
+    - reference: PMID:19210957
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "IVA administration significantly inhibited (14)CO(2) production from \nacetate (22%) and citrate synthase activity (20%) in cerebral cortex homogenates \nprepared 24 h after injection."
+      explanation: Rat cerebral cortex data support impaired energy metabolism after isovaleric acid exposure, which can contribute to encephalopathy.
   - target: Lethargy
     description: Cerebral energy impairment can contribute to reduced alertness during acute crises.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19210957
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "IVA administration significantly inhibited (14)CO(2) production from \nacetate (22%) and citrate synthase activity (20%) in cerebral cortex homogenates \nprepared 24 h after injection."
+      explanation: Rat cerebral cortex data support energy impairment after isovaleric acid exposure; this provides mechanistic support for reduced alertness during crises.
 - name: Neuronal membrane dysfunction via Na+,K+-ATPase inhibition
   description: 'Isovaleric acid directly inhibits Na+,K+-ATPase activity in cerebral cortex, a crucial enzyme for maintaining membrane potential and normal neurotransmission. This inhibition is observed as early as 2 hours after exposure and persists at 24 hours, contributing to the acute encephalopathy seen during metabolic crises.
 
@@ -426,9 +618,21 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - impaired basal membrane potential and neurotransmission
+    evidence:
+    - reference: PMID:19210957
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "IVA injection significantly inhibited \nNa(+),K(+)-ATPase activity (25%) in cerebral cortex of rats 2 or 24 h after IVA \nadministration, while pre-treatment of rats with creatine completely prevented \nthe inhibitory effects of IVA on Na(+),K(+)-ATPase."
+      explanation: Rat data show isovaleric acid inhibits cerebral cortical Na+,K+-ATPase, supporting a membrane-pump mechanism for encephalopathy.
   - target: Seizures
     description: Disrupted neuronal membrane potential can contribute to seizure susceptibility during crises.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:19210957
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "It is presumed that inhibition of these activities may be \ninvolved in the pathophysiology of the neurological dysfunction of isovaleric \nacademic patients."
+      explanation: The model-organism study interprets Na+,K+-ATPase and energy-metabolism inhibition as possible contributors to neurological dysfunction in IVA.
 phenotypes:
 - name: Metabolic acidosis
   frequency: VERY_FREQUENT


### PR DESCRIPTION
## Summary
- Added evidence to all previously unsupported Isovaleric Acidemia downstream edges.
- Preserved the existing connected graph structure while grounding biochemical readout, crisis phenotype, hyperammonemia, mitochondrial stress, and Na+,K+-ATPase neurotoxicity links in cached snippets.
- Kept scope to `kb/disorders/Isovaleric_Acidemia.yaml`; restored validator-induced reference-cache churn.

## Validation
- `just validate kb/disorders/Isovaleric_Acidemia.yaml`
- `just validate-terms kb/disorders/Isovaleric_Acidemia.yaml`
- `just validate-references kb/disorders/Isovaleric_Acidemia.yaml` (stock validator reports 0 checks for this file)
- Normalized snippet audit: `checked=97 missing=0 no_cache=0`
- Graph audit: `pathophysiology=7 phenotypes=15 biochemical=6 treatments=7 edges=34`; unexplained phenotypes `0`; biochemical readouts not downstream `0`; edges without evidence `0`
- `git diff --check`
