### PR TITLE
Add evidence to Fabry disease pathograph edges

### DIFF
--- a/kb/disorders/Fabry_Disease.yaml
+++ b/kb/disorders/Fabry_Disease.yaml
@@ -1,6 +1,6 @@
 name: Fabry disease
 creation_date: '2026-01-08T17:12:45Z'
-updated_date: '2026-05-21T02:37:55Z'
+updated_date: '2026-05-21T16:39:58Z'
 category: Mendelian
 disease_term:
   preferred_term: Fabry disease
@@ -291,9 +291,27 @@ pathophysiology:
   downstream:
   - target: Lysosomal Gb3 and lyso-Gb3 accumulation
     description: Reduced alpha-galactosidase A activity prevents normal lysosomal clearance of Gb3 and related glycosphingolipids.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Fabry disease (FD) is a rare lysosomal storage disorder, characterized by a reduction in α-galactosidase A enzyme activity and the progressive accumulation of globotriaosylceramide (GL3) and its metabolites in the cells of various organs.
+      explanation: Review evidence directly links reduced alpha-galactosidase A activity to progressive GL3 and metabolite accumulation.
   - target: Endoplasmic reticulum stress and unfolded protein response
     description: Misfolded alpha-galactosidase A variants can trigger ER stress and UPR activation.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - misfolded alpha-galactosidase A variants
+    - endoplasmic-reticulum protein quality-control stress
+    evidence:
+    - reference: PMID:39978321
+      reference_title: "The Inflammatory Pathogenetic Pathways of Fabry Nephropathy and Agalopathy: <italic>GLA</italic> Variant Induction of Endoplasmic Reticulum Stress."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Missense variants in the coding sequence of the GLA gene would generate the misfolding of the altered protein alpha-galactosidase A. Emergence of misfolded proteins may generate stress of the endoplasmic reticulum, leading to induction of the unfolded protein response (UPR)
+      explanation: This review supports the mechanistic path from GLA missense variants through alpha-galactosidase A misfolding to ER stress and UPR activation.
 - name: Lysosomal Gb3 and lyso-Gb3 accumulation
   description: >
     Deficient α-galactosidase A activity causes progressive lysosomal accumulation of globotriaosylceramide (Gb3/GL-3)
@@ -330,11 +348,37 @@ pathophysiology:
   downstream:
   - target: Lyso-Gb3
     description: Impaired alpha-galactosidase A activity produces accumulation of Gb3 and its deacylated biomarker lyso-Gb3.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20716442
+      reference_title: "How well does urinary lyso-Gb3 function as a biomarker in Fabry disease?"
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "BACKGROUND: Fabry disease is characterized by accumulation of glycosphingolipids, such as globotriaosylceramide (Gb(3)), in many tissues and body fluids. A novel plasma biomarker, globotriaosylsphingosine (lyso-Gb(3)), is increased in patients with the disease."
+      explanation: Fabry patient biomarker evidence directly links glycosphingolipid accumulation with increased lyso-Gb3 in the disease.
   - target: Tissue-specific glycosphingolipid storage
     description: The shared lysosomal storage lesion occurs in multiple organ systems and must be interpreted in local tissue contexts.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Accumulation of GL3 in the kidney, heart, vasculature, neurons, skin, gastrointestinal tract and auditory system correlates to cellular damage and irreversible organ damage
+      explanation: The review supports branching from shared GL3 accumulation into organ-specific storage and tissue damage.
   - target: Innate immune activation and inflammation
     description: Gb3 and lyso-Gb3 accumulation promotes inflammatory mediator production.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Gb3 and lyso-Gb3 sensing by innate immune cells
+    - cytokine release
+    evidence:
+    - reference: PMID:39978321
+      reference_title: "The Inflammatory Pathogenetic Pathways of Fabry Nephropathy and Agalopathy: <italic>GLA</italic> Variant Induction of Endoplasmic Reticulum Stress."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: It has been demonstrated that intralysosomal accumulation of Gb3 and LysoGb3 triggers an inflammatory response.
+      explanation: The review directly supports inflammatory activation downstream of intralysosomal Gb3 and LysoGb3 accumulation.
 - name: Tissue-specific glycosphingolipid storage
   description: >
     The same lysosomal substrate burden occurs across kidney, heart, blood vessels, neurons, skin, ocular tissues, and
@@ -356,17 +400,64 @@ pathophysiology:
   downstream:
   - target: Renal glycosphingolipid storage and podocyte injury
     description: Kidney and podocyte substrate accumulation defines the renal branch and is the context for renal GL-3 tissue readouts.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27129690
