### PR TITLE
Add evidence to HMGCL aciduria pathograph

### DIFF
--- a/kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: 3-Hydroxy-3-Methylglutaric Aciduria
 category: Mendelian
 creation_date: '2026-02-23T00:00:00Z'
-updated_date: '2026-05-20T09:03:03Z'
+updated_date: '2026-05-21T13:49:02Z'
 synonyms:
 - HMG-CoA lyase deficiency
 - HMGCLD
@@ -92,9 +92,23 @@ pathophysiology:
   - target: Ketogenesis failure and energy crisis
     causal_link_type: DIRECT
     description: Loss of HMGCL function blocks hepatic ketone body generation during catabolic states.
+    evidence:
+    - reference: PMID:32059735
+      reference_title: "3-hydroxy-3-methylglutaryl-coenzyme A lyase deficiency: one disease - many faces."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: 3-hydroxy-3-methylglutaryl-coenzyme A lyase deficiency (HMGCLD) is an autosomal recessive disorder of ketogenesis and leucine degradation due to mutations in HMGCL.
+      explanation: The systematic review directly links HMGCL mutations to the ketogenesis arm of the disease.
   - target: Leucine catabolic block and organic acid accumulation
     causal_link_type: DIRECT
     description: Loss of HMGCL function also blocks leucine degradation, causing upstream toxic organic acid accumulation.
+    evidence:
+    - reference: PMID:32059735
+      reference_title: "3-hydroxy-3-methylglutaryl-coenzyme A lyase deficiency: one disease - many faces."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: 3-hydroxy-3-methylglutaryl-coenzyme A lyase deficiency (HMGCLD) is an autosomal recessive disorder of ketogenesis and leucine degradation due to mutations in HMGCL.
+      explanation: The systematic review directly links HMGCL mutations to the leucine-degradation arm of the disease.
 - name: Ketogenesis failure and energy crisis
   description: 'Loss of HMGCL-mediated HMG-CoA cleavage abolishes ketogenesis, depriving brain and heart of essential energy substrates during fasting and catabolic stress. This produces hypoketotic hypoglycemia and metabolic acidosis during acute crises.
 
@@ -142,31 +156,87 @@ pathophysiology:
   - target: Ketone bodies
     causal_link_type: DIRECT
     description: HMGCL deficiency blocks ketone body synthesis, producing absent or inappropriately low ketones during fasting and illness.
+    evidence:
+    - reference: PMID:3099065
+      reference_title: "3-Hydroxy-3-methylglutaryl-coenzyme a lyase deficiency: a review."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: they cannot make ketone bodies in response to prolonged fasting.
+      explanation: The clinical review directly supports impaired ketone body production during fasting.
   - target: Hypoglycemia
     causal_link_type: DIRECT
     description: Failure to generate ketone bodies during fasting leaves patients dependent on circulating glucose, causing hypoketotic hypoglycemia.
+    evidence:
+    - reference: PMID:36771238
+      reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: 3-Hydroxy-3-Methylglutaryl-CoA Lyase (HMGCL) deficiency can be a very severe disorder that typically presents with acute metabolic decompensation with features of hypoketotic hypoglycemia
+      explanation: The Australian cohort review links HMGCL deficiency decompensation with hypoketotic hypoglycemia.
   - target: Metabolic acidosis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Acute catabolism combines impaired ketone production with organic acid accumulation.
     description: Acute decompensation from ketogenesis failure and organic acid accumulation produces metabolic acidosis.
+    evidence:
+    - reference: PMID:36771238
+      reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: features of hypoketotic hypoglycemia, hyperammonemia, and metabolic acidosis.
+      explanation: The cohort review lists metabolic acidosis among acute decompensation features.
   - target: Lethargy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hypoglycemia and metabolic acidosis impair cerebral energy availability during crisis.
     description: Acute energy crisis causes reduced arousal and encephalopathic presentation.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patients may suffer from severe attacks of metabolic decompensation with lethargy, seizures, hypotonia, vomiting and acidosis with hypoketotic hypoglycemia
