### PR TITLE
Add evidence to alpha-mannosidosis downstream edges

### DIFF
--- a/kb/disorders/Alpha_Mannosidosis.yaml
+++ b/kb/disorders/Alpha_Mannosidosis.yaml
@@ -1,7 +1,7 @@
 name: Alpha-mannosidosis
 category: Mendelian
 creation_date: "2026-05-04T17:13:27Z"
-updated_date: "2026-05-21T09:16:35Z"
+updated_date: "2026-05-21T15:18:10Z"
 synonyms:
 - Lysosomal alpha-D-mannosidase deficiency
 description: >
@@ -342,7 +342,7 @@ pathophysiology:
       reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
       supports: PARTIAL
       evidence_source: HUMAN_CLINICAL
-      snippet: "disabilities, hearing impairment, motor function disturbances, facial coarsening"
+      snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
       explanation: >
         The patient cohort supports neurologic and motor manifestations in
         alpha-mannosidosis; specific storage-to-CNS intermediates remain
@@ -355,7 +355,7 @@ pathophysiology:
       reference_title: Alpha-mannosidosis.
       supports: PARTIAL
       evidence_source: HUMAN_CLINICAL
-      snippet: "manifested by recurrent infections, especially in the first decade of life"
+      snippet: "Main features are immune deficiency (manifested by recurrent infections, especially in the first decade of life),"
       explanation: >
         The review supports recurrent infections as a core manifestation,
         partially supporting the systemic storage-to-immune branch.
@@ -367,7 +367,7 @@ pathophysiology:
       reference_title: Alpha-mannosidosis.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
-      snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and"
+      snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and deformation of the sternum)"
       explanation: >
         The review directly supports skeletal abnormalities in
         alpha-mannosidosis, linking storage disease to the skeletal branch.
@@ -397,28 +397,124 @@ pathophysiology:
         phenotype, supporting it as a storage biomarker.
   - target: Hearing impairment
     description: Multisystem storage disease includes moderate-to-severe hearing impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hearing impairment (moderate-to-severe sensorineural hearing loss)"
+      explanation: This evidence supports Hearing impairment as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Cataract
     description: Ocular involvement in alpha-mannosidosis includes cataract.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000518 | Cataract | Very frequent (99-80%)
+      explanation: This evidence supports Cataract as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Corneal opacity
     description: Ocular storage manifestations can include corneal opacity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007957 | Corneal opacity | Very frequent (99-80%)
+      explanation: This evidence supports Corneal opacity as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Infantile form cataract
     description: The infantile alpha-mannosidosis subtype includes cataract.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000518 | Cataract | Frequent (79-30%)
+      explanation: This evidence supports Infantile form cataract as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Infantile form strabismus
     description: The infantile alpha-mannosidosis subtype includes strabismus.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000486 | Strabismus | Frequent (79-30%)
+      explanation: This evidence supports Infantile form strabismus as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Infantile form hypermetropia
     description: The infantile alpha-mannosidosis subtype includes hypermetropia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000540 | Hypermetropia | Frequent (79-30%)
+      explanation: This evidence supports Infantile form hypermetropia as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Infantile form myopia
     description: The infantile alpha-mannosidosis subtype includes myopia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000545 | Myopia | Frequent (79-30%)
+      explanation: This evidence supports Infantile form myopia as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Splenomegaly
     description: Visceral storage manifestations include splenic enlargement.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001744 | Splenomegaly | Very frequent (99-80%)
+      explanation: This evidence supports Splenomegaly as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Hepatomegaly
     description: Visceral storage manifestations include hepatic enlargement.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002240 | Hepatomegaly | Very frequent (99-80%)
+      explanation: This evidence supports Hepatomegaly as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Infantile form hepatosplenomegaly
     description: The infantile subtype includes combined hepatic and splenic enlargement.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001433 | Hepatosplenomegaly | Frequent (79-30%)
+      explanation: This evidence supports Infantile form hepatosplenomegaly as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Generalized abnormality of skin
     description: Multisystem storage manifestations include generalized skin abnormalities.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0011354 | Generalized abnormality of skin | Frequent (79-30%)