+      reference_title: "Significant improvement in Fabry disease podocytopathy after 3 years of treatment with agalsidase beta."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Despite normal renal function and urinalysis, renal biopsy showed abnormal structure, with marked accumulation of GL-3 in podocytes, partial effacement of foot processes and irregularly reduced expression of nephrin in the slit diaphragm.
+      explanation: Human renal biopsy evidence places GL-3 accumulation specifically in podocytes and links it to podocyte structural injury.
   - target: Cardiac glycosphingolipid storage and myocardial remodeling
     description: Cardiac substrate accumulation drives the branch leading to hypertrophic and fibrotic Fabry cardiomyopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33602475
+      reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Fabry disease (FD) is a rare X-linked inherited lysosomal storage disorder caused by deficient α-galactosidase A activity that leads to an accumulation of globotriasylceramide (Gb3) in affected tissues, including the heart.
+      explanation: The cardiac review supports heart-specific Gb3 accumulation as a Fabry disease tissue branch.
   - target: Vascular endothelial glycosphingolipid storage and dysfunction
     description: Vascular and endothelial substrate accumulation defines the branch leading to cerebrovascular and cochleo-vestibular manifestations.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Accumulation of GL3 in the kidney, heart, vasculature, neurons, skin, gastrointestinal tract and auditory system correlates to cellular damage and irreversible organ damage
+      explanation: The review includes vasculature among GL3-affected compartments where storage correlates with cellular and organ damage.
   - target: Peripheral small-fiber and autonomic glycosphingolipid storage
     description: Neuronal and autonomic substrate accumulation defines the pain, sweating, heat-intolerance, and gastrointestinal branches.
-  - target: Corneal glycosphingolipid deposition
-    description: Ocular substrate deposition defines the cornea verticillata and opacity branch.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Accumulation of GL3 in the kidney, heart, vasculature, neurons, skin, gastrointestinal tract and auditory system correlates to cellular damage and irreversible organ damage
+      explanation: The review includes neurons and gastrointestinal tract among GL3-affected compartments, supporting the peripheral/autonomic branch.
+  - target: Ocular glycosphingolipid deposition
+    description: Ocular substrate deposition defines the corneal and lenticular opacity branch.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31939530
+      reference_title: "Fabry disease: genetics, pathology, and treatment."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Gb3 accumulates in lysosomes of different types of cells of the heart, kidneys, skin, eyes, central nervous system, and gastrointestinal system
+      explanation: The review includes the eyes among tissues with lysosomal Gb3 accumulation, supporting the ocular branch.
   - target: Cutaneous vascular glycosphingolipid storage
     description: Cutaneous vascular substrate accumulation defines the angiokeratoma branch.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Accumulation of GL3 in the kidney, heart, vasculature, neurons, skin, gastrointestinal tract and auditory system correlates to cellular damage and irreversible organ damage
+      explanation: The review includes skin and vasculature among GL3-affected tissues, supporting the cutaneous vascular storage branch.
 - name: Renal glycosphingolipid storage and podocyte injury
   description: >
     GL-3 accumulation in kidney cells, especially podocytes, injures the glomerular filtration barrier. Podocyte storage
@@ -398,13 +489,67 @@ pathophysiology:
   downstream:
   - target: Autophagy impairment
     description: Fabry podocyte injury includes lysosomal and autophagy dysfunction.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - lysosomal dysfunction in GLA-edited podocytes
+    - podocyte cellular stress response
+    evidence:
+    - reference: PMID:39100494
+      reference_title: "Genome-wide expression analysis in a Fabry disease human podocyte cell line."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: The complex pathogenesis of FD involves lysosomal dysfunction, altered autophagy, and mitochondrial abnormalities.
+      explanation: Fabry podocyte-model evidence links the renal cellular disease context to altered autophagy.
   - target: Mitochondrial dysfunction and oxidative stress
     description: Fabry podocyte models show oxidative-stress and mitochondrial-abnormality pathways downstream of GLA deficiency.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - GLA-edited podocyte stress-response changes
+    - mitochondrial abnormalities
+    evidence:
+    - reference: PMID:39100494
+      reference_title: "Genome-wide expression analysis in a Fabry disease human podocyte cell line."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Functional analysis of differentially expressed genes showed their involvement in various pathways related to oxidative stress, inflammation, fatty acid metabolism, collagen and extracellular matrix homeostasis, kidney injury, apoptosis, autophagy, and cellular stress response.
+      explanation: Transcriptomic analysis of Fabry podocytes supports oxidative-stress and cellular-stress pathways downstream of podocyte dysfunction.
   - target: Proteinuria
     description: Podocyte injury damages the filtration barrier and contributes to proteinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - podocyte foot-process injury
+    - slit-diaphragm dysfunction
+    - glomerular filtration barrier injury
+    evidence:
+    - reference: PMID:28613767
+      reference_title: "Fabry Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Ocular involvement includes corneal and lenticular abnormalities, while progressive renal involvement leads to proteinuria and eventual end-stage renal disease.
+      explanation: The clinical review supports proteinuria as a consequence of progressive renal involvement in Fabry disease.
   - target: Chronic kidney disease
     description: Persistent renal cellular injury contributes to Fabry nephropathy progression.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - progressive renal cellular injury