+      explanation: The human biomarker study background lists lethargy during severe metabolic decompensation.
   - target: Vomiting
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Vomiting occurs during acute metabolic decompensation episodes.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patients may suffer from severe attacks of metabolic decompensation with lethargy, seizures, hypotonia, vomiting and acidosis with hypoketotic hypoglycemia
+      explanation: The human biomarker study background lists vomiting during severe metabolic decompensation.
   - target: Cardiomyopathy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Cardiac vulnerability may reflect loss of ketone-derived energy substrate during stress.
+    evidence:
+    - reference: PMID:7807935
+      reference_title: "Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase deficiency.
+      explanation: The indexed case-report title directly supports cardiomyopathy as an HMGCLD complication.
   - target: Acute liver failure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Severe metabolic decompensation can present atypically with fulminant liver failure.
+    evidence:
+    - reference: PMID:36771238
+      reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: there were two patients that presented atypically-one with fulminant liver failure and the other with isolated developmental delay.
+      explanation: The Australian cohort review documents fulminant liver failure as an atypical presentation.
   - target: Hepatomegaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatomegaly is reported during acute metabolic crises and hepatic metabolic stress.
+    evidence:
+    - reference: PMID:34573903
+      reference_title: "An Atypical Case of Head Tremor and Extensive White Matter in an Adult Female Caused by 3-Hydroxy-3-methylglutaryl-CoA Lyase Deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: this disorder is characterized by a life-threatening metabolic intoxication with a presentation including severe hypoglycemia without ketosis, metabolic acidosis, hyper-ammoniemia, hepatomegaly and a coma.
+      explanation: The case report review lists hepatomegaly among life-threatening HMGCLD intoxication features.
 - name: Leucine catabolic block and organic acid accumulation
   description: 'HMGCL is also required for leucine degradation. Blockade causes upstream accumulation of leucine-derived metabolites including 3-hydroxy-3-methylglutaric acid, 3-methylglutaconic acid, 3-methylglutaric acid, and 3-hydroxyisovaleric acid. Illness-driven leucine flux increases toxic metabolite excretion, implying leucine-derived toxicity is particularly prominent under inflammatory and catabolic stress.
 
@@ -229,27 +299,69 @@ pathophysiology:
   - target: Acyl-CoA disequilibrium and secondary hyperammonemia
     causal_link_type: DIRECT
     description: Blocked leucine degradation increases leucine-related acyl-CoAs and disrupts hepatic acyl-CoA balance.
+    evidence:
+    - reference: PMID:23861731
+      reference_title: "A liver-specific defect of Acyl-CoA degradation produces hyperammonemia, hypoglycemia and a distinct hepatic Acyl-CoA pattern."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: KIC loading also increased levels of several leucine-related acyl-CoAs and reduced acetyl-CoA levels.
+      explanation: Liver-specific HMGCL knockout data support leucine-stress acyl-CoA disequilibrium downstream of the block.
   - target: HMG-mediated neurotoxicity via mitochondrial dysfunction
     causal_link_type: DIRECT
     description: Accumulation of 3-hydroxy-3-methylglutaric acid drives mitochondrial dysfunction in vulnerable brain regions.
+    evidence:
+    - reference: PMID:39062136
+      reference_title: "3-Hydroxy-3-Methylglutaric Acid Disrupts Brain Bioenergetics, Redox Homeostasis, and Mitochondrial Dynamics and Affects Neurodevelopment in Neonatal Wistar Rats."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Our findings provide evidence that HMG causes oxidative stress, bioenergetic dysfunction, and neurodevelopmental changes in neonatal rats
+      explanation: The neonatal rat model directly links accumulated HMG to mitochondrial/bioenergetic neurotoxicity.
   - target: 3-Hydroxy-3-methylglutaric acid (HMG)
     causal_link_type: DIRECT
     description: Blocked HMG-CoA cleavage produces the characteristic accumulation of HMG.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with HMGCLD present with a diagnostic urinary pattern of elevated organic acids such as 3‐hydroxyisovaleric acid (3HIV‐A), 3‐methylglutaconic acid (3MGC‐A), 3‐hydroxy‐3‐methylglutaric acid (3H3MG‐A), 3‐methylglutaric acid (3MG‐A) and in some cases 3‐methylcrotonylglycine."
