### PR TITLE
Add Homocystinuria causal link types

### DIFF
--- a/kb/disorders/Homocystinuria.yaml
+++ b/kb/disorders/Homocystinuria.yaml
@@ -1,7 +1,7 @@
 name: Homocystinuria
 category: Mendelian
 creation_date: '2025-06-12T20:16:27Z'
-updated_date: '2026-05-18T08:50:07Z'
+updated_date: '2026-05-21T18:27:18Z'
 synonyms:
 - Classical homocystinuria
 - CBS-deficient homocystinuria
@@ -97,6 +97,7 @@ pathophysiology:
   downstream:
   - target: Disrupted transsulfuration and methionine metabolism
     description: Reduced CBS activity blocks homocysteine-to-cystathionine flux.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:27778219
       reference_title: "Guidelines for the diagnosis and management of cystathionine beta-synthase deficiency."
@@ -155,6 +156,7 @@ pathophysiology:
   downstream:
   - target: Total homocysteine (tHcy)
     description: CBS blockade produces the diagnostic accumulation of total plasma homocysteine.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:27778219
       reference_title: "Guidelines for the diagnosis and management of cystathionine beta-synthase deficiency."
@@ -164,6 +166,7 @@ pathophysiology:
       explanation: The guideline directly supports homocysteine accumulation downstream of impaired CBS activity.
   - target: Hyperhomocystinemia
     description: Elevated plasma homocysteine is the clinical phenotype-level expression of the biochemical block.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -171,6 +174,7 @@ pathophysiology:
       explanation: Orphanet classifies hyperhomocystinemia as very frequent in CBS-deficient homocystinuria.
   - target: Methionine
     description: The CBS block occurs in methionine catabolism and causes upstream methionine accumulation in classical HCU.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -178,6 +182,9 @@ pathophysiology:
       explanation: Orphanet explicitly describes methionine and homocysteine accumulation in CBS-deficient homocystinuria.
   - target: Cysteine
     description: Blocked transsulfuration reduces downstream cysteine production.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - CBS-dependent cystathionine production precedes cystathionase-mediated cysteine synthesis.
     evidence:
     - reference: PMID:39366068
       reference_title: "Mechanism of action and impact of thiol homeostasis on efficacy of an enzyme replacement therapy for classical homocystinuria."
@@ -187,6 +194,7 @@ pathophysiology:
       explanation: The ERT mechanism paper supports the substrate-level CBS flux step; cysteine depletion is inferred from interruption of the downstream transsulfuration pathway.
   - target: Hepatomegaly
     description: Hepatomegaly is grouped with systemic manifestations of sulfur-amino-acid metabolic disruption in HCU.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: PARTIAL
@@ -194,6 +202,7 @@ pathophysiology:
       explanation: Orphanet supports hepatomegaly as an occasional phenotype; the metabolic-node assignment reflects hepatic sulfur-amino-acid pathway involvement.
   - target: Oxidative stress and mitochondrial dysfunction
     description: Homocysteine burden and downstream thiol imbalance contribute to oxidative and mitochondrial stress.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:39567721
       reference_title: "Oxidative damage and mitochondrial dysfunction in cystathionine beta-synthase deficiency."
@@ -203,6 +212,7 @@ pathophysiology:
       explanation: Patient biomarker data link total homocysteine burden to mitochondrial stress readouts.
   - target: Fibrin homocysteinylation and collagen cross-link deficiency
     description: Reactive homocysteine species modify plasma proteins, while patient data support a collagen cross-linking defect in bone.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:24659173
       reference_title: "Impact of homocysteine-thiolactone on plasma fibrin networks."
@@ -212,6 +222,7 @@ pathophysiology:
       explanation: This ex vivo plasma study supports a protein-modification mechanism downstream of homocysteine-thiolactone.
   - target: Homocysteic acid neuroexcitotoxicity
     description: Homocysteine-derived excitatory metabolites affect neuronal signaling.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:1676834
       reference_title: "L-homocysteic acid mediates synaptic excitation at NMDA receptors in the hippocampus."