+    - glomerular and interstitial damage
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Damage leads to renal dysfunction and end-stage renal disease
+      explanation: The GL3 clinical-relevance review links storage-associated renal damage to renal dysfunction and end-stage renal disease.
+  - target: Renal Globotriaosylceramide Inclusions
+    description: Renal podocyte GL-3 storage can be observed as biopsy-level renal globotriaosylceramide inclusions.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27129690
+      reference_title: "Significant improvement in Fabry disease podocytopathy after 3 years of treatment with agalsidase beta."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Despite normal renal function and urinalysis, renal biopsy showed abnormal structure, with marked accumulation of GL-3 in podocytes, partial effacement of foot processes and irregularly reduced expression of nephrin in the slit diaphragm.
+      explanation: Human biopsy evidence supports renal GL-3 inclusions as a direct tissue readout of the renal podocyte storage branch.
 - name: Cardiac glycosphingolipid storage and myocardial remodeling
   description: >
     Gb3 accumulation in cardiac tissue contributes to Fabry cardiomyopathy, with cardiomyocyte hypertrophy, myocardial
@@ -436,11 +581,44 @@ pathophysiology:
   downstream:
   - target: Fibrosis and extracellular matrix remodeling
     description: Cardiac storage and injury promote myocardial fibrosis and remodeling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cardiac glycosphingolipid storage
+    - myocardial inflammation and remodeling
+    evidence:
+    - reference: PMID:33602475
+      reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death
+      explanation: The cardiac review links Fabry cardiac involvement with myocardial fibrosis and remodeling-related outcomes.
   - target: Cardiomyocyte autophagy impairment and oxidative stress
     description: Cardiomyocyte storage models show autophagy impairment, ROS production, cell death, and hypertrophic changes.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - cardiomyocyte Gb3 accumulation
+    - autophagic-flux impairment
+    - mitochondrial ROS production
+    evidence:
+    - reference: PMID:30965672
+      reference_title: "Generation of GLA-Knockout Human Embryonic Stem Cell Lines to Model Autophagic Dysfunction and Exosome Secretion in Fabry Disease-Associated Hypertrophic Cardiomyopathy."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: This caused impairment of autophagic flux and protein turnover, resulting in an increase of reactive oxygen species and apoptosis.
+      explanation: GLA-null human stem-cell-derived cardiomyocyte evidence supports autophagy impairment and ROS production downstream of the cardiac disease model.
   - target: Atrial cardiomyocyte electrophysiological remodeling
     description: Atrial cardiomyocyte storage models show electrophysiological and calcium-handling changes linked to arrhythmia risk.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - atrial cardiomyocyte alpha-galactosidase A deficiency
+    - atrial globotriaosylceramide accumulation
+    evidence:
+    - reference: PMID:40557493
+      reference_title: "Early Atrial Remodeling Drives Arrhythmia in Fabry Disease."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: GLA p.N215S iPSC-CMs were deficient in α-Gal A and exhibited globotriaosylceramide accumulation. Atrial GLA p.N215S iPSC-CMs demonstrated a more positive diastolic membrane potential, faster action potential upstroke velocity, greater incidence of delayed afterdepolarizations, greater contraction force, and alterations in calcium handling compared with wild-type iPSC-CMs.
+      explanation: The atrial iPSC-cardiomyocyte model connects Fabry enzyme deficiency and globotriaosylceramide accumulation to atrial electrophysiological remodeling.
 - name: Cardiomyocyte autophagy impairment and oxidative stress
   description: >
     In cardiac pluripotent-stem-cell models of Fabry disease, GLA deficiency and Gb3 accumulation impair autophagic flux
@@ -489,7 +667,18 @@ pathophysiology:
   downstream:
   - target: Left ventricular hypertrophy
     description: Cardiomyocyte hypertrophic changes contribute to the LVH branch of Fabry cardiomyopathy.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - impaired cardiomyocyte autophagic flux
+    - mitochondrial ROS production
+    - hypertrophic cardiomyocyte remodeling
+    evidence:
+    - reference: PMID:30965672
+      reference_title: "Generation of GLA-Knockout Human Embryonic Stem Cell Lines to Model Autophagic Dysfunction and Exosome Secretion in Fabry Disease-Associated Hypertrophic Cardiomyopathy."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: cardiomyocytes differentiated from these hESCs (GLA-null CMs) were characterized by the accumulation of Gb3 and significant increases of cell surface area, the landmarks of FD-associated cardiomyopathy.
+      explanation: The GLA-null cardiomyocyte model supports hypertrophic cellular remodeling in the same model that shows autophagy and ROS abnormalities.
 - name: Atrial cardiomyocyte electrophysiological remodeling
   description: >
     Fabry atrial cardiomyocyte models show altered action-potential behavior, calcium handling, and contraction, and
