### PR TITLE
[codex] Add evidence to Tyrosinemia Type I pathograph edges

### DIFF
--- a/kb/disorders/Tyrosinemia_Type_I.yaml
+++ b/kb/disorders/Tyrosinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Tyrosinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-21T12:50:43Z'
+updated_date: '2026-05-21T13:02:01Z'
 synonyms:
 - Hepatorenal tyrosinemia
 - HT-1
@@ -146,9 +146,9 @@ pathophysiology:
     evidence:
     - reference: PMID:9689118
       supports: SUPPORT
-      evidence_source: MODEL_ORGANISM
+      evidence_source: IN_VITRO
       snippet: the addition of fumarylacetoacetate induced the release of cytochrome c from the mitochondria.
-      explanation: Model and cell-free evidence directly links FAA to mitochondrial cytochrome c release in the apoptosis branch.
+      explanation: Cell-free biochemical evidence directly links FAA to mitochondrial cytochrome c release in the apoptosis branch.
   - target: Succinylacetone inhibition of heme biosynthesis
     causal_link_type: DIRECT
     description: Succinylacetone accumulation perturbs ALAD-linked heme biosynthesis and contributes to porphyria-like crises.
@@ -242,6 +242,11 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Tyrosinemia type I (hepatorenal tyrosinemia, HT-1) is an autosomal recessive condition resulting in hepatic failure
       explanation: Clinical consensus supports hepatic failure as a core HT-1 manifestation, providing the clinical basis for downstream coagulopathy.
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: routine coagulation tests, liver enzymes, and bilirubin concentrations should be measured per age-related recommendations.
+      explanation: GeneReviews surveillance guidance explicitly includes routine coagulation testing in HT-1 liver-disease monitoring.
   - target: Hepatomegaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatic injury and regenerative stress can present with enlarged liver.
@@ -1022,9 +1027,9 @@ biochemical:
     - reference: PMID:9689118
       reference_title: "Hepatocyte injury in tyrosinemia type 1 is induced by fumarylacetoacetate and is inhibited by caspase inhibitors."
       supports: SUPPORT
-      evidence_source: MODEL_ORGANISM
+      evidence_source: IN_VITRO
       snippet: the addition of fumarylacetoacetate induced the release of cytochrome c from the mitochondria.
-      explanation: Model evidence connects FAA directly to mitochondrial cytochrome c release, the initiating event in this apoptosis branch.
+      explanation: Cell-free evidence connects FAA directly to mitochondrial cytochrome c release, the initiating event in this apoptosis branch.
   evidence:
   - reference: PMID:38505790
     reference_title: "Decoding hepatorenal tyrosinemia type 1: Unraveling the impact of early detection, NTBC, and the role of liver transplantation."
@@ -1035,9 +1040,9 @@ biochemical:
   - reference: PMID:9689118
     reference_title: "Hepatocyte injury in tyrosinemia type 1 is induced by fumarylacetoacetate and is inhibited by caspase inhibitors."
     supports: SUPPORT
-    evidence_source: MODEL_ORGANISM
+    evidence_source: IN_VITRO
     snippet: the addition of fumarylacetoacetate induced the release of cytochrome c from the mitochondria.
-    explanation: Demonstrates direct toxicity of FAA at the mitochondrial level.
+    explanation: Demonstrates direct cell-free toxicity of FAA at the mitochondrial level.
 genetic:
 - name: FAH deficiency
   gene_term:
@@ -1084,6 +1089,25 @@ genetic:
     evidence_source: OTHER
     snippet: "FAH | HGNC:3579 | tyrosinemia type I | MONDO:0010161 | AR | Definitive"
     explanation: ClinGen classifies the FAH-tyrosinemia type I gene-disease relationship as definitive with autosomal recessive inheritance.
+environmental:
+- name: Catabolic and dietary stress
+  notes: >
+    Excess dietary protein, protein malnutrition, prolonged fasting,
+    intercurrent catabolic illness, and inadequate calories during procedures or
+    other stressors should be avoided because they can worsen metabolic
+    instability.
+  evidence:
+  - reference: PMID:20301688
+    reference_title: "Tyrosinemia Type I."
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: >-
+      Agents/circumstances to avoid: Excessive dietary protein or protein
+      malnutrition inducing catabolic state; prolonged fasting; catabolic illness
+      (intercurrent infection, brief febrile illness post vaccination);
+      inadequate caloric provision during other stressors, especially when
+      fasting is involved (surgery or procedure requiring fasting/anesthesia).
+    explanation: GeneReviews directly lists dietary and catabolic circumstances to avoid in HT-1.
 treatments:
 - name: Nitisinone (NTBC) therapy
   description: 'Nitisinone (2-[2-nitro-4-trifluoromethylbenzoyl]-1,3-cyclohexanedione) is a potent inhibitor of 4-hydroxyphenylpyruvate dioxygenase (HPD), the second enzyme in tyrosine degradation. By blocking HPD, NTBC prevents formation of the toxic downstream metabolites FAA, MAA, and SA. Early initiation of NTBC, ideally before symptom onset via NBS identification, provides greater than 90% survival and dramatically reduces the need for liver transplantation.

