### PR TITLE
Connect PKU biochemical readouts

### DIFF
--- a/kb/disorders/Phenylketonuria.yaml
+++ b/kb/disorders/Phenylketonuria.yaml
@@ -1,6 +1,6 @@
 name: Phenylketonuria
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-05-19T01:05:00Z'
+updated_date: '2026-05-21T13:15:04Z'
 category: Genetic
 parents:
 - Metabolic Disease
@@ -401,6 +401,26 @@ pathophysiology:
     snippet: "Phenylketonuria (PKU) is caused by mutations in the phenylalanine hydroxylase gene (PAH) with consequent elevation of blood phenylalanine (Phe), reduction in tyrosine (Tyr) and elevation of Phe/Tyr ratio (P/T)."
     explanation: Independent clinical study confirms elevated blood phenylalanine in PKU.
   downstream:
+  - target: Blood Phenylalanine
+    description: Elevated blood phenylalanine is the direct biochemical readout of impaired PAH-dependent phenylalanine clearance.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24385074
+      reference_title: "Phenylalanine hydroxylase deficiency: diagnosis and management guideline."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Phenylalanine hydroxylase deficiency, traditionally known as phenylketonuria, results in the accumulation of phenylalanine in the blood of affected individuals and was the first inborn error of metabolism to be identified through population screening."
+      explanation: Directly supports blood phenylalanine accumulation as the biochemical readout of PKU hyperphenylalaninemia.
+  - target: Phenylalanine to Tyrosine Ratio
+    description: Hyperphenylalaninemia contributes to an elevated phenylalanine-to-tyrosine ratio.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21216643
+      reference_title: "The effect of blood phenylalanine concentration on Kuvan™ response in phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Phenylketonuria (PKU) is caused by mutations in the phenylalanine hydroxylase gene (PAH) with consequent elevation of blood phenylalanine (Phe), reduction in tyrosine (Tyr) and elevation of Phe/Tyr ratio (P/T)."
+      explanation: Clinical data link elevated phenylalanine with increased Phe/Tyr ratio in PKU.
   - target: Competitive Large Neutral Amino Acid Transport at the Blood-Brain Barrier
     description: Excess phenylalanine competitively perturbs transport of other neutral amino acids into brain.
     evidence:
@@ -509,6 +529,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "There is a strong relation between protein insufficiency, as determined by plasma prealbumin levels, and linear growth impairment."
       explanation: Directly connects protein insufficiency to the growth-delay phenotype in children with PKU.
+  - target: Plasma Prealbumin
+    description: Plasma prealbumin is a monitoring readout for protein sufficiency during phenylalanine-restricted therapy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:12183721
+      reference_title: "Protein insufficiency and linear growth restriction in phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "We suggest that a plasma prealbumin level of at least 20 mg/dL is necessary for optimal growth in children with PKU."
+      explanation: Supports plasma prealbumin as a clinically relevant protein-sufficiency readout in treated children with PKU.
 - name: Reduced Bone Mineral Density in PKU
   description: >-
     Adults and children with PKU have repeatedly been reported to have lower
@@ -550,6 +580,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: "Ten out of 11 articles found BMD was significantly lower in patients with PKU."
       explanation: Supports lower BMD as the quantitative basis for osteopenia in the PKU bone-health evidence base.
+  - target: Bone Mineral Density Z-score
+    description: Bone mineral density Z-score is a quantitative readout of reduced bone density in PKU cohorts.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39267130
+      reference_title: "Meta-analysis of bone mineral density in adults with phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Adults with PKU had lower BMD Z-scores than the reference (non-PKU) population but < 1 in 10 were below the expected range for age."
+      explanation: Supports BMD Z-score as the quantitative biochemical/clinical readout of reduced bone mineral density in PKU.
 - name: Maternal Hyperphenylalaninemia Teratogenicity
   description: >-
     In women with PKU or hyperphenylalaninemia, poor phenylalanine control during
@@ -625,6 +665,26 @@ pathophysiology:
     snippet: "Phenylketonuria (PKU) is caused by mutations in the phenylalanine hydroxylase gene (PAH) with consequent elevation of blood phenylalanine (Phe), reduction in tyrosine (Tyr) and elevation of Phe/Tyr ratio (P/T)."
     explanation: Human PKU cohort data directly reports reduced tyrosine associated with hyperphenylalaninemia.
   downstream:
+  - target: Blood Tyrosine
+    description: Reduced PAH-mediated conversion of phenylalanine to tyrosine is reflected by decreased blood tyrosine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:30570999
+      reference_title: "Phenylketonuria (PKU)."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Elevated blood Phe levels and decreased Tyr levels characterize PKU."
+      explanation: Directly supports decreased blood tyrosine as the biochemical readout of relative tyrosine deficiency in PKU.
+  - target: Phenylalanine to Tyrosine Ratio
+    description: Reduced tyrosine availability contributes to the elevated phenylalanine-to-tyrosine ratio.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21216643
+      reference_title: "The effect of blood phenylalanine concentration on Kuvan™ response in phenylketonuria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Phenylketonuria (PKU) is caused by mutations in the phenylalanine hydroxylase gene (PAH) with consequent elevation of blood phenylalanine (Phe), reduction in tyrosine (Tyr) and elevation of Phe/Tyr ratio (P/T)."
+      explanation: Clinical data link reduced tyrosine with increased Phe/Tyr ratio in PKU.
   - target: Impaired Melanin Biosynthesis
     description: Reduced tyrosine supply limits melanin production.
     evidence:


### PR DESCRIPTION
## Summary
- Connect PKU biochemical biomarkers back into the pathograph via downstream mechanism edges
- Add evidence-backed edges for blood phenylalanine, blood tyrosine, Phe/Tyr ratio, plasma prealbumin, and BMD Z-score
- Update PKU metadata timestamp

## Validation
- just validate kb/disorders/Phenylketonuria.yaml
- just validate-references kb/disorders/Phenylketonuria.yaml
- just validate-terms kb/disorders/Phenylketonuria.yaml
- normalized snippet audit: checked=198 missing=0 no_cache=0
- graph audit: pathophysiology=17 phenotypes=26 biochemical=6 treatments=5 edges=53 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check

## Scope
- Only kb/disorders/Phenylketonuria.yaml is intentionally changed
- Restored unrelated validator churn in references_cache/PMID_24904092.md and references_cache/PMID_31292197.md