@@ -527,9 +716,28 @@ pathophysiology:
   downstream:
   - target: Early atrial ECG changes
     description: Atrial electrical remodeling manifests clinically as early P-wave and PQ-interval changes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40557493
+      reference_title: "Early Atrial Remodeling Drives Arrhythmia in Fabry Disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: ECG analysis demonstrated P-wave duration and PQ interval shortening in FD adults before the onset of cardiomyopathy.
+      explanation: Human ECG analysis supports early atrial conduction changes as a downstream manifestation of Fabry atrial remodeling.
   - target: Cardiac arrhythmia
     description: Atrial electrophysiological remodeling contributes to atrial fibrillation and other arrhythmia risk.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - altered atrial action-potential behavior
+    - abnormal calcium handling
+    - atrial fibrillation vulnerability
+    evidence:
+    - reference: PMID:40557493
+      reference_title: "Early Atrial Remodeling Drives Arrhythmia in Fabry Disease."
+      supports: SUPPORT
+      evidence_source: COMPUTATIONAL
+      snippet: Simulations with these changes in the in silico models resulted in similar P-wave morphology changes to those seen in early FD cardiomyopathy and increased atrial fibrillation vulnerability.
+      explanation: Computational atrial modeling links the observed Fabry atrial-cell changes to increased atrial fibrillation vulnerability.
 - name: Vascular endothelial glycosphingolipid storage and dysfunction
   description: >
     Gb3/lyso-Gb3 accumulation in endothelial and vascular cells leads to adhesion-molecule upregulation, reduced nitric
@@ -570,10 +778,44 @@ pathophysiology:
   downstream:
   - target: Stroke
     description: Vascular and endothelial dysfunction contribute to cerebrovascular events.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - vascular GL3-associated cellular damage
+    - endothelial dysfunction
+    - cerebrovascular ischemia
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Damage leads to renal dysfunction and end-stage renal disease; myocardial hypertrophy with heart failure and arrhythmias; ischemic stroke; neuropathic pain; skin lesions; intestinal ischemia and dysmotility; and hearing loss.
+      explanation: The GL3 clinical-relevance review links tissue damage downstream of GL3 accumulation to ischemic stroke.
   - target: Transient ischemic attack
     description: Fabry vasculopathy contributes to transient cerebral ischemic events.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Fabry vasculopathy
+    - cerebrovascular ischemia
+    evidence:
+    - reference: PMID:21290706
+      reference_title: "Nervous system manifestations of Fabry disease: data from FOS – the Fabry Outcome Survey."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Thus, 13.2% (15.1% males, 11.5% females) have suffered an ischaemic stroke or transient ischaemic attack, usually at an early age.
+      explanation: Fabry Outcome Survey data support stroke or TIA as clinical downstream events of the nervous-system and vascular branch.
   - target: Hearing impairment
     description: Vascular and nervous-system involvement can contribute to cochleo-vestibular manifestations.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - auditory-system GL3 accumulation
+    - vascular and neural injury
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Damage leads to renal dysfunction and end-stage renal disease; myocardial hypertrophy with heart failure and arrhythmias; ischemic stroke; neuropathic pain; skin lesions; intestinal ischemia and dysmotility; and hearing loss.
+      explanation: The review links GL3-associated tissue damage to hearing loss, supporting the cochleo-vestibular branch.
   - target: Tinnitus
     description: Auditory-system glycosphingolipid storage and vasculopathy contribute to cochleo-vestibular symptoms including tinnitus.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -628,6 +870,17 @@ pathophysiology:
   downstream:
   - target: Acroparesthesia
     description: Sensory-neuron dysfunction contributes to distal paresthesias and neuropathic pain crises.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neuronal glycosphingolipid storage
+    - small-fiber dysfunction
+    evidence:
+    - reference: PMID:31939530
+      reference_title: "Fabry disease: genetics, pathology, and treatment."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The onset of symptoms occurs during childhood, with acroparesthesia, heat intolerance, and gastrointestinal symptoms, such as nausea, vomiting, abdominal pain, and neuropathic pain
+      explanation: The review places acroparesthesia in the early neurological and autonomic symptom cluster downstream of Fabry storage.
   - target: Neuropathic pain
     description: Small-fiber dysfunction produces chronic or episodic neuropathic pain and Fabry pain crises.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -694,10 +947,10 @@ pathophysiology:
       snippet: "The onset of symptoms occurs during childhood, with acroparesthesia, heat intolerance, and gastrointestinal symptoms, such as nausea, vomiting, abdominal pain, and neuropathic pain"
       explanation: The review lists nausea and vomiting among early gastrointestinal symptoms in Fabry disease.
 
-- name: Corneal glycosphingolipid deposition
+- name: Ocular glycosphingolipid deposition
   description: >
