### PR TITLE
[codex] Strengthen SSADH pathograph connectivity

### DIFF
--- a/kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Succinic Semialdehyde Dehydrogenase Deficiency
 creation_date: "2026-05-11T09:21:23Z"
-updated_date: "2026-05-18T03:57:48Z"
+updated_date: "2026-05-21T11:46:20Z"
 category: Mendelian
 synonyms:
 - 4-hydroxybutyric aciduria
@@ -226,9 +226,50 @@ pathophysiology:
     intermediate_mechanisms:
     - excess GABA and GHB exposure in basal ganglia circuits
     description: GABA/GHB accumulation affects basal ganglia-rich neural circuits, consistent with globus pallidus neuropathology and MRI abnormalities.
+    evidence:
+    - reference: PMID:31117962
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cerebral MRI showed symmetrical hyperintense signal of bilateral globus pallidus and basal ganglia in patient 1"
+      explanation: Human MRI evidence supports basal ganglia and globus pallidus involvement downstream of SSADH deficiency.
   - target: Abnormality of metabolism/homeostasis
     causal_link_type: DIRECT
     description: Elevated GABA, GHB, and related metabolites constitute the core metabolic homeostasis abnormality in SSADH deficiency.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001939 | Abnormality of metabolism/homeostasis | Very frequent (99-80%)"
+      explanation: Orphanet records abnormal metabolism/homeostasis as a very frequent SSADH deficiency phenotype.
+  - target: Elevated 4-hydroxybutyric acid
+    causal_link_type: DIRECT
+    description: SSADH deficiency elevates GHB/4-hydroxybutyric acid as a core diagnostic metabolite.
+    evidence:
+    - reference: PMID:31117962
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Urine organic acid analysis revealed elevated GHB in all the patients."
+      explanation: Human case-series evidence supports elevated GHB/4-hydroxybutyric acid as a biochemical readout of metabolite accumulation.
+  - target: Elevated gamma-aminobutyric acid
+    causal_link_type: DIRECT
+    description: Impaired GABA catabolism elevates GABA in physiological fluids.
+    evidence:
+    - reference: PMID:32967698
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The metabolic signature includes elevated GHB and GABA in physiological fluids, among other metabolites [11]."
+      explanation: Human biomarker evidence supports elevated GABA as part of the SSADH metabolic signature.
+  - target: Elevated 4,5-dihydroxyhexanoic acid
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - succinic-semialdehyde-derived metabolite accumulation
+    description: Untargeted and targeted metabolomics show 4,5-DHHA elevation alongside GHB in SSADH deficiency.
+    evidence:
+    - reference: PMID:37455357
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Targeted analysis of NGMS data from cerebrospinal fluid (CSF) showed a moderate increase of aspartic acid, glutaric acid, glycolic acid, 4-guanidinobutanoic acid, and 2-hydroxyglutaric acid, and prominent elevations of GHB and 4,5-dihydroxyhexanoic acid (4,5-DHHA) in SSADHD samples."
+      explanation: Patient CSF metabolomics supports 4,5-DHHA as a biochemical readout of the SSADH metabolite signature.
   - target: Oxidative and Mitochondrial Stress
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
@@ -276,21 +317,45 @@ pathophysiology:
     - globus pallidus involvement
     - basal ganglia signal abnormality
     description: Basal ganglia vulnerability is reflected by recurrent globus-pallidus and basal-ganglia T2 hyperintensity on MRI.
+    evidence:
+    - reference: PMID:31117962
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cerebral MRI showed symmetrical hyperintense signal of bilateral globus pallidus and basal ganglia in patient 1"
+      explanation: Human MRI evidence directly supports basal-ganglia/globus-pallidus hyperintensity.
   - target: Dystonia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - basal ganglia circuit dysfunction
     description: Basal ganglia circuit involvement can contribute to dystonia within the SSADH movement-disorder spectrum.
