### PR TITLE
Connect HMGCS2 deficiency pathograph

### DIFF
--- a/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
@@ -292,7 +292,7 @@ pathophysiology:
       reference_title: "Japanese patients with mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency: In vitro functional analysis of five novel HMGCS2 mutations."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "Fatty liver was identified in three cases, which suggested the unavailability of fatty"
+      snippet: "Fatty liver was identified in three cases, which suggested the unavailability of fatty acids."
       explanation: The Japanese patient series links HMGCS2 deficiency crises with fatty liver.
   - target: Ketone bodies
     description: Decreased ketone bodies are the direct biochemical readout of impaired hepatic ketogenesis.
@@ -680,7 +680,7 @@ phenotypes:
     reference_title: "Japanese patients with mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency: In vitro functional analysis of five novel HMGCS2 mutations."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "liver was identified in three cases, which suggested the unavailability of fatty"
+    snippet: "liver was identified in three cases, which suggested the unavailability of fatty acids."
     explanation: The Japanese case series identified fatty liver in three of four patients.
   - reference: PMID:32952630
     reference_title: "Japanese patients with mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency: In vitro functional analysis of five novel HMGCS2 mutations."

--- a/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency
 creation_date: '2026-05-04T09:20:00Z'
-updated_date: '2026-05-18T15:36:48Z'
+updated_date: '2026-05-21T13:26:32Z'
 category: Mendelian
 description: >
   3-hydroxy-3-methylglutaryl-CoA synthase deficiency is an autosomal
@@ -199,6 +199,13 @@ pathophysiology:
   downstream:
   - target: Impaired Hepatic Ketogenesis
     description: HMGCS2 loss blocks mitochondrial ketone body synthesis from acetyl-CoA and acetoacetyl-CoA.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "mutations in the HMGCS2 gene, leading to impaired ketogenesis."
+      explanation: The systematic review directly links HMGCS2 mutations to impaired ketogenesis.
 - name: Impaired Hepatic Ketogenesis
   description: >
     HMGCS2 normally catalyzes formation of HMG-CoA from acetoacetyl-CoA and
@@ -256,10 +263,47 @@ pathophysiology:
   downstream:
   - target: Catabolic Stress Metabolic Decompensation
     description: Inadequate ketogenesis during fasting or illness causes energy failure and acute metabolic crises.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Most patients presented with acute metabolic decompensation with hypoglycemia, dicarboxyluria and inadequate ketonuria."
+      explanation: Human case synthesis links impaired ketogenesis to acute metabolic decompensation with inadequate ketone production.
   - target: Acute-Phase Acetylcarnitine and Organic Acid Pattern
     description: Acetyl-CoA cannot enter ketogenesis normally, contributing to elevated acetylcarnitine, dicarboxylic aciduria, and 4HMP excretion during crises.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dicarboxylic acid levels were elevated in 54/56 cases."
+      explanation: The systematic review supports the acute organic-acid component of the biochemical pattern.
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The plasma C2/C0 acylcarnitine ratio was abnormal in 16/18 (88.9 %) of acute plasma samples"
+      explanation: The systematic review supports the acute acylcarnitine-ratio component of the biochemical pattern.
   - target: Hepatic steatosis
     description: Blocked ketogenesis is associated with fatty liver during acute decompensation.
+    evidence:
+    - reference: PMID:32952630
+      reference_title: "Japanese patients with mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency: In vitro functional analysis of five novel HMGCS2 mutations."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Fatty liver was identified in three cases, which suggested the unavailability of fatty"
+      explanation: The Japanese patient series links HMGCS2 deficiency crises with fatty liver.
+  - target: Ketone bodies
+    description: Decreased ketone bodies are the direct biochemical readout of impaired hepatic ketogenesis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Most patients presented with acute metabolic decompensation with hypoglycemia, dicarboxyluria and inadequate ketonuria."
+      explanation: Inadequate ketonuria supports decreased ketone bodies as a readout of the ketogenesis block.
 - name: Catabolic Stress Metabolic Decompensation
   description: >
     During fasting, gastroenteritis, poor intake, or illness, impaired