@@ -279,6 +290,7 @@ pathophysiology:
   downstream:
   - target: Hyperhomocystinemia
     description: MTHFR deficiency converges with CBS deficiency on elevated homocysteine as a shared biochemical phenotype.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:40440437
       reference_title: "Homocystinuria due to Deficiency of N(5,10)-Methylenetetrahydrofolate Reductase Activity."
@@ -288,6 +300,7 @@ pathophysiology:
       explanation: GeneReviews directly lists increased plasma and urine homocysteine in MTHFR-deficiency homocystinuria.
   - target: Total homocysteine (tHcy)
     description: Plasma homocysteine surveillance reports disease activity in MTHFR-deficiency homocystinuria.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:40440437
       reference_title: "Homocystinuria due to Deficiency of N(5,10)-Methylenetetrahydrofolate Reductase Activity."
@@ -323,6 +336,7 @@ pathophysiology:
   downstream:
   - target: GDF-15 (mitokine)
     description: GDF-15 is elevated as a mitochondrial stress biomarker and correlates with total homocysteine in patients.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39567721
       reference_title: "Oxidative damage and mitochondrial dysfunction in cystathionine beta-synthase deficiency."
@@ -332,6 +346,7 @@ pathophysiology:
       explanation: Patient data link homocysteine burden with the GDF-15 mitokine readout.
   - target: FGF-21 (mitokine)
     description: FGF-21 elevation is part of the patient mitochondrial stress signature.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39567721
       reference_title: "Oxidative damage and mitochondrial dysfunction in cystathionine beta-synthase deficiency."
@@ -341,6 +356,7 @@ pathophysiology:
       explanation: Patient data support FGF-21 alteration as a mitochondrial stress marker in CBSD.
   - target: NAD+/NADH ratio
     description: NAD redox imbalance is a measurable downstream readout of mitochondrial dysfunction.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39567721
       reference_title: "Oxidative damage and mitochondrial dysfunction in cystathionine beta-synthase deficiency."
@@ -350,6 +366,7 @@ pathophysiology:
       explanation: Patient data directly support altered NAD+/NADH ratio in CBSD.
   - target: Endothelial dysfunction, thrombosis, and vascular injury
     description: Oxidative injury contributes to endothelial dysfunction and thrombotic vascular complications.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:38201964
       reference_title: "Hyperhomocysteinemia in Adult Patients: A Treatable Metabolic Condition."
@@ -380,6 +397,7 @@ pathophysiology:
   downstream:
   - target: CBS molecular function deficiency
     description: Misfolding and proteasomal turnover reduce residual CBS activity for many pathogenic missense variants.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39041895
       reference_title: "Cellular turnover and degradation of the most common missense cystathionine beta-synthase variants causing homocystinuria."
@@ -388,6 +406,23 @@ pathophysiology:
       snippet: "instability of the C-terminal regulatory domain, which likely translates into CBS misfolding, impaired assembly, and loss of function."
       explanation: Cellular turnover data directly connect variant instability and misfolding to CBS loss of function.
   - target: Disrupted transsulfuration and methionine metabolism
+    description: Proteostasis-mediated CBS loss of function reduces transsulfuration flux.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Misfolded CBS degradation reduces functional CBS enzyme activity.
+    evidence:
+    - reference: PMID:39041895
+      reference_title: "Cellular turnover and degradation of the most common missense cystathionine beta-synthase variants causing homocystinuria."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "instability of the C-terminal regulatory domain, which likely translates into CBS misfolding, impaired assembly, and loss of function."
+      explanation: Cellular turnover data connect CBS variant misfolding to loss of function, the proximal intermediate that disrupts transsulfuration.
+    - reference: PMID:27778219
+      reference_title: "Guidelines for the diagnosis and management of cystathionine beta-synthase deficiency."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Cystathionine beta-synthase (CBS) deficiency is a rare inherited disorder in the methionine catabolic pathway, in which the impaired synthesis of cystathionine leads to accumulation of homocysteine."
+      explanation: The guideline links CBS functional deficiency to impaired cystathionine synthesis and homocysteine accumulation.
 - name: Endothelial dysfunction, thrombosis, and vascular injury
   description: 'Homocysteine-driven oxidative stress and protein modifications cause endothelial cell dysfunction and platelet activation, promoting thrombus formation and vascular occlusion. Modification of fibrinogen by homocysteine thiolactone increases resistance to fibrinolysis, providing a direct mechanistic link to the high thromboembolism risk in HCU.
 
