### PR TITLE
Connect D-2-HGA biochemical readouts

### DIFF
--- a/kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
+++ b/kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
@@ -1,7 +1,7 @@
 name: D-2-Hydroxyglutaric Aciduria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T16:14:01Z'
+updated_date: '2026-05-21T14:05:29Z'
 synonyms:
 - D-2-HGA
 - D2HGA
@@ -170,6 +170,16 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: Both gene defects lead to supraphysiological accumulation of D-2-HG in urine, plasma and CSF, representing the biochemical hallmarks of the diseases.
       explanation: The review directly supports increased D-2-HG as the biochemical endpoint of impaired clearance.
+  - target: Urinary organic acids (2-hydroxyglutarate)
+    description: Urinary organic acid testing is a diagnostic readout of excess D-2-HG from the type I clearance defect after chiral confirmation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20020533
+      reference_title: "Evidence for genetic heterogeneity in D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: We performed molecular, enzyme, and metabolic studies in 50 patients with D-2-hydroxyglutaric aciduria (D-2-HGA) who accumulated D-2-hydroxyglutarate (D-2-HG) in physiological fluids.
+      explanation: The cohort supports body-fluid D-2-HG accumulation as the biochemical readout captured by organic-acid testing.
 - name: IDH2 neomorphic molecular function gain (type II)
   description: 'In D-2-HGA type II, heterozygous IDH2 gain-of-function variants (typically at Arg140) confer neomorphic catalytic activity.
 
@@ -268,6 +278,26 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: We have detected heterozygous germline mutations in IDH2 that alter enzyme residue Arg(140) in 15 unrelated patients with d-2-hydroxyglutaric aciduria (D-2-HGA), a rare neurometabolic disorder characterized by supraphysiological levels of D-2-HG.
       explanation: The IDH2 cohort directly links IDH2 Arg140 mutations with supraphysiological D-2-HG levels.
+  - target: Alpha-ketoglutarate
+    description: Mutant IDH2 consumes 2-ketoglutarate as substrate for neomorphic D-2-HG production, making local alpha-ketoglutarate depletion an inferred biochemical readout.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20847235
+      reference_title: "IDH2 mutations in patients with D-2-hydroxyglutaric aciduria."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These mutations disable the enzymes' normal ability to convert isocitrate to 2-ketoglutarate (2-KG) and confer on the enzymes a new function: the ability to convert 2-KG to d-2-hydroxyglutarate (D-2-HG)."
+      explanation: The patient study supports mutant IDH2 use of 2-KG to produce D-2-HG; alpha-ketoglutarate reduction is inferred from substrate consumption.
+  - target: Urinary organic acids (2-hydroxyglutarate)
+    description: Urinary organic acid testing also reports the type II D-2-HG overproduction mechanism after chiral and molecular confirmation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20020533
+      reference_title: "Evidence for genetic heterogeneity in D-2-hydroxyglutaric aciduria."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: normal D-2-HGDH activity and higher D-2-HG levels in body fluids compared with Type I patients.
+      explanation: The genetic-heterogeneity study supports higher body-fluid D-2-HG in the non-D2HGDH subtype later attributed to IDH2.
 - name: Mitochondrial bioenergetic dysfunction and oxidative stress
   description: 'Elevated D-2-HG perturbs mitochondrial energy metabolism and redox homeostasis in both subtypes. The structural similarity of D-2-HG to alpha-ketoglutarate allows it to interfere with TCA cycle enzymes and mitochondrial respiratory chain function, leading to impaired energy production and increased oxidative stress, particularly affecting neurons and cardiomyocytes.
 
@@ -328,6 +358,18 @@ pathophysiology:
       evidence_source: HUMAN_CLINICAL
       snippet: For the child with cardiomyopathy, chronic D-2-HG inhibition was associated with improved cardiac function, and for both children, therapy was associated with improved daily functioning, global motility and social interactions.
       explanation: Human enasidenib treatment supports cardiomyopathy as a D-2-HG-responsive downstream phenotype.
+  - target: Serum phospholipids (type II)
+    description: Serum phospholipid changes report downstream lipid and redox pathway effects in the type II D-2-HGA treatment context.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - lipid and redox-related gene pathway remodeling
+    evidence:
+    - reference: PMID:37248298
+      reference_title: "Enasidenib treatment in two individuals with D-2-hydroxyglutaric aciduria carrying a germline IDH2 mutation."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Treatment of the child with cardiomyopathy led to therapy-coordinated changes in serum phospholipid levels, which were partly recapitulated in cultured fibroblasts, associated with complex effects on lipid and redox-related gene pathways.
+      explanation: Human treatment data support serum phospholipids as a pharmacodynamic readout of downstream lipid/redox remodeling.
   - target: Epilepsy
     description: D-2-HGA-associated neurometabolic dysfunction manifests with seizures.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES


### PR DESCRIPTION
## Summary
- Connect previously unlinked D-2-HGA biochemical readouts into the pathograph
- Add downstream edges for urinary organic acids/2-HG, alpha-ketoglutarate, and serum phospholipids
- Update D-2-HGA metadata timestamp

## Validation
- just validate kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
- just validate-references kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
- just validate-terms kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml
- normalized snippet audit: checked=84 missing=0 no_cache=0
- graph audit: pathophysiology=6 phenotypes=10 biochemical=4 treatments=7 edges=22 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check

## Scope
- Only kb/disorders/D-2-Hydroxyglutaric_Aciduria.yaml is intentionally changed
- Restored unrelated validator churn in references_cache/PMID_24904092.md and references_cache/PMID_31292197.md