### PR TITLE
Add Wilson disease pathograph edge evidence

### DIFF
--- a/kb/disorders/Wilsons_Disease.yaml
+++ b/kb/disorders/Wilsons_Disease.yaml
@@ -1,6 +1,6 @@
 name: Wilson Disease
 creation_date: '2025-12-19T14:27:56Z'
-updated_date: '2026-05-21T03:16:32Z'
+updated_date: '2026-05-21T16:57:45Z'
 category: Genetic
 description: >
   Wilson disease is a rare autosomal recessive disorder of copper metabolism caused by mutations
@@ -425,7 +425,14 @@ pathophysiology:
   downstream:
   - target: Hepatic Copper Accumulation
     description: Loss of biliary copper excretion leads to progressive copper retention in hepatocytes.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Copper accumulation in the liver is due to impaired biliary excretion of copper caused by the inheritable malfunctioning or missing ATP7B protein.
+      explanation: Directly supports impaired biliary copper excretion as the cause of hepatic copper accumulation.
 - name: Impaired Ceruloplasmin Loading
   description: >
     ATP7B normally loads copper into apoceruloplasmin in the trans-Golgi network.
@@ -456,7 +463,14 @@ pathophysiology:
   downstream:
   - target: Ceruloplasmin
     description: Failure to load copper into apoceruloplasmin leads to low circulating ceruloplasmin.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16382340
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: ATP7B is the gene product of the WD gene located on chromosome 13 and resides in hepatocytes in the trans-Golgi network, transporting copper into the secretory pathway for incorporation into apoceruloplasmin and excretion into the bile.
+      explanation: Links ATP7B secretory-pathway copper transport to apoceruloplasmin loading, explaining low circulating ceruloplasmin when loading fails.
 - name: Hepatic Copper Accumulation
   description: >
     Impaired biliary excretion causes progressive copper retention in
@@ -486,11 +500,34 @@ pathophysiology:
   downstream:
   - target: Hepatocyte Injury
     description: Copper overload in hepatocytes drives oxidative stress and cell death.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24517326
+      reference_title: Pathological mitochondrial copper overload in livers of Wilson's disease patients and related animal models.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: On the contrary, however, when copper is massively deposited in mitochondria, severe structural and respiratory impairments are observed upon disease progression. This provokes reactive oxygen species and consequently causes the mitochondrial membranes to disintegrate, which triggers hepatocyte death.
+      explanation: Shows that pathological hepatic mitochondrial copper deposition drives respiratory injury, ROS, membrane disintegration, and hepatocyte death.
   - target: Systemic Copper Distribution
     description: Overflow of copper from the liver enters the circulation and deposits in extrahepatic organs.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports release of toxic copper from liver cells into circulation with deposition and injury in extrahepatic organs.
   - target: Hepatic Copper
     description: Retained hepatic copper becomes measurably increased on liver biopsy.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15205951
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.
+      explanation: Identifies increased hepatic copper content as the measurable biochemical readout of hepatic copper accumulation.
 - name: Systemic Copper Distribution
   description: >
     When hepatic copper storage capacity is exceeded, free copper enters
@@ -510,53 +547,191 @@ pathophysiology:
   downstream:
   - target: Neurodegeneration
     description: Copper deposition in the basal ganglia and other brain regions causes neuronal injury.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433113
+      reference_title: 'Wilson disease: brain pathology.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: In Wilson disease (WD), brain cellular damage is thought to be due to copper deposition. Striatal lesions are the most characteristic lesions found in the brain of patients with neurologic symptoms, as emphasized in the initial reports of S.A.K. Wilson.
+      explanation: Supports copper deposition as a driver of brain cellular damage and characteristic neurologic lesions.
   - target: Non-Ceruloplasmin-Bound Serum Copper
     description: Overflow of hepatocellular copper raises the circulating free copper fraction.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:16709660