+      explanation: This evidence supports Generalized abnormality of skin as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
   - target: Inguinal hernia
     description: Connective-tissue and visceral manifestations include inguinal hernia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000023 | Inguinal hernia | Frequent (79-30%)
+      explanation: This evidence supports Inguinal hernia as an alpha-mannosidosis manifestation; the edge remains indirect because the specific intermediates from Mannose-rich oligosaccharide lysosomal storage to this phenotype are not fully resolved.
 - name: Neurodevelopmental and motor impairment
   description: >
     Central nervous system involvement produces intellectual disability,
@@ -446,43 +542,179 @@ pathophysiology:
     reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "disabilities, hearing impairment, motor function disturbances, facial coarsening"
+    snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
     explanation: Patient cohort summarizes neurologic and motor manifestations.
   downstream:
   - target: Intellectual disability
     description: Progressive CNS involvement impairs cognition and adaptive function.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26048034
+      reference_title: 'Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
+      explanation: This evidence supports Intellectual disability as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Global developmental delay
     description: Early neurodevelopmental involvement delays acquisition of developmental milestones.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001263 | Global developmental delay | Very frequent (99-80%)
+      explanation: This evidence supports Global developmental delay as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Hypotonia
     description: Motor system involvement contributes to low tone and delayed motor function.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001252 | Hypotonia | Frequent (79-30%)
+      explanation: This evidence supports Hypotonia as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Atypical behavior
     description: CNS involvement includes behavioral manifestations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000708 | Atypical behavior | Frequent (79-30%)
+      explanation: This evidence supports Atypical behavior as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Hallucinations
     description: Psychiatric involvement can include hallucinations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000738 | Hallucinations | Occasional (29-5%)
+      explanation: This evidence supports Hallucinations as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Increased intracranial pressure
     description: Neurologic involvement can include increased intracranial pressure.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002516 | Increased intracranial pressure | Occasional (29-5%)
+      explanation: This evidence supports Increased intracranial pressure as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form intellectual disability
     description: Neurodevelopmental involvement in the infantile subtype includes intellectual disability.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001249 | Intellectual disability | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form intellectual disability as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form hypotonia
     description: Motor involvement in the infantile subtype includes hypotonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001252 | Hypotonia | Frequent (79-30%)
+      explanation: This evidence supports Infantile form hypotonia as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form short attention span
     description: Neurodevelopmental involvement in the infantile subtype includes impaired attention.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000736 | Short attention span | Frequent (79-30%)
+      explanation: This evidence supports Infantile form short attention span as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form delayed speech and language development
     description: CNS involvement impairs speech and language development in the infantile subtype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000750 | Delayed speech and language development | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form delayed speech and language development as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Ataxia in alpha-mannosidosis subtypes
     description: Motor-system involvement includes ataxia across recorded subtypes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001251 | Ataxia | Frequent (79-30%)
+      explanation: This evidence supports Ataxia in alpha-mannosidosis subtypes as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form mild intellectual disability
     description: The infantile subtype includes mild intellectual disability in Orphanet records.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001256 | Intellectual disability, mild | Frequent (79-30%)
+      explanation: This evidence supports Infantile form mild intellectual disability as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Adult form mild intellectual disability
     description: The adult subtype includes mild intellectual disability in Orphanet records.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309288
+      reference_title: Alpha-mannosidosis, adult form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001256 | Intellectual disability, mild | Very frequent (99-80%)
+      explanation: This evidence supports Adult form mild intellectual disability as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form motor delay
     description: Motor-system involvement in the infantile subtype delays motor milestones.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001270 | Motor delay | Frequent (79-30%)
+      explanation: This evidence supports Infantile form motor delay as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form specific learning disability
     description: Neurodevelopmental involvement in the infantile subtype includes specific learning disability.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001328 | Specific learning disability | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form specific learning disability as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Infantile form myopathy
     description: Motor-system involvement in the infantile subtype includes myopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003198 | Myopathy | Frequent (79-30%)
+      explanation: This evidence supports Infantile form myopathy as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
   - target: Asthenia in alpha-mannosidosis subtypes
     description: Motor and systemic involvement includes asthenia across recorded subtypes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0025406 | Asthenia | Frequent (79-30%)
