### PR TITLE
[codex] Add evidence to MSUD pathograph edges

### DIFF
--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1,6 +1,6 @@
 name: Maple Syrup Urine Disease
 creation_date: '2026-01-09T01:00:56Z'
-updated_date: '2026-05-19T21:35:01Z'
+updated_date: '2026-05-21T12:26:02Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -172,6 +172,14 @@ pathophysiology:
     explanation: Confirms BCKDH enzyme dysfunction is the core defect in MSUD.
   downstream:
   - target: Systemic BCAA and BCKA Accumulation
+    description: BCKDH complex deficiency blocks BCAA oxidation and produces systemic elevations of BCAAs, ketoacids, and alloisoleucine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Maple syrup urine disease (MSUD) is an inborn error of metabolism caused by defects in the branched-chain α-ketoacid dehydrogenase complex, which results in elevations of the branched-chain amino acids (BCAAs) in plasma, α-ketoacids in urine, and production of the pathognomonic disease marker, alloisoleucine."
+      explanation: Human review evidence directly links BCKDH complex defects to the systemic BCAA, ketoacid, and alloisoleucine accumulation that defines MSUD.
 - name: Systemic BCAA and BCKA Accumulation
   description: >
     BCKDH deficiency causes systemic accumulation of leucine, isoleucine, valine
@@ -238,45 +246,139 @@ pathophysiology:
     explanation: Confirms elevation of BCAAs, ketoacids, and alloisoleucine in MSUD.
   downstream:
   - target: Leucine and Ketoacid Neurotoxicity
+    description: Systemic leucine elevation generates KIC, a major toxic metabolite that impairs mitochondrial function at disease-relevant concentrations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "KIC and its’ corresponding branched-chain amino acid (BCAA) precursor, leucine are the major toxic metabolites associated with MSUD related symptoms"
+      explanation: Model-system evidence identifies leucine and KIC as the major toxic metabolites associated with MSUD symptoms.
   - target: Blood-Brain Barrier Transport Competition
+    description: Plasma amino acid dysregulation limits brain neutral amino acid availability and contributes to persistent neurochemical deficiencies.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - LAT1-mediated large neutral amino acid competition at the blood-brain barrier.
+    evidence:
+    - reference: PMID:23478409
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "amino acid dysregulation results in aberrant neural networks with neurochemical deficiencies that persist after transplant and correlate with neuropsychiatric morbidities"
+      explanation: Patient MRS and neuropsychiatric data support amino-acid dysregulation as producing persistent brain neurochemical deficiencies.
   - target: Skeletal Muscle Dysfunction
+    description: Systemic branched-chain ketoacid accumulation includes muscle KIC accumulation, disrupting mitochondrial metabolites and muscle structure.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - KIC accumulation in skeletal muscle and impaired mitochondrial metabolism.
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Metformin-treatment significantly reduced levels of KIC in the muscle (by 69%) and serum (by 56%) isolated from iMSUD mice, and restored levels of mitochondrial metabolites"
+      explanation: MSUD mouse data support KIC accumulation in muscle with associated mitochondrial metabolite disruption.
   - target: Elevated Branched Chain Amino Acids
     description: Primary BCAA catabolic blockade causes elevated circulating branched-chain amino acids.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "results in elevations of the branched-chain amino acids (BCAAs) in plasma"
+      explanation: Human review evidence directly supports elevated plasma BCAAs downstream of BCKDH complex defects.
   - target: Plasma Leucine
     description: Leucine accumulates in plasma when BCKDH cannot oxidize branched-chain ketoacids downstream of leucine transamination.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301495
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Elevated concentrations of branched-chain amino acids (BCAAs; leucine, isoleucine, and valine) and alloisoleucine"
+      explanation: GeneReviews identifies elevated leucine as part of the diagnostic BCAA accumulation pattern in MSUD.
   - target: Plasma Isoleucine
     description: Isoleucine accumulates in plasma as part of the systemic BCAA elevation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301495
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Elevated concentrations of branched-chain amino acids (BCAAs; leucine, isoleucine, and valine) and alloisoleucine"
+      explanation: GeneReviews identifies elevated isoleucine as part of the diagnostic BCAA accumulation pattern in MSUD.
   - target: Plasma Valine
     description: Valine accumulates in plasma as part of the systemic BCAA elevation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301495
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Elevated concentrations of branched-chain amino acids (BCAAs; leucine, isoleucine, and valine) and alloisoleucine"
+      explanation: GeneReviews identifies elevated valine as part of the diagnostic BCAA accumulation pattern in MSUD.
   - target: Alloisoleucine
     description: Systemic BCAA imbalance produces the pathognomonic alloisoleucine marker.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "production of the pathognomonic disease marker, alloisoleucine."
