### PR TITLE
Add Hemochromatosis pathograph edge evidence

### DIFF
--- a/kb/disorders/Hemochromatosis.yaml
+++ b/kb/disorders/Hemochromatosis.yaml
@@ -1,6 +1,6 @@
 name: Hemochromatosis
 creation_date: '2026-01-09T07:07:01Z'
-updated_date: '2026-05-19T00:02:52Z'
+updated_date: '2026-05-21T17:57:54Z'
 category: Mendelian
 disease_term:
   preferred_term: hereditary hemochromatosis
@@ -204,7 +204,12 @@ pathophysiology:
   downstream:
   - target: Low Hepcidin Leads to Ferroportin Hyperabsorption
     description: Inappropriately low hepcidin releases the ferroportin brake on intestinal iron efflux.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23985001
+      supports: SUPPORT
+      snippet: Hereditary hemochromatosis is an inherited iron overload disorder caused by inappropriately low hepcidin secretion leading to increased duodenal absorption of dietary iron
+      explanation: Supports low hepcidin secretion as the upstream mechanism that increases duodenal dietary iron absorption.
 - name: BMP6-Dependent Hepcidin Regulation Defect
   description: >
     Disease-causing BMP6 variants impair an upstream hepcidin regulatory pathway,
@@ -244,7 +249,13 @@ pathophysiology:
   downstream:
   - target: Low Hepcidin Leads to Ferroportin Hyperabsorption
     description: BMP6-linked hepcidin dysregulation converges on insufficient hepcidin restraint of ferroportin.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:26582087
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: resulted in defective secretion of BMP6; reduced signaling via SMAD1, SMAD5, and SMAD8; and loss of hepcidin production.
+      explanation: Functional assays support BMP6 signaling defects causing loss of hepcidin production.
 - name: Non-HFE Hepcidin Deficiency
   description: >
     HJV, HAMP, and TFR2 pathogenic variants cause non-HFE hemochromatosis by
@@ -293,7 +304,13 @@ pathophysiology:
   downstream:
   - target: Low Hepcidin Leads to Ferroportin Hyperabsorption
     description: Non-HFE hepcidin-pathway defects converge on inadequate hepcidin restraint of ferroportin-mediated iron export.
-
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32327622
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Thus, patients homozygous for this mutation are unable to induce hepcidin transcription
+      explanation: HJV-related juvenile hemochromatosis illustrates non-HFE hepcidin-pathway variants preventing hepcidin transcription.
 - name: Low Hepcidin Leads to Ferroportin Hyperabsorption
   description: >
     Suppressed hepcidin fails to internalize and degrade ferroportin on enterocytes, so
@@ -323,6 +340,13 @@ pathophysiology:
   downstream:
   - target: Systemic Iron Overload
     description: Increased intestinal ferroportin-mediated export expands the plasma iron pool.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: hepcidin insufficiency in the context of normal erythropoiesis, iron hyperabsorption, and expansion of the plasma iron pool with increased transferrin saturation
+      explanation: Links hepcidin insufficiency and iron hyperabsorption to expansion of the plasma iron pool.
 - name: Systemic Iron Overload
   description: >
     Hepcidin insufficiency causes iron hyperabsorption, plasma iron-pool expansion,
@@ -357,22 +381,100 @@ pathophysiology:
     snippet: "This results in the formation of toxic non-transferrin-bound iron, which ultimately accumulates in multiple organs, including the liver, heart, endocrine glands, and joints."
     explanation: The expanded iron pool forms toxic non-transferrin-bound iron and accumulates in multiple target organs.
   downstream:
+  - target: Elevated Transferrin Saturation
+    description: Plasma iron-pool expansion raises transferrin saturation, the diagnostic hallmark of hemochromatosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: iron hyperabsorption, and expansion of the plasma iron pool with increased transferrin saturation, the diagnostic hallmark of the disease
+      explanation: Directly supports elevated transferrin saturation as the biochemical readout of plasma iron-pool expansion.
+  - target: Increased Circulating Ferritin
+    description: Progressive systemic iron overload increases ferritin as a circulating marker of iron stores.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23985001
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This can result in elevated serum ferritin, iron deposition in various organs and ultimately end-organ damage
+      explanation: Supports elevated serum ferritin as a biochemical consequence of systemic organ iron deposition.
   - target: Hepatic Iron Toxicity
     description: Increased gut iron transfer elevates circulating iron and drives hepatic deposition.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This results in the formation of toxic non-transferrin-bound iron, which ultimately accumulates in multiple organs, including the liver, heart, endocrine glands, and joints.