+      reference_title: "Clinical presentation, diagnosis and long-term outcome of Wilson's disease: a cohort study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively.
+      explanation: Supports non-ceruloplasmin-bound serum copper as a diagnostic biochemical manifestation of systemic Wilson copper dysregulation.
   - target: 24-Hour Urinary Copper
     description: Increased circulating free copper drives elevated urinary copper excretion.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15205951
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.
+      explanation: Supports increased urinary copper excretion as a biochemical readout of increased circulating/free copper burden.
   - target: Kayser-Fleischer Rings
     description: Copper deposition in Descemet membrane produces Kayser-Fleischer corneal rings.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists kayser-fleischer rings among Wilson disease clinical features.
   - target: Renal Tubular Dysfunction
     description: Copper deposition in the kidneys contributes to renal tubular injury and dysfunction.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists renal tubular dysfunction among Wilson disease clinical features.
   - target: Cardiomyopathy
     description: Cardiac copper deposition contributes to myocardial injury and cardiomyopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists cardiomyopathy among Wilson disease clinical features.
   - target: Heart Failure
     description: Copper-mediated cardiac injury can progress to clinical heart failure.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Copper-related cardiomyopathy and cardiac remodeling.
+    evidence:
+    - reference: PMID:28947309
+      reference_title: "Wilson's Disease and Cardiac Myopathy."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: patients with Wilson's disease had a 55% higher risk of incident HF (HR 1.55, 95% CI 1.41 to 1.71, p <0.0001)
+      explanation: Population-level clinical data support increased heart-failure risk in Wilson disease, consistent with downstream cardiac involvement from copper dysregulation.
   - target: Cardiac Arrhythmia
     description: Copper-mediated cardiac involvement increases the risk of clinically significant arrhythmias.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists cardiac arrhythmia among Wilson disease clinical features.
   - target: Osteopenia
     description: Extrahepatic copper toxicity contributes to reduced bone mineral density.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Renal tubular dysfunction, altered mineral balance, and reduced bone mineral density.
+    evidence:
+    - reference: PMID:29110062
+      reference_title: "Osteoporosis and bone mineral density in patients with Wilson's disease: a systematic review and meta-analysis."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "The pooled prevalencerates of osteopenia and osteoporosis in WD patients were 36.5%"
+      explanation: Meta-analysis supports osteopenia and osteoporosis as Wilson disease bone manifestations downstream of systemic disease.
   - target: Osteoporosis
     description: Chronic extrahepatic copper toxicity contributes to pathologic bone loss in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Renal tubular dysfunction, altered mineral balance, and reduced bone mineral density.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists osteoporosis among Wilson disease clinical features.
   - target: Arthralgia
     description: Musculoskeletal copper deposition and bone disease contribute to arthralgia.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Wilson disease osteoarticular involvement and bone-density abnormalities.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists arthralgia among Wilson disease clinical features.
   - target: Sunflower Cataract
     description: Copper deposition in ocular tissues can produce the rare sunflower cataract phenotype.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:6000642 | Sunflower cataract | Very rare (<4-1%)
+      explanation: Orphanet records sunflower cataract as a Wilson disease phenotype; the edge places this feature downstream of systemic copper disease.
   - target: Abnormality Of The Menstrual Cycle
     description: Systemic copper disease and chronic hepatic dysfunction can disrupt reproductive cycling through incompletely resolved endocrine intermediates.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000140 | Abnormality of the menstrual cycle | Very frequent (99-80%)
+      explanation: Orphanet records abnormality of the menstrual cycle as a Wilson disease phenotype; the edge places this feature downstream of systemic copper disease.
   - target: Bone Pain
     description: Copper-related skeletal disease and low bone mineral density can manifest with bone pain.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Osteopenia, osteoporosis, osteomalacia, and renal tubular mineral dysregulation.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002653 | Bone pain | Very frequent (99-80%)
+      explanation: Orphanet records bone pain as a Wilson disease phenotype; the edge places this feature downstream of systemic copper disease.
   - target: Arthritis
     description: Systemic copper-related musculoskeletal involvement includes arthritic manifestations in a subset of patients.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Musculoskeletal copper toxicity, arthropathy, and low bone-density complications.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Supports systemic copper redistribution causing organ injury and lists arthritis among Wilson disease clinical features.
   - target: Joint Swelling
     description: Musculoskeletal involvement can present with inflammatory or arthropathic joint swelling.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Wilson disease arthropathy and related skeletal inflammation.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001386 | Joint swelling | Very frequent (99-80%)