+      explanation: Human review evidence identifies alloisoleucine as the pathognomonic MSUD disease marker.
   - target: Alpha-Ketoisocaproic Acid (KIC)
     description: Leucine-derived KIC accumulates upstream of the BCKDH enzyme block.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "BCKDH dysfunction results in the accumulation of the keto-acids ketoisocaproic acid (KIC) from leucine, ketoisovaleric acid (KIV) from valine and ketomethylvaleric acid (KMV) from isoleucine"
+      explanation: MSUD model evidence directly supports KIC accumulation from leucine when BCKDH is dysfunctional.
   - target: Alpha-Ketoisovaleric Acid (KIV)
     description: Valine-derived KIV accumulates upstream of the BCKDH enzyme block.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "BCKDH dysfunction results in the accumulation of the keto-acids ketoisocaproic acid (KIC) from leucine, ketoisovaleric acid (KIV) from valine and ketomethylvaleric acid (KMV) from isoleucine"
+      explanation: MSUD model evidence directly supports KIV accumulation from valine when BCKDH is dysfunctional.
   - target: Alpha-Keto-beta-Methylvaleric Acid (KMV)
     description: Isoleucine-derived KMV accumulates upstream of the BCKDH enzyme block.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "BCKDH dysfunction results in the accumulation of the keto-acids ketoisocaproic acid (KIC) from leucine, ketoisovaleric acid (KIV) from valine and ketomethylvaleric acid (KMV) from isoleucine"
+      explanation: MSUD model evidence directly supports KMV accumulation from isoleucine when BCKDH is dysfunctional.
   - target: Abnormal Urinary Odor
     description: Accumulated branched-chain ketoacid metabolites generate the characteristic maple-syrup odor.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Sotolone and related odor-producing metabolites from branched-chain ketoacid accumulation.
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The classic presentation occurs in the neonatal period with developmental delay, failure to thrive, feeding difficulties, and maple syrup odor in the cerumen and urine"
+      explanation: Human review evidence supports maple-syrup odor in urine and cerumen as a classic clinical consequence of the metabolic accumulation.
   - target: Metabolic Acidosis
     description: Accumulated organic ketoacids contribute to metabolic acidosis during decompensation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36550798
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The main clinical symptoms of maple syrup urine disease (MSUD) are dehydration, acidosis, nervous system symptoms and intellectual disability."
+      explanation: Human case-review evidence identifies acidosis as a main MSUD clinical symptom during metabolic disease.
   - target: Failure to Thrive
     description: Persistent BCAA imbalance and recurrent decompensation impair feeding, growth, and weight gain.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Feeding difficulty, catabolic stress, and recurrent metabolic decompensation.
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The classic presentation occurs in the neonatal period with developmental delay, failure to thrive, feeding difficulties, and maple syrup odor in the cerumen and urine"
+      explanation: Human review evidence supports failure to thrive as part of the classic presentation associated with MSUD metabolic intoxication.
 - name: Blood-Brain Barrier Transport Competition
   description: >
     Elevated plasma leucine competes for transport across the blood-brain barrier
@@ -309,6 +411,16 @@ pathophysiology:
     explanation: Demonstrates that amino acid dysregulation, including transport competition at the BBB, leads to neurochemical deficiencies in MSUD patients.
   downstream:
   - target: Brain Neurotransmitter Depletion
+    description: Amino acid dysregulation at the blood-brain barrier leads to measurable brain neurochemical deficiencies.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced brain availability of large neutral amino acids and altered neurotransmitter metabolism.
+    evidence:
+    - reference: PMID:23478409
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "amino acid dysregulation results in aberrant neural networks with neurochemical deficiencies that persist after transplant and correlate with neuropsychiatric morbidities"
+      explanation: Patient data directly link amino-acid dysregulation to persistent neurochemical deficiencies and neuropsychiatric morbidity.
 - name: Brain Neurotransmitter Depletion
   description: >
     Leucine and KIC entry into the brain via LAT1 and monocarboxylate transporters
@@ -350,11 +462,23 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Neurotransmitter depletion, low N-acetylaspartate, and neuropsychiatric morbidity.
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The classic presentation occurs in the neonatal period with developmental delay, failure to thrive, feeding difficulties, and maple syrup odor in the cerumen and urine"
+      explanation: Human review evidence supports developmental delay as part of the classic MSUD presentation downstream of metabolic brain injury.
   - target: Intellectual Disability
     description: Persistent brain amino-acid and neurotransmitter dysregulation contributes to cognitive impairment.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Neurotransmitter depletion and neuronal energy compromise.
+    evidence:
+    - reference: PMID:23478409
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Compared with 26 age-matched controls, MSUD patients were at higher risk for disorders of cognition, attention, and mood."
+      explanation: Human neuropsychiatric study supports cognitive morbidity in MSUD patients with brain neurochemical abnormalities.
 - name: Leucine and Ketoacid Neurotoxicity
   description: >
     Elevated leucine and its metabolite alpha-ketoisocaproic acid (KIC) are
