### PR TITLE
Add evidence to 5-oxoprolinase downstream edges

### DIFF
--- a/kb/disorders/5-Oxoprolinase_Deficiency.yaml
+++ b/kb/disorders/5-Oxoprolinase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 5-Oxoprolinase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-20T10:10:56Z'
+updated_date: '2026-05-21T14:27:09Z'
 synonyms:
 - Oxoprolinuria due to oxoprolinase deficiency
 - OPLAH deficiency
@@ -227,48 +227,147 @@ pathophysiology:
   - target: Increased urinary 5-oxoproline
     causal_link_type: DIRECT
     description: Failure to clear 5-oxo-L-proline causes elevated urinary 5-oxoproline.
+    evidence:
+    - reference: PMID:25851806
+      reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "elevated urine 5-oxoproline."
+      explanation: Clinical series supports elevated urinary 5-oxoproline as the direct biochemical consequence represented by this edge.
   - target: Increased urinary L-pyroglutamic acid
     causal_link_type: DIRECT
     description: Urinary L-pyroglutamic acid is the HPO phenotype corresponding to accumulated 5-oxoproline.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0410132 | Increased level of L-pyroglutamic acid in urine | Very frequent (99-80%)"
+      explanation: Orphanet maps OPLAH deficiency to increased urinary L-pyroglutamic acid, the clinical descriptor for urinary 5-oxoproline accumulation.
   - target: Metabolic acidosis
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Metabolic acidosis is reported in OPLAH deficiency, but the causal connection to 5-oxoprolinuria is incompletely resolved.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001942 | Metabolic acidosis | Occasional (29-5%)"
+      explanation: Orphanet supports metabolic acidosis as an occasional OPLAH-deficiency phenotype; the edge remains indirect because the biochemical intermediates are unresolved.
   - target: Hypoglycemia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypoglycemia is an occasional Orphanet phenotype with uncertain mechanistic connection to OPLAH deficiency.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001943 | Hypoglycemia | Occasional (29-5%)"
+      explanation: Orphanet supports hypoglycemia as an occasional reported phenotype, while the causal route from 5-oxoproline accumulation remains undefined.
   - target: Feeding difficulties in infancy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Feeding problems occur in symptomatic 5-oxoprolinuria reports, but penetrance and causality remain uncertain.
+    evidence:
+    - reference: PMID:25851806
+      reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "feeding deficiency"
+      explanation: Human clinical series supports feeding problems among symptomatic 5-oxoprolinuria patients; the edge remains indirect because OPLAH-specific causality is uncertain.
   - target: Failure to thrive
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Failure to thrive is an occasional reported manifestation in the variable symptomatic spectrum.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001508 | Failure to thrive | Occasional (29-5%)"
+      explanation: Orphanet supports failure to thrive as an occasional manifestation; the connection to the primary metabolite abnormality is treated as indirect.
   - target: Global developmental delay
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Developmental delay is reported in symptomatic patients, but larger series note incomplete segregation with 5-oxoprolinuria.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Frequent (79-30%)"
+      explanation: Orphanet supports global developmental delay as a frequent reported phenotype, although the edge remains mechanistically indirect.
   - target: Hypotonia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypotonia is an occasional reported neurologic phenotype with uncertain direct mechanism.
+    evidence:
+    - reference: ORPHA:33572
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001252 | Hypotonia | Occasional (29-5%)"
+      explanation: Orphanet supports hypotonia as an occasional neurologic phenotype; direct intermediates downstream of 5-oxoproline accumulation are not established.
   - target: Seizure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Seizures are reported in symptomatic patients, but a direct biochemical mechanism is not established.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "presented with epilepsy at the age"
+      explanation: Case report supports seizures in an OPLAH-deficient patient, while the causal path from metabolite accumulation remains unresolved.
   - target: Delayed speech and language development
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Speech delay is part of the reported variable neurologic spectrum.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "He did not speak fluently."
+      explanation: Case report supports delayed speech/language involvement in an OPLAH-deficient child; the mechanism remains indirect.
   - target: Cerebral atrophy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Brain atrophy has been reported in a symptomatic OPLAH-deficient patient, but causality remains case-level.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Progressive cerebral atrophy, hypomyelination, ventriculomegaly, and corpus callosum hypoplasia"