+      explanation: Orphanet records joint swelling as a Wilson disease phenotype; the edge places this feature downstream of systemic copper disease.
   - target: Pathologic Fracture
     description: Chronic skeletal involvement with osteopenia or osteoporosis increases vulnerability to pathologic fracture.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Osteopenia and osteoporosis.
 
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002756 | Pathologic fracture | Very frequent (99-80%)
+      explanation: Orphanet records pathologic fracture as a Wilson disease phenotype; the edge places this feature downstream of systemic copper disease.
 - name: Hepatocyte Injury
   description: >
     Copper accumulation in hepatocytes causes oxidative stress, mitochondrial
@@ -635,57 +810,199 @@ pathophysiology:
   downstream:
   - target: Hepatic Stellate Cell Activation
     description: Injured hepatocytes activate pro-fibrotic stellate-cell responses in the liver.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Copper-triggered TGF-beta/Smad and NF-kappaB signaling.
+    evidence:
+    - reference: PMID:41006805
+      reference_title: "The pathogenesis of liver fibrosis in Wilson's disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Copper ions also activate signaling pathways such as the TGF-β1/Smad and NF-κB pathways, which stimulate hepatic stellate cells and promote their transdifferentiation into collagen-secreting myofibroblasts
+      explanation: Supports copper-triggered profibrotic signaling that stimulates hepatic stellate-cell activation.
   - target: Hepatitis
     description: Hepatocellular oxidative injury and inflammation manifest clinically as hepatitis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433112
+      reference_title: Wilson disease - liver pathology.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The liver in Wilson disease may demonstrate a wide range of damage patterns. Some patients may present almost no detectable microscopic pathology, while others display lesions consistent with fulminant hepatitis or acute liver failure. Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis. Additional findings include liver cell degeneration and ballooning, Mallory hyaline bodies, liver cell necrosis, and glycogenation of periportal hepatocytic nuclei.
+      explanation: Supports Wilson disease hepatocellular injury patterns that include the liver pathology represented by hepatitis.
   - target: Hepatomegaly
     description: Hepatocyte swelling and inflammatory liver injury can produce hepatomegaly.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic inflammation, cell swelling, and organ enlargement.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002240 | Hepatomegaly | Very frequent (99-80%)
+      explanation: Orphanet records hepatomegaly as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Jaundice
     description: Acute hepatocellular dysfunction impairs bilirubin handling and can produce jaundice.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatocellular dysfunction and impaired bilirubin handling.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000952 | Jaundice | Very frequent (99-80%)
+      explanation: Orphanet records jaundice as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Acute Hepatic Failure
     description: Severe hepatocyte death can precipitate fulminant hepatic failure.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433112
+      reference_title: Wilson disease - liver pathology.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The liver in Wilson disease may demonstrate a wide range of damage patterns. Some patients may present almost no detectable microscopic pathology, while others display lesions consistent with fulminant hepatitis or acute liver failure. Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis. Additional findings include liver cell degeneration and ballooning, Mallory hyaline bodies, liver cell necrosis, and glycogenation of periportal hepatocytic nuclei.
+      explanation: Wilson liver pathology includes fulminant hepatitis or acute liver failure, supporting acute failure as a severe hepatocyte-injury outcome.
   - target: Hemolytic Anemia
     description: Abrupt copper release from injured liver can trigger oxidant hemolysis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Abrupt hepatic copper release and oxidant red-cell injury.
+    evidence:
+    - reference: PMID:24577547
+      reference_title: Acute hemolytic anemia as an initial presentation of Wilson disease in children.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hemolytic anemia in WD occurs in up to 17% of patients at some point during their illness.
+      explanation: Supports hemolytic anemia as a recognized Wilson disease manifestation linked to hepatic copper injury and release.
   - target: Vomiting
     description: Acute hepatic decompensation can present with vomiting as part of the hepatic illness syndrome.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acute hepatic illness and decompensation.