+      explanation: This evidence supports Asthenia in alpha-mannosidosis subtypes as an alpha-mannosidosis manifestation represented under the Neurodevelopmental and motor impairment branch.
 - name: Immune deficiency and recurrent infections
   description: >
     Immune dysfunction is a core alpha-mannosidosis manifestation and is
@@ -498,27 +730,99 @@ pathophysiology:
     reference_title: Alpha-mannosidosis.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "manifested by recurrent infections, especially in the first decade of life"
+    snippet: "Main features are immune deficiency (manifested by recurrent infections, especially in the first decade of life),"
     explanation: Review directly supports immunodeficiency with recurrent infections.
   downstream:
   - target: Recurrent respiratory infections
     description: Immunodeficiency contributes to recurrent respiratory infections.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Main features are immune deficiency (manifested by recurrent infections, especially in the first decade of life),"
+      explanation: This evidence supports Recurrent respiratory infections as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Chronic otitis media
     description: Recurrent infections include frequent middle-ear disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000389 | Chronic otitis media | Frequent (79-30%)
+      explanation: This evidence supports Chronic otitis media as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Infantile form otitis media
     description: Recurrent middle-ear infections are prominent in the infantile subtype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000388 | Otitis media | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form otitis media as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Infantile form mixed hearing impairment
     description: Recurrent middle-ear disease can contribute to the conductive component of mixed hearing impairment in the infantile subtype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000410 | Mixed hearing impairment | Frequent (79-30%)
+      explanation: This evidence supports Infantile form mixed hearing impairment as an alpha-mannosidosis manifestation; the edge is indirect because the Immune deficiency and recurrent infections branch uses recurrent middle-ear disease as an intermediate.
   - target: Infantile form pneumonia
     description: Immunodeficiency predisposes to pneumonia in the infantile subtype.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002090 | Pneumonia | Frequent (79-30%)
+      explanation: This evidence supports Infantile form pneumonia as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Infantile form recurrent infections
     description: The infantile subtype includes recurrent infections as a core immune manifestation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002719 | Recurrent infections | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form recurrent infections as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Adult form recurrent infections
     description: The adult subtype can also retain recurrent infections.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309288
+      reference_title: Alpha-mannosidosis, adult form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002719 | Recurrent infections | Frequent (79-30%)
+      explanation: This evidence supports Adult form recurrent infections as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Infantile form immunodeficiency
     description: The infantile subtype includes immunodeficiency.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002721 | Immunodeficiency | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form immunodeficiency as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
   - target: Infantile form recurrent gastroenteritis
     description: Immune dysfunction can include recurrent gastrointestinal infections.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0031123 | Recurrent gastroenteritis | Frequent (79-30%)
+      explanation: This evidence supports Infantile form recurrent gastroenteritis as an alpha-mannosidosis manifestation represented under the Immune deficiency and recurrent infections branch.
 - name: Skeletal and craniofacial storage manifestations
   description: >
     Storage disease produces progressive craniofacial coarsening and skeletal
@@ -540,77 +844,325 @@ pathophysiology:
     reference_title: Alpha-mannosidosis.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and"
+    snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and deformation of the sternum)"
     explanation: Review supports skeletal dysplasia and spinal/thoracic involvement.
   - reference: PMID:26048034
     reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "disabilities, hearing impairment, motor function disturbances, facial coarsening"
+    snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
     explanation: Cohort review supports craniofacial and musculoskeletal involvement.
   downstream:
   - target: Coarse facial features
     description: Craniofacial storage contributes to coarse facial appearance.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26048034
+      reference_title: 'Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
+      explanation: This evidence supports Coarse facial features as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Skeletal dysplasia
     description: Skeletal involvement causes dysplasia and delayed skeletal maturation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002652 | Skeletal dysplasia | Very frequent (99-80%)
+      explanation: This evidence supports Skeletal dysplasia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Scoliosis
     description: Vertebral and skeletal involvement contributes to spinal curvature.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:18651971
+      reference_title: Alpha-mannosidosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and deformation of the sternum)"
+      explanation: This evidence supports Scoliosis as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Macroglossia
     description: Craniofacial and oral storage manifestations include macroglossia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000158 | Macroglossia | Very frequent (99-80%)