+      explanation: Case report documents cerebral atrophy in an OPLAH-deficient patient, supporting the association while retaining indirect causality.
   - target: Postnatal macrocephaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Postnatal macrocephaly has been reported in a symptomatic patient and in Orphanet, without a defined intermediate mechanism.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "postnatal macrocephaly"
+      explanation: Case report supports postnatal macrocephaly in OPLAH deficiency; intermediate mechanisms remain undefined.
   - target: Cerebral hypomyelination
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypomyelination was reported in a symptomatic patient with elevated urinary 5-oxoproline.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Progressive cerebral atrophy, hypomyelination, ventriculomegaly, and corpus callosum hypoplasia"
+      explanation: Case report documents hypomyelination with other MRI abnormalities in an OPLAH-deficient patient.
   - target: Ventriculomegaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Ventriculomegaly was reported in a symptomatic OPLAH-deficient patient, but mechanism is unresolved.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Progressive cerebral atrophy, hypomyelination, ventriculomegaly, and corpus callosum hypoplasia"
+      explanation: Case report documents ventriculomegaly among MRI findings in an OPLAH-deficient patient.
   - target: Hypoplasia of the corpus callosum
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Corpus callosum hypoplasia was reported in a symptomatic OPLAH-deficient patient, with uncertain causality.
+    evidence:
+    - reference: PMID:39129838
+      reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Progressive cerebral atrophy, hypomyelination, ventriculomegaly, and corpus callosum hypoplasia"
+      explanation: Case report documents corpus callosum hypoplasia among MRI findings in an OPLAH-deficient patient.
 phenotypes:
 - name: Increased urinary L-pyroglutamic acid
   frequency: VERY_FREQUENT

--- a/kb/disorders/5-Oxoprolinase_Deficiency.yaml
+++ b/kb/disorders/5-Oxoprolinase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 5-Oxoprolinase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-21T14:37:10Z'
+updated_date: '2026-05-21T14:44:51Z'
 synonyms:
 - Oxoprolinuria due to oxoprolinase deficiency
 - OPLAH deficiency
@@ -695,6 +695,9 @@ treatments:
     No disease-modifying therapy is established for OPLAH deficiency. Management
     is therefore centered on long-term observation and standard symptomatic care
     for manifestations such as epilepsy, developmental delay, and speech delay.
+    A reported antioxidant and cofactor regimen did not improve the two
+    OPLAH-deficient patients in one mixed 5-oxoprolinuria series, so this entry
+    does not model that regimen as an effective OPLAH-directed therapy.
   treatment_term:
     preferred_term: supportive care
     term:
@@ -720,6 +723,12 @@ treatments:
     evidence_source: OTHER
     snippet: "No treatment has been recommended for gamma-glutamyl transpeptidase, 5-oxoprolinase and dipeptidase deficiency."
     explanation: Glutathione-metabolism review supports absence of an established disease-specific therapy.
+  - reference: PMID:25851806
+    reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "After treatment by l-carnitine, vitamin E, B1, B2 and coenzyme Q10, three patients with GSS deficiency improved, but the two 5-oxoprolinase-deficient patients did not respond to treatment."
+    explanation: Clinical series supports not modeling antioxidant/cofactor therapy as effective for OPLAH-deficient patients.
   - reference: PMID:39129838
     reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
     supports: SUPPORT

--- a/kb/disorders/5-Oxoprolinase_Deficiency.yaml
+++ b/kb/disorders/5-Oxoprolinase_Deficiency.yaml
@@ -1,7 +1,7 @@
 name: 5-Oxoprolinase Deficiency
 category: Mendelian
 creation_date: '2026-05-03T00:00:00Z'
-updated_date: '2026-05-21T14:27:09Z'
+updated_date: '2026-05-21T14:37:10Z'
 synonyms:
 - Oxoprolinuria due to oxoprolinase deficiency
 - OPLAH deficiency
@@ -221,7 +221,7 @@ pathophysiology:
     reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "elevated urine 5-oxoproline."
+    snippet: "All patients had significantly elevated urine 5-oxoproline."
     explanation: Clinical series documents elevated urinary 5-oxoproline in affected patients.
   downstream:
   - target: Increased urinary 5-oxoproline
@@ -232,7 +232,7 @@ pathophysiology:
       reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "elevated urine 5-oxoproline."