+      explanation: The human biomarker study supports elevated HMG/3H3MG-A downstream of the leucine-catabolism block.
   - target: 3-Methylglutaconic acid (3-MGC)
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Upstream trans-3-methylglutaconyl-CoA is diverted to 3-methylglutaconic acid.
     description: Leucine pathway blockade produces elevated urinary 3-methylglutaconic acid.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Using untargeted metabolomic analysis of HMGCLD patient plasma, 3MGC‐A and 3H3MG‐A were found among the most discriminating metabolites between patient and control group."
+      explanation: Human metabolomics supports elevated 3MGC-A as a discriminating downstream biomarker.
   - target: 3-Methylglutaric acid (3-MGL)
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Accumulating leucine catabolism intermediates are converted to urinary organic acids.
     description: Leucine catabolic block produces elevated urinary 3-methylglutaric acid.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Patients with HMGCLD present with a diagnostic urinary pattern of elevated organic acids such as 3‐hydroxyisovaleric acid (3HIV‐A), 3‐methylglutaconic acid (3MGC‐A), 3‐hydroxy‐3‐methylglutaric acid (3H3MG‐A), 3‐methylglutaric acid (3MG‐A) and in some cases 3‐methylcrotonylglycine."
+      explanation: The human biomarker study supports elevated 3MG-A as part of the diagnostic organic-acid pattern.
   - target: 3-Hydroxyisovalerylcarnitine (C5-OH)
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Upstream leucine-derived acyl-CoA species are conjugated to carnitine.
     description: Blocked leucine catabolism raises C5-OH acylcarnitine, the newborn screening marker.
+    evidence:
+    - reference: PMID:32685354
+      reference_title: "A newborn screening approach to diagnose 3-hydroxy-3-methylglutaryl-CoA lyase deficiency."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Plasma of these patients contains elevated levels of 3‐hydroxyisovalerylcarnitine (3HIV‐C)"
+      explanation: The human biomarker study supports elevated C5-OH/3HIV-C downstream of the leucine catabolic block.
 - name: Acyl-CoA disequilibrium and secondary hyperammonemia
   description: 'Chronic HMGCL deficiency and acute crises each produce distinct abnormal hepatic acyl-CoA patterns. Leucine metabolite loading increases leucine-related acyl-CoAs while depleting acetyl-CoA. Acetyl-CoA depletion impairs N-acetylglutamate synthesis, which is required for urea cycle activation via carbamoyl phosphate synthetase 1, producing secondary hyperammonemia. This mechanism was confirmed by carglumate rescue of hyperammonemia in a liver-specific HMGCL knockout mouse model.
 
@@ -302,14 +414,45 @@ pathophysiology:
   - target: Acetyl-CoA
     causal_link_type: DIRECT
     description: Leucine metabolite loading in HMGCL-deficient hepatocytes reduces acetyl-CoA levels.
+    evidence:
+    - reference: PMID:23861731
+      reference_title: "A liver-specific defect of Acyl-CoA degradation produces hyperammonemia, hypoglycemia and a distinct hepatic Acyl-CoA pattern."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: KIC loading also increased levels of several leucine-related acyl-CoAs and reduced acetyl-CoA levels.
+      explanation: The HMGCL-deficient liver model directly supports acetyl-CoA depletion under leucine stress.
+  - target: Ammonia
+    causal_link_type: DIRECT
+    description: Increased ammonia is the biochemical readout of secondary hyperammonemia caused by impaired urea-cycle activation.
+    evidence:
+    - reference: PMID:36771238
+      reference_title: "Treatment of HMG-CoA Lyase Deficiency-Longitudinal Data on Clinical and Nutritional Management of 10 Australian Cases."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: features of hypoketotic hypoglycemia, hyperammonemia, and metabolic acidosis.
+      explanation: Human clinical review supports hyperammonemia as a biochemical feature of acute HMGCLD decompensation.
   - target: Hyperammonemia
     causal_link_type: DIRECT
     description: Acetyl-CoA depletion limits N-acetylglutamate-dependent urea-cycle activation, causing secondary hyperammonemia.
