### PR TITLE
Backfill reference_title on Chordoma evidence items (#1119)

### DIFF
--- a/kb/disorders/Chordoma.yaml
+++ b/kb/disorders/Chordoma.yaml
@@ -1,6 +1,6 @@
 name: Chordoma
 creation_date: '2026-04-12T05:10:25Z'
-updated_date: '2026-05-18T00:00:00Z'
+updated_date: '2026-05-21T00:00:00Z'
 category: Cancer
 description: >-
   Chordoma is a rare malignant bone tumor arising from embryonic remnants of the
@@ -52,11 +52,13 @@ pathophysiology:
       label: cell differentiation
   evidence:
   - reference: PMID:16538613
+    reference_title: "Brachyury, a crucial regulator of notochordal development, is a novel biomarker for chordomas."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "These data provide compelling evidence that chordomas derive from notochord and demonstrate that brachyury is a specific marker for the notochord and notochord-derived tumours."
     explanation: Human tumor profiling supports a notochord-derived tumor lineage marked by brachyury expression.
   - reference: PMID:30664779
+    reference_title: Small-molecule targeting of brachyury transcription factor addiction in chordoma.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "These systematic approaches reveal that the developmental transcription factor T (brachyury; TBXT) is the top selectively essential gene in chordoma"
@@ -84,11 +86,13 @@ pathophysiology:
     description: RTK-driven survival signaling supports continued invasive local growth.
   evidence:
   - reference: PMID:31221659
+    reference_title: "Active receptor tyrosine kinases, but not Brachyury, are sufficient to trigger chordoma in zebrafish."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
     snippet: "In contrast, the chordoma-implicated receptor tyrosine kinases (RTKs) EGFR and Kdr/VEGFR2 are sufficient to transform notochord cells."
     explanation: The zebrafish model shows that activated RTK signaling can initiate notochordal transformation.
   - reference: PMID:25323095
+    reference_title: "Immunohistochemical expression of receptor tyrosine kinase PDGFR-α, c-Met, and EGFR in skull base chordoma."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Platelet-derived growth factor receptor-α (PDGFR-α), epidermal growth factor receptor (EGFR), c-Met, and CD-34 were detected in 100, 92, 100, and 59% of cases, respectively."
@@ -107,6 +111,7 @@ pathophysiology:
       label: phosphatidylinositol 3-kinase/protein kinase B signal transduction
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "In addition, we find potentially clinically actionable PI3K signalling mutations in 16% of cases."
@@ -132,11 +137,13 @@ pathophysiology:
       label: regulation of cell cycle
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Collectively, these studies have identified recurrent loss of CDKN2A as a key driver in chordoma development."
     explanation: Genomic surveys of sporadic chordoma identify CDKN2A loss as a recurrent driver event in chordoma development.
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Known somatic changes of chordoma, such as homozygous deletion of CDKN2A"
@@ -159,11 +166,13 @@ pathophysiology:
     description: Chromatin dysregulation helps stabilize TBXT-dependent tumor identity.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Drivers in another SWI/SNF gene, PBRM1 (10/104 cases) and the histone methyltransferase, SETD2 (5/104) implicate defective chromatin modelling as a major driver of chordoma."
     explanation: Tumor sequencing identifies chromatin regulator defects as a separate recurrent driver class in chordoma.
   - reference: PMID:32855205
+    reference_title: Inhibition of Histone H3K27 Demethylases Inactivates Brachyury (TBXT) and Promotes Chordoma Cell Death.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "Pharmacologic inhibition of H3K27-demethylases in human chordoma cells promotes epigenetic silencing of oncogenic TBXT, alters gene networks critical to survival, and represents a potential novel therapy."
@@ -195,6 +204,7 @@ pathophysiology:
       chordoma cell migration and local invasiveness.
   evidence:
   - reference: PMID:36804377
+    reference_title: Transcriptional Profiling Supports the Notochordal Origin of Chordoma and Its Dependence on a TGFB1-TBXT Network.
     supports: SUPPORT
     evidence_source: COMPUTATIONAL
     snippet: "the TBXT/transforming growth factor beta (TGF-β)/SOX6/SOX9 pathway was hyperactivated in the tumor, suggesting that pathways associated with chondrogenesis were a central driver of chordoma development"
@@ -202,6 +212,7 @@ pathophysiology:
       Gene expression profiling of chordoma vs. notochord identifies the
       TGFβ-TBXT pathway as a core hyperactivated signaling axis in chordoma.
   - reference: PMID:36804377
+    reference_title: Transcriptional Profiling Supports the Notochordal Origin of Chordoma and Its Dependence on a TGFB1-TBXT Network.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "Experimental validation in chordoma cells confirmed these findings and emphasized the dependence of chordoma proliferation and survival on TGF-β."
@@ -236,6 +247,7 @@ pathophysiology:
       contributes to the destructive, recurrence-prone growth of chordoma.
   evidence:
   - reference: PMID:36127333
+    reference_title: Single-cell transcriptome reveals cellular hierarchies and guides p-EMT-targeted trial in skull base chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "signatures related to partial epithelial-mesenchymal transition (p-EMT) were found to be significant in malignant cells and were related to the invasion and poor prognosis of SBC"
@@ -244,6 +256,7 @@ pathophysiology:
       tumors identifies a partial-EMT signature in malignant cells that is
       associated with invasion and poor prognosis.
   - reference: PMID:36127333
+    reference_title: Single-cell transcriptome reveals cellular hierarchies and guides p-EMT-targeted trial in skull base chordoma.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "YL-13027, a p-EMT inhibitor that acts through the TGF-β signaling pathway, demonstrated remarkable potency in inhibiting the invasiveness of SBC in preclinical models"
@@ -252,6 +265,7 @@ pathophysiology:
       preclinical models, confirming that the EMT program is engaged
       downstream of TGF-β signaling and is therapeutically targetable.
   - reference: PMID:29880900
+    reference_title: "miR-16-5p inhibits chordoma cell proliferation, invasion and metastasis by targeting Smad3."
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "overexpression of miR-16-5p significantly upregulated the expression of E-cadherin and downregulated the expression of N-cadherin and vimentin at both the mRNA and protein levels in U-CH1 and U-CH2 cells"
@@ -260,6 +274,7 @@ pathophysiology:
       the EMT marker switch (E-cadherin gain, N-cadherin and vimentin loss),
       supporting EMT as a driver of chordoma invasiveness in vitro.
   - reference: PMID:29880900
+    reference_title: "miR-16-5p inhibits chordoma cell proliferation, invasion and metastasis by targeting Smad3."
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
     snippet: "we constructed a xenograft model of human chordoma cells in nude mice, which are rarely used in chordoma research, and found that overexpression of miR-16-5p can suppress tumor growth in vivo"
@@ -287,6 +302,7 @@ pathophysiology:
       label: bone tissue
   evidence:
   - reference: PMID:38652222
+    reference_title: Chordoma cells possess bone-dissolving activity at the bone invasion front.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "In chordoma, we propose that in addition to conventional bone resorption by osteoclasts, chordoma cells possess bone-dissolving activity at the tumor-bone boundary."
@@ -304,6 +320,7 @@ phenotypes:
       label: Back pain
   evidence:
   - reference: PMID:36063190
+    reference_title: Imaging of spinal chordoma and benign notochordal cell tumor (BNCT) with radiologic pathologic correlation.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Clinical symptoms, while nonspecific and location dependent, include back pain, numbness, myelopathy, and bowel/bladder incontinence."
@@ -320,6 +337,7 @@ phenotypes:
       label: Myelopathy
   evidence:
   - reference: PMID:36063190
+    reference_title: Imaging of spinal chordoma and benign notochordal cell tumor (BNCT) with radiologic pathologic correlation.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Clinical symptoms, while nonspecific and location dependent, include back pain, numbness, myelopathy, and bowel/bladder incontinence."
@@ -336,6 +354,7 @@ phenotypes:
       label: Urinary incontinence
   evidence:
   - reference: PMID:29423299
+    reference_title: "Managing bowel and bladder impairments in sacral chordoma patients: a case-based approach."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Because of their location, chordomas can affect bowel and bladder continence resulting in either an upper or a lower motor neuron functional pattern."
@@ -352,6 +371,7 @@ phenotypes:
       label: Bowel incontinence
   evidence:
   - reference: PMID:29423299
+    reference_title: "Managing bowel and bladder impairments in sacral chordoma patients: a case-based approach."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Because of their location, chordomas can affect bowel and bladder continence resulting in either an upper or a lower motor neuron functional pattern."
@@ -368,6 +388,7 @@ phenotypes:
       label: Headache
   evidence:
   - reference: PMID:28059654
+    reference_title: "Clinical features and surgical outcomes of patients with skull base chordoma: a retrospective analysis of 238 patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Headache and neck pain (33.2%) and diplopia (29%) were the most common initial symptoms."
@@ -384,6 +405,7 @@ phenotypes:
       label: Diplopia
   evidence:
   - reference: PMID:28059654
+    reference_title: "Clinical features and surgical outcomes of patients with skull base chordoma: a retrospective analysis of 238 patients."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Headache and neck pain (33.2%) and diplopia (29%) were the most common initial symptoms."
@@ -395,6 +417,7 @@ biochemical:
     distinguish chordoma from most histologic mimics.
   evidence:
   - reference: PMID:26099010
+    reference_title: "Nuclear Brachyury Expression Is Consistent in Chordoma, Common in Germ Cell Tumors and Small Cell Carcinomas, and Rare in Other Carcinomas and Sarcomas: An Immunohistochemical Study of 5229 Cases."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "With these reservations, we have demonstrated the presence of nuclear brachyury immunoreactivity to be a sensitive and fairly specific marker for chordoma."
@@ -415,16 +438,19 @@ genetic:
     somatic TBXT duplication or gain that recapitulates the same architecture.
   evidence:
   - reference: PMID:19801981
+    reference_title: T (brachyury) gene duplication confers major susceptibility to familial chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "We provide here evidence that duplications of the T gene confer major susceptibility to familial chordoma."
     explanation: Linkage and array-CGH analysis across multiplex chordoma families establish germline TBXT (T) duplication as a major familial chordoma susceptibility allele.
   - reference: PMID:19801981
+    reference_title: T (brachyury) gene duplication confers major susceptibility to familial chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "we identified unique duplications of a region on 6q27 in four multiplex families with at least three cases of chordoma"
     explanation: The same study localizes the germline duplication to the 6q27 TBXT locus across four chordoma kindreds.
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "We reveal somatic duplications of the notochordal transcription factor brachyury (T) in up to 27% of cases."
@@ -441,6 +467,7 @@ genetic:
     and support therapeutic exploration of PI3K-AKT-mTOR pathway inhibition.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "These included activating mutations in PIK3CA (n = 9) and truncating variants in PIK3R1 (n = 1) and PTEN (n = 7)."
@@ -457,6 +484,7 @@ genetic:
     therapeutically relevant PI3K-signaling subset identified in chordoma.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "These included activating mutations in PIK3CA (n = 9) and truncating variants in PIK3R1 (n = 1) and PTEN (n = 7)."
@@ -473,6 +501,7 @@ genetic:
     chordomas and supports pathway-directed therapeutic approaches.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "These included activating mutations in PIK3CA (n = 9) and truncating variants in PIK3R1 (n = 1) and PTEN (n = 7)."
@@ -491,11 +520,13 @@ genetic:
     for CDK4/6 inhibitor strategies in CDKN2A-deficient chordoma.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Collectively, these studies have identified recurrent loss of CDKN2A as a key driver in chordoma development."
     explanation: Multiple genomic surveys of sporadic chordoma identify CDKN2A loss as a recurrent driver event.
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Known somatic changes of chordoma, such as homozygous deletion of CDKN2A"
@@ -512,6 +543,7 @@ genetic:
     chordoma and implicates SWI/SNF-complex dysfunction in disease biology.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Drivers in another SWI/SNF gene, PBRM1 (10/104 cases) and the histone methyltransferase, SETD2 (5/104) implicate defective chromatin modelling as a major driver of chordoma."
@@ -528,6 +560,7 @@ genetic:
     pattern seen in sporadic chordoma.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Drivers in another SWI/SNF gene, PBRM1 (10/104 cases) and the histone methyltransferase, SETD2 (5/104) implicate defective chromatin modelling as a major driver of chordoma."
@@ -544,6 +577,7 @@ genetic:
     sporadic chordomas.
   evidence:
   - reference: PMID:29026114
+    reference_title: The driver landscape of sporadic chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "We identified driver events in further cancer genes not previously implicated in chordoma including recurrent mutation of the SWI/SNF complex sub-unit gene ARID1A (4/104 cases)."
@@ -560,6 +594,7 @@ genetic:
     an aggressive molecular subtype distinct from conventional chordoma.
   evidence:
   - reference: PMID:32631481
+    reference_title: Poorly differentiated SMARCB1/INI1-negative chordomas.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Poorly differentiated SMARCB1/INI1-negative chordoma is a unique subset of chordoma representing a clinically, histopathologically, and molecularly distinct entity with rapid progression and poor prognosis which should not be confused with conventional chordomas."
@@ -577,6 +612,7 @@ treatments:
       label: surgical procedure
   evidence:
   - reference: PMID:24774721
+    reference_title: Randomized phase II trial of hypofractionated proton versus carbon ion radiation therapy in patients with sacrococcygeal chordoma-the ISAC trial protocol.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Surgical resection is still the standard treatment."
@@ -592,6 +628,7 @@ treatments:
       label: radiation therapy
   evidence:
   - reference: PMID:36813169
+    reference_title: Clinical outcomes and toxicities of 100 patients treated with proton therapy for chordoma on the proton collaborative group prospective registry.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "2/3-year LC, PFS, and OS rates are 97%/94%, 89%/74%, and 89%/83%, respectively."
@@ -613,6 +650,7 @@ treatments:
         label: imatinib
   evidence:
   - reference: PMID:22331945
+    reference_title: Phase II study of imatinib in advanced chordoma.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "There were 35 patients with stable disease (SD, 70%) and a 64% clinical benefit rate (ie, RECIST complete response + PR + SD ≥ 6 months)."
@@ -633,6 +671,7 @@ treatments:
         label: afatinib
   evidence:
   - reference: PMID:29237806
+    reference_title: Afatinib Is a New Therapeutic Approach in Chordoma with a Unique Ability to Target EGFR and Brachyury.
     supports: SUPPORT
     evidence_source: IN_VITRO
     snippet: "Afatinib was the only EGFR inhibitor with activity across the chordoma panel."
@@ -658,6 +697,7 @@ treatments:
         label: palbociclib
   evidence:
   - reference: PMID:40627883
+    reference_title: "CDK4/6 inhibition in advanced chordoma: final results of the NCT PMO-1601 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "After a median follow-up of 28 months, the DCR was 39%, with 11 patients achieving stable diseases."
@@ -665,6 +705,7 @@ treatments:
       Phase II trial (NCT PMO-1601) of palbociclib in p16/CDKN2A-deficient
       advanced chordoma demonstrates clinically meaningful disease control.
   - reference: PMID:40627883
+    reference_title: "CDK4/6 inhibition in advanced chordoma: final results of the NCT PMO-1601 trial."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: "Although antitumor activity was modest, the trial met its primary endpoint."
@@ -688,6 +729,7 @@ clinical_trials:
       label: Chordoma
   evidence:
   - reference: clinicaltrials:NCT01811394
+    reference_title: Hypofractionated Ion Irradiation (Protons or Carbon Ions) of Sacrococcygeal Chordoma
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
     snippet: >-


### PR DESCRIPTION
## Summary

Adds the recommended `reference_title` field to **all 42 evidence items** in `kb/disorders/Chordoma.yaml`. Each title is sourced verbatim from the matching committed `references_cache/` entry (no PubMed re-fetch, no hand-written titles).

This closes the single largest compliance gap on the Chordoma entry:

| Metric | Before | After |
|--------|--------|-------|
| Global compliance | 58.1% (72/124) | **91.9% (114/124)** |
| Weighted compliance | 57.5% | **92.5%** |

`reference_title` coverage is now 100% across pathophysiology (16/16), genetic (12/12), phenotypes (6/6), treatments (6/6), biochemical (1/1), and clinical_trials (1/1) evidence.

## Context

Issue #1119 ("Add dismech entry: Chordoma") has long been satisfied — `Chordoma.yaml` exists and has received multiple enrichment PRs. However a compliance scan showed it was the clear outlier among the cancer-batch entries (58% vs. 82–88% for its siblings), almost entirely because every evidence item lacked `reference_title`. This is a bounded, deterministic fix.

## What was intentionally NOT changed

- **Remaining compliance gaps** (now ~10 checks): `datasets` block, `has_subtypes[].evidence` (4 subtypes), and `pathophysiology[].downstream[].evidence` (5 causal edges). These require sourcing **new** verified citations with exact-quote snippets, which is higher-risk work best done as a separate, deliberately-curated follow-up rather than bundled into a mechanical backfill.
- Incidental `references_cache/*.md` quoting normalizations emitted by the validator tooling were reverted so this PR touches only `Chordoma.yaml`.

## Validation

All run against the modified file from the worktree:

- `just validate kb/disorders/Chordoma.yaml` — schema + terms + references: **passed**
- `just validate-terms kb/disorders/Chordoma.yaml` — **Validation passed**
- `just validate-references kb/disorders/Chordoma.yaml` — **All validations passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)