+      snippet: "All patients had significantly elevated urine 5-oxoproline."
       explanation: Clinical series supports elevated urinary 5-oxoproline as the direct biochemical consequence represented by this edge.
   - target: Increased urinary L-pyroglutamic acid
     causal_link_type: DIRECT
@@ -269,7 +269,7 @@ pathophysiology:
       reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "feeding deficiency"
+      snippet: "Patients were hospitalized between the age of 13days to 1year and 3months for hypersomnia, developmental retardation, feeding deficiency, vomiting, icterus and recurrent pneumonia."
       explanation: Human clinical series supports feeding problems among symptomatic 5-oxoprolinuria patients; the edge remains indirect because OPLAH-specific causality is uncertain.
   - target: Failure to thrive
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -306,7 +306,7 @@ pathophysiology:
       reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "presented with epilepsy at the age"
+      snippet: "presented with epilepsy at the age of 2 years."
       explanation: Case report supports seizures in an OPLAH-deficient patient, while the causal path from metabolite accumulation remains unresolved.
   - target: Delayed speech and language development
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -316,7 +316,7 @@ pathophysiology:
       reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "He did not speak fluently."
+      snippet: "He did not speak fluently. He was using 5-10 words with decreased language fluency."
       explanation: Case report supports delayed speech/language involvement in an OPLAH-deficient child; the mechanism remains indirect.
   - target: Cerebral atrophy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -336,7 +336,7 @@ pathophysiology:
       reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "postnatal macrocephaly"
+      snippet: "His past medical history revealed postnatal macrocephaly, hydrocephalus, and well-controlled epilepsy with levetiracetam."
       explanation: Case report supports postnatal macrocephaly in OPLAH deficiency; intermediate mechanisms remain undefined.
   - target: Cerebral hypomyelination
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -450,7 +450,7 @@ phenotypes:
     reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "presented with epilepsy at the age"
+    snippet: "presented with epilepsy at the age of 2 years."
     explanation: Case report documents epilepsy in a child with a homozygous OPLAH variant.
 - name: Delayed speech and language development
   frequency: OCCASIONAL
@@ -469,7 +469,7 @@ phenotypes:
     reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "He did not speak fluently."
+    snippet: "He did not speak fluently. He was using 5-10 words with decreased language fluency."
     explanation: Recent case report documents impaired speech fluency.
 - name: Hypoglycemia
   frequency: OCCASIONAL
@@ -501,7 +501,7 @@ phenotypes:
     reference_title: "Five Chinese patients with 5-oxoprolinuria due to glutathione synthetase and 5-oxoprolinase deficiencies."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "feeding deficiency"
+    snippet: "Patients were hospitalized between the age of 13days to 1year and 3months for hypersomnia, developmental retardation, feeding deficiency, vomiting, icterus and recurrent pneumonia."
     explanation: The Chinese clinical series reported feeding problems among symptomatic 5-oxoprolinuria patients.
 - name: Failure to thrive
   frequency: OCCASIONAL
@@ -565,7 +565,7 @@ phenotypes:
     reference_title: "Is 5-Oxoprolinase Deficiency More than Just a Benign Condition?"
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "postnatal macrocephaly"
+    snippet: "His past medical history revealed postnatal macrocephaly, hydrocephalus, and well-controlled epilepsy with levetiracetam."
     explanation: Recent case report documents postnatal macrocephaly in a symptomatic OPLAH-deficient child.
 - name: Cerebral hypomyelination
   description: Cerebral hypomyelination has been reported in a symptomatic child with OPLAH-associated 5-oxoprolinuria.


### PR DESCRIPTION
## Summary
- add edge-level evidence to all downstream edges from gamma-glutamyl cycle block and 5-oxoproline accumulation
- keep uncertain clinical effects marked as INDIRECT_UNKNOWN_INTERMEDIATES while documenting patient/Orphanet support
- update the curation timestamp only; no reference cache files are intentionally changed

## Validation
- just validate kb/disorders/5-Oxoprolinase_Deficiency.yaml
- just validate-references kb/disorders/5-Oxoprolinase_Deficiency.yaml
- just validate-terms kb/disorders/5-Oxoprolinase_Deficiency.yaml
- snippet audit: checked=72 missing=0 no_cache=0
- graph audit: pathophysiology=2 phenotypes=15 biochemical=2 treatments=3 edges=18 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check