### PR TITLE
Add evidence to cystinosis pathograph edges

### DIFF
--- a/kb/disorders/Cystinosis.yaml
+++ b/kb/disorders/Cystinosis.yaml
@@ -1,7 +1,7 @@
 name: Cystinosis
 category: Mendelian
 creation_date: "2026-05-03T00:00:00Z"
-updated_date: "2026-05-05T12:34:37Z"
+updated_date: "2026-05-21T15:52:21Z"
 synonyms:
 - Protein defect of cystin transport
 - Cystine storage disease
@@ -54,7 +54,7 @@ has_subtypes:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "This is the most common form (95% of individuals with cystinosis)."
     explanation: GeneReviews identifies nephropathic infantile cystinosis as the dominant cystinosis subtype.
 - name: Nephropathic juvenile cystinosis
@@ -80,7 +80,7 @@ has_subtypes:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Renal glomerular failure occurs in untreated affected individuals, usually between ages 15 and 25 years."
     explanation: GeneReviews distinguishes later-onset juvenile disease by delayed renal failure.
 - name: Non-nephropathic ocular cystinosis
@@ -106,7 +106,7 @@ has_subtypes:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Non-nephropathic adult (ocular) cystinosis: Characterized by photophobia resulting from corneal cystine crystal accumulation."
     explanation: GeneReviews distinguishes the non-nephropathic ocular phenotype from nephropathic disease.
 external_assertions:
@@ -157,7 +157,7 @@ inheritance:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Cystinosis is inherited in an autosomal recessive manner."
     explanation: GeneReviews confirms autosomal recessive inheritance.
 pathophysiology:
@@ -214,12 +214,20 @@ pathophysiology:
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "caused by mutations in the CTNS gene that encodes"
     explanation: Review evidence connects CTNS mutations to cystinosin deficiency in patients.
   downstream:
   - target: Intralysosomal cystine accumulation and lysosomal dysfunction
     description: Impaired cystinosin-mediated export produces intralysosomal cystine accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      reference_title: Cystinosis (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: A rare lysosomal disease characterized by an accumulation of cystine inside the lysosomes
+      explanation: This evidence supports Intralysosomal cystine accumulation and lysosomal dysfunction as a cystinosis consequence represented by the CTNS lysosomal cystine transporter deficiency edge.
 - name: Intralysosomal cystine accumulation and lysosomal dysfunction
   description: >
     Failure to export cystine causes cystine accumulation in lysosomes throughout
@@ -251,24 +259,56 @@ pathophysiology:
   - reference: PMID:27990015
     reference_title: "The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "results in an accumulation of cystine in all organs"
     explanation: Review evidence supports multisystem cystine accumulation from the transporter defect.
   - reference: PMID:27990015
     reference_title: "The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "identified a role for cystinosin beyond cystine transport, in endolysosomal trafficking and proteolysis, lysosomal clearance, autophagy"
     explanation: Mechanistic review links cystinosin deficiency to broader lysosomal and autophagy abnormalities.
   downstream:
   - target: Proximal tubule cell dysfunction and renal Fanconi syndrome
     description: Proximal tubule cells are especially vulnerable to cystinosin loss and lysosomal dysfunction.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27990015
+      reference_title: 'The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives.'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: renal Fanconi syndrome is often the first manifestation of cystinosis
+      explanation: This evidence supports Proximal tubule cell dysfunction and renal Fanconi syndrome as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Intralysosomal cystine accumulation and lysosomal dysfunction to this target are not fully resolved.
   - target: Corneal cystine crystal deposition
     description: Cystine deposition in the cornea causes crystals and photophobia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: resulting from corneal cystine crystal accumulation.
+      explanation: This evidence supports Corneal cystine crystal deposition as a cystinosis consequence represented by the Intralysosomal cystine accumulation and lysosomal dysfunction edge.
   - target: Extrarenal tissue cystine accumulation
     description: Multisystem cystine accumulation drives endocrine, myopathic, hepatic, pancreatic, and neurologic complications.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: accumulation of cystine in almost all cells, leading to cellular dysfunction
+      explanation: This evidence supports Extrarenal tissue cystine accumulation as a cystinosis consequence represented by the Intralysosomal cystine accumulation and lysosomal dysfunction edge.
   - target: Elevated leukocyte cystine
     description: Lysosomal cystine storage is measured diagnostically as elevated cystine in leukocytes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: elevated cystine concentration in polymorphonuclear leukocytes
+      explanation: This evidence supports Elevated leukocyte cystine as a cystinosis consequence represented by the Intralysosomal cystine accumulation and lysosomal dysfunction edge.
 - name: Proximal tubule cell dysfunction and renal Fanconi syndrome
   description: >
     Cystinosin deficiency causes early and severe proximal tubule dysfunction.
@@ -294,50 +334,151 @@ pathophysiology:
   - reference: PMID:27990015
     reference_title: "The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "renal Fanconi syndrome is often the first manifestation of cystinosis"
     explanation: Review evidence identifies Fanconi syndrome as the early clinical manifestation.
   - reference: PMID:27990015
     reference_title: "The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "dysfunction of proximal tubule cells"
     explanation: Supports proximal tubule cell dysfunction as the renal mechanism.
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "signs of renal tubular Fanconi syndrome (polyuria, polydipsia, dehydration, and acidosis)"
     explanation: GeneReviews ties the renal tubular defect to characteristic clinical and biochemical losses.
   downstream:
   - target: Progressive kidney failure
     description: Chronic glomerular damage and tubular disease progress to kidney failure when untreated.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: within the first 12 years of life if untreated
+      explanation: This evidence supports Progressive kidney failure as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Proximal tubule cell dysfunction and renal Fanconi syndrome.
   - target: Electrolyte wasting, rickets, and growth failure
     description: Tubular wasting drives mineral/electrolyte abnormalities, skeletal disease, and impaired growth.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: poor growth, hypophosphatemic/calcipenic rickets
+      explanation: This evidence supports Electrolyte wasting, rickets, and growth failure as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Renal Fanconi syndrome
     description: Proximal tubular dysfunction presents clinically as renal Fanconi syndrome.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001994 | Renal Fanconi syndrome | Very frequent (99-80%)
+      explanation: This evidence supports Renal Fanconi syndrome as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Renal tubular dysfunction
     description: The proximal tubular defect produces broader renal tubular dysfunction.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000124 | Renal tubular dysfunction | Very frequent (99-80%)
+      explanation: This evidence supports Renal tubular dysfunction as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Renal tubular solute wasting
     description: Fanconi syndrome causes urinary wasting of electrolytes, minerals, glucose, amino acids, and low-molecular-weight solutes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301574
+      reference_title: Cystinosis.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: increased urinary excretion of electrolytes (sodium, potassium, bicarbonate), minerals
+      explanation: This evidence supports Renal tubular solute wasting as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Decreased circulating carnitine concentration
     description: Fanconi-related tubular solute and nutrient wasting can contribute to reduced circulating carnitine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003234 | Decreased circulating carnitine concentration | Occasional (29-5%)
+      explanation: This evidence supports Decreased circulating carnitine concentration as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Proteinuria
     description: Tubular injury includes urinary loss of low-molecular-weight proteins.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000093 | Proteinuria | Very frequent (99-80%)
+      explanation: This evidence supports Proteinuria as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Glycosuria
     description: Impaired proximal tubular reabsorption causes urinary glucose loss.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003076 | Glycosuria | Frequent (79-30%)
+      explanation: This evidence supports Glycosuria as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Aminoaciduria
     description: Impaired proximal tubular reabsorption causes urinary amino-acid loss.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003355 | Aminoaciduria | Very frequent (99-80%)
+      explanation: This evidence supports Aminoaciduria as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Hyperphosphaturia
     description: Impaired proximal tubular phosphate reabsorption causes phosphate wasting.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003109 | Hyperphosphaturia | Frequent (79-30%)
+      explanation: This evidence supports Hyperphosphaturia as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Aciduria
     description: Tubular bicarbonate and acid-base handling abnormalities contribute to aciduria.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0012072 | Aciduria | Frequent (79-30%)
+      explanation: This evidence supports Aciduria as a cystinosis consequence represented by the Proximal tubule cell dysfunction and renal Fanconi syndrome edge.
   - target: Nephrogenic diabetes insipidus
     description: Proximal tubular disease and renal concentrating defects contribute to nephrogenic diabetes insipidus.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0009806 | Nephrogenic diabetes insipidus | Very frequent (99-80%)
+      explanation: This evidence supports Nephrogenic diabetes insipidus as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Proximal tubule cell dysfunction and renal Fanconi syndrome.
   - target: Polydipsia
     description: Tubular dysfunction with concentrating defects produces polydipsia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001959 | Polydipsia | Very frequent (99-80%)
+      explanation: This evidence supports Polydipsia as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Proximal tubule cell dysfunction and renal Fanconi syndrome.
   - target: Dehydration
     description: Polyuria and renal tubular wasting predispose affected children to dehydration.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001944 | Dehydration | Very frequent (99-80%)
+      explanation: This evidence supports Dehydration as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Proximal tubule cell dysfunction and renal Fanconi syndrome.
 - name: Electrolyte wasting, rickets, and growth failure
   description: >
     Renal Fanconi syndrome causes urinary wasting of electrolytes, bicarbonate,
@@ -370,48 +511,139 @@ pathophysiology:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "poor growth, hypophosphatemic/calcipenic rickets"
     explanation: GeneReviews connects nephropathic cystinosis to poor growth and rickets.
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "increased urinary excretion of electrolytes (sodium, potassium, bicarbonate), minerals"
     explanation: GeneReviews documents the renal tubular wasting mechanism.
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "elevated serum alkaline phosphatase; and hypocalcemia,"
     explanation: GeneReviews supports downstream mineral and biochemical abnormalities from tubular wasting.
   downstream:
   - target: Rickets
     description: Mineral wasting contributes to hypophosphatemic/calcipenic rickets.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002748 | Rickets | Frequent (79-30%)
+      explanation: This evidence supports Rickets as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Short stature
     description: Chronic Fanconi syndrome and mineral losses contribute to impaired growth.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0004322 | Short stature | Very frequent (99-80%)
+      explanation: This evidence supports Short stature as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Hypophosphatemia
     description: Phosphate wasting causes hypophosphatemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002148 | Hypophosphatemia | Very frequent (99-80%)
+      explanation: This evidence supports Hypophosphatemia as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Hypokalemia
     description: Potassium wasting causes hypokalemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002900 | Hypokalemia | Very frequent (99-80%)
+      explanation: This evidence supports Hypokalemia as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Metabolic acidosis
     description: Bicarbonate wasting contributes to metabolic acidosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001942 | Metabolic acidosis | Occasional (29-5%)
+      explanation: This evidence supports Metabolic acidosis as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Hypocalcemia
     description: Mineral wasting contributes to hypocalcemia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002901 | Hypocalcemia | Frequent (79-30%)
+      explanation: This evidence supports Hypocalcemia as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Hyponatremia
     description: Sodium wasting can contribute to hyponatremia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002902 | Hyponatremia | Occasional (29-5%)
+      explanation: This evidence supports Hyponatremia as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Elevated circulating alkaline phosphatase concentration
     description: Rickets and mineral bone disease are accompanied by elevated alkaline phosphatase.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003155 | Elevated circulating alkaline phosphatase concentration | Frequent (79-30%)
+      explanation: This evidence supports Elevated circulating alkaline phosphatase concentration as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Osteomalacia
     description: Chronic mineral wasting contributes to osteomalacia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002749 | Osteomalacia | Frequent (79-30%)
+      explanation: This evidence supports Osteomalacia as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Failure to thrive
     description: Tubular wasting, acidosis, and mineral depletion impair weight gain.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001508 | Failure to thrive | Very frequent (99-80%)
+      explanation: This evidence supports Failure to thrive as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Growth delay
     description: Chronic Fanconi syndrome and mineral losses impair growth.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001510 | Growth delay | Frequent (79-30%)
+      explanation: This evidence supports Growth delay as a cystinosis consequence represented by the Electrolyte wasting, rickets, and growth failure edge.
   - target: Nephrocalcinosis
     description: Disturbed renal mineral handling can contribute to nephrocalcinosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000121 | Nephrocalcinosis | Frequent (79-30%)
+      explanation: This evidence supports Nephrocalcinosis as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Electrolyte wasting, rickets, and growth failure.
   - target: Nephrolithiasis
     description: Disturbed renal mineral handling can contribute to nephrolithiasis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000787 | Nephrolithiasis | Frequent (79-30%)
+      explanation: This evidence supports Nephrolithiasis as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Electrolyte wasting, rickets, and growth failure.
 - name: Progressive kidney failure
   description: >
     In untreated nephropathic cystinosis, renal Fanconi syndrome and glomerular
@@ -426,20 +658,34 @@ pathophysiology:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "within the first 12 years of life if untreated"
     explanation: GeneReviews describes childhood progression to end-stage kidney disease without treatment.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "develop end-stage renal disease (ESRD) by 10-12 years of age."
     explanation: Treatment review confirms the natural-history timing of untreated kidney failure.
   downstream:
   - target: Renal insufficiency
     description: Progressive glomerular impairment manifests as renal insufficiency and end-stage kidney disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000083 | Renal insufficiency | Frequent (79-30%)
+      explanation: This evidence supports Renal insufficiency as a cystinosis consequence represented by the Progressive kidney failure edge.
   - target: Nephropathy
     description: Chronic tubular and glomerular injury produce nephropathic disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000112 | Nephropathy | Very frequent (99-80%)
+      explanation: This evidence supports Nephropathy as a cystinosis consequence represented by the Progressive kidney failure edge.
 - name: Corneal cystine crystal deposition
   description: >
     Cystine crystal deposition in the cornea is a hallmark ocular manifestation
@@ -459,24 +705,52 @@ pathophysiology:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "resulting from corneal cystine crystal accumulation."
     explanation: GeneReviews directly links ocular symptoms to corneal cystine crystal accumulation.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Early corneal cystine crystal deposition is a hallmark of the disease."
     explanation: Review evidence supports corneal crystal deposition as a hallmark feature.
   downstream:
   - target: Photophobia
     description: Corneal cystine crystal deposition causes photophobia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000613 | Photophobia | Very frequent (99-80%)
+      explanation: This evidence supports Photophobia as a cystinosis consequence represented by the Corneal cystine crystal deposition edge.
   - target: Corneal opacity
     description: Corneal crystal disease contributes to corneal opacity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007957 | Corneal opacity | Very frequent (99-80%)
+      explanation: This evidence supports Corneal opacity as a cystinosis consequence represented by the Corneal cystine crystal deposition edge.
   - target: Band keratopathy
     description: Chronic corneal involvement can present as band keratopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000585 | Band keratopathy | Frequent (79-30%)
+      explanation: This evidence supports Band keratopathy as a cystinosis consequence represented by the Corneal cystine crystal deposition edge.
   - target: Visual impairment
     description: Ocular cystine crystal disease can impair vision.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000505 | Visual impairment | Occasional (29-5%)
+      explanation: This evidence supports Visual impairment as a cystinosis consequence; the edge is indirect because known clinical intermediates connect it to Corneal cystine crystal deposition.
 - name: Extrarenal tissue cystine accumulation
   description: >
     Continued cystine storage affects multiple organs over time, including the
@@ -491,68 +765,260 @@ pathophysiology:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "accumulation of cystine in almost all cells, leading to cellular dysfunction"
     explanation: GeneReviews connects widespread cystine accumulation to cellular and organ dysfunction.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "may affect several other organs over time, including the eye, thyroid gland, gonads, pancreas, muscles"
     explanation: Treatment review enumerates the multi-organ complications of cystinosis.
   downstream:
   - target: Retinopathy
     description: Eye involvement beyond the cornea can include retinopathy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000488 | Retinopathy | Frequent (79-30%)
+      explanation: This evidence supports Retinopathy as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Hypothyroidism
     description: Thyroid involvement causes hypothyroidism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000821 | Hypothyroidism | Very frequent (99-80%)
+      explanation: This evidence supports Hypothyroidism as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Hypogonadism
     description: Gonadal involvement contributes to hypogonadism.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000135 | Hypogonadism | Frequent (79-30%)
+      explanation: This evidence supports Hypogonadism as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Delayed puberty
     description: Gonadal endocrine dysfunction can delay puberty.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000823 | Delayed puberty | Very frequent (99-80%)
+      explanation: This evidence supports Delayed puberty as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Azoospermia
     description: Male gonadal involvement can result in azoospermia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000027 | Azoospermia | Occasional (29-5%)
+      explanation: This evidence supports Azoospermia as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Glucose intolerance
     description: Pancreatic involvement can impair glucose handling.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001952 | Glucose intolerance | Occasional (29-5%)
+      explanation: This evidence supports Glucose intolerance as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Abnormality of endocrine pancreas physiology
     description: Pancreatic involvement can alter endocrine pancreas function.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0012093 | Abnormality of endocrine pancreas physiology | Occasional (29-5%)
+      explanation: This evidence supports Abnormality of endocrine pancreas physiology as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Type I diabetes mellitus
     description: Pancreatic endocrine dysfunction can manifest as diabetes mellitus.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100651 | Type I diabetes mellitus | Very frequent (99-80%)
+      explanation: This evidence supports Type I diabetes mellitus as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Myopathy
     description: Muscle involvement contributes to cystinotic myopathy.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003198 | Myopathy | Very frequent (99-80%)
+      explanation: This evidence supports Myopathy as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Muscle weakness
     description: Myopathic involvement causes progressive muscle weakness.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001324 | Muscle weakness | Very frequent (99-80%)
+      explanation: This evidence supports Muscle weakness as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: EMG myopathic abnormalities
     description: Muscle involvement can produce myopathic abnormalities on electromyography.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: 'HP:0003458 | EMG: myopathic abnormalities | Frequent (79-30%)'
+      explanation: This evidence supports EMG myopathic abnormalities as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Hypotonia
     description: Neuromuscular involvement can manifest as hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001252 | Hypotonia | Occasional (29-5%)
+      explanation: This evidence supports Hypotonia as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Gait disturbance
     description: Neuromuscular involvement can impair gait.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001288 | Gait disturbance | Occasional (29-5%)
+      explanation: This evidence supports Gait disturbance as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Dysphagia
     description: Gastrointestinal and muscle involvement can produce swallowing difficulty.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1007/s00467-023-06211-6
+      reference_title: 'Gastrointestinal challenges in nephropathic cystinosis: clinical perspectives'
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: vomiting, hyperacidity, dysphagia, dysmotility, and diarrhea, are nearly universal among patients with nephropathic cystinosis.
+      explanation: This evidence supports Dysphagia as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Feeding difficulties
     description: Gastrointestinal involvement contributes to feeding difficulties.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0011968 | Feeding difficulties | Frequent (79-30%)
+      explanation: This evidence supports Feeding difficulties as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Vomiting
     description: Gastrointestinal involvement contributes to vomiting.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002013 | Vomiting | Very frequent (99-80%)
+      explanation: This evidence supports Vomiting as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Constipation
     description: Gastrointestinal dysmotility can contribute to constipation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002019 | Constipation | Occasional (29-5%)
+      explanation: This evidence supports Constipation as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Malabsorption
     description: Gastrointestinal and pancreatic involvement can contribute to malabsorption.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002024 | Malabsorption | Occasional (29-5%)
+      explanation: This evidence supports Malabsorption as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Exocrine pancreatic insufficiency
     description: Pancreatic involvement can impair exocrine pancreatic function.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001738 | Exocrine pancreatic insufficiency | Occasional (29-5%)
+      explanation: This evidence supports Exocrine pancreatic insufficiency as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Hepatomegaly
     description: Liver involvement can manifest as hepatomegaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002240 | Hepatomegaly | Frequent (79-30%)
+      explanation: This evidence supports Hepatomegaly as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Splenomegaly
     description: Hepatic and portal-system involvement can manifest as splenomegaly.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001744 | Splenomegaly | Frequent (79-30%)
+      explanation: This evidence supports Splenomegaly as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Portal hypertension
     description: Hepatobiliary involvement can contribute to portal hypertension.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001409 | Portal hypertension | Occasional (29-5%)
+      explanation: This evidence supports Portal hypertension as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Mild intellectual disability
     description: Nervous-system involvement can affect neurocognitive development.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001256 | Intellectual disability, mild | Occasional (29-5%)
+      explanation: This evidence supports Mild intellectual disability as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Aphasia
     description: Nervous-system involvement can contribute to language impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002381 | Aphasia | Occasional (29-5%)
+      explanation: This evidence supports Aphasia as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Cranial nerve paralysis
     description: Nervous-system involvement can manifest as cranial nerve dysfunction.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0006824 | Cranial nerve paralysis | Occasional (29-5%)
+      explanation: This evidence supports Cranial nerve paralysis as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
   - target: Fatigue
     description: Multisystem cystinosis burden can contribute to fatigue.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0012378 | Fatigue | Very frequent (99-80%)
+      explanation: This evidence supports Fatigue as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
+  - target: Fever
+    description: Multisystem cystinosis can include fever, with the specific storage-to-fever intermediate unresolved.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:213
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001945 | Fever | Occasional (29-5%)
+      explanation: This evidence supports Fever as a cystinosis manifestation; the edge remains indirect because the specific intermediates from Extrarenal tissue cystine accumulation to this target are not fully resolved.
 phenotypes:
 - name: Azoospermia
   category: Reproductive
@@ -721,7 +1187,7 @@ phenotypes:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "photophobia resulting from corneal cystine crystal accumulation."
     explanation: GeneReviews links photophobia directly to corneal cystine crystal accumulation.
 - name: Nephrolithiasis
@@ -982,7 +1448,7 @@ phenotypes:
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "present with renal Fanconi syndrome by 6-12 months of age"
     explanation: Review evidence supports early renal Fanconi syndrome in nephropathic cystinosis.
 - name: Vomiting
@@ -1013,7 +1479,7 @@ phenotypes:
   - reference: DOI:10.1007/s00467-023-06211-6
     reference_title: "Gastrointestinal challenges in nephropathic cystinosis: clinical perspectives"
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "vomiting, hyperacidity, dysphagia, dysmotility, and diarrhea, are nearly universal among patients with nephropathic cystinosis."
     explanation: Gastrointestinal review evidence supports dysphagia as a common sequela of nephropathic cystinosis.
 - name: Constipation
@@ -1391,11 +1857,19 @@ biochemical:
     Elevated cystine concentration in polymorphonuclear leukocytes is a
     diagnostic biochemical finding and reflects the lysosomal cystine storage
     mechanism.
+  readouts:
+  - target: Intralysosomal cystine accumulation and lysosomal dysfunction
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Elevated cystine in polymorphonuclear leukocytes reports the systemic
+      lysosomal cystine storage mechanism caused by CTNS/cystinosin deficiency.
   evidence:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "elevated cystine concentration in polymorphonuclear leukocytes"
     explanation: GeneReviews lists elevated leukocyte cystine as a diagnostic criterion.
 - name: Renal tubular solute wasting
@@ -1403,11 +1877,20 @@ biochemical:
   context: >
     Fanconi syndrome causes urinary wasting of electrolytes, bicarbonate,
     minerals, glucose, amino acids, and low-molecular-weight proteins.
+  readouts:
+  - target: Proximal tubule cell dysfunction and renal Fanconi syndrome
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: >
+      Increased urinary losses of electrolytes, minerals, glucose, amino acids,
+      and low-molecular-weight solutes report the proximal-tubule Fanconi
+      syndrome mechanism.
   evidence:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "increased urinary excretion of electrolytes (sodium, potassium, bicarbonate), minerals"
     explanation: GeneReviews describes the characteristic renal tubular losses.
 diagnosis:
@@ -1420,7 +1903,7 @@ diagnosis:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "cystine crystals in the cornea identified on slit lamp examination"
     explanation: GeneReviews lists slit-lamp identification of corneal crystals as diagnostic evidence.
 - name: Leukocyte or fibroblast cystine measurement
@@ -1433,7 +1916,7 @@ diagnosis:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "elevated cystine concentration in polymorphonuclear leukocytes"
     explanation: GeneReviews identifies elevated leukocyte cystine as a diagnostic criterion.
 - name: CTNS molecular genetic testing
@@ -1446,7 +1929,7 @@ diagnosis:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "biallelic pathogenic variants in CTNS identified by molecular"
     explanation: GeneReviews includes biallelic CTNS pathogenic variants in diagnostic testing.
 genetic:
@@ -1468,7 +1951,7 @@ genetic:
     - reference: PMID:20301574
       reference_title: "Cystinosis."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "Cystinosis is inherited in an autosomal recessive manner."
       explanation: GeneReviews confirms autosomal recessive inheritance.
   variants:
@@ -1480,7 +1963,7 @@ genetic:
     - reference: PMID:20301574
       reference_title: "Cystinosis."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "biallelic pathogenic variants in CTNS identified by molecular"
       explanation: GeneReviews includes biallelic CTNS pathogenic variants in diagnostic testing.
   - name: Common 57-kb CTNS deletion
@@ -1505,13 +1988,13 @@ genetic:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "caused by pathogenic variants in CTNS."
     explanation: GeneReviews identifies CTNS pathogenic variants as causative.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "It is caused by mutations in the CTNS gene that encodes"
     explanation: Review evidence confirms CTNS encodes cystinosin and causes cystinosis.
   - reference: url:https://www.ncbi.nlm.nih.gov/books/NBK1400/
@@ -1552,20 +2035,20 @@ treatments:
     - reference: PMID:27990015
       reference_title: "The renal Fanconi syndrome in cystinosis: pathogenic insights and therapeutic perspectives."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "cysteamine, facilitates lysosomal cystine clearance"
       explanation: Review evidence directly supports lysosomal cystine clearance as the treatment mechanism.
   evidence:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "cystine depletion therapy (cysteamine bitartrate) significantly delays progression of glomerular damage."
     explanation: GeneReviews supports cysteamine bitartrate as disease-directed therapy that delays kidney damage.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "long-term cysteamine treatment delays progression to ESRD"
     explanation: Treatment review supports long-term clinical benefit of cysteamine.
 - name: Cysteamine ophthalmic drops
@@ -1590,7 +2073,7 @@ treatments:
     - reference: PMID:20301574
       reference_title: "Cystinosis."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "Cysteamine ophthalmic drops can relieve photophobia."
       explanation: GeneReviews supports topical cysteamine for symptoms caused by corneal cystine crystal disease.
   target_phenotypes:
@@ -1606,13 +2089,13 @@ treatments:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Cysteamine ophthalmic drops can relieve photophobia."
     explanation: GeneReviews supports ophthalmic cysteamine for photophobia.
   - reference: PMID:29260317
     reference_title: Effects of long-term cysteamine treatment in patients with cystinosis.
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "needs to be combined with cysteamine eye drops for"
     explanation: Treatment review supports combining oral cysteamine with eye drops for corneal involvement.
 - name: Fanconi syndrome replacement therapy
@@ -1629,6 +2112,13 @@ treatments:
   - target: Proximal tubule cell dysfunction and renal Fanconi syndrome
     treatment_effect: MODULATES
     description: Replacement therapy mitigates consequences of renal tubular wasting.
+    evidence:
+    - reference: PMID:20301574
+      reference_title: "Cystinosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Renal Fanconi syndrome is treated by replacement of tubular losses of electrolytes"
+      explanation: GeneReviews supports replacement therapy as management for renal tubular wasting downstream of Fanconi syndrome.
   target_phenotypes:
   - preferred_term: Renal Fanconi syndrome
     term:
@@ -1650,7 +2140,7 @@ treatments:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Renal Fanconi syndrome is treated by replacement of tubular losses of electrolytes"
     explanation: GeneReviews supports replacement of tubular losses as Fanconi syndrome management.
 - name: Growth hormone therapy
@@ -1679,14 +2169,14 @@ treatments:
     - reference: PMID:20301574
       reference_title: "Cystinosis."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "growth hormone therapy as needed"
       explanation: GeneReviews lists growth hormone therapy for growth problems in cystinosis.
   evidence:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "growth hormone therapy as needed"
     explanation: GeneReviews lists growth hormone therapy as supportive management when needed for growth problems.
 - name: L-thyroxine therapy
@@ -1709,14 +2199,14 @@ treatments:
     - reference: PMID:20301574
       reference_title: "Cystinosis."
       supports: SUPPORT
-      evidence_source: OTHER
+      evidence_source: HUMAN_CLINICAL
       snippet: "L-thyroxine as needed for hypothyroidism"
       explanation: GeneReviews lists thyroid hormone replacement for cystinosis-associated hypothyroidism.
   evidence:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "L-thyroxine as needed for hypothyroidism"
     explanation: GeneReviews lists L-thyroxine as supportive treatment for hypothyroidism.
 - name: Renal dialysis
@@ -1732,6 +2222,13 @@ treatments:
   - target: Progressive kidney failure
     treatment_effect: MODULATES
     description: Dialysis manages kidney failure rather than correcting cystinosin deficiency.
+    evidence:
+    - reference: PMID:20301574
+      reference_title: "Cystinosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "additional treatment of renal glomerular disease include dialysis and kidney transplant"
+      explanation: GeneReviews lists dialysis as renal replacement management once cystinosis progresses to glomerular kidney disease.
   target_phenotypes:
   - preferred_term: Renal insufficiency
     term:
@@ -1741,7 +2238,7 @@ treatments:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "additional treatment of renal glomerular disease include dialysis and kidney transplant"
     explanation: GeneReviews lists dialysis as additional treatment for renal glomerular disease.
 - name: Kidney transplantation
@@ -1757,6 +2254,13 @@ treatments:
   - target: Progressive kidney failure
     treatment_effect: MODULATES
     description: Transplantation replaces failed kidney function without reversing systemic cystine storage.
+    evidence:
+    - reference: PMID:20301574
+      reference_title: "Cystinosis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Kidney transplantation is indicated when other medical treatments are no longer effective."
+      explanation: GeneReviews supports kidney transplantation as management for progressive renal disease not controlled by medical therapy.
   target_phenotypes:
   - preferred_term: Renal insufficiency
     term:
@@ -1766,7 +2270,7 @@ treatments:
   - reference: PMID:20301574
     reference_title: "Cystinosis."
     supports: SUPPORT
-    evidence_source: OTHER
+    evidence_source: HUMAN_CLINICAL
     snippet: "Kidney transplantation is indicated when other medical treatments are no longer effective."
     explanation: GeneReviews supports kidney transplantation for refractory renal disease.
 clinical_trials:
@@ -1796,6 +2300,8 @@ references:
   findings: []
 - reference: PMID:20301574
   title: Cystinosis.
+  tags:
+  - GeneReviews
   findings: []
 - reference: PMID:11689434
   title: "Cystinosin, the protein defective in cystinosis, is a H(+)-driven lysosomal cystine transporter."


### PR DESCRIPTION
## Summary
- add causal link types and evidence blocks to every Cystinosis downstream edge
- connect the previously unexplained Fever phenotype through an explicitly indirect extrarenal-tissue edge
- add biochemical readout links and evidence for previously unsupported treatment-mechanism targets

## Validation
- `just validate kb/disorders/Cystinosis.yaml`
- `just validate-terms kb/disorders/Cystinosis.yaml`
- `just validate-references kb/disorders/Cystinosis.yaml` (repo wrapper reports 0 checks)
- independent snippet audit: `checked=182 missing=0 no_cache=0`
- graph audit: `unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_without_readouts=0 treatment_targets_without_evidence=0`
- `uv run python -m dismech.graph --validate kb/disorders/Cystinosis.yaml`
- `git diff --check`