+      explanation: Supports toxic non-transferrin-bound iron accumulating in target organs relevant to hepatic iron toxicity.
   - target: Cardiac Iron Deposition
     description: Chronic plasma iron loading promotes myocardial iron accumulation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This results in the formation of toxic non-transferrin-bound iron, which ultimately accumulates in multiple organs, including the liver, heart, endocrine glands, and joints.
+      explanation: Supports toxic non-transferrin-bound iron accumulating in target organs relevant to cardiac iron deposition.
   - target: Pancreatic Iron Toxicity
     description: Systemic iron excess leads to iron deposition in pancreatic islets.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301523
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: TFR2-related hemochromatosis (TFR2-HC) is characterized by increased intestinal iron absorption resulting in iron accumulation in the liver, heart, pancreas, and endocrine organs.
+      explanation: GeneReviews supports increased intestinal iron absorption causing iron accumulation in the pancreas and other organs.
   - target: Pituitary-Gonadal Iron Toxicity
     description: Systemic iron loading affects endocrine tissues, especially pituitary gonadotropes.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This results in the formation of toxic non-transferrin-bound iron, which ultimately accumulates in multiple organs, including the liver, heart, endocrine glands, and joints.
+      explanation: Supports toxic non-transferrin-bound iron accumulating in target organs relevant to pituitary-gonadal iron toxicity.
   - target: Iron-Associated Arthropathy
     description: Toxic iron species and joint deposition contribute to hemochromatosis arthropathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39644049
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: This results in the formation of toxic non-transferrin-bound iron, which ultimately accumulates in multiple organs, including the liver, heart, endocrine glands, and joints.
+      explanation: Supports toxic non-transferrin-bound iron accumulating in target organs relevant to iron-associated arthropathy.
   - target: Dermal Iron and Melanin Deposition
     description: Iron loading contributes to bronze skin pigmentation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0000953 | Hyperpigmentation of the skin | Very frequent (99-80%)
+      explanation: Orphanet lists hyperpigmentation of the skin as a very frequent phenotype of symptomatic HFE-related hemochromatosis.
   - target: Iron-Associated Bone Fragility
     description: Iron deposition in bone and gonadal injury contribute to low bone density and fracture risk.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Iron deposition in bone and gonadal endocrine injury.
+    evidence:
+    - reference: PMID:31989186
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Parenchyma damage may be a consequence of iron deposition in affected organs (e.g., liver, pancreas, gonads) as well as bones and joints, leading to osteoporosis with increased fracture risk and arthropathy.
+      explanation: Human hemochromatosis bone study links iron deposition in bones and joints to osteoporosis, fracture risk, and arthropathy.
   - target: Systemic Iron Overload Symptoms
     description: Multi-organ iron overload produces constitutional symptoms including fatigue and weight loss.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Multi-organ iron deposition, chronic inflammatory stress, and endocrine/liver complications.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: abdominal pain, weakness, lethargy, weight loss, elevated serum aminotransferase levels
+      explanation: Orphanet lists weakness, lethargy, and weight loss among symptomatic HFE-related hemochromatosis manifestations, supporting a systemic symptom cluster downstream of iron overload.
 - name: Hepatic Iron Toxicity
   description: >
     Excess iron deposits in hepatocytes leading to oxidative stress, lipid peroxidation,
@@ -405,14 +507,57 @@ pathophysiology:
   downstream:
   - target: Hepatomegaly
     description: Hepatocyte injury and remodeling contribute to progressive liver enlargement.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatocyte injury, liver remodeling, and organ enlargement.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002240 | Hepatomegaly | Frequent (79-30%)
+      explanation: Orphanet records hepatomegaly as a frequent hemochromatosis phenotype downstream of liver iron involvement.
   - target: Elevated Hepatic Transaminases
     description: Hepatocellular injury releases circulating hepatic transaminases.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38886778
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The proband is a 64-year-old man complaining of persistent abnormality of liver enzyme levels for 1 year
+      explanation: Clinical case evidence supports persistent liver enzyme abnormalities as a manifestation of hemochromatosis liver injury.
   - target: Abdominal Pain
     description: Hepatic iron loading and liver enlargement can manifest as abdominal pain.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Liver enlargement, capsular distension, and hepatic inflammation.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0002027 | Abdominal pain | Frequent (79-30%)