+    evidence:
+    - reference: PMID:29914392
+      reference_title: "Three novel mutations in the ATP7B gene of unrelated Vietnamese patients with Wilson disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: These patients had clinical features such as numbness of hands and feet, vomiting, insomnia, palsy, liver failure and Kayser-Fleischer (K-F) rings
+      explanation: Case-based clinical evidence supports vomiting as part of Wilson disease presentations that include liver failure.
   - target: Cuproptosis
     description: Proposed copper-dependent cell death pathways may amplify hepatocyte injury.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Copper overload, mitochondrial stress, and copper-dependent cell-death signaling.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Many interesting disease details were published on the mechanistic steps, such as the generation of reactive oxygen species (ROS) and cuproptosis causing a copper dependent cell death.
+      explanation: Supports cuproptosis as a proposed copper-dependent cell-death layer that can amplify hepatic injury.
   - target: Ferroptosis
     description: Secondary iron deposition may superimpose ferroptotic injury in a subset of patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Secondary hepatic iron accumulation and lipid-peroxidation stress.
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: In the liver of patients with Wilson disease, also, increased iron deposits were found that may lead to iron-related ferroptosis responsible for phospholipid peroxidation within membranes of subcellular organelles
+      explanation: Supports iron-linked ferroptosis as an inferred secondary hepatic injury mechanism in Wilson disease contexts.
   - target: Hepatic Steatosis
     description: Copper-mediated hepatic injury commonly produces steatosis on liver biopsy.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433112
+      reference_title: Wilson disease - liver pathology.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The liver in Wilson disease may demonstrate a wide range of damage patterns. Some patients may present almost no detectable microscopic pathology, while others display lesions consistent with fulminant hepatitis or acute liver failure. Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis. Additional findings include liver cell degeneration and ballooning, Mallory hyaline bodies, liver cell necrosis, and glycogenation of periportal hepatocytic nuclei.
+      explanation: Supports Wilson disease hepatocellular injury patterns that include the liver pathology represented by hepatic steatosis.
   - target: Acute Hepatitis
     description: Acute hepatocellular injury can present with an acute hepatitis phenotype.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433112
+      reference_title: Wilson disease - liver pathology.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The liver in Wilson disease may demonstrate a wide range of damage patterns. Some patients may present almost no detectable microscopic pathology, while others display lesions consistent with fulminant hepatitis or acute liver failure. Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis. Additional findings include liver cell degeneration and ballooning, Mallory hyaline bodies, liver cell necrosis, and glycogenation of periportal hepatocytic nuclei.
+      explanation: Supports Wilson disease hepatocellular injury patterns that include the liver pathology represented by acute hepatitis.
   - target: Elevated Circulating Hepatic Transaminase Concentration
     description: Hepatocyte injury releases hepatic enzymes, producing elevated circulating transaminases.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002910 | Elevated circulating hepatic transaminase concentration | Very frequent (99-80%)
+      explanation: Orphanet records elevated circulating hepatic transaminase concentration as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Pruritus
     description: Hepatic dysfunction and cholestatic intermediates can contribute to pruritus in Wilson disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hepatic dysfunction and impaired bile-acid handling.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000989 | Pruritus | Very frequent (99-80%)
+      explanation: Orphanet records pruritus as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Abdominal Pain
     description: Hepatic inflammation and decompensation can present with abdominal pain.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hepatic inflammation, hepatomegaly, and acute liver decompensation.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002027 | Abdominal pain | Occasional (29-5%)
+      explanation: Orphanet records abdominal pain as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Failure To Thrive
     description: Chronic hepatic disease and systemic illness can impair growth and weight gain.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Chronic liver disease, reduced intake, and systemic inflammatory illness.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001508 | Failure to thrive | Very frequent (99-80%)
+      explanation: Orphanet records failure to thrive as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Weight Loss
     description: Chronic hepatic disease and systemic illness can produce catabolic weight loss.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Chronic liver disease, reduced intake, and systemic inflammatory illness.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001824 | Weight loss | Very frequent (99-80%)
+      explanation: Orphanet records weight loss as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
   - target: Anemia
     description: Hepatic decompensation can contribute to anemia through hemolytic and advanced-liver-disease intermediates.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Coombs-negative hemolysis and advanced liver disease.
 
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001903 | Anemia | Very frequent (99-80%)
+      explanation: Orphanet records anemia as a Wilson disease phenotype; the edge models it as a clinical consequence of hepatic injury or decompensation.
 - name: Hepatic Stellate Cell Activation
   conforms_to: fibrotic_response#Mesenchymal Cell Activation
   description: >