-    Glycosphingolipid deposition in corneal tissues produces the ocular branch of Fabry disease, including whorl-like
-    cornea verticillata and corneal opacity detected on slit-lamp examination.
+    Glycosphingolipid deposition in ocular tissues produces the ocular branch of Fabry disease, including whorl-like
+    cornea verticillata, corneal opacity, and lenticular opacity/cataract detected on eye examination.
   evidence:
   - reference: PMID:31939530
     reference_title: "Fabry disease: genetics, pathology, and treatment."
@@ -710,7 +963,7 @@ pathophysiology:
     supports: SUPPORT
     evidence_source: OTHER
     snippet: "Ocular involvement includes corneal and lenticular abnormalities"
-    explanation: StatPearls directly supports corneal involvement in Fabry disease.
+    explanation: StatPearls directly supports corneal and lenticular ocular involvement in Fabry disease.
   cell_types:
   - preferred_term: corneal epithelial cell
     term:
@@ -721,12 +974,40 @@ pathophysiology:
     term:
       id: UBERON:0001772
       label: corneal epithelium
+  - preferred_term: lens of camera-type eye
+    term:
+      id: UBERON:0000965
+      label: lens of camera-type eye
   downstream:
   - target: Cornea verticillata
-    description: Corneal glycosphingolipid deposition produces whorl-like corneal deposits.
+    description: Ocular glycosphingolipid deposition produces whorl-like corneal deposits.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31939530
+      reference_title: "Fabry disease: genetics, pathology, and treatment."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Subsequently, symptoms related to progressive impairment appear, such as angiokeratomas, cornea verticillata, left ventricular hypertrophy, myocardial fibrosis, proteinuria, and renal insufficiency
+      explanation: The review lists cornea verticillata among Fabry manifestations that follow progressive tissue impairment.
   - target: Corneal opacity
-    description: Corneal glycosphingolipid deposition can contribute to corneal opacity.
-
+    description: Ocular glycosphingolipid deposition can contribute to corneal opacity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:324
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007957 | Corneal opacity | Very frequent (99-80%)
+      explanation: Orphanet records corneal opacity as a very frequent Fabry disease manifestation, supporting this ocular downstream target.
+  - target: Cataract
+    description: Lenticular glycosphingolipid involvement contributes to cataract/lens opacity in Fabry disease.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:324
+      reference_title: "Fabry disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000518 | Cataract | Frequent (79-30%)
+      explanation: Orphanet records cataract as a frequent Fabry disease manifestation, supporting this lenticular ocular downstream target.
 - name: Cutaneous vascular glycosphingolipid storage
   description: >
     GL3 accumulation in skin and cutaneous microvasculature contributes to angiokeratomas and other microvascular skin
@@ -757,7 +1038,14 @@ pathophysiology:
   downstream:
   - target: Angiokeratomas
     description: Cutaneous microvascular storage and dilation contribute to angiokeratoma formation.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28613767
+      reference_title: "Fabry Disease."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Common presenting features include severe episodic pain in the extremities consistent with acroparesthesia, microvascular skin lesions, eg, angiokeratomas, and abnormalities of sweating that may manifest as anhidrosis, hypohidrosis, or hyperhidrosis.
+      explanation: StatPearls identifies angiokeratomas as microvascular skin lesions, supporting the edge from cutaneous vascular storage to angiokeratomas.
 - name: Endoplasmic reticulum stress and unfolded protein response
   description: >
     Misfolded α-Gal A variants trigger endoplasmic reticulum stress and activate the unfolded protein response (UPR).
@@ -782,7 +1070,14 @@ pathophysiology:
   downstream:
   - target: Innate immune activation and inflammation
     description: UPR activation causes pro-inflammatory cytokine release and contributes to inflammatory status.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39978321
+      reference_title: "The Inflammatory Pathogenetic Pathways of Fabry Nephropathy and Agalopathy: <italic>GLA</italic> Variant Induction of Endoplasmic Reticulum Stress."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The UPR causes the release of pro-inflammatory cytokines and contributes to inflammatory status.
+      explanation: The review directly supports pro-inflammatory cytokine release downstream of UPR activation.
 - name: Mitochondrial dysfunction and oxidative stress
   description: >
     Fabry podocyte models show mitochondrial abnormalities and oxidative-stress pathway activation downstream of GLA
@@ -841,9 +1136,32 @@ pathophysiology:
   downstream:
   - target: Proteinuria
     description: Fabry podocyte lysosomal dysfunction contributes to podocyte injury and proteinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - lysosomal dysfunction in podocytes