+      explanation: Orphanet records abdominal pain as a frequent hemochromatosis phenotype, consistent with hepatic iron toxicity and liver enlargement.
   - target: Cirrhosis
     description: Chronic iron-mediated hepatocellular injury and fibrotic remodeling can progress to cirrhosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Iron-mediated oxidative injury, fibrosis, and architectural remodeling.
+    evidence:
+    - reference: PMID:37763705
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The key organ that is affected by iron overload is the liver, suffering from fibrosis, cirrhosis or hepatocellular carcinoma
+      explanation: Supports liver iron overload progressing through fibrosis to cirrhosis.
   - target: Hepatocellular Carcinoma
     description: Advanced iron-mediated liver injury and carcinogenic iron stress increase HCC risk.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Iron-mediated oxidative DNA damage, fibrosis, and cirrhosis.
+    evidence:
+    - reference: PMID:23985001
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Iron overload is being recognized to play a carcinogenic role in hepatocellular carcinoma and other cancers
+      explanation: Supports iron overload as a carcinogenic driver of hepatocellular carcinoma.
 - name: Cardiac Iron Deposition
   description: >
     Iron accumulation in cardiomyocytes causes oxidative damage and impaired contractility,
@@ -444,6 +589,13 @@ pathophysiology:
   downstream:
   - target: Cardiomyopathy
     description: Oxidative myocardial injury and contractile dysfunction manifest as cardiomyopathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:35449524
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Hemochromatosis type 2 or juvenile hemochromatosis has an early onset of severe iron overload resulting in organ manifestation such as liver fibrosis, cirrhosis, cardiomyopathy, arthropathy, hypogonadism, diabetes
+      explanation: Supports cardiomyopathy as an organ manifestation of severe hemochromatosis iron overload.
 - name: Pancreatic Iron Toxicity
   description: >
     Iron deposition in pancreatic beta cells causes oxidative damage and impaired insulin
@@ -475,8 +627,26 @@ pathophysiology:
   downstream:
   - target: Diabetes Mellitus
     description: Beta-cell dysfunction from iron toxicity impairs insulin output and drives diabetes.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Beta-cell oxidative injury, impaired insulin secretion, and sustained hyperglycemia.
+    evidence:
+    - reference: PMID:35662478
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Early diagnosis and treatment by phlebotomy can prevent cirrhosis, hepatocellular carcinoma, diabetes, arthropathy and other complications.
+      explanation: Guidelines list diabetes as a preventable complication of hemochromatosis iron loading.
   - target: Hyperglycemia
     description: Impaired beta-cell insulin secretion first manifests as elevated blood glucose.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Beta-cell oxidative injury and impaired insulin secretion.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003074 | Hyperglycemia | Frequent (79-30%)
+      explanation: Orphanet records hyperglycemia as a frequent hemochromatosis feature downstream of pancreatic endocrine iron injury.
 - name: Pituitary-Gonadal Iron Toxicity
   description: >
     Iron deposition in endocrine tissues, especially the pituitary gland, injures
@@ -512,12 +682,46 @@ pathophysiology:
   downstream:
   - target: Hypogonadotropic Hypogonadism
     description: Pituitary iron deposition disrupts gonadotropin output.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32327622
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The more intense and early accumulation of iron in juvenile hemochromatosis seems to be responsible for the greater severity and diversification of affected organs, especially the heart and pituitary gland
+      explanation: Supports pituitary iron accumulation as a key endocrine injury site in juvenile hemochromatosis.
   - target: Erectile Dysfunction
     description: Hypogonadism from pituitary iron toxicity can impair male sexual function.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypogonadotropic hypogonadism and androgen deficiency.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0100639 | Erectile dysfunction | Occasional (29-5%)
+      explanation: Orphanet records erectile dysfunction as a hemochromatosis phenotype; the edge places it downstream of pituitary-gonadal iron toxicity.
   - target: Amenorrhea
     description: Gonadotropin deficiency from pituitary iron toxicity can suppress menstrual cycling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypogonadotropic hypogonadism and gonadotropin deficiency.