+      explanation: This evidence supports Macroglossia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Narrow palate
     description: Craniofacial development and storage manifestations include a narrow palate.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000189 | Narrow palate | Frequent (79-30%)
+      explanation: This evidence supports Narrow palate as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Gingival overgrowth
     description: Oral soft-tissue storage manifestations include gingival overgrowth.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000212 | Gingival overgrowth | Frequent (79-30%)
+      explanation: This evidence supports Gingival overgrowth as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Macrocephaly
     description: Craniofacial storage manifestations include macrocephaly.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000256 | Macrocephaly | Occasional (29-5%)
+      explanation: This evidence supports Macrocephaly as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Mandibular prognathia
     description: Craniofacial skeletal involvement can produce mandibular prognathia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000303 | Mandibular prognathia | Occasional (29-5%)
+      explanation: This evidence supports Mandibular prognathia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Hypertelorism
     description: Craniofacial involvement includes hypertelorism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000316 | Hypertelorism | Frequent (79-30%)
+      explanation: This evidence supports Hypertelorism as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Prominent supraorbital ridges
     description: Craniofacial coarsening includes prominent supraorbital ridges.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000336 | Prominent supraorbital ridges | Frequent (79-30%)
+      explanation: This evidence supports Prominent supraorbital ridges as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Macrotia
     description: Craniofacial dysmorphism includes macrotia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000400 | Macrotia | Frequent (79-30%)
+      explanation: This evidence supports Macrotia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Short neck
     description: Craniofacial and skeletal involvement includes a short neck.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000470 | Short neck | Frequent (79-30%)
+      explanation: This evidence supports Short neck as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Widely spaced teeth
     description: Oral and craniofacial involvement includes widely spaced teeth.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000687 | Widely spaced teeth | Occasional (29-5%)
+      explanation: This evidence supports Widely spaced teeth as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Dental malocclusion
     description: Craniofacial skeletal and dental involvement includes malocclusion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000689 | Dental malocclusion | Occasional (29-5%)
+      explanation: This evidence supports Dental malocclusion as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Arthritis
     description: Skeletal involvement can include arthritis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001369 | Arthritis | Occasional (29-5%)
+      explanation: This evidence supports Arthritis as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Hip dysplasia
     description: Skeletal dysplasia includes hip involvement.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001385 | Hip dysplasia | Frequent (79-30%)
+      explanation: This evidence supports Hip dysplasia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Delayed skeletal maturation
     description: Skeletal storage manifestations include delayed skeletal maturation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002750 | Delayed skeletal maturation | Very frequent (99-80%)
+      explanation: This evidence supports Delayed skeletal maturation as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Kyphosis
     description: Vertebral skeletal involvement contributes to kyphosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002808 | Kyphosis | Frequent (79-30%)
+      explanation: This evidence supports Kyphosis as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Craniofacial hyperostosis
     description: Craniofacial skeletal involvement includes hyperostosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0004493 | Craniofacial hyperostosis | Very frequent (99-80%)
+      explanation: This evidence supports Craniofacial hyperostosis as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Depressed nasal bridge
     description: Craniofacial coarsening includes a depressed nasal bridge.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0005280 | Depressed nasal bridge | Very frequent (99-80%)
+      explanation: This evidence supports Depressed nasal bridge as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Bowing of the long bones
     description: Skeletal dysplasia includes bowing of long bones.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0006487 | Bowing of the long bones | Frequent (79-30%)
+      explanation: This evidence supports Bowing of the long bones as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Hypoplastic inferior ilia
     description: Pelvic skeletal dysplasia includes hypoplastic inferior ilia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0008821 | Hypoplastic inferior ilia | Very frequent (99-80%)
+      explanation: This evidence supports Hypoplastic inferior ilia as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Open bite
     description: Craniofacial and dental involvement includes open bite.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0010807 | Open bite | Frequent (79-30%)
+      explanation: This evidence supports Open bite as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Avascular necrosis
     description: Skeletal involvement can include avascular necrosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0010885 | Avascular necrosis | Occasional (29-5%)
+      explanation: This evidence supports Avascular necrosis as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Abnormality of the helix
     description: Craniofacial dysmorphism includes abnormal helix morphology.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0011039 | Abnormality of the helix | Frequent (79-30%)