@@ -722,7 +1039,14 @@ pathophysiology:
   downstream:
   - target: Excessive Hepatic ECM Deposition
     description: Activated stellate cells and myofibroblasts drive excess extracellular matrix deposition.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:41006805
+      reference_title: "The pathogenesis of liver fibrosis in Wilson's disease: hepatocyte injury and regulation mediated by copper metabolism dysregulation."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: collagen-secreting myofibroblasts, which then accelerate extracellular matrix deposition.
+      explanation: Directly supports extracellular-matrix deposition downstream of collagen-secreting myofibroblast conversion.
 - name: Excessive Hepatic ECM Deposition
   conforms_to: fibrotic_response#Excessive ECM Deposition
   description: >
@@ -759,27 +1083,63 @@ pathophysiology:
   downstream:
   - target: Cirrhosis
     description: Progressive matrix deposition and architectural distortion manifest clinically as cirrhosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433112
+      reference_title: Wilson disease - liver pathology.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The liver in Wilson disease may demonstrate a wide range of damage patterns. Some patients may present almost no detectable microscopic pathology, while others display lesions consistent with fulminant hepatitis or acute liver failure. Most liver biopsy specimens show moderate to severe steatosis, variable degree of portal and/or lobular inflammation, and fibrosis eventually progressing to cirrhosis. Additional findings include liver cell degeneration and ballooning, Mallory hyaline bodies, liver cell necrosis, and glycogenation of periportal hepatocytic nuclei.
+      explanation: Supports fibrosis progressing to cirrhosis as the architectural consequence of excessive hepatic matrix deposition.
   - target: Ascites
     description: Cirrhotic architectural distortion can lead to portal hypertension and fluid accumulation as ascites.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cirrhosis and portal hypertension.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001541 | Ascites | Occasional (29-5%)
+      explanation: Orphanet records ascites as a Wilson disease phenotype; the edge places it downstream of fibrotic/cirrhotic liver disease and portal-hypertension intermediates.
   - target: Splenomegaly
     description: Fibrotic progression to cirrhosis can produce portal-hypertension-associated splenomegaly.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cirrhosis, portal hypertension, and congestive splenic enlargement.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001744 | Splenomegaly | Very frequent (99-80%)
+      explanation: Orphanet records splenomegaly as a Wilson disease phenotype; the edge places it downstream of fibrotic/cirrhotic liver disease and portal-hypertension intermediates.
   - target: Thrombocytopenia
     description: Cirrhosis and portal hypertension can cause hypersplenism-associated thrombocytopenia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cirrhosis, portal hypertension, splenomegaly, and hypersplenism.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001873 | Thrombocytopenia | Very frequent (99-80%)
+      explanation: Orphanet records thrombocytopenia as a Wilson disease phenotype; the edge places it downstream of fibrotic/cirrhotic liver disease and portal-hypertension intermediates.
   - target: Bruising Susceptibility
     description: Advanced hepatic fibrosis can contribute to bruising through synthetic dysfunction and thrombocytopenia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cirrhosis, impaired coagulation factor synthesis, and thrombocytopenia.
 
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000978 | Bruising susceptibility | Very frequent (99-80%)
+      explanation: Orphanet records bruising susceptibility as a Wilson disease phenotype; the edge places it downstream of fibrotic/cirrhotic liver disease and portal-hypertension intermediates.
 - name: Neurodegeneration
   description: >
     Copper deposition is thought to drive brain cellular damage with
@@ -842,66 +1202,244 @@ pathophysiology:
   downstream:
   - target: Tremor
     description: Basal ganglia and cerebellar circuit injury contributes to tremor.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33474589
+      reference_title: "Neurological features and outcomes of Wilson's disease: a single-center experience."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: most common neurological manifestation was dystonia, followed by tremor and parkinsonism.
+      explanation: Clinical neurological Wilson disease data support tremor as a common manifestation of neurologic involvement.
   - target: Dystonia
     description: Striatal injury disrupts motor circuit output and contributes to dystonia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33474589