+    evidence:
+    - reference: PMID:32327622
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: she presented with arthralgia, diffuse abdominal pain, adynamia, hair loss, darkening of the skin and amenorrhea
+      explanation: Case evidence supports amenorrhea occurring with juvenile hemochromatosis endocrine iron disease.
   - target: Hypothyroidism
     description: Pituitary siderosis can also cause secondary hypothyroidism in severe hemochromatosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Pituitary siderosis and secondary hypothyroidism.
+    evidence:
+    - reference: PMID:32327622
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The patient was diagnosed with juvenile hemochromatosis presenting with hypogonadotropic hypogonadism, cardiomyopathy, insulin-dependent diabetes mellitus, and secondary hypothyroidism.
+      explanation: Case evidence supports secondary hypothyroidism occurring with pituitary iron involvement in juvenile hemochromatosis.
 - name: Iron-Associated Arthropathy
   description: >
     Iron overload damages joints and periarticular tissues, producing the characteristic
@@ -547,6 +751,13 @@ pathophysiology:
   downstream:
   - target: Arthropathy
     description: Joint iron-associated tissue injury manifests as hemochromatosis arthropathy.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:32728396
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The frequency of radiographic MCP2-3 arthropathy was 37.6% (95% CI 0.28-0.48).
+      explanation: Cross-sectional human data support arthropathy as a common hemochromatosis joint manifestation.
 - name: Dermal Iron and Melanin Deposition
   description: >
     Iron accumulation contributes to increased melanin and iron deposition in the
@@ -570,6 +781,13 @@ pathophysiology:
   downstream:
   - target: Skin Hyperpigmentation
     description: Dermal iron and pigment deposition produce bronze hyperpigmentation.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0007574 | Generalized bronze hyperpigmentation | Frequent (79-30%)
+      explanation: Orphanet records generalized bronze hyperpigmentation as a frequent hemochromatosis phenotype.
 - name: Iron-Associated Bone Fragility
   description: >
     Iron overload affects bone and gonadal endocrine function, reducing bone density
@@ -599,8 +817,24 @@ pathophysiology:
   downstream:
   - target: Osteoporosis
     description: Iron-associated bone remodeling abnormalities manifest as osteoporosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:31989186
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: Parenchyma damage may be a consequence of iron deposition in affected organs (e.g., liver, pancreas, gonads) as well as bones and joints, leading to osteoporosis with increased fracture risk and arthropathy.
+      explanation: Human hemochromatosis bone study directly links iron deposition in bones and joints to osteoporosis and increased fracture risk.
   - target: Decreased Muscle Mass
     description: Hypogonadism and systemic iron-overload effects contribute to reduced muscle mass.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hypogonadism, chronic systemic illness, and reduced musculoskeletal reserve.
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0003199 | Decreased muscle mass | Frequent (79-30%)
+      explanation: Orphanet records decreased muscle mass as a frequent hemochromatosis phenotype downstream of systemic musculoskeletal and endocrine effects.
 - name: Systemic Iron Overload Symptoms
   description: >
     Chronic multi-organ iron overload causes constitutional symptoms, including
@@ -624,8 +858,22 @@ pathophysiology:
   downstream:
   - target: Fatigue
     description: Progressive systemic iron overload manifests as chronic fatigue.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:39337031
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: The HH patients exhibited significantly worse fatigue across all the scales.
+      explanation: Human fatigue-scale data support fatigue as a symptomatic consequence of hemochromatosis.
   - target: Weight Loss
     description: Advanced systemic iron overload can produce unintentional weight loss.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:465508
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: HP:0001824 | Weight loss | Occasional (29-5%)
+      explanation: Orphanet records weight loss as a hemochromatosis phenotype within the systemic symptom cluster.
 phenotypes:
 - name: Hepatomegaly
   category: Hepatic


### PR DESCRIPTION
## Summary
- add causal link types and edge-level evidence across the Hemochromatosis pathograph
- connect transferrin saturation and ferritin as downstream biochemical readouts of systemic iron overload
- keep scope to kb/disorders/Hemochromatosis.yaml

## Validation
- just validate kb/disorders/Hemochromatosis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Hemochromatosis.yaml
- manual snippet audit: checked=145 missing=0 no_cache=0
- graph audit: pathophysiology=13 phenotypes=18 biochemical=2 edges=32; unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0
- git diff --check