--- a/kb/disorders/Tyrosinemia_Type_I.yaml
+++ b/kb/disorders/Tyrosinemia_Type_I.yaml
@@ -1,7 +1,7 @@
 name: Tyrosinemia Type I
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-20T07:19:09Z'
+updated_date: '2026-05-21T12:50:43Z'
 synonyms:
 - Hepatorenal tyrosinemia
 - HT-1
@@ -64,11 +64,23 @@ pathophysiology:
   - target: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
     causal_link_type: DIRECT
     description: FAH block causes upstream toxic tyrosine-pathway metabolites to accumulate.
+    evidence:
+    - reference: PMID:38505790
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This leads to the accumulation of toxic metabolites such as fumaryl and maleylacetoacetate, which can damage the liver, kidneys, and nervous system.
+      explanation: Clinical review evidence directly links FAH deficiency to toxic fumaryl and maleylacetoacetate accumulation.
   - target: Tyrosine
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Impaired terminal tyrosine catabolism and nitisinone treatment both increase tyrosine-pathway substrate burden.
     description: Defective tyrosine catabolism contributes to elevated tyrosine, particularly during HPD inhibition with nitisinone.
+    evidence:
+    - reference: PMID:28771246
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Newborn screening (NBS) utilizing blood succinylacetone as the NBS marker is superior to observing tyrosine levels as a way of identifying neonates with HT-1.
+      explanation: Consensus review supports tyrosine as a measurable but less-specific biochemical signal in HT-1.
 - name: Toxic fumarylacetoacetate and maleylacetoacetate accumulation
   description: 'FAH deficiency causes accumulation of fumarylacetoacetate (FAA) and maleylacetoacetate (MAA), with secondary formation of succinylacetone (SA). These toxic tyrosine-pathway metabolites damage the liver, kidneys, and nervous system, and FAA directly triggers mitochondrial cytochrome c release in hepatocytes.
 
@@ -111,30 +123,72 @@ pathophysiology:
   - target: Fumarylacetoacetate (FAA)
     causal_link_type: DIRECT
     description: FAH deficiency directly increases the toxic substrate fumarylacetoacetate.
+    evidence:
+    - reference: PMID:38505790
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This leads to the accumulation of toxic metabolites such as fumaryl and maleylacetoacetate, which can damage the liver, kidneys, and nervous system.
+      explanation: Clinical review evidence supports fumaryl/fumarylacetoacetate-pathway metabolite accumulation downstream of FAH deficiency.
   - target: Succinylacetone (SA)
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Accumulated fumarylacetoacetate and maleylacetoacetate generate succinylacetone through alternative routes.
     description: Toxic tyrosine intermediates produce the pathognomonic metabolite succinylacetone.
+    evidence:
+    - reference: PMID:38132825
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Elevated succinylacetone (SA) is pathognomonic for TT1 and therefore often used as marker for TT1 newborn screening (NBS).
+      explanation: Human screening evidence supports succinylacetone as the pathognomonic toxic-metabolite readout of TT1.
   - target: FAA-induced mitochondrial apoptosis in hepatocytes
     causal_link_type: DIRECT
     description: FAA reactivity drives mitochondrial injury and caspase-mediated hepatocyte apoptosis.
+    evidence:
+    - reference: PMID:9689118
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: the addition of fumarylacetoacetate induced the release of cytochrome c from the mitochondria.
+      explanation: Model and cell-free evidence directly links FAA to mitochondrial cytochrome c release in the apoptosis branch.
   - target: Succinylacetone inhibition of heme biosynthesis
     causal_link_type: DIRECT
     description: Succinylacetone accumulation perturbs ALAD-linked heme biosynthesis and contributes to porphyria-like crises.
