### PR TITLE
Augment von Willebrand Disease Type 1 with gene conversion variant information

### DIFF
--- a/kb/disorders/Hereditary_von_Willebrand_Disease.yaml
+++ b/kb/disorders/Hereditary_von_Willebrand_Disease.yaml
@@ -56,6 +56,7 @@ has_subtypes:
     explanation: Gene conversion variants are documented in a rare case of Type 1 VWD with coexisting hemophilia A.
   - reference: PMID:42144917
     supports: SUPPORT
+    evidence_source: COMPUTATIONAL
     snippet: "In-silico analysis showed loss of the Gly1229-Thr1231 hydrogen bond destabilizing the D'D3 domain"
     explanation: Structural modeling demonstrates how gene conversion variants impair VWF domain stability.
 - name: Type 2 von Willebrand Disease

--- a/kb/disorders/Hereditary_von_Willebrand_Disease.yaml
+++ b/kb/disorders/Hereditary_von_Willebrand_Disease.yaml
@@ -41,7 +41,7 @@ prevalence:
       registries and referral centers.
 has_subtypes:
 - name: Type 1 von Willebrand Disease
-  description: Partial quantitative deficiency of von Willebrand factor.
+  description: Partial quantitative deficiency of von Willebrand factor. Genetic heterogeneity includes rare VWF gene conversion variants that can destabilize the D'D3 domain and impair VWF function.
   evidence:
   - reference: PMID:21289515
     reference_title: "von Willebrand disease."
@@ -49,6 +49,15 @@ has_subtypes:
     snippet: "There are three subtypes: types 1 and 3 represent quantitative variants
       and type 2 is a group of four qualitative variants:"
     explanation: The abstract notes type 1 as a quantitative subtype.
+  - reference: PMID:42144917
+    reference_title: "Molecular pathogenesis of coexisting type 1 von Willebrand disease caused by gene conversion and severe hemophilia a with F8 intron 22 inversion in a Chinese patient."
+    supports: SUPPORT
+    snippet: "characterized by VWF gene conversion variants (p.V1229G and p.N1231T)"
+    explanation: Gene conversion variants are documented in a rare case of Type 1 VWD with coexisting hemophilia A.
+  - reference: PMID:42144917
+    supports: SUPPORT
+    snippet: "In-silico analysis showed loss of the Gly1229-Thr1231 hydrogen bond destabilizing the D'D3 domain"
+    explanation: Structural modeling demonstrates how gene conversion variants impair VWF domain stability.
 - name: Type 2 von Willebrand Disease
   description: Qualitative defects of von Willebrand factor with impaired
     function.