+    - podocyte injury
+    - glomerular filtration barrier injury
+    evidence:
+    - reference: PMID:39100494
+      reference_title: "Genome-wide expression analysis in a Fabry disease human podocyte cell line."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Functional analysis of differentially expressed genes showed their involvement in various pathways related to oxidative stress, inflammation, fatty acid metabolism, collagen and extracellular matrix homeostasis, kidney injury, apoptosis, autophagy, and cellular stress response.
+      explanation: Fabry podocyte transcriptomics links autophagy-related cellular stress with kidney-injury pathways that can lead to proteinuria.
   - target: Chronic kidney disease
     description: Persistent podocyte injury and lysosomal dysfunction contribute to Fabry nephropathy progression.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - persistent podocyte lysosomal dysfunction
+    - podocyte injury
+    - progressive kidney injury
+    evidence:
+    - reference: PMID:37014703
+      reference_title: "Accumulation of α-synuclein mediates podocyte injury in Fabry nephropathy."
+      supports: PARTIAL
+      evidence_source: HUMAN_CLINICAL
+      snippet: Current therapies for Fabry disease are based on reversing intracellular accumulation of globotriaosylceramide (Gb3) by enzyme replacement therapy (ERT) or chaperone-mediated stabilization of the defective enzyme, thereby alleviating lysosomal dysfunction. However, their effect in the reversal of end-organ damage, like kidney injury and chronic kidney disease, remains unclear.
+      explanation: Human-biopsy study framing supports persistent lysosomal/podocyte injury as a contributor to kidney injury and chronic kidney disease, though it does not isolate autophagy alone.
 - name: Innate immune activation and inflammation
   description: >
     Gb3/lyso-Gb3 accumulation and unfolded-protein stress activate innate inflammatory programs, including complement
@@ -880,11 +1198,44 @@ pathophysiology:
   downstream:
   - target: Renal glycosphingolipid storage and podocyte injury
     description: Kidney-associated cytokine production and inflammation contribute to the renal injury branch.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - pro-inflammatory cytokine signaling
+    - podocyte stress-response activation
+    evidence:
+    - reference: PMID:39100494
+      reference_title: "Genome-wide expression analysis in a Fabry disease human podocyte cell line."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: Functional analysis of differentially expressed genes showed their involvement in various pathways related to oxidative stress, inflammation, fatty acid metabolism, collagen and extracellular matrix homeostasis, kidney injury, apoptosis, autophagy, and cellular stress response.
+      explanation: Fabry podocyte transcriptomics supports inflammatory and kidney-injury pathways within the renal branch.
   - target: Vascular endothelial glycosphingolipid storage and dysfunction
     description: Chronic inflammatory signaling propagates vascular and endothelial dysfunction.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - endothelial inflammatory events
+    - adhesion-molecule and cytokine signaling
+    evidence:
+    - reference: PMID:39408658
+      reference_title: "In Silico Modeling of Fabry Disease Pathophysiology for the Identification of Early Cellular Damage Biomarker Candidates."
+      supports: PARTIAL
+      evidence_source: COMPUTATIONAL
+      snippet: are the accumulation of sphingolipids and subsequent inflammatory events, mainly at the endothelial level. The outcomes include different nervous system manifestations as well as multiple organ damage.
+      explanation: Computational systems-biology evidence supports inflammatory events at the endothelial level as part of Fabry vascular injury.
   - target: Fibrosis and extracellular matrix remodeling
     description: Inflammatory cytokines including TGF-beta promote profibrotic tissue remodeling.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - pro-inflammatory cytokine release
+    - TGF-beta signaling
+    - profibrotic remodeling
+    evidence:
+    - reference: PMID:39978321
+      reference_title: "The Inflammatory Pathogenetic Pathways of Fabry Nephropathy and Agalopathy: <italic>GLA</italic> Variant Induction of Endoplasmic Reticulum Stress."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: These processes determine the activation of inflammation processes associated with chronic inflammation and tissue fibrosis.
+      explanation: The inflammatory-pathways review links chronic inflammatory activation to tissue fibrosis.
 - name: Fibrosis and extracellular matrix remodeling
   description: >
     TGF-β-driven profibrotic signaling leads to extracellular matrix deposition in kidney and heart. This fibrotic process
@@ -920,11 +1271,43 @@ pathophysiology:
   downstream:
   - target: Chronic kidney disease
     description: Renal fibrosis contributes to progressive kidney dysfunction.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - renal sclerosis and fibrosis
+    - progressive renal dysfunction
+    evidence:
+    - reference: PMID:36334424
+      reference_title: "Clinical relevance of globotriaosylceramide accumulation in Fabry disease and the effect of agalsidase beta in affected tissues."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Accumulation of GL3 in the kidney, heart, vasculature, neurons, skin, gastrointestinal tract and auditory system correlates to cellular damage and irreversible organ damage, as a result of sclerosis, fibrosis, apoptosis, inflammation, and endothelial dysfunction. Damage leads to renal dysfunction and end-stage renal disease
+      explanation: The review links fibrosis and other GL3-associated damage mechanisms to renal dysfunction and end-stage renal disease.
   - target: Left ventricular hypertrophy
     description: Cardiac fibrosis and remodeling accompany hypertrophic Fabry cardiomyopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - myocardial remodeling