+    evidence:
+    - reference: PMID:6826727
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Our data indicate that succinylacetone is an extremely potent competitive inhibitor of ALA dehydratase in human as well as in animal tissues.
+      explanation: Biochemical evidence directly supports succinylacetone as the ALAD inhibitor linking toxic metabolite accumulation to heme-biosynthesis disruption.
   - target: Renal proximal tubule toxic injury
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Toxic tyrosine-pathway metabolites damage renal tissue as well as liver.
     description: Tyrosine-pathway metabolite toxicity causes renal tubular injury and Fanconi-like tubulopathy.
+    evidence:
+    - reference: PMID:38505790
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This leads to the accumulation of toxic metabolites such as fumaryl and maleylacetoacetate, which can damage the liver, kidneys, and nervous system.
+      explanation: Clinical review evidence directly links toxic tyrosine metabolites to kidney damage.
   - target: Neurocognitive impairment
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Toxic metabolite effects on the nervous system and long-term treatment factors contribute to neurocognitive risk.
+    evidence:
+    - reference: PMID:38505790
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: They are also at risk of long-term neurocognitive impairment, which highlights the need for neurocognitive assessment and therapy.
+      explanation: Clinical review evidence supports long-term neurocognitive impairment as an HT-1 risk.
   - target: Persistent hepatocarcinogenic programs under NTBC therapy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Residual FAH deficiency leaves hepatic stress and regenerative programs despite upstream HPD blockade.
     description: Residual FAH deficiency leaves chronic pro-oncogenic hepatic stress despite upstream metabolic blockade by NTBC.
+    evidence:
+    - reference: PMID:36980965
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: NTBC does not restore the enzymatic defects inflicted by the disease nor does it cure HT1.
+      explanation: Continuous-NTBC model evidence supports residual FAH-defect biology despite upstream pharmacologic blockade.
 - name: FAA-induced mitochondrial apoptosis in hepatocytes
   description: 'Fumarylacetoacetate directly triggers mitochondrial outer membrane permeabilization with release of cytochrome c, activating the caspase cascade and inducing hepatocyte apoptosis. Caspase inhibitors were shown to prevent liver failure in FAH-deficient mouse models, confirming the causal role of the intrinsic apoptotic pathway.
 
@@ -171,14 +225,32 @@ pathophysiology:
   - target: Acute liver failure
     causal_link_type: DIRECT
     description: Caspase-mediated hepatocyte death causes acute hepatic failure in severe or untreated HT-1.
+    evidence:
+    - reference: PMID:9689118
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: We also found that caspase inhibitors were highly effective in preventing the liver failure induced by HGA in the double-mutant mice.
+      explanation: Mouse-model evidence supports caspase-mediated hepatocyte injury as causal for liver failure.
   - target: Coagulopathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hepatocyte apoptosis causes hepatic synthetic failure.
     description: Acute hepatic failure impairs coagulation factor synthesis.
+    evidence:
+    - reference: PMID:28771246
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Tyrosinemia type I (hepatorenal tyrosinemia, HT-1) is an autosomal recessive condition resulting in hepatic failure
+      explanation: Clinical consensus supports hepatic failure as a core HT-1 manifestation, providing the clinical basis for downstream coagulopathy.
   - target: Hepatomegaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatic injury and regenerative stress can present with enlarged liver.
+    evidence:
+    - reference: PMID:39050308
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We present a case of HT-1 in a three-year-old female child characterized by abdominal distension, facial edema, lower limb edema, and an enlarged liver with parenchymal disease.
+      explanation: Human case evidence documents enlarged liver with parenchymal disease in late-presenting HT-1.
 - name: Renal proximal tubule toxic injury
   description: 'Accumulated tyrosine-pathway metabolites injure kidney tissue, especially the proximal tubule, causing a Fanconi-like renal phenotype with phosphate wasting. This renal tubular mechanism explains renal tubular dysfunction and secondary hypophosphatemic rickets in HT-1.
 
@@ -209,11 +281,23 @@ pathophysiology:
   - target: Renal tubular dysfunction
     causal_link_type: DIRECT
     description: Toxic injury to proximal tubule epithelium produces Fanconi-like renal tubular dysfunction.
+    evidence:
+    - reference: PMID:28771246
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Tyrosinemia type I (hepatorenal tyrosinemia, HT-1) is an autosomal recessive condition resulting in hepatic failure with comorbidities involving the renal and neurologic systems
+      explanation: Clinical consensus directly supports renal-system involvement in HT-1.
   - target: Rickets
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Proximal tubular phosphate wasting causes hypophosphatemic rickets.
     description: Renal Fanconi syndrome causes phosphate wasting and secondary rickets.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