+      reference_title: "Neurological features and outcomes of Wilson's disease: a single-center experience."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: most common neurological manifestation was dystonia, followed by tremor and parkinsonism.
+      explanation: Clinical neurological Wilson disease data support dystonia as a common manifestation of neurologic involvement.
   - target: Parkinsonism
     description: Basal ganglia dysfunction can manifest clinically as parkinsonism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33474589
+      reference_title: "Neurological features and outcomes of Wilson's disease: a single-center experience."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: most common neurological manifestation was dystonia, followed by tremor and parkinsonism.
+      explanation: Clinical neurological Wilson disease data support parkinsonism as a common manifestation of neurologic involvement.
   - target: Bradykinesia
     description: Extrapyramidal circuit dysfunction contributes to bradykinesia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433096
+      reference_title: 'Wilson disease: neurologic features.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Wilson disease (WD) is a neurodegenerative disorder, which presents as a spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia
+      explanation: Supports bradykinesia as part of the neurologic manifestation spectrum of Wilson disease neurodegeneration.
   - target: Rigidity
     description: Extrapyramidal circuit dysfunction contributes to rigidity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433096
+      reference_title: 'Wilson disease: neurologic features.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Wilson disease (WD) is a neurodegenerative disorder, which presents as a spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia
+      explanation: Supports rigidity as part of the neurologic manifestation spectrum of Wilson disease neurodegeneration.
   - target: Chorea
     description: Basal ganglia injury can produce choreiform hyperkinesia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433096
+      reference_title: 'Wilson disease: neurologic features.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Wilson disease (WD) is a neurodegenerative disorder, which presents as a spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia
+      explanation: Supports chorea as part of the neurologic manifestation spectrum of Wilson disease neurodegeneration.
   - target: Dysarthria
     description: Motor network injury affecting bulbar and extrapyramidal function contributes to dysarthria.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433096
+      reference_title: 'Wilson disease: neurologic features.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Wilson disease (WD) is a neurodegenerative disorder, which presents as a spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia
+      explanation: Supports dysarthria as part of the neurologic manifestation spectrum of Wilson disease neurodegeneration.
   - target: Ataxia
     description: Cerebellar and brainstem involvement contributes to ataxia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38731973
+      reference_title: 'Wilson Disease: Copper-Mediated Cuproptosis, Iron-Related Ferroptosis, and Clinical Highlights, with Comprehensive and Critical Analysis Update.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Released from the liver cells due to limited storage capacity, the toxic copper enters the circulation and arrives at other organs, causing local accumulation and cell injury. This explains why copper injures not only the liver, but also the brain, kidneys, eyes, heart, muscles, and bones, explaining the multifaceted clinical features of Wilson disease. Among these are depression, psychosis, dysarthria, ataxia, writing problems, dysphagia, renal tubular dysfunction, Kayser-Fleischer corneal rings, cardiomyopathy, cardiac arrhythmias, rhabdomyolysis, osteoporosis, osteomalacia, arthritis, and arthralgia.
+      explanation: Wilson disease clinical highlights list ataxia among features explained by copper injury to organs including the brain.
   - target: Dysphagia
     description: Bulbar motor dysfunction contributes to dysphagia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28433096
+      reference_title: 'Wilson disease: neurologic features.'
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: Wilson disease (WD) is a neurodegenerative disorder, which presents as a spectrum of neurologic manifestations that includes tremor, bradykinesia, rigidity, dystonia, chorea, dysarthria, and dysphagia
+      explanation: Supports dysphagia as part of the neurologic manifestation spectrum of Wilson disease neurodegeneration.
   - target: Drooling
     description: Bulbar dysfunction and impaired swallowing contribute to drooling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Bulbar dysfunction and impaired swallowing.
+    evidence:
+    - reference: PMID:3595645
+      reference_title: "Presenting symptoms and natural history of Wilson disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: the most frequent were in order of frequency jaundice, dysarthria, clumsiness, tremor, drooling, gait disturbance, malaise and arthralgia
+      explanation: Large case-series data list drooling among frequent Wilson disease manifestations, consistent with neurologic bulbar dysfunction.
   - target: Anxiety
     description: Copper-mediated brain injury can contribute to neuropsychiatric symptoms including anxiety.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuropsychiatric circuit dysfunction.