+    evidence:
+    - reference: PMID:38499966
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "After ataxia, dystonia (19%), chorea (11%) and hypokinesia (15%) were the most frequent movement disorders."
+      explanation: Registry follow-up data support dystonia as part of the SSADH movement-disorder spectrum.
   - target: Chorea
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - basal ganglia circuit dysfunction
     description: Basal ganglia circuit involvement can contribute to chorea within the SSADH movement-disorder spectrum.
+    evidence:
+    - reference: PMID:38499966
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "After ataxia, dystonia (19%), chorea (11%) and hypokinesia (15%) were the most frequent movement disorders."
+      explanation: Registry follow-up data support chorea as part of the SSADH movement-disorder spectrum.
   - target: Exertional dyskinesia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - basal ganglia circuit dysfunction
     description: Basal ganglia circuit involvement can contribute to exertional dyskinesia within the SSADH movement-disorder spectrum.
+    evidence:
+    - reference: PMID:20301374
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "movement disorders (such as ataxia, dystonia, and exertional dyskinesia), sleep disturbances, attention problems, anxiety, and obsessive-compulsive behaviors."
+      explanation: GeneReviews lists exertional dyskinesia among SSADH deficiency movement manifestations.
 - name: GABAergic Network Dysfunction
   description: >-
     Patient-derived GABAergic neuronal models and longitudinal human data
@@ -336,53 +401,149 @@ pathophysiology:
   - target: Intellectual disability
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: GABAergic network dysfunction contributes to impaired neurocognitive development.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001249 | Intellectual disability | Very frequent (99-80%)"
+      explanation: Orphanet lists intellectual disability as a very frequent SSADH deficiency phenotype.
   - target: Global developmental delay
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Altered early-life inhibitory signaling contributes to developmental delay.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Very frequent (99-80%)"
+      explanation: Orphanet lists global developmental delay as a very frequent SSADH deficiency phenotype.
   - target: Hypotonia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Neurodevelopmental network dysfunction contributes to low muscle tone.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001252 | Hypotonia | Very frequent (99-80%)"
+      explanation: Orphanet lists hypotonia as a very frequent SSADH deficiency phenotype.
   - target: Ataxia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Central nervous system dysfunction contributes to impaired coordination.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001251 | Ataxia | Very frequent (99-80%)"
+      explanation: Orphanet lists ataxia as a very frequent SSADH deficiency phenotype.
   - target: Bilateral tonic-clonic seizure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Altered neuronal excitability contributes to epilepsy and convulsive seizures.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002069 | Bilateral tonic-clonic seizure | Frequent (79-30%)"
+      explanation: Orphanet lists bilateral tonic-clonic seizures as a frequent SSADH deficiency phenotype.
   - target: Status epilepticus
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Severe seizure susceptibility can progress to prolonged seizures.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002133 | Status epilepticus | Frequent (79-30%)"
+      explanation: Orphanet lists status epilepticus as a frequent SSADH deficiency phenotype.
   - target: Generalized myoclonic seizure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Altered neuronal excitability contributes to generalized myoclonic seizures.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002123 | Generalized myoclonic seizure | Frequent (79-30%)"
+      explanation: Orphanet lists generalized myoclonic seizures as a frequent SSADH deficiency phenotype.
   - target: Sudden unexpected death in epilepsy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - epilepsy
     description: The epilepsy phenotype carries a recognized SUDEP risk in SSADH deficiency.