+    evidence:
+    - reference: PMID:23861731
+      reference_title: "A liver-specific defect of Acyl-CoA degradation produces hyperammonemia, hypoglycemia and a distinct hepatic Acyl-CoA pattern."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: KIC-induced hyperammonemia improved following administration of carglumate (N-carbamyl-L-glutamic acid), which substitutes for the product of an acetyl-CoA-dependent reaction essential for urea cycle function
+      explanation: The liver-specific knockout model links acetyl-CoA-dependent urea-cycle activation to hyperammonemia.
   - target: Hypoglycemia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Abnormal hepatic acyl-CoA balance impairs gluconeogenic response to pyruvate.
     description: Acyl-CoA disequilibrium contributes to hypoglycemia during acute crises.
+    evidence:
+    - reference: PMID:23861731
+      reference_title: "A liver-specific defect of Acyl-CoA degradation produces hyperammonemia, hypoglycemia and a distinct hepatic Acyl-CoA pattern."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: Hyperammonemia and hypoglycemia, cardinal features of many inborn errors of acyl-CoA metabolism, occurred spontaneously in some HLLKO mice and were inducible by administering KIC.
+      explanation: The HMGCL-deficient liver model supports hypoglycemia downstream of hepatic acyl-CoA disruption.
 - name: HMG-mediated neurotoxicity via mitochondrial dysfunction
   description: 'The major accumulating metabolite 3-hydroxy-3-methylglutaric acid (HMG) directly disrupts brain mitochondrial function. In neonatal rat brain, HMG exposure reduces succinate dehydrogenase and respiratory chain complex II-III and IV activity in the cerebral cortex and striatum, impairs antioxidant defenses, and increases DRP1 levels indicating mitochondrial fission. These mechanisms connect metabolite accumulation to the neurological vulnerability observed early in life.
 
@@ -381,6 +524,13 @@ pathophysiology:
     intermediate_mechanisms:
     - HMG disrupts brain mitochondrial bioenergetics, redox homeostasis, and mitochondrial dynamics.
     description: HMG-mediated mitochondrial dysfunction contributes to neurologic injury and developmental vulnerability.
+    evidence:
+    - reference: PMID:39062136
+      reference_title: "3-Hydroxy-3-Methylglutaric Acid Disrupts Brain Bioenergetics, Redox Homeostasis, and Mitochondrial Dynamics and Affects Neurodevelopment in Neonatal Wistar Rats."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: HMG-injected animals showed impaired performance in all sensorimotor tests examined.
+      explanation: The HMG exposure model supports neurodevelopmental injury downstream of mitochondrial dysfunction.
 - name: Neurologic injury and neurodevelopmental sequelae
   description: 'Acute metabolic crises and accumulating organic acids injure vulnerable neural tissue, producing seizures, developmental and speech delay, hypotonia, and MRI abnormalities including leukoencephalopathy and rare cerebral atrophy.
 
@@ -412,21 +562,63 @@ pathophysiology:
   - target: Seizures
     causal_link_type: DIRECT
     description: Seizures are part of the neurologic sequelae of HMGCLD.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Common neurological findings include seizures 17/62 (27.41%)
+      explanation: The Saudi cohort directly reports seizures among neurologic findings.
   - target: Global developmental delay
     causal_link_type: DIRECT
     description: Developmental delay is a neurodevelopmental sequela in a subset of patients.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: speech delay 7/62 (11.29%), hyperactivity 4/62 (4.83%), developmental delay 6/62
+      explanation: The Saudi cohort directly reports developmental delay among long-term neurologic findings.
   - target: Speech delay
     causal_link_type: DIRECT
     description: Speech delay reflects neurodevelopmental involvement.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: speech delay 7/62 (11.29%)
+      explanation: The Saudi cohort directly reports speech delay among neurologic findings.
   - target: Muscular hypotonia
     causal_link_type: DIRECT
     description: Hypotonia is reported among neurologic findings in HMGCLD cohorts.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: hypotonic 3/62 (4.83%)
+      explanation: The Saudi cohort directly reports hypotonia among neurologic findings.
   - target: Leukoencephalopathy
     causal_link_type: DIRECT
     description: White matter signal abnormalities represent leukoencephalopathy on brain MRI.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: An MRI of the brain exhibited nonspecific periventricular and deep white matter hyperintense signal changes in 16 patients (25.80%)