--- a/references_cache/PMID_42144917.md
+++ b/references_cache/PMID_42144917.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:42144917"
+title: Molecular pathogenesis of coexisting type 1 von Willebrand disease caused by gene conversion and severe hemophilia a with F8 intron 22 inversion in a Chinese patient.
+authors:
+- Wei Z
+- Ling Y
+- Xu Y
+- Jiang J
+- Lv X
+- Su X
+- Zhou Y
+- He Y
+- Zhang F
+journal: Blood Coagul Fibrinolysis
+year: '2026'
+doi: 10.1097/MBC.0000000000001435
+content_type: abstract_only
+---
+
+# Molecular pathogenesis of coexisting type 1 von Willebrand disease caused by gene conversion and severe hemophilia a with F8 intron 22 inversion in a Chinese patient.
+**Authors:** Wei Z, Ling Y, Xu Y, Jiang J, Lv X, Su X, Zhou Y, He Y, Zhang F
+**Journal:** Blood Coagul Fibrinolysis (2026)
+**DOI:** [10.1097/MBC.0000000000001435](https://doi.org/10.1097/MBC.0000000000001435)
+
+## Content
+
+1. Blood Coagul Fibrinolysis. 2026 May 18. doi: 10.1097/MBC.0000000000001435. 
+Online ahead of print.
+
+Molecular pathogenesis of coexisting type 1 von Willebrand disease caused by 
+gene conversion and severe hemophilia a with F8 intron 22 inversion in a Chinese 
+patient.
+
+Wei Z(1)(2), Ling Y(3), Xu Y(4), Jiang J(1), Lv X(1), Su X(5), Zhou Y(6), He 
+Y(1), Zhang F(1).
+
+Author information:
+(1)Department of Clinical Laboratory, the First Affiliated Hospital of Guangxi 
+Medical University, Key Laboratory of Clinical Laboratory Medicine of Guangxi 
+Department of Education.
+(2)Department of Clinical Laboratory, The Third People's Hospital of Hechi, 
+Hechi, Guangxi, China.
+(3)Department of Pediatrics, The First Affiliated Hospital of Guangxi Medical 
+University, Nanning, Guangxi, China.
+(4)Department of Hematology, The First Affiliated Hospital of Guangxi Medical 
+University, Nanning, Guangxi, China.
+(5)Department of Intensive Care Medicine, Guangxi Medical University Cancer 
+Hospital, Nanning, Guangxi, China.
+(6)School of Medicine, Jiangsu University, Zhenjiang, Jiangsu, China.
+
+To identify and characterize a case of coexisting von Willebrand disease (VWD) 
+and hemophilia A, and elucidate the underlying genetic mutations and molecular 
+mechanisms. Coagulation function, VWF activity (VWF:Act), and VWF antigen 
+(VWF:Ag) were measured using a fully automatic coagulometer. FVIII recovery rate 
+and half-life were assessed with PKSolver, and FVIII inhibitors were detected 
+using the Bethesda assay. VWF multimer analysis was performed to clarify the 
+clinical phenotype. Genetic analysis included next-generation sequencing of the 
+VWF gene and multiplex ligation-dependent probe amplification (MLPA) for F8 gene 
+inversions. Bioinformatics tools (ClustalX-2.1, SWISS-MODEL, PyMOL) were used to 
+analyze mutation conservation and impact on protein structure. Laboratory 
+findings revealed severe hemophilia A (FVIII:C 0.5%) and mild type-1 VWD. FVIII 
+recovery was 67.5% with a 4.9 h half-life, and no inhibitors were detected. 
+Genotyping revealed F8 intron 22 inversion, two VWF gene conversion variants 
+(p.V1229G; p.N1231T) inherited maternally, and a paternal missense variant 
+(p.R2118W). In-silico analysis showed loss of the Gly1229-Thr1231 hydrogen bond 
+destabilizing the D'D3 domain, whereas p.R2118W preserved hydrogen bonding in 
+the D4 domain, supporting mild structural impact. We confirmed a case of severe 
+hemophilia A coexisting with type 1 VWD, characterized by VWF gene conversion 
+variants (p.V1229G and p.N1231T) and a heterozygous missense mutation p.R2118W, 
+along with an intron 22 inversion in the F8 gene. These gene conversion variants 
+are rarely reported in China. These findings provide insights into the molecular 
+pathogenesis of combined VWD and hemophilia A.
+
+Copyright © 2026 Wolters Kluwer Health, Inc. All rights reserved.
+
+DOI: 10.1097/MBC.0000000000001435
+PMID: 42144917


### PR DESCRIPTION
## Summary

Augmented the Type 1 von Willebrand Disease subtype with documented evidence of rare VWF gene conversion variants (p.V1229G, p.N1231T) from a case report.

**Changes:**
- Expanded Type 1 VWD description to mention genetic heterogeneity and rare gene conversion variants
- Added two evidence items from PMID:42144917 documenting:
  1. The specific variants (p.V1229G and p.N1231T) found in a patient case
  2. Structural analysis showing how these variants destabilize the VWF D'D3 domain

**Impact:** Enriches understanding of Type 1 VWD genetic diversity and molecular mechanisms of variant-induced pathophysiology.

**Validation:** ✅ All schema, reference, and term validation checks pass.

Resolves #3062

🤖 Generated with [Claude Code](https://claude.com/claude-code)