+      explanation: GeneReviews directly links renal tubular dysfunction with growth failure and rickets in untreated HT-1.
 - name: Chronic hepatic injury and regeneration
   description: 'Untreated or late-treated HT-1 produces chronic hepatic injury with regeneration, fibrosis, cirrhosis, and malignant transformation risk. Continuous NTBC reduces acute toxicity but does not restore FAH activity, so residual liver-disease and HCC-associated programs can persist.
 
@@ -250,24 +334,54 @@ pathophysiology:
   - target: Hepatic fibrosis
     causal_link_type: DIRECT
     description: Chronic hepatic injury in untreated HT-1 produces fibrosis.
+    evidence:
+    - reference: PMID:38132825
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Undiagnosed and untreated tyrosinemia type 1 (TT1) individuals carry a significant risk for developing liver fibrosis, cirrhosis and hepatocellular carcinoma (HCC).
+      explanation: Human evidence directly supports liver fibrosis as a risk of untreated TT1.
   - target: Hepatic cirrhosis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Progressive fibrosis remodels hepatic architecture.
     description: Chronic hepatic injury and fibrosis can progress to cirrhosis.
+    evidence:
+    - reference: PMID:38132825
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Undiagnosed and untreated tyrosinemia type 1 (TT1) individuals carry a significant risk for developing liver fibrosis, cirrhosis and hepatocellular carcinoma (HCC).
+      explanation: Human evidence supports cirrhosis as part of the chronic untreated TT1 liver-disease spectrum.
   - target: Hepatocellular carcinoma
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Chronic hepatocyte injury and regeneration create pro-oncogenic stress.
     description: Chronic liver injury and regeneration increase HCC risk.
+    evidence:
+    - reference: PMID:38132825
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Undiagnosed and untreated tyrosinemia type 1 (TT1) individuals carry a significant risk for developing liver fibrosis, cirrhosis and hepatocellular carcinoma (HCC).
+      explanation: Human evidence supports HCC as a complication of the chronic untreated TT1 hepatic-injury branch.
   - target: Failure to thrive
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Chronic liver disease and metabolic instability impair growth.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
+      explanation: GeneReviews supports growth failure in the context of liver and renal tubular dysfunction in untreated HT-1.
   - target: Edema
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Liver synthetic dysfunction and portal-hypertensive physiology can cause fluid retention.
     description: Advanced hepatic disease can cause peripheral edema or ascites.
+    evidence:
+    - reference: PMID:39050308
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We present a case of HT-1 in a three-year-old female child characterized by abdominal distension, facial edema, lower limb edema, and an enlarged liver with parenchymal disease.
+      explanation: Human case evidence documents edema in a patient with HT-1 liver disease.
 - name: Succinylacetone inhibition of heme biosynthesis
   description: 'Succinylacetone (SA) is a competitive inhibitor of delta-aminolevulinic acid dehydratase (ALAD), blocking the heme biosynthetic pathway and causing accumulation of delta-aminolevulinic acid (ALA). This produces porphyria-like neurovisceral crises with neuropathy, similar to acute intermittent porphyria or lead poisoning.
 
@@ -327,26 +441,56 @@ pathophysiology:
   - target: Delta-aminolevulinic acid (ALA)
     causal_link_type: DIRECT
     description: ALAD inhibition increases ALA accumulation.
+    evidence:
+    - reference: PMID:6826727
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: patients with this hereditary disease excrete excessive amounts of delta-aminolevulinic acid (ALA) in urine
+      explanation: Human biochemical evidence supports ALA accumulation downstream of succinylacetone-mediated ALAD inhibition.
   - target: Peripheral neuropathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - ALA accumulation produces porphyria-like neurovisceral crises.
     description: Porphyria-like crises in HT-1 can include peripheral neuropathy.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+      explanation: GeneReviews directly lists peripheral neuropathy during HT-1 neurologic crises.
   - target: Abdominal pain
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - ALA accumulation produces porphyria-like neurovisceral crises.
     description: Porphyria-like neurologic crises in HT-1 can include abdominal pain.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+      explanation: GeneReviews directly lists abdominal pain during HT-1 neurologic crises.
   - target: Encephalopathy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - ALA accumulation produces porphyria-like neurovisceral crises.
     description: Porphyria-like neurologic crises in HT-1 can include altered mental status.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+      explanation: GeneReviews directly lists change in mental status during HT-1 neurologic crises.
   - target: Respiratory failure
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - ALA accumulation produces porphyria-like neurovisceral crises.
     description: Severe neurologic crises in HT-1 can include respiratory failure.