+    evidence:
+    - reference: PMID:35269750
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Paradoxically, over half of patients with SSADHD also develop epilepsy and face a significant risk of sudden unexpected death in epilepsy (SUDEP)."
+      explanation: Mechanism review evidence links SSADH-associated epilepsy to SUDEP risk.
   - target: Expressive language delay
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Early-life neurotransmitter network dysfunction contributes to prominent language-development delay.
+    evidence:
+    - reference: PMID:38658850
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Language developmental delays were more prominent than motor."
+      explanation: Natural-history cohort evidence supports expressive-language delay as a prominent SSADH deficiency phenotype.
   - target: Sleep disturbance
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: GABAergic network dysfunction contributes to sleep dysregulation.
+    evidence:
+    - reference: PMID:38658850
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Autism, epilepsy, movement disorders, sleep disturbances, and various psychiatric behaviors constituted the core of the disorder's clinical phenotype."
+      explanation: Natural-history cohort evidence identifies sleep disturbance as part of the core phenotype.
   - target: Autism
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Altered inhibitory and excitatory signaling contributes to autistic features in the core neurodevelopmental phenotype.
+    evidence:
+    - reference: PMID:38658850
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Autism, epilepsy, movement disorders, sleep disturbances, and various psychiatric behaviors constituted the core of the disorder's clinical phenotype."
+      explanation: Natural-history cohort evidence identifies autism as part of the core phenotype.
   - target: Atypical behavior
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Neurodevelopmental network dysfunction contributes to behavioral dysregulation.
+    evidence:
+    - reference: ORPHA:22
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000708 | Atypical behavior | Frequent (79-30%)"
+      explanation: Orphanet lists atypical behavior as a frequent SSADH deficiency phenotype.
   - target: Anxiety
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: GABAergic network dysfunction contributes to anxiety in the neuropsychiatric phenotype.
+    evidence:
+    - reference: PMID:20301374
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "movement disorders (such as ataxia, dystonia, and exertional dyskinesia), sleep disturbances, attention problems, anxiety, and obsessive-compulsive behaviors."
+      explanation: GeneReviews lists anxiety among SSADH deficiency neuropsychiatric manifestations.
   - target: Obsessive-compulsive trait
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Altered inhibitory signaling contributes to obsessive-compulsive behaviors in the neuropsychiatric phenotype.
+    evidence:
+    - reference: PMID:20301374
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "movement disorders (such as ataxia, dystonia, and exertional dyskinesia), sleep disturbances, attention problems, anxiety, and obsessive-compulsive behaviors."
+      explanation: GeneReviews lists obsessive-compulsive behaviors among SSADH deficiency neuropsychiatric manifestations.
   - target: Attention deficit hyperactivity disorder
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: GABAergic network dysfunction contributes to short attention span and distractibility in the behavioral phenotype.
+    evidence:
+    - reference: PMID:20301374
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "movement disorders (such as ataxia, dystonia, and exertional dyskinesia), sleep disturbances, attention problems, anxiety, and obsessive-compulsive behaviors."
+      explanation: GeneReviews lists attention problems among SSADH deficiency neuropsychiatric manifestations.
   - target: Aggressive behavior
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Neuropsychiatric dysregulation can include aggression and related behavioral symptoms.
+    evidence:
+    - reference: PMID:39011401
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The disorder is due to bi-allelic pathogenic variants in ALDH5A1 and is usually characterized by moderate-to-severe developmental delays, hypotonia, intellectual disability, ataxia, seizures, hyperkinetic behavior, aggression, psychiatric disorders, and sleep disturbances."
+      explanation: Diagnostic cohort evidence lists aggression among typical SSADH deficiency manifestations.
 - name: Oxidative and Mitochondrial Stress
   description: >-
     SSADH deficiency can include redox imbalance and mitochondrial dysfunction,


### PR DESCRIPTION
## Summary
- Added evidence to all previously unsupported SSADH downstream edges.
- Added downstream links from GABA/GHB accumulation to the existing biochemical readouts: elevated 4-hydroxybutyric acid, elevated GABA, and elevated 4,5-DHHA.
- Kept scope to `kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml`; restored validator-induced reference-cache churn.

## Validation
- `just validate kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml`
- `just validate-terms kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml`
- `just validate-references kb/disorders/Succinic_Semialdehyde_Dehydrogenase_Deficiency.yaml` (stock validator reports 0 checks for this file)
- Normalized snippet audit: `checked=87 missing=0 no_cache=0`
- Graph audit: `pathophysiology=6 phenotypes=21 biochemical=3 treatments=2 edges=29`; unexplained phenotypes `0`; biochemical readouts not downstream `0`; edges without evidence `0`
- `git diff --check`