@@ -282,12 +326,40 @@ pathophysiology:
   downstream:
   - target: Hypoglycemia
     description: Failure to generate ketone bodies under catabolic stress accompanies hypoglycemia.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Most patients presented with acute metabolic decompensation with hypoglycemia, dicarboxyluria and inadequate ketonuria."
+      explanation: The systematic review identifies hypoglycemia as a core feature of acute decompensation.
   - target: Metabolic acidosis
     description: Acute decompensation commonly includes severe metabolic acidosis.
+    evidence:
+    - reference: PMID:35308163
+      reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Each patient (10/10) had a different degree of hepatomegaly and increased aminotransferase, severe metabolic acidosis, and hypofibrinogenemia."
+      explanation: The Chinese patient series supports metabolic acidosis during acute decompensation.
   - target: Seizure
     description: Severe acute crises may include seizures.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other commonly observed symptoms during the first clinical episode included poor intake, altered consciousness, dyspnea, seizures and hepatomegaly."
+      explanation: The systematic review lists seizures among common first-episode symptoms.
   - target: Hepatomegaly
     description: Hepatic metabolic stress during crises is associated with hepatomegaly.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Other commonly observed symptoms during the first clinical episode included poor intake, altered consciousness, dyspnea, seizures and hepatomegaly."
+      explanation: The systematic review lists hepatomegaly among common first-episode symptoms.
   - target: Hypoketotic hypoglycemia
     description: Ketogenesis failure during catabolic stress produces hypoglycemia with inadequate ketone production.
     evidence:
@@ -409,6 +481,43 @@ pathophysiology:
   downstream:
   - target: Dicarboxylic aciduria
     description: Acute organic acid profiles commonly show dicarboxylic aciduria.
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dicarboxylic acid levels were elevated in 54/56 cases."
+      explanation: The systematic review supports dicarboxylic aciduria as part of the acute organic-acid pattern.
+  - target: 4-hydroxy-6-methyl-2-pyrone
+    description: Urinary 4HMP is a frequent acute-phase readout of the HMGCS2 deficiency organic-acid pattern.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "4-hydroxy-6-methyl-2-pyrone (4HMP) was detected in 33/35 urine samples taken"
+      explanation: The systematic review supports 4HMP as a frequent acute-phase biochemical readout.
+  - target: Dicarboxylic acids
+    description: Elevated dicarboxylic acids are the biochemical readout corresponding to dicarboxylic aciduria during acute crises.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Dicarboxylic acid levels were elevated in 54/56 cases."
+      explanation: The systematic review quantifies elevated dicarboxylic acids during acute episodes.
+  - target: Plasma C2/C0 acylcarnitine ratio
+    description: The plasma C2/C0 acylcarnitine ratio reports the acute acetylcarnitine pattern caused by blocked ketogenesis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39798988
+      reference_title: "Mitochondrial HMG-CoA synthase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The plasma C2/C0 acylcarnitine ratio was abnormal in 16/18 (88.9 %) of acute plasma samples"
+      explanation: The systematic review supports increased C2/C0 ratio as an acute-phase biochemical readout.
 phenotypes:
 - name: Hypoglycemia
   frequency: VERY_FREQUENT


### PR DESCRIPTION
## Summary
- Add evidence to all previously unevidenced HMGCS2 deficiency downstream pathophysiology edges
- Connect biochemical readouts downstream from mechanism nodes: ketone bodies, 4HMP, dicarboxylic acids, and plasma C2/C0 acylcarnitine ratio
- Update HMGCS2 deficiency metadata timestamp

## Validation
- just validate kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
- just validate-references kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
- just validate-terms kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
- normalized snippet audit: checked=95 missing=0 no_cache=0
- graph audit: pathophysiology=4 phenotypes=15 biochemical=4 treatments=4 edges=22 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check

## Scope
- Only kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml is intentionally changed
- Restored unrelated validator churn in references_cache/PMID_24904092.md and references_cache/PMID_31292197.md