+    evidence:
+    - reference: PMID:20301688
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
+      explanation: GeneReviews directly lists respiratory failure during HT-1 neurologic crises.
 - name: Persistent hepatocarcinogenic programs under NTBC therapy
   description: 'Although nitisinone prevents acute toxicity by blocking upstream toxic metabolite formation, it does not restore FAH activity. Transcriptomic analysis in FAH-deficient mice under continuous NTBC revealed persistent enrichment of genes related to liver disease, liver regeneration, and hepatocellular carcinoma. This supports the ongoing HCC risk even in treated patients.
 
@@ -380,16 +524,34 @@ pathophysiology:
     intermediate_mechanisms:
     - Persistent liver-disease and HCC-associated transcriptional programs remain under NTBC.
     description: Residual hepatic disease programs under NTBC support sustained HCC risk.
+    evidence:
+    - reference: PMID:36980965
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: The differentially expressed genes were enriched in toxicological gene classes related to liver disease, liver damage, liver regeneration and liver cancer, in particular HCC.
+      explanation: Continuous-NTBC mouse transcriptomics supports persistent HCC-related liver-disease programs.
   - target: Alpha-fetoprotein (AFP)
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - AFP is used as a marker of hepatic disease activity and HCC surveillance.
     description: Persistent HCC risk motivates AFP surveillance in HT-1.
+    evidence:
+    - reference: PMID:17008115
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: A rise of alpha-fetoprotein (AFP) is an indicator of liver cancer.
+      explanation: Patient AFP data support AFP as a surveillance readout tied to liver cancer risk in HT-1.
   - target: Elevated alpha-fetoprotein
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hepatic injury and HCC risk drive AFP monitoring.
     description: AFP elevation is tracked as a marker of disease activity and malignant transformation risk.
+    evidence:
+    - reference: PMID:17008115
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Apart from a rise of AFP, a slow AFP decrease, and never normalizing levels of AFP are important predictors of liver cancer development in further life.
+      explanation: Human AFP trajectory data support elevated or non-normalizing AFP as a biomarker of HT-1 liver cancer risk.
 phenotypes:
 - name: Acute liver failure
   description: 'Acute hepatic decompensation is a hallmark of untreated or severe HT-1, driven by FAA-mediated oxidative damage and caspase-dependent apoptosis of hepatocytes. In untreated acute-form HT-1, liver failure typically presents in the first months of life.
@@ -502,7 +664,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
     explanation: GeneReviews directly lists rickets in association with renal tubular dysfunction in untreated HT-1.
 - name: Peripheral neuropathy
@@ -518,7 +680,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
     explanation: GeneReviews directly lists peripheral neuropathy during HT-1 neurologic crises.
   - reference: PMID:28771246
@@ -540,7 +702,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
     explanation: GeneReviews directly lists abdominal pain during HT-1 neurologic crises.
 - name: Encephalopathy
@@ -556,7 +718,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
     explanation: GeneReviews directly lists change in mental status during HT-1 neurologic crises.
 - name: Respiratory failure
@@ -572,7 +734,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: neurologic crises lasting one to seven days that can include change in mental status, abdominal pain, peripheral neuropathy, and/or respiratory failure
     explanation: GeneReviews directly lists respiratory failure during HT-1 neurologic crises.
 - name: Neurocognitive impairment
@@ -604,7 +766,7 @@ phenotypes:
   - reference: PMID:20301688
     reference_title: "Tyrosinemia Type I."
     supports: SUPPORT
-    evidence_source: HUMAN_CLINICAL
+    evidence_source: OTHER
     snippet: liver dysfunction and renal tubular dysfunction associated with growth failure and rickets.
     explanation: GeneReviews directly supports growth failure in untreated HT-1.
   - reference: PMID:39050308


### PR DESCRIPTION
## Summary
- Added evidence to all 27 Tyrosinemia Type I pathophysiology downstream edges.
- Preserved the existing graph structure while making each causal edge evidence-backed.
- Normalized GeneReviews PMID:20301688 evidence_source entries to OTHER for consistency with review-source handling.
- Kept scope to kb/disorders/Tyrosinemia_Type_I.yaml; restored unrelated reference-cache churn before commit.

## Validation
- just validate kb/disorders/Tyrosinemia_Type_I.yaml
- just validate-terms kb/disorders/Tyrosinemia_Type_I.yaml
- just validate-references kb/disorders/Tyrosinemia_Type_I.yaml (repo validator reports Total checks: 0)
- normalized snippet audit: checked=94 missing=0 no_cache=0
- graph audit: pathophysiology=7 phenotypes=16 biochemical=5 treatments=7 edges=27; unexplained_phenotypes=0; biochemical_not_downstream=0; edges_without_evidence=0
- git diff --check