+    evidence:
+    - reference: PMID:1821256
+      reference_title: "The psychiatric presentations of Wilson's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%). Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.
+      explanation: Supports anxiety within the psychiatric manifestation spectrum of Wilson disease neurologic involvement.
   - target: Depression
     description: Neuropsychiatric brain involvement contributes to depressive symptoms.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuropsychiatric circuit dysfunction.
+    evidence:
+    - reference: PMID:1821256
+      reference_title: "The psychiatric presentations of Wilson's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%). Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.
+      explanation: Supports depression within the psychiatric manifestation spectrum of Wilson disease neurologic involvement.
   - target: Psychosis
     description: Severe neuropsychiatric involvement can manifest as psychosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuropsychiatric circuit dysfunction.
+    evidence:
+    - reference: PMID:1821256
+      reference_title: "The psychiatric presentations of Wilson's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%). Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.
+      explanation: Supports psychosis within the psychiatric manifestation spectrum of Wilson disease neurologic involvement.
   - target: Personality Changes
     description: Fronto-striatal and related network dysfunction can manifest as personality change.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Fronto-striatal and related neuropsychiatric circuit dysfunction.
+    evidence:
+    - reference: PMID:1821256
+      reference_title: "The psychiatric presentations of Wilson's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%). Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.
+      explanation: Supports personality changes within the psychiatric manifestation spectrum of Wilson disease neurologic involvement.
   - target: Intellectual Disability
     description: Copper-related brain injury can cause cognitive dysfunction; the intellectual-disability HPO mapping is retained as a broader cognitive phenotype.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Cognitive dysfunction from copper-related neural injury.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001249 | Intellectual disability | Very frequent (99-80%)
+      explanation: Orphanet records intellectual disability as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Seizure
     description: Structural and metabolic brain involvement can lower seizure threshold in a subset of patients.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Copper-related brain lesions and neuroinflammation.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001250 | Seizure | Occasional (29-5%)
+      explanation: Orphanet records seizure as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Gait Disturbance
     description: Basal ganglia, cerebellar, and brainstem involvement can disrupt gait.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001288 | Gait disturbance | Very frequent (99-80%)
+      explanation: Orphanet records gait disturbance as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Clumsiness
     description: Motor-circuit involvement can present clinically as clumsiness.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002312 | Clumsiness | Very frequent (99-80%)
+      explanation: Orphanet records clumsiness as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Excessive Salivation
     description: Bulbar dysfunction and impaired swallowing can produce excessive salivation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Bulbar motor dysfunction and dysphagia.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003781 | Excessive salivation | Occasional (29-5%)
+      explanation: Orphanet records excessive salivation as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Proximal Lower Limb Muscle Weakness
     description: Neurologic motor involvement and systemic muscle effects can present as proximal lower-limb weakness.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Extrapyramidal motor dysfunction and Wilson disease muscle involvement.
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0008994 | Proximal muscle weakness in lower limbs | Very frequent (99-80%)
+      explanation: Orphanet records proximal lower limb muscle weakness as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Focal T2 Hyperintense Brainstem Lesion
     description: Brainstem involvement on MRI reflects focal structural injury within neurologic Wilson disease.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:905
+      reference_title: Wilson disease (Orphanet structured-database record)
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0012748 | Focal T2 hyperintense brainstem lesion | Occasional (29-5%)
+      explanation: Orphanet records focal t2 hyperintense brainstem lesion as a Wilson disease phenotype; the edge models it downstream of copper-related neurologic injury.
   - target: Aggressive Behavior
     description: Neuropsychiatric involvement can manifest with irritability and aggression.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Psychiatric manifestations of copper-related brain involvement.