+    - hypertrophic cardiomyopathy progression
+    evidence:
+    - reference: PMID:33602475
+      reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias, which limit quality of life and represent the most common causes of death
+      explanation: The cardiac review places left ventricular hypertrophy and myocardial fibrosis together in Fabry cardiac involvement.
   - target: Cardiac arrhythmia
     description: Myocardial fibrosis creates an arrhythmogenic substrate.
-
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - myocardial fibrosis
+    - arrhythmogenic substrate formation
+    evidence:
+    - reference: PMID:33602475
+      reference_title: "Cardiac Involvement in Fabry Disease: JACC Review Topic of the Week."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Cardiovascular involvement usually manifests as left ventricular hypertrophy, myocardial fibrosis, heart failure, and arrhythmias
+      explanation: The cardiac review supports arrhythmias as a downstream manifestation in the myocardial fibrosis/remodeling branch.
 phenotypes:
 - name: Acroparesthesia
   category: Neurological
@@ -1320,6 +1703,30 @@ phenotypes:
     term:
       id: HP:0007957
       label: Corneal opacity
+
+- name: Cataract
+  category: Ophthalmological
+  description: >
+    Lens opacity/cataract is a frequent ocular manifestation of Fabry disease and is anatomically distinct from corneal opacity.
+  frequency: FREQUENT
+  evidence:
+  - reference: ORPHA:324
+    reference_title: "Fabry disease (Orphanet structured-database record)"
+    supports: SUPPORT
+    evidence_source: OTHER
+    snippet: "HP:0000518 | Cataract | Frequent (79-30%)"
+    explanation: Orphanet phenotype data records cataract as a frequent manifestation of Fabry disease.
+  - reference: PMID:20301469
+    reference_title: "Fabry Disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "characteristic corneal and lenticular opacities"
+    explanation: GeneReviews describes lenticular opacities as characteristic ocular features of classic Fabry disease.
+  phenotype_term:
+    preferred_term: Cataract
+    term:
+      id: HP:0000518
+      label: Cataract
 
 biochemical:
 - name: Lyso-Gb3
@@ -1933,6 +2340,12 @@ computational_models:
     snippet: "Simulations with these changes in the in silico models resulted in similar P-wave morphology changes to those seen in early FD cardiomyopathy and increased atrial fibrillation vulnerability."
     explanation: The paper supports a computational model linking cellular Fabry atrial remodeling to early ECG and arrhythmia-risk outputs.
 
+references:
+- reference: PMID:20301469
+  title: Fabry Disease.
+  tags:
+  - GeneReviews
+  findings: []
 notes: >
   Early diagnosis and treatment initiation are critical for improving outcomes. Progressive organ damage despite enzyme replacement
   therapy suggests ongoing pathogenic mechanisms beyond lipid substrate, including persistent inflammation, oxidative stress, fibrosis,