@@ -400,24 +524,56 @@ pathophysiology:
     explanation: Demonstrates KIC-specific neurotoxicity inducing apoptosis in neural cell cultures.
   downstream:
   - target: Cerebral Energy Failure and Oxidative Stress
+    description: KIC neurotoxicity impairs mitochondrial function, linking leucine/ketoacid accumulation to cerebral energy failure.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "KIC is an inhibitor of mitochondrial function at disease relevant concentrations."
+      explanation: Model-system evidence directly supports KIC-mediated mitochondrial impairment as a proximal mechanism for energy failure.
   - target: Encephalopathy
     description: Acute leucine and KIC neurotoxicity drives neonatal and episodic metabolic encephalopathy.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23478409
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Maple syrup urine disease (MSUD) is an inherited disorder of branched chain amino acid metabolism presenting with neonatal encephalopathy, episodic metabolic decompensation, and chronic amino acid imbalances."
+      explanation: Human clinical evidence links MSUD amino-acid metabolism disorder to neonatal encephalopathy and episodic decompensation.
   - target: Lethargy
     description: Acute neurotoxicity during metabolic decompensation manifests clinically as lethargy.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Acute metabolic encephalopathy.
+    evidence:
+    - reference: PMID:32491705
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "It classically manifests in the neonatal period with failure to thrive, delayed developmental milestones, feeding difficulties, lethargy, irritability, and a maple syrup odor first noticeable in the cerumen and then the urine."
+      explanation: Clinical summary supports lethargy as a classic neonatal manifestation of MSUD intoxication.
   - target: Poor Feeding
     description: Neonatal neurotoxicity and encephalopathy impair feeding during classic presentation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Acute metabolic encephalopathy and reduced alertness.
+    evidence:
+    - reference: PMID:28919799
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The classic presentation occurs in the neonatal period with developmental delay, failure to thrive, feeding difficulties, and maple syrup odor in the cerumen and urine"
+      explanation: Human review evidence supports feeding difficulties as part of the classic neonatal presentation of MSUD.
   - target: Vomiting
     description: Acute metabolic decompensation with neurotoxicity can present with vomiting.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Acute metabolic decompensation and encephalopathy.
+    evidence:
+    - reference: PMID:35578286
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In some patients, enteral administration is not possible, either because the patient presents with vomiting, coma, or refuses nasogastric administration"
+      explanation: Prospective decompensation-management study supports vomiting as a presentation during acute MSUD episodes.
 - name: Cerebral Energy Failure and Oxidative Stress
   description: >
     KIC-mediated inhibition of mitochondrial dehydrogenases and electron transport
@@ -471,19 +627,52 @@ pathophysiology:
     explanation: Low NAA and creatine in MSUD brains reflects cerebral energy failure and neuronal compromise.
   downstream:
   - target: Neural Cell Death via Apoptosis and Autophagy
+    description: Energy failure and metabolite toxicity trigger apoptotic and autophagic injury programs in neural cells and brain tissue.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Mitochondrial respiratory stress and BCAA/KIC-induced neural cell death programs.
+    evidence:
+    - reference: DOI:10.1091/mbc.11.5.1919
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "increased concentrations of MSUD metabolites, in particular α-keto isocaproic acid, specifically induced apoptosis in glial and neuronal cells in culture"
+      explanation: Neural cell culture evidence supports MSUD metabolites as inducing apoptosis in glial and neuronal cells.
+    - reference: DOI:10.1007/s11011-022-01109-y
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "BCAA significantly increased the levels of Beclin-1, ATG7, and ATG5 in the cerebral cortex of rats"
+      explanation: Rat-model evidence supports BCAA-induced autophagy pathway activation in brain tissue.
   - target: Cerebral Edema
     description: Severe cerebral energy failure and oxidative stress culminate in cerebral edema during intoxication.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301495
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severe intoxication culminates in critical cerebral edema, coma, and central respiratory failure."
+      explanation: GeneReviews directly supports cerebral edema as a severe consequence of MSUD intoxication.
   - target: Coma
     description: Severe cerebral edema and energy failure can progress to coma.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cerebral edema and severe metabolic encephalopathy.
+    evidence:
+    - reference: PMID:20301495
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Severe intoxication culminates in critical cerebral edema, coma, and central respiratory failure."
+      explanation: GeneReviews directly supports coma as a severe consequence of MSUD intoxication.
   - target: Seizures
     description: Brain energy failure and injury lower seizure threshold during severe intoxication.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cerebral edema, metabolic encephalopathy, and neuronal injury.
