### PR TITLE
Add evidence to PDH deficiency downstream edges

### DIFF
--- a/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
+++ b/kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: Pyruvate Dehydrogenase Deficiency
 creation_date: "2026-05-05T20:20:53Z"
-updated_date: "2026-05-21T06:27:58Z"
+updated_date: "2026-05-21T14:56:54Z"
 category: Mendelian
 parents:
 - mitochondrial disease
@@ -352,57 +352,183 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21908116
+      reference_title: Pyruvate dehydrogenase deficiency and epilepsy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The pyruvate dehydrogenase complex (PDHc) is a mitochondrial matrix multienzyme complex that provides the link between glycolysis and the tricarboxylic acid (TCA) cycle by catalyzing the conversion of pyruvate into acetyl-CoA.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Decreased PDH complex activity
     causal_link_type: DIRECT
     description: Loss of PDH complex subunit or regulatory function is measured clinically as reduced PDH complex activity.
+    evidence:
+    - reference: ORPHA:255138
+      reference_title: Pyruvate dehydrogenase E1-beta deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002928 | Decreased activity of the pyruvate dehydrogenase complex | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: PDH complex enzyme activity
     causal_link_type: DIRECT
     description: The initiating molecular lesion lowers residual PDH complex enzyme activity.
+    evidence:
+    - reference: PMID:22896851
+      reference_title: 'The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: lower residual enzyme activities than subjects who were still alive at the time of reporting.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: DLAT-associated E2 neurodegenerative movement-retinal syndrome
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: DLAT/E2 deficiency is a specific PDH complex subtype with retinal, neurodegenerative, movement, and basal-ganglia imaging findings.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: A very rare form of pyruvate dehydrogenase deficiency (PDHD) characterized by variable lactic acidosis and neurological dysfunction, mainly appearing during childhood.
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: DLD-associated E3 hepatic and branched-chain ketoacid dysfunction
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: DLD/E3 deficiency is a specific PDH complex subtype that can include hepatic disease and branched-chain amino-acid abnormalities.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Pyruvate dehydrogenase E3 deficiency is a very rare subtype of pyruvate dehydrogenase deficiency (PDHD) characterized by either early-onset lactic acidosis and delayed development, later-onset neurological dysfunction or liver disease.
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Abnormal facial shape
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Orphanet records craniofacial morphology as part of the PDH deficiency phenotype spectrum; the intermediate developmental mechanism is not resolved here.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001999 | Abnormal facial shape | Very frequent (99-80%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Frontal bossing
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002007 | Frontal bossing | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: High palate
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000218 | High palate | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Trigonocephaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000243 | Trigonocephaly | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Narrow face
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000275 | Narrow face | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Epicanthus
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000286 | Epicanthus | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Hypertelorism
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000316 | Hypertelorism | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Long philtrum
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000343 | Long philtrum | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Wide nasal bridge
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000431 | Wide nasal bridge | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Upslanted palpebral fissure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Craniofacial morphology is linked to the primary genetic-metabolic disorder, with unresolved intermediate developmental mechanisms.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000582 | Upslanted palpebral fissure | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Pectus excavatum
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: This skeletal phenotype is recorded in the PDH deficiency spectrum, but the intermediate morphogenetic mechanism is not specified.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000767 | Pectus excavatum | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Multiple lipomas
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: This cutaneous phenotype is recorded in the PDH deficiency spectrum, but the intermediate mechanism is not specified.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001012 | Multiple lipomas | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Osteolytic defects of the middle phalanx of the 4th toe
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: This skeletal phenotype is recorded in the PDH deficiency spectrum, but the intermediate mechanism is not specified.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100453 | Osteolytic defects of the middle phalanx of the 4th toe | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 - name: PDHA1 variant folding and assembly defects
   description: >-
     Many PDHA1 E1-alpha pathogenic variants impair folding, E1 incorporation,
@@ -428,6 +554,13 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29445841
+      reference_title: Folding and assembly defects of pyruvate dehydrogenase deficiency-related variants in the E1α subunit of the pyruvate dehydrogenase complex.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Our studies suggest that pathogenic E1α variants may be associated with structural changes of PDC and impaired folding of E1α."
+      explanation: Functional studies support PDHA1 variant folding and assembly defects as a direct route to impaired PDC activity and reduced pyruvate oxidation.
 - name: LONP1 impaired phospho-E1-alpha proteolysis
   description: >-
     Biallelic pathogenic LONP1 variants can impair mitochondrial LonP1 protease
@@ -467,9 +600,23 @@ pathophysiology:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Failed LonP1 degradation of phosphorylated E1-alpha increases the inhibitory phosphorylated E1-alpha pool, lowering PDH activity and pyruvate oxidation.
+    evidence:
+    - reference: PMID:30304514
+      reference_title: "Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "PDH dysfunction was caused by increased levels of the phosphorylated E1α subunit of PDH, which inhibits enzyme activity."
+      explanation: Patient-derived fibroblast evidence supports inhibitory phospho-E1-alpha accumulation as the intermediate lowering PDH activity and pyruvate oxidation.
   - target: Decreased PDH complex activity
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Patient fibroblasts with biallelic LONP1 variants showed reduced PDH activity through inhibitory E1-alpha phosphorylation.
+    evidence:
+    - reference: PMID:30304514
+      reference_title: "Bi-allelic mutations of LONP1 encoding the mitochondrial LonP1 protease cause pyruvate dehydrogenase deficiency and profound neurodegeneration with progressive cerebellar atrophy."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "the siblings' fibroblasts had reduced pyruvate dehydrogenase (PDH) activity"
+      explanation: Patient-derived fibroblast evidence directly supports decreased PDH activity downstream of biallelic LONP1 dysfunction.
 - name: Thiamine-responsive PDHA1 residual activity
   description: >-
     Selected PDHA1 variants can retain thiamine-responsive residual activity,
@@ -503,6 +650,13 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26008863
+      reference_title: Pyruvate dehydrogenase deficiency presenting as isolated paroxysmal exercise induced dystonia successfully reversed with thiamine supplementation.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "PDH deficiency caused by a Leu216Ser mutation in PDHA1."
+      explanation: This supports reduced PDH function in a selected thiamine-responsive PDHA1 variant branch.
 - name: Reduced pyruvate decarboxylation to acetyl-CoA
   description: >-
     PDH complex deficiency blocks oxidative decarboxylation of pyruvate to
@@ -539,8 +693,22 @@ pathophysiology:
   downstream:
   - target: Lactate and pyruvate accumulation
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22896851
+      reference_title: 'The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Although the clinical spectrum of PDC deficiency is broad, the dominant clinical phenotype includes presentation during the first year of life; neurological and neuromuscular degeneration; structural lesions revealed by neuroimaging; lactic acidosis and a blood lactate:pyruvate ratio ≤ 20.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Cerebral energy failure and neurodevelopmental injury
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21908116
+      reference_title: Pyruvate dehydrogenase deficiency and epilepsy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: In severe deficiency states the resulting energy deficit impacts on brain development in utero resulting in structural brain anomalies and epilepsy.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
 - name: PDK-regulated residual PDH activity
   description: >-
     Residual PDH complex activity is modulated by phosphorylation of E1-alpha by
@@ -567,6 +735,13 @@ pathophysiology:
   downstream:
   - target: Reduced pyruvate decarboxylation to acetyl-CoA
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23467562
+      reference_title: Phenylbutyrate therapy for pyruvate dehydrogenase complex deficiency and lactic acidosis.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Phosphorylation of specific serine residues of the E1α subunit of PDHC by pyruvate dehydrogenase kinase (PDK) inactivates the enzyme, whereas dephosphorylation restores PDHC activity."
+      explanation: This supports PDK-regulated phosphorylation as a direct modulator of active PDH complex and pyruvate oxidation.
 - name: Lactate and pyruvate accumulation
   description: >-
     When pyruvate cannot efficiently enter the PDH complex reaction, pyruvate
@@ -595,18 +770,53 @@ pathophysiology:
   downstream:
   - target: Congenital lactic acidosis
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Manifestations range from often fatal, severe, neonatal lactic acidosis to later-onset neurological disorders.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Lactate
     causal_link_type: DIRECT
     description: Impaired pyruvate oxidation increases lactate in blood and CSF.
+    evidence:
+    - reference: PMID:22896851
+      reference_title: 'The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Patients who died were younger, presented clinically earlier and had higher blood lactate levels and lower residual enzyme activities than subjects who were still alive at the time of reporting.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Pyruvate
     causal_link_type: DIRECT
     description: Blocked PDH flux leaves pyruvate insufficiently cleared.
+    evidence:
+    - reference: PMID:23467562
+      reference_title: Phenylbutyrate therapy for pyruvate dehydrogenase complex deficiency and lactic acidosis.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: A deficiency of any enzyme in these pathways results in inadequate removal of pyruvate and lactate from blood and tissues and causes lactic acidosis.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Increased circulating lactate
     causal_link_type: DIRECT
     description: Lactate accumulation appears clinically as increased circulating lactate concentration.
+    evidence:
+    - reference: ORPHA:79243
+      reference_title: Pyruvate dehydrogenase E1-alpha deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002151 | Increased circulating lactate concentration | Very frequent (99-80%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Increased serum pyruvate
     causal_link_type: DIRECT
     description: Pyruvate accumulation appears clinically as increased circulating pyruvate concentration.
+    evidence:
+    - reference: ORPHA:79243
+      reference_title: Pyruvate dehydrogenase E1-alpha deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003542 | Increased serum pyruvate | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
 - name: Cerebral energy failure and neurodevelopmental injury
   description: >-
     Reduced acetyl-CoA delivery to the TCA cycle and mitochondrial energy
@@ -644,20 +854,62 @@ pathophysiology:
   downstream:
   - target: Neurodevelopmental delay and hypotonia
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:22896851
+      reference_title: 'The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Neurodevelopmental delay and hypotonia were the commonest clinical signs of PDC deficiency.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Seizures and movement disorders
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:21908116
+      reference_title: Pyruvate dehydrogenase deficiency and epilepsy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Milder deficiency states present with variable manifestations that include cognitive delay, ataxia, and seizures.
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Aplasia/Hypoplasia of the corpus callosum
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Energy failure in brain development is associated with structural brain malformations, including corpus-callosum dysgenesis.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007370 | Aplasia/Hypoplasia of the corpus callosum | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Ventriculomegaly
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Structural brain abnormalities in PDH complex deficiency include ventriculomegaly.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002119 | Ventriculomegaly | Occasional (29-5%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Neurodegeneration
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Chronic cerebral energy failure contributes to progressive neurological degeneration.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002180 | Neurodegeneration | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Microcephaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Microcephaly is linked to the neurodevelopmental injury spectrum, with intermediate growth mechanisms not resolved here.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000252 | Microcephaly | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 - name: Congenital lactic acidosis
   description: >-
     Lactate accumulation causes congenital or early-onset lactic acidosis, often
@@ -674,24 +926,73 @@ pathophysiology:
   - target: Lactic acidosis
     causal_link_type: DIRECT
     description: Congenital lactic acidosis is the clinical manifestation of lactate accumulation.
+    evidence:
+    - reference: PMID:22896851
+      reference_title: 'The spectrum of pyruvate dehydrogenase complex deficiency: clinical, biochemical and genetic features in 371 patients.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: lactic acidosis and a blood lactate:pyruvate ratio ≤ 20
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Tachypnea
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Tachypnea can reflect respiratory compensation during metabolic acidosis.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002789 | Tachypnea | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Dyspnea
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Dyspnea is recorded in the PDH deficiency phenotype spectrum and can accompany severe metabolic decompensation.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002094 | Dyspnea | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Lethargy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Metabolic decompensation from lactic acidosis contributes to lethargy.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001254 | Lethargy | Very frequent (99-80%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Feeding difficulties in infancy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Feeding difficulty is part of the early severe presentation; the immediate intermediate is not resolved in this graph.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0008872 | Feeding difficulties in infancy | Very frequent (99-80%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Vomiting
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Vomiting is recorded in the E3 deficiency metabolic-decompensation phenotype spectrum.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002013 | Vomiting | Very frequent (99-80%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Hypoglycemia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypoglycemia is recorded in E3 deficiency and grouped here with metabolic decompensation features.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001943 | Hypoglycemia | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 - name: Neurodevelopmental delay and hypotonia
   description: >-
     Neurodevelopmental delay and hypotonia are among the most common clinical
@@ -707,18 +1008,53 @@ pathophysiology:
   - target: Hypotonia
     causal_link_type: DIRECT
     description: Hypotonia is one of the commonest signs in the PDC deficiency spectrum.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001252 | Hypotonia | Very frequent (99-80%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Global developmental delay
     causal_link_type: DIRECT
     description: Global developmental delay is the clinical phenotype captured by this neurodevelopmental injury node.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001263 | Global developmental delay | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Cerebral palsy
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: PDH deficiency can resemble nonprogressive cerebral palsy, especially in female PDHA1 deficiency.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100021 | Cerebral palsy | Occasional (29-5%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Growth delay
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Growth delay is part of the broader developmental phenotype spectrum.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001510 | Growth delay | Very frequent (99-80%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Intrauterine growth retardation
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Intrauterine growth restriction is part of the broader developmental phenotype spectrum.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001511 | Intrauterine growth retardation | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 - name: Seizures and movement disorders
   description: >-
     Severe and milder PDH deficiency states can produce seizures, ataxia,
@@ -741,45 +1077,143 @@ pathophysiology:
   - target: Seizure
     causal_link_type: DIRECT
     description: Seizures are a core manifestation of PDH-related cerebral energy failure.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001250 | Seizure | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Ataxia
     causal_link_type: DIRECT
     description: Milder PDH deficiency states can include ataxia.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001251 | Ataxia | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Spasticity
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Spasticity is a pyramidal motor manifestation within the PDH neurologic phenotype spectrum.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001257 | Spasticity | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Dysarthria
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Dysarthria is grouped with PDH-related movement and motor-control dysfunction.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001260 | Dysarthria | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Choreoathetosis
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Choreoathetosis is grouped with PDH-related movement disorder manifestations.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001266 | Choreoathetosis | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Gait disturbance
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Gait disturbance follows from ataxic, dystonic, or pyramidal motor involvement.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001288 | Gait disturbance | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Dystonia
     causal_link_type: DIRECT
     description: Dystonia is directly supported as a PDH deficiency manifestation.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001332 | Dystonia | Occasional (29-5%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Tremor
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Tremor is grouped with the movement-disorder manifestations of PDH deficiency.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001337 | Tremor | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Abnormal pyramidal sign
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Pyramidal signs reflect motor pathway involvement in the PDH neurologic phenotype.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007256 | Abnormal pyramidal sign | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Abnormality of eye movement
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Abnormal eye movements are grouped with the neurologic movement-control phenotype.
+    evidence:
+    - reference: ORPHA:765
+      reference_title: Pyruvate dehydrogenase deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000496 | Abnormality of eye movement | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Paroxysmal dystonia
     causal_link_type: DIRECT
     description: Paroxysmal dystonia is a subtype-specific dystonic manifestation.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002268 | Paroxysmal dystonia | Frequent (79-30%)
+      explanation: This evidence supports the target as a direct PDH-deficiency consequence represented by the edge.
   - target: Broad-based gait
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Broad-based gait is a subtype-specific gait manifestation linked to movement-system involvement.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002136 | Broad-based gait | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Lower limb hyperreflexia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Lower-limb hyperreflexia is grouped with pyramidal motor involvement.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002395 | Lower limb hyperreflexia | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Atypical behavior
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Atypical behavior is grouped with neurologic involvement, with intermediate neurobehavioral mechanisms not resolved here.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000708 | Atypical behavior | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 - name: DLAT-associated E2 neurodegenerative movement-retinal syndrome
   description: >-
     The DLAT/E2 subtype is characterized by childhood lactic acidosis and
@@ -809,27 +1243,83 @@ pathophysiology:
   - target: Retinal degeneration
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Retinal degeneration is an E2-deficiency neurologic sensory phenotype.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000546 | Retinal degeneration | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Neurodegeneration
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Neurodegeneration is recorded as a frequent E2-deficiency manifestation.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002180 | Neurodegeneration | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Paroxysmal dystonia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Paroxysmal dystonia is recorded as a frequent E2-deficiency movement phenotype.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002268 | Paroxysmal dystonia | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Broad-based gait
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Broad-based gait is recorded as a frequent E2-deficiency gait phenotype.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002136 | Broad-based gait | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Lower limb hyperreflexia
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: Lower-limb hyperreflexia is recorded as a frequent E2-deficiency pyramidal sign.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002395 | Lower limb hyperreflexia | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Eye of the tiger anomaly of globus pallidus
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: This globus-pallidus imaging sign is recorded in E2 deficiency.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002454 | Eye of the tiger anomaly of globus pallidus | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Atypical behavior
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Atypical behavior is recorded in E2 deficiency, with intermediate neurobehavioral mechanisms not resolved here.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000708 | Atypical behavior | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Low levels of vitamin B1
     causal_link_type: UNKNOWN
     description: Low vitamin B1 is recorded in the E2 deficiency phenotype table; its mechanistic role is not resolved here.
+    evidence:
+    - reference: ORPHA:79244
+      reference_title: Pyruvate dehydrogenase E2 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100503 | Low levels of vitamin B1 | Very frequent (99-80%)
+      explanation: This evidence supports the target association, while the causal role remains unresolved.
 - name: DLD-associated E3 hepatic and branched-chain ketoacid dysfunction
   description: >-
     The DLD/E3 subtype can present with early lactic acidosis, delayed
@@ -858,27 +1348,83 @@ pathophysiology:
   - target: Hepatic failure
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatic failure is an E3-deficiency systemic manifestation of DLD-related disease.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001399 | Hepatic failure | Occasional (29-5%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Hypoglycemia
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypoglycemia is recorded in E3 deficiency and grouped with metabolic decompensation features.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001943 | Hypoglycemia | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Vomiting
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Vomiting is recorded in the E3 deficiency metabolic-decompensation phenotype spectrum.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002013 | Vomiting | Very frequent (99-80%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Hepatomegaly
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatomegaly is an E3-deficiency systemic manifestation of DLD-related disease.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002240 | Hepatomegaly | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Hepatic encephalopathy
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hepatic encephalopathy is an E3-deficiency systemic manifestation of DLD-related disease.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002480 | Hepatic encephalopathy | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Elevated circulating hepatic transaminase concentration
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Elevated transaminases are an E3-deficiency hepatic biochemical manifestation.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002910 | Elevated circulating hepatic transaminase concentration | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
   - target: Elevated plasma branched chain amino acids
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     description: DLD/E3 deficiency overlaps with E3-deficient maple syrup urine disease, producing branched-chain amino acid abnormalities.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0008344 | Elevated plasma branched chain amino acids | Frequent (79-30%)
+      explanation: This evidence supports the target association; the edge uses the known intermediate relationship described in the upstream mechanism.
   - target: Hypercoagulability
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     description: Hypercoagulability is recorded in E3 deficiency, with intermediate mechanisms not resolved here.
+    evidence:
+    - reference: ORPHA:2394
+      reference_title: Pyruvate dehydrogenase E3 deficiency (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100724 | Hypercoagulability | Frequent (79-30%)
+      explanation: This evidence supports the target phenotype association; the edge remains indirect because intervening mechanisms are not resolved.
 phenotypes:
 - category: Biochemical
   name: Lactic acidosis


### PR DESCRIPTION
## Summary
- add edge-level evidence to all 78 downstream edges in Pyruvate Dehydrogenase Deficiency
- keep existing graph structure and causal_link_type assignments, including indirect labels for unresolved phenotype mechanisms
- use existing cached references only; no intentional reference-cache changes

## Validation
- just validate kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
- just validate-references kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
- just validate-terms kb/disorders/Pyruvate_Dehydrogenase_Deficiency.yaml
- snippet audit: checked=208 missing=0 no_cache=0
- graph audit: pathophysiology=13 phenotypes=55 biochemical=3 treatments=4 edges=78 unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0
- git diff --check