--- a/references_cache/PMID_20301469.md
+++ b/references_cache/PMID_20301469.md
@@ -1,0 +1,115 @@
+---
+reference_id: "PMID:20301469"
+title: Fabry Disease.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Mehta A
+- Hughes DA
+year: '1993'
+content_type: abstract_only
+---
+
+# Fabry Disease.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Mehta A, Hughes DA
+
+## Content
+
+1. Fabry Disease.
+
+Mehta A(1), Hughes DA(2).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2002 Aug 5 [updated 2024 Apr 11].
+
+Author information:
+(1)Emeritus Professor, Department of Haematology, University College London
+School of Medicine, London, United Kingdom
+(2)Professor, Experimental Haematology, Lysosomal Storage Disorders Unit,
+Department of Haematology, Royal Free Hospital, University College London,
+London, United Kingdom
+
+CLINICAL CHARACTERISTICS: Fabry disease is the most common of the lysosomal
+storage disorders and results from deficient activity of the enzyme
+alpha-galactosidase A (α-Gal A), leading to progressive lysosomal deposition of
+globotriaosylceramide and its derivatives in cells throughout the body. The
+classic form, occurring in males with less than 1% α-Gal A enzyme activity,
+usually has its onset in childhood or adolescence with periodic crises of severe
+pain in the extremities (acroparesthesia), the appearance of vascular cutaneous
+lesions (angiokeratomas), sweating abnormalities (anhidrosis, hypohidrosis, and
+rarely hyperhidrosis), characteristic corneal and lenticular opacities, and
+proteinuria. Gradual deterioration of kidney function to end-stage kidney
+disease (ESKD) usually occurs in men in the third to fifth decade. In middle
+age, most males successfully treated for ESKD develop cardiac and/or
+cerebrovascular disease, a major cause of morbidity and mortality. Heterozygous
+females typically have milder symptoms at a later age of onset than males.
+Rarely, females may be relatively asymptomatic throughout a normal life span or
+may have symptoms as severe as those observed in males with the classic
+phenotype. In contrast, late-onset forms occur in males with greater than 1%
+α-Gal A activity. Clinical manifestations include cardiac disease, which usually
+presents in the sixth to eighth decade with left ventricular hypertrophy,
+cardiomyopathy, arrhythmia, and proteinuria; kidney failure, associated with
+ESKD but without the skin lesions or pain; or cerebrovascular disease presenting
+as stroke or transient ischemic attack.
+DIAGNOSIS/TESTING: Identification of deficient α-Gal A enzyme activity in
+plasma, isolated leukocytes, and/or cultured cells is the most efficient and
+reliable method of diagnosing Fabry disease in males. Identification of a
+hemizygous GLA pathogenic variant by molecular genetic testing confirms the
+diagnosis in a male proband. Identification of a heterozygous GLA pathogenic
+variant by molecular genetic testing establishes the diagnosis in a heterozygous
+female.
+MANAGEMENT: Targeted therapies: Enzyme replacement therapy (ERT) with or without
+chaperone therapy (e.g., migalastat) to prevent and/or delay the progression of
+renal, cardiac, and cerebrovascular manifestations. Experts recommend that ERT
+be initiated as early as possible in all males with Fabry disease (including
+children and those with ESKD undergoing dialysis and kidney transplantation) and
+in females with clinical disease manifestations, as all are at high risk for
+renal, cardiac, and cerebrovascular complications. Supportive care:
+Diphenylhydantoin, carbamazepine, or gabapentin to reduce pain
+(acroparesthesia); aspirin, lipid-lowering agents, and blood pressure control
+for cardiac ischemia; aspirin and/or other antiplatelet agents may be
+recommended for stroke prophylaxis; ACE inhibitors or angiotensin receptor
+blockers to reduce proteinuria; chronic hemodialysis and/or kidney
+transplantation for ESKD; rehabilitation and hearing aids for auditory and
+vestibular symptoms; management of psychiatric manifestations per psychologist.
+Surveillance: Annual assessment for angiokeratomas, acroparesthesia, sweating
+abnormalities, and gastrointestinal, pulmonary, and vascular manifestations;
+annual cardiology assessment with EKG and echocardiogram as recommended by
+cardiologist from age 18 years in males, biannual cardiology assessments in
+females from age 18 years; annual neurologic assessment with brain MRI\MRA every
+two to three years beginning at age 18 years; assessment of renal function
+including blood urea nitrogen, creatinine, and urinalysis annually or more
+frequently as needed; annual audiology evaluations in males beginning at age 18
+years and biannually in females; psychological assessment beginning at age 18
+years annually or more frequently as needed. Agents/circumstances to avoid:
+Smoking. Amiodarone may or may not have detrimental effects in individuals with
+Fabry disease; evidence is insufficient. Evaluation of relatives at risk: Early
+identification of affected male and female relatives by molecular genetic
+testing (if the GLA pathogenic variant in the family is known) or, in males
+only, measurement of α-Gal A enzyme activity (if the GLA pathogenic variant in
+the family is not known) in order to initiate appropriate management as early as
+possible in affected individuals.
+GENETIC COUNSELING: Fabry disease is inherited in an X-linked manner: hemizygous
+males are affected; heterozygous females may be as severely affected as males or
+asymptomatic throughout a normal life span. In a family with more than one
+affected individual, the mother of an affected male is an obligate heterozygote.
+If a male is the only affected family member, his mother is likely heterozygous
+for the GLA pathogenic variant; rarely, a single affected male in a family may
+have a de novo pathogenic variant. A heterozygous female has a 50% chance of
+transmitting the GLA pathogenic variant in each pregnancy. An affected male
+transmits the pathogenic variant to all his daughters and none of his sons. Once
+the GLA pathogenic variant has been identified in an affected family member,
+molecular genetic testing for at-risk relatives, prenatal testing for a
+pregnancy at increased risk, and preimplantation genetic testing are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 20301469


### PR DESCRIPTION
## Summary
- add causal link types and edge-level evidence to Fabry disease downstream graph edges
- connect renal GL-3 inclusions as a downstream biochemical readout of the renal podocyte storage branch
- keep PR scoped to kb/disorders/Fabry_Disease.yaml

## Validation
- just validate kb/disorders/Fabry_Disease.yaml
- just validate-terms kb/disorders/Fabry_Disease.yaml
- just validate-references kb/disorders/Fabry_Disease.yaml (wrapper reports Total checks: 0)
- uv run python -m dismech.graph --validate kb/disorders/Fabry_Disease.yaml
- manual snippet audit: checked=162 missing=0 no_cache=0
- git diff --check