+      explanation: The Saudi cohort directly supports white matter signal abnormalities as a leukoencephalopathy readout.
   - target: Cerebral atrophy
     causal_link_type: DIRECT
     description: Cerebral atrophy is a rare severe brain imaging sequela.
+    evidence:
+    - reference: PMID:35646072
+      reference_title: "HMG-CoA Lyase Deficiency: A Retrospective Study of 62 Saudi Patients."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: cerebral atrophy was found in one (1/62; 1.612%) patient.
+      explanation: The Saudi cohort directly supports cerebral atrophy as a rare neurologic sequela.
 phenotypes:
 - name: Metabolic acidosis
   frequency: FREQUENT
@@ -1084,6 +1276,10 @@ notes: 'The 2024 discovery of non-enzymatic mitochondrial protein acylation (3MG
 
   '
 references:
+- reference: PMID:7807935
+  title: Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase deficiency.
+- reference: PMID:34573903
+  title: An Atypical Case of Head Tremor and Extensive White Matter in an Adult Female Caused by 3-Hydroxy-3-methylglutaryl-CoA Lyase Deficiency.
 - reference: DOI:10.20517/jtgg.2023.12
   title: Use of sodium D, L-3-hydroxybutyrate as adjunct therapy in two siblings with HMG-CoA lyase deficiency
   found_in:

--- a/references_cache/PMID_7807935.md
+++ b/references_cache/PMID_7807935.md
@@ -1,0 +1,48 @@
+---
+reference_id: "PMID:7807935"
+title: Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase deficiency.
+authors:
+- Gibson KM
+- Cassidy SB
+- Seaver LH
+- Wanders RJ
+- Kennaway NG
+- Mitchell GA
+- Spark RP
+journal: J Inherit Metab Dis
+year: '1994'
+doi: 10.1007/BF00711810
+keywords:
+- "Amino Acid Metabolism, Inborn Errors/complications, pathology"
+- "Cardiomyopathy, Dilated/enzymology, etiology, pathology"
+- Fatal Outcome
+- Gas Chromatography-Mass Spectrometry
+- Heart Ventricles/pathology
+- Humans
+- Infant
+- Male
+- Oxo-Acid-Lyases/deficiency
+content_type: abstract_only
+---
+
+# Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase deficiency.
+**Authors:** Gibson KM, Cassidy SB, Seaver LH, Wanders RJ, Kennaway NG, Mitchell GA, Spark RP
+**Journal:** J Inherit Metab Dis (1994)
+**DOI:** [10.1007/BF00711810](https://doi.org/10.1007/BF00711810)
+
+## Content
+
+1. J Inherit Metab Dis. 1994;17(3):291-4. doi: 10.1007/BF00711810.
+
+Fatal cardiomyopathy associated with 3-hydroxy-3-methylglutaryl-CoA lyase
+deficiency.
+
+Gibson KM(1), Cassidy SB, Seaver LH, Wanders RJ, Kennaway NG, Mitchell GA, Spark
+RP.
+
+Author information:
+(1)Kimberly H. Courtwright and Joseph W. Summers Metabolic Disease Center,
+Baylor University Medical Center, Dallas, TX.
+
+DOI: 10.1007/BF00711810
+PMID: 7807935 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary
- Add evidence to all previously unevidenced downstream HMGCL aciduria pathophysiology edges
- Connect the Ammonia biochemical readout downstream of the secondary hyperammonemia mechanism
- Add PMID:7807935 as an intentional reference cache for the cardiomyopathy edge
- Update HMGCL aciduria metadata timestamp

## Validation
- just validate kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
- just validate-references kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
- just validate-terms kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml
- normalized snippet audit: checked=78 missing=0 no_cache=0
- graph audit: pathophysiology=6 phenotypes=14 biochemical=7 treatments=8 edges=27 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check

## Scope
- Intentional files: kb/disorders/3-Hydroxy-3-Methylglutaric_Aciduria.yaml and references_cache/PMID_7807935.md
- Restored unrelated validator churn in references_cache/PMID_24904092.md and references_cache/PMID_31292197.md
- Fetched but did not use PMID:1886403; removed the untracked cache before commit