+    evidence:
+    - reference: PMID:1821256
+      reference_title: "The psychiatric presentations of Wilson's disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Personality changes, particularly irritability and aggression, were most commonly described (45.9%), followed by depression (27%). Cognitive changes, anxiety, psychosis, and catatonia, while less frequent, also occurred.
+      explanation: Supports aggressive behavior within the psychiatric manifestation spectrum of Wilson disease neurologic involvement.
 - name: Cuproptosis
   description: >
     Copper-dependent cell death has been proposed in Wilson disease, involving
@@ -2224,6 +2762,19 @@ biochemical:
 - name: Ceruloplasmin
   presence: Decreased
   context: Low in over 90 percent of patients (less than 20 mg/dL)
+  readouts:
+  - target: Impaired Ceruloplasmin Loading
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low circulating ceruloplasmin reports failed ATP7B-dependent copper incorporation into apoceruloplasmin.
+    evidence:
+    - reference: PMID:15205951
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.
+      explanation: Supports low serum ceruloplasmin as a diagnostic biochemical readout of Wilson disease copper-handling failure.
   evidence:
   - reference: PMID:15205951
     reference_title: "Wilson disease."
@@ -2239,6 +2790,19 @@ biochemical:
 - name: Non-Ceruloplasmin-Bound Serum Copper
   presence: Elevated
   context: Free copper fraction is elevated and used both diagnostically and for treatment monitoring
+  readouts:
+  - target: Systemic Copper Distribution
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Higher non-ceruloplasmin-bound copper reflects the circulating free-copper burden after hepatic copper handling fails.
+    evidence:
+    - reference: PMID:16709660
+      reference_title: "Clinical presentation, diagnosis and long-term outcome of Wilson's disease: a cohort study."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Diagnostic criteria for non-caeruloplasmin-bound serum copper, serum caeruloplasmin, 24-h urinary copper excretion, liver copper content, presence of Kayser-Fleischer rings and histological signs of chronic liver damage were reached in 86.6%, 88.2%, 87.1%, 92.7%, 66.3% and 73% of patients, respectively.
+      explanation: Supports non-ceruloplasmin-bound serum copper as a diagnostic marker of systemic Wilson copper dysregulation.
   evidence:
   - reference: PMID:16709660
     reference_title: "Clinical presentation, diagnosis and long-term outcome of Wilson's disease: a cohort study."
@@ -2253,6 +2817,19 @@ biochemical:
 - name: 24-Hour Urinary Copper
   presence: Elevated
   context: Elevated urinary copper is diagnostic and is also followed during chelation therapy
+  readouts:
+  - target: Systemic Copper Distribution
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased urinary copper excretion reflects excess circulating/free copper available for renal excretion.
+    evidence:
+    - reference: PMID:15205951
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.
+      explanation: Supports increased urinary copper excretion as a diagnostic biochemical readout in Wilson disease.
   evidence:
   - reference: PMID:15205951
     reference_title: "Wilson disease."
@@ -2267,6 +2844,19 @@ biochemical:
 - name: Hepatic Copper
   presence: Elevated
   context: Liver biopsy with elevated copper is diagnostic
+  readouts:
+  - target: Hepatic Copper Accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated liver copper content directly reports hepatic copper accumulation.
+    evidence:
+    - reference: PMID:15205951
+      reference_title: Wilson disease.
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: The diagnosis of WD is commonly made on the basis of typical clinical and laboratory findings, including low serum ceruloplasmin, increased urinary copper excretion, and increased hepatic copper content.
+      explanation: Supports increased hepatic copper content as the biochemical readout of hepatic copper accumulation.
   evidence:
   - reference: PMID:15205951
     reference_title: "Wilson disease."


### PR DESCRIPTION
## Summary
- add evidence and causal link types to Wilson disease downstream pathograph edges
- add biomarker readout links for ceruloplasmin, non-ceruloplasmin-bound serum copper, urinary copper, and hepatic copper
- keep scope to kb/disorders/Wilsons_Disease.yaml

## Validation
- just validate kb/disorders/Wilsons_Disease.yaml
- just validate-terms kb/disorders/Wilsons_Disease.yaml
- just validate-references kb/disorders/Wilsons_Disease.yaml
- uv run python -m dismech.graph --validate kb/disorders/Wilsons_Disease.yaml
- manual snippet audit: checked=248 missing=0 no_cache=0
- git diff --check