### PR TITLE
[codex] Render semantic refs as in-page links

### DIFF
--- a/src/dismech/render.py
+++ b/src/dismech/render.py
@@ -278,6 +278,27 @@ def _make_anchor_id(prefix: str, value: str) -> str:
     return f"{prefix}-{slug or 'item'}"
 
 
+def _build_semantic_ref_index(disorder: dict) -> dict[str, str]:
+    """Resolve YAML semantic refs to in-page HTML fragment links."""
+    ref_index: dict[str, str] = {}
+
+    pathophysiology_items = disorder.get("pathophysiology") or []
+    if isinstance(pathophysiology_items, list):
+        for item in pathophysiology_items:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if not name:
+                continue
+            anchor_id = item.get("_anchor_id") or _make_anchor_id(
+                "pathophysiology", str(name)
+            )
+            item.setdefault("_anchor_id", anchor_id)
+            ref_index[f"pathophysiology#{name}"] = f"#{anchor_id}"
+
+    return ref_index
+
+
 @lru_cache(maxsize=8)
 def _build_disorder_page_index(
     disorders_dir: str,
@@ -1327,6 +1348,7 @@ def render_disorder(
     )
     _annotate_model_links(disorder)
     _annotate_hypothesis_group_links(disorder)
+    semantic_ref_index = _build_semantic_ref_index(disorder)
 
     # Set up Jinja2 environment
     if template_path is None:
@@ -1344,6 +1366,9 @@ def render_disorder(
     # Register custom filters
     current_term_id = _extract_disorder_term_id(disorder)
     env.filters["curie_to_url"] = curie_to_url
+    env.filters["semantic_ref_href"] = (
+        lambda ref: semantic_ref_index.get(str(ref), "") if ref is not None else ""
+    )
     env.filters["basename"] = lambda p: Path(p).name
     env.filters["dismech_page_url"] = _build_dismech_page_url_filter(
         yaml_path.parent,

--- a/src/dismech/templates/disorder.html.j2
+++ b/src/dismech/templates/disorder.html.j2
@@ -1092,6 +1092,17 @@
             word-break: break-word;
         }
 
+        a.entity-ref-chip {
+            display: inline-block;
+            text-decoration: none;
+        }
+
+        a.entity-ref-chip:hover {
+            background: #e0e7ff;
+            border-color: #818cf8;
+            color: #312e81;
+        }
+
         /* Histopathology */
         .histopathology-box {
             background: #fff7ed;
@@ -2993,10 +3004,19 @@
         <div class="experiment-section-title">{{ title }}</div>
         <div class="entity-ref-list">
             {% for ref in refs %}
-            <span class="entity-ref-chip">{{ ref }}</span>
+            {{ render_entity_ref(ref) }}
             {% endfor %}
         </div>
     </div>
+    {% endif %}
+    {% endmacro %}
+
+    {% macro render_entity_ref(ref) %}
+    {% set ref_href = ref | semantic_ref_href %}
+    {% if ref_href %}
+    <a class="entity-ref-chip" href="{{ ref_href }}">{{ ref }}</a>
+    {% else %}
+    <span class="entity-ref-chip">{{ ref }}</span>
     {% endif %}
     {% endmacro %}
 
@@ -3038,7 +3058,7 @@
     <div class="experiment-subitem">
         <div class="experiment-subitem-name">{{ perturbation.name or 'Perturbation' }}</div>
         {% if perturbation.target %}
-        <div class="entity-ref-list"><span class="entity-ref-chip">{{ perturbation.target }}</span></div>
+        <div class="entity-ref-list">{{ render_entity_ref(perturbation.target) }}</div>
         {% endif %}
         {% if perturbation.description %}
         <div style="margin-top: 6px;">{{ perturbation.description }}</div>
@@ -3067,7 +3087,7 @@
     <div class="experiment-subitem">
         <div class="experiment-subitem-name">{{ readout.name or 'Readout' }}</div>
         {% if readout.target %}
-        <div class="entity-ref-list"><span class="entity-ref-chip">{{ readout.target }}</span></div>
+        <div class="entity-ref-list">{{ render_entity_ref(readout.target) }}</div>
         {% endif %}
         {% if readout.description %}
         <div style="margin-top: 6px;">{{ readout.description }}</div>
@@ -4231,7 +4251,7 @@
                     <div class="experiment-section-title">Attached to</div>
                     <div class="entity-ref-list">
                         {% for ref in discussion.attaches_to %}
-                        <span class="entity-ref-chip">{{ ref }}</span>
+                        {{ render_entity_ref(ref) }}
                         {% endfor %}
                     </div>
                 </div>

--- a/tests/test_render_discussions.py
+++ b/tests/test_render_discussions.py
@@ -16,6 +16,12 @@ def test_render_discussion_proposed_experiment(tmp_path: Path) -> None:
         yaml.safe_dump(
             {
                 "name": "Gap Disorder",
+                "pathophysiology": [
+                    {
+                        "name": "Missing Step",
+                        "description": "A declared pathophysiology node.",
+                    }
+                ],
                 "discussions": [
                     {
                         "discussion_id": "gap_test",
@@ -75,3 +81,5 @@ def test_render_discussion_proposed_experiment(tmp_path: Path) -> None:
     assert "Readouts" in html
     assert "Barrier leak should track the perturbation." in html
     assert 'href="#discussions"' in html
+    assert 'id="pathophysiology-missing-step"' in html
+    assert html.count('href="#pathophysiology-missing-step"') >= 4


### PR DESCRIPTION
## Summary
- Adds an in-page semantic reference index for `pathophysiology#...` references.
- Renders resolved discussion and proposed-experiment semantic refs as same-page chip links while preserving plain chips for unresolved refs.
- Extends the discussion renderer test to assert linked pathophysiology anchors.

## Validation
- `uv run pytest tests/test_render_discussions.py tests/test_render_experimental_model_links.py tests/test_render_models.py -q`
- Rendered `/tmp/Parkinsons_Disease_knowledge_gaps.html` and confirmed `pathophysiology#Dopaminergic Neuron Loss` links to `#pathophysiology-dopaminergic-neuron-loss` alongside `PMID:38405931` / iSCORE-PD content.
- Rendered `/tmp/Long_COVID_knowledge_gaps.html` and confirmed `pathophysiology#Mast Cell Activation` / `pathophysiology#Neuroinflammation` links plus BioLP/Ringeisen references.
- `git diff --check`