+      explanation: This evidence supports Abnormality of the helix as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Synostosis of joints
     description: Skeletal involvement includes joint synostosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:61
+      reference_title: Alpha-mannosidosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100240 | Synostosis of joints | Occasional (29-5%)
+      explanation: This evidence supports Synostosis of joints as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Infantile form coarse facial features
     description: The infantile subtype includes coarse facial features.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000280 | Coarse facial features | Frequent (79-30%)
+      explanation: This evidence supports Infantile form coarse facial features as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Infantile form hypertelorism
     description: The infantile subtype includes hypertelorism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000316 | Hypertelorism | Frequent (79-30%)
+      explanation: This evidence supports Infantile form hypertelorism as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Infantile form dysostosis multiplex
     description: The infantile subtype includes dysostosis multiplex.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000943 | Dysostosis multiplex | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form dysostosis multiplex as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Infantile form facial shape deformation
     description: The infantile subtype includes facial shape deformation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0011334 | Facial shape deformation | Frequent (79-30%)
+      explanation: This evidence supports Infantile form facial shape deformation as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
   - target: Infantile form abnormal skeletal morphology
     description: The infantile subtype includes abnormal skeletal morphology.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:309282
+      reference_title: Alpha-mannosidosis, infantile form (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0011842 | Abnormality of skeletal morphology | Very frequent (99-80%)
+      explanation: This evidence supports Infantile form abnormal skeletal morphology as an alpha-mannosidosis manifestation represented under the Skeletal and craniofacial storage manifestations branch.
 histopathology:
 - name: Lysosomal cellular storage pathology
   description: >
@@ -805,7 +1357,7 @@ phenotypes:
     reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "disabilities, hearing impairment, motor function disturbances, facial coarsening"
+    snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
     explanation: Cohort review supports facial coarsening as a clinical manifestation.
 - name: Mandibular prognathia
   frequency: OCCASIONAL
@@ -868,7 +1420,7 @@ phenotypes:
     reference_title: Alpha-mannosidosis.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "hearing impairment (moderate-to-severe"
+    snippet: "hearing impairment (moderate-to-severe sensorineural hearing loss)"
     explanation: Review supports hearing impairment as a core manifestation.
 - name: Chronic otitis media
   frequency: FREQUENT
@@ -1001,7 +1553,7 @@ phenotypes:
     reference_title: "Alpha-mannosidosis: correlation between phenotype, genotype and mutant MAN2B1 subcellular localisation."
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "Symptoms include intellectual"
+    snippet: "Symptoms include intellectual disabilities, hearing impairment, motor function disturbances, facial coarsening and musculoskeletal abnormalities."
     explanation: Cohort review supports intellectual disability as a clinical manifestation.
 - name: Hypotonia
   frequency: FREQUENT
@@ -1139,7 +1691,7 @@ phenotypes:
     reference_title: Alpha-mannosidosis.
     supports: SUPPORT
     evidence_source: HUMAN_CLINICAL
-    snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and"
+    snippet: "skeletal abnormalities (mild-to-moderate dysostosis multiplex, scoliosis and deformation of the sternum)"
     explanation: Review directly supports scoliosis as a skeletal manifestation.
 - name: Skeletal dysplasia
   frequency: VERY_FREQUENT


### PR DESCRIPTION
## Summary
- add evidence blocks and causal link types to all previously unevidenced Alpha-mannosidosis downstream phenotype edges
- keep the existing MAN2B1 enzyme defect, oligosaccharide storage, biochemical readout, and treatment structure intact
- expand several short human-clinical snippets to fuller exact cached abstract quotes

## Validation
- `just validate kb/disorders/Alpha_Mannosidosis.yaml`
- `just validate-terms kb/disorders/Alpha_Mannosidosis.yaml`
- `just validate-references kb/disorders/Alpha_Mannosidosis.yaml` (repo wrapper reports 0 checks)
- independent snippet audit: `checked=203 missing=0 no_cache=0`
- graph audit: `unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0`
- `uv run python -m dismech.graph --validate kb/disorders/Alpha_Mannosidosis.yaml`
- `git diff --check`