+    evidence:
+    - reference: PMID:32491705
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "If left untreated, the most severe, classic form of MSUD can quickly lead to irreversible neurological injury manifesting as brain damage, seizures, a coma, or central respiratory failure within just 7 to 10 days after birth."
+      explanation: Clinical summary supports seizures as a severe neurologic consequence of untreated classic MSUD intoxication.
 - name: Neural Cell Death via Apoptosis and Autophagy
   description: >
     Sustained exposure to elevated BCAAs and BCKAs triggers both apoptotic and
@@ -538,6 +727,12 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Brain damage from sustained leucine and ketoacid toxicity.
+    evidence:
+    - reference: PMID:21839471
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "One-third of our patients were mentally impaired (IQ ≤ 70) before transplantation, with no statistically significant change 1 year later."
+      explanation: Human transplant follow-up supports persistent intellectual impairment after preexisting MSUD brain injury.
 - name: Skeletal Muscle Dysfunction
   description: >
     Skeletal muscle is a major site of BCAA transamination via mitochondrial
@@ -584,6 +779,17 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Muscle atrophy and impaired skeletal-muscle energy metabolism.
+    evidence:
+    - reference: PMID:27373929
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "shows significant skeletal muscle dysfunction as by judged decreased muscle"
+      explanation: MSUD mouse evidence supports skeletal-muscle dysfunction as part of the disease mechanism.
+    - reference: PMID:31559730
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Physical examination of the neonates were similar having stupor, hypotonia and depressed newborn reflexes."
+      explanation: Human neonatal MSUD decompensation evidence supports hypotonia as a clinical manifestation.
 phenotypes:
 - name: Abnormal Urinary Odor
   category: Other

--- a/kb/disorders/Maple_Syrup_Urine_Disease.yaml
+++ b/kb/disorders/Maple_Syrup_Urine_Disease.yaml
@@ -1,6 +1,6 @@
 name: Maple Syrup Urine Disease
 creation_date: '2026-01-09T01:00:56Z'
-updated_date: '2026-05-21T12:26:02Z'
+updated_date: '2026-05-21T12:38:33Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -549,7 +549,7 @@ pathophysiology:
     evidence:
     - reference: PMID:32491705
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: "It classically manifests in the neonatal period with failure to thrive, delayed developmental milestones, feeding difficulties, lethargy, irritability, and a maple syrup odor first noticeable in the cerumen and then the urine."
       explanation: Clinical summary supports lethargy as a classic neonatal manifestation of MSUD intoxication.
   - target: Poor Feeding
@@ -670,7 +670,7 @@ pathophysiology:
     evidence:
     - reference: PMID:32491705
       supports: SUPPORT
-      evidence_source: HUMAN_CLINICAL
+      evidence_source: OTHER
       snippet: "If left untreated, the most severe, classic form of MSUD can quickly lead to irreversible neurological injury manifesting as brain damage, seizures, a coma, or central respiratory failure within just 7 to 10 days after birth."
       explanation: Clinical summary supports seizures as a severe neurologic consequence of untreated classic MSUD intoxication.
 - name: Neural Cell Death via Apoptosis and Autophagy
@@ -835,7 +835,7 @@ phenotypes:
   - reference: PMID:32491705
     reference_title: "Maple Syrup Urine Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "It classically manifests in the neonatal period with failure to thrive, delayed developmental milestones, feeding difficulties, lethargy, irritability, and a maple syrup odor first noticeable in the cerumen and then the urine."
     explanation: Confirms lethargy as a classic neonatal manifestation of MSUD.
 - name: Encephalopathy
@@ -865,7 +865,7 @@ phenotypes:
   - reference: PMID:32491705
     reference_title: "Maple Syrup Urine Disease."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: "If left untreated, the most severe, classic form of MSUD can quickly lead to irreversible neurological injury manifesting as brain damage, seizures, a coma, or central respiratory failure within just 7 to 10 days after birth."
     explanation: Confirms seizures as a neurological manifestation of untreated classic MSUD.
 - name: Hypotonia


### PR DESCRIPTION
## Summary
- Added evidence to all 29 Maple Syrup Urine Disease pathophysiology downstream edges.
- Preserved the existing connected graph structure while making each causal edge evidence-backed.
- Kept scope to kb/disorders/Maple_Syrup_Urine_Disease.yaml; restored unrelated reference-cache churn before commit.

## Validation
- just validate kb/disorders/Maple_Syrup_Urine_Disease.yaml
- just validate-terms kb/disorders/Maple_Syrup_Urine_Disease.yaml
- just validate-references kb/disorders/Maple_Syrup_Urine_Disease.yaml (repo validator reports Total checks: 0)
- normalized snippet audit: checked=116 missing=0 no_cache=0
- graph audit: pathophysiology=8 phenotypes=14 biochemical=7 treatments=9 edges=29; unexplained_phenotypes=0; biochemical_not_downstream=0; edges_without_evidence=0
- git diff --check