@@ -422,6 +457,7 @@ pathophysiology:
   downstream:
   - target: Thromboembolism
     description: Endothelial injury, altered coagulation, and impaired fibrinolysis drive the aggregate thromboembolism phenotype.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:3872065
       reference_title: "The natural history of homocystinuria due to cystathionine beta-synthase deficiency."
@@ -431,6 +467,7 @@ pathophysiology:
       explanation: Natural history data quantify thromboembolic events as a major vascular outcome of CBS deficiency.
   - target: Arterial thrombosis
     description: The vascular-injury mechanism includes arterial thrombotic events.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:38201964
       reference_title: "Hyperhomocysteinemia in Adult Patients: A Treatable Metabolic Condition."
@@ -440,6 +477,7 @@ pathophysiology:
       explanation: The review explicitly links hyperhomocysteinemia with arterial thrombotic vascular events.
   - target: Venous thrombosis
     description: The vascular-injury mechanism includes venous thrombotic events.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:38201964
       reference_title: "Hyperhomocysteinemia in Adult Patients: A Treatable Metabolic Condition."
@@ -449,6 +487,7 @@ pathophysiology:
       explanation: The review explicitly links hyperhomocysteinemia with venous thrombotic vascular events.
   - target: Pulmonary embolism
     description: Pulmonary embolism is a frequent embolic manifestation of the thrombotic vascular mechanism.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -456,6 +495,7 @@ pathophysiology:
       explanation: Orphanet classifies pulmonary embolism as a frequent phenotype in CBS-deficient homocystinuria.
   - target: Cerebral ischemia
     description: Arterial thrombosis can produce cerebral ischemia and stroke-like presentations.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -463,6 +503,7 @@ pathophysiology:
       explanation: Orphanet classifies cerebral ischemia as a frequent phenotype in CBS-deficient homocystinuria.
   - target: Stroke
     description: Arterial or venous thrombotic vascular events can present clinically as stroke.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:38201964
       reference_title: "Hyperhomocysteinemia in Adult Patients: A Treatable Metabolic Condition."
@@ -472,6 +513,7 @@ pathophysiology:
       explanation: The review links hyperhomocysteinemia with arterial and venous thrombotic vascular events, the mechanism underlying stroke presentations.
   - target: Cerebral venous sinus thrombosis
     description: Venous thrombosis can involve the cerebral venous sinuses.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -479,6 +521,7 @@ pathophysiology:
       explanation: Orphanet classifies cerebral venous sinus thrombosis as an occasional phenotype in CBS-deficient homocystinuria.
   - target: Hypertension
     description: Vascular remodeling and endothelial dysfunction provide a mechanism for frequent hypertension.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -486,6 +529,7 @@ pathophysiology:
       explanation: Orphanet classifies hypertension as frequent in CBS-deficient homocystinuria.
   - target: Livedo reticularis
     description: Cutaneous livedo reflects microvascular involvement in the vascular phenotype cluster.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -493,6 +537,7 @@ pathophysiology:
       explanation: Orphanet classifies livedo reticularis as an occasional phenotype in CBS-deficient homocystinuria.
   - target: Pancreatitis
     description: Pancreatitis is grouped with occasional systemic complications that can plausibly reflect vascular injury in severe HCU.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: PARTIAL
@@ -529,6 +574,7 @@ pathophysiology:
   downstream:
   - target: Osteoporosis
     description: Reduced collagen cross-linking contributes to the bone fragility and osteoporosis phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:8611653
       reference_title: "Evidence for McKusick's hypothesis of deficient collagen cross-linking in patients with homocystinuria."
@@ -538,6 +584,7 @@ pathophysiology:
       explanation: The patient study directly links deficient collagen cross-linking to bone manifestations.
   - target: Recurrent fractures
     description: Collagen cross-link deficiency provides a mechanism for bone fragility and fracture susceptibility.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -545,6 +592,7 @@ pathophysiology:
       explanation: Orphanet classifies recurrent fractures as very frequent in CBS-deficient homocystinuria.
   - target: Ectopia lentis
     description: Connective-tissue matrix dysfunction provides a mechanistic bridge to lens zonule instability and ectopia lentis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:3872065
       reference_title: "The natural history of homocystinuria due to cystathionine beta-synthase deficiency."
@@ -554,6 +602,7 @@ pathophysiology:
       explanation: Natural history data support lens dislocation as a major structural complication of CBS deficiency.
   - target: Myopia
     description: Myopia is grouped with ocular structural complications downstream of connective-tissue involvement in HCU.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -561,6 +610,7 @@ pathophysiology:
       explanation: Orphanet classifies myopia as a frequent ocular phenotype in CBS-deficient homocystinuria.
   - target: Amblyopia
     description: Amblyopia is linked to the ocular structural phenotype cluster, including lens displacement and refractive disturbance.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -568,6 +618,7 @@ pathophysiology:
       explanation: Orphanet classifies amblyopia as frequent in CBS-deficient homocystinuria.
   - target: Glaucoma
     description: Glaucoma can occur as part of the ocular complication cluster associated with lens instability.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -575,6 +626,7 @@ pathophysiology:
       explanation: Orphanet classifies glaucoma as an occasional ocular phenotype in CBS-deficient homocystinuria.
   - target: Retinal detachment
     description: Retinal detachment belongs to the ocular complication cluster downstream of connective-tissue and high-myopia effects.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -582,6 +634,7 @@ pathophysiology:
       explanation: Orphanet classifies retinal detachment as an occasional ocular phenotype in CBS-deficient homocystinuria.
   - target: Strabismus
     description: Strabismus is grouped with ocular structural and refractive complications in CBS-deficient homocystinuria.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -589,6 +642,7 @@ pathophysiology:
       explanation: Orphanet classifies strabismus as an occasional ocular phenotype in CBS-deficient homocystinuria.
   - target: Cataract
     description: Cataract is grouped with lens and ocular complications in CBS-deficient homocystinuria.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -596,6 +650,7 @@ pathophysiology:
       explanation: Orphanet classifies cataract as an occasional ocular phenotype in CBS-deficient homocystinuria.
   - target: Marfanoid habitus
     description: Collagen cross-link and connective-tissue disruption provide a mechanism for the marfanoid skeletal habitus.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:33295057
       reference_title: "Cystathionine beta-synthase deficiency in the E-HOD registry-part I."
@@ -605,6 +660,7 @@ pathophysiology:
       explanation: E-HOD registry data support marfanoid features as part of early classical homocystinuria.
   - target: Arachnodactyly
     description: Arachnodactyly is part of the marfanoid connective-tissue phenotype cluster.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -612,6 +668,7 @@ pathophysiology:
       explanation: Orphanet classifies arachnodactyly as very frequent in CBS-deficient homocystinuria.
   - target: Dental crowding
     description: Dental crowding is grouped with the craniofacial and skeletal connective-tissue phenotype cluster.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -619,6 +676,7 @@ pathophysiology:
       explanation: Orphanet classifies dental crowding as very frequent in CBS-deficient homocystinuria.
   - target: Scoliosis
     description: Scoliosis is a skeletal deformity downstream of connective-tissue and bone-matrix abnormalities.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -626,6 +684,7 @@ pathophysiology:
       explanation: Orphanet classifies scoliosis as frequent in CBS-deficient homocystinuria.
   - target: Pectus excavatum
     description: Pectus excavatum is part of the thoracic skeletal deformity cluster in CBS-deficient homocystinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -633,6 +692,7 @@ pathophysiology:
       explanation: Orphanet classifies pectus excavatum as frequent in CBS-deficient homocystinuria.
   - target: Pectus carinatum
     description: Pectus carinatum is part of the thoracic skeletal deformity cluster in CBS-deficient homocystinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -640,6 +700,7 @@ pathophysiology:
       explanation: Orphanet classifies pectus carinatum as frequent in CBS-deficient homocystinuria.
   - target: Kyphosis
     description: Kyphosis reflects the skeletal deformity and bone-quality phenotype cluster.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -647,6 +708,7 @@ pathophysiology:
       explanation: Orphanet classifies kyphosis as frequent in CBS-deficient homocystinuria.
   - target: Genu valgum
     description: Genu valgum is grouped with lower-limb skeletal deformities in CBS-deficient homocystinuria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -654,6 +716,7 @@ pathophysiology:
       explanation: Orphanet classifies genu valgum as frequent in CBS-deficient homocystinuria.
   - target: Joint stiffness
     description: Joint stiffness is part of the connective-tissue and skeletal phenotype cluster.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -661,6 +724,7 @@ pathophysiology:
       explanation: Orphanet classifies joint stiffness as frequent in CBS-deficient homocystinuria.
   - target: Pes cavus
     description: Pes cavus is grouped with skeletal and lower-limb structural manifestations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -668,6 +732,7 @@ pathophysiology:
       explanation: Orphanet classifies pes cavus as frequent in CBS-deficient homocystinuria.
   - target: High palate
     description: High palate is grouped with craniofacial skeletal manifestations of the connective-tissue phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -675,6 +740,7 @@ pathophysiology:
       explanation: Orphanet classifies high palate as occasional in CBS-deficient homocystinuria.
   - target: Sparse scalp hair
     description: Sparse scalp hair is grouped with the connective-tissue and integumentary phenotype spectrum in HCU.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: PARTIAL
@@ -720,6 +786,7 @@ pathophysiology:
   downstream:
   - target: Intellectual disability
     description: Neuroexcitotoxicity provides a plausible contribution to cognitive impairment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:3872065
       reference_title: "The natural history of homocystinuria due to cystathionine beta-synthase deficiency."
@@ -729,6 +796,7 @@ pathophysiology:
       explanation: Natural history data quantify cognitive impairment severity by biochemical responsiveness group.
   - target: Global developmental delay
     description: Early neurotoxicity contributes to delayed neurodevelopment.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:33295057
       reference_title: "Cystathionine beta-synthase deficiency in the E-HOD registry-part I."
@@ -738,6 +806,7 @@ pathophysiology:
       explanation: E-HOD registry data support developmental delay in the severe non-responder group.
   - target: Seizures
     description: NMDA-receptor activation by homocysteic acid provides a plausible seizure mechanism.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:1676834
       reference_title: "L-homocysteic acid mediates synaptic excitation at NMDA receptors in the hippocampus."
@@ -747,6 +816,7 @@ pathophysiology:
       explanation: NMDA agonism supports a mechanistic bridge to seizure susceptibility, while the human phenotype is separately supported in the phenotype entry.
   - target: Psychosis
     description: Neurochemical disturbance may contribute to occasional psychiatric manifestations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -754,6 +824,7 @@ pathophysiology:
       explanation: Orphanet supports psychosis as an occasional neuropsychiatric manifestation of CBS-deficient homocystinuria.
   - target: Depression
     description: Depression is grouped with neuropsychiatric manifestations plausibly linked to metabolic neurotoxicity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -761,6 +832,7 @@ pathophysiology:
       explanation: Orphanet classifies depression as an occasional phenotype in CBS-deficient homocystinuria.
   - target: Anxiety
     description: Anxiety is grouped with neuropsychiatric manifestations plausibly linked to metabolic neurotoxicity.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT
@@ -768,6 +840,7 @@ pathophysiology:
       explanation: Orphanet classifies anxiety as an occasional phenotype in CBS-deficient homocystinuria.
   - target: Dystonia
     description: Dystonia is grouped with neurologic manifestations potentially arising from metabolic or vascular brain injury.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:394
       supports: SUPPORT


### PR DESCRIPTION
## Summary
- add `causal_link_type` to all 55 Homocystinuria downstream edges
- add evidence and a description for the previously bare `CBS protein misfolding and proteostasis disruption -> Disrupted transsulfuration and methionine metabolism` edge
- keep the PR scoped to `kb/disorders/Homocystinuria.yaml`

## Validation
- `just validate kb/disorders/Homocystinuria.yaml` passed
- `uv run python -m dismech.graph --validate kb/disorders/Homocystinuria.yaml` passed
- Manual snippet audit: `checked=170 missing=0 no_cache=0`
- Graph audit: `pathophysiology=8 phenotypes=40 biochemical=6 edges=55`; `unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0`
- `git diff --check` passed

Recurring validator cache churn in `references_cache/PMID_24904092.md` and `references_cache/PMID_31292197.md` was restored before commit.