### PR TITLE
Add HMGCS2 deficiency causal link types

### DIFF
--- a/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
+++ b/kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
@@ -1,6 +1,6 @@
 name: 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency
 creation_date: '2026-05-04T09:20:00Z'
-updated_date: '2026-05-21T13:26:32Z'
+updated_date: '2026-05-21T19:05:00Z'
 category: Mendelian
 description: >
   3-hydroxy-3-methylglutaryl-CoA synthase deficiency is an autosomal
@@ -199,6 +199,7 @@ pathophysiology:
   downstream:
   - target: Impaired Hepatic Ketogenesis
     description: HMGCS2 loss blocks mitochondrial ketone body synthesis from acetyl-CoA and acetoacetyl-CoA.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -263,6 +264,9 @@ pathophysiology:
   downstream:
   - target: Catabolic Stress Metabolic Decompensation
     description: Inadequate ketogenesis during fasting or illness causes energy failure and acute metabolic crises.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Reduced ketone body availability during fasting or illness leaves patients dependent on limited glucose stores.
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -272,6 +276,9 @@ pathophysiology:
       explanation: Human case synthesis links impaired ketogenesis to acute metabolic decompensation with inadequate ketone production.
   - target: Acute-Phase Acetylcarnitine and Organic Acid Pattern
     description: Acetyl-CoA cannot enter ketogenesis normally, contributing to elevated acetylcarnitine, dicarboxylic aciduria, and 4HMP excretion during crises.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Acetyl-CoA diversion to acetylcarnitine and alternative fatty-acid oxidation products during failed ketogenesis.
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -287,6 +294,9 @@ pathophysiology:
       explanation: The systematic review supports the acute acylcarnitine-ratio component of the biochemical pattern.
   - target: Hepatic steatosis
     description: Blocked ketogenesis is associated with fatty liver during acute decompensation.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Altered hepatic fatty-acid handling during acute failed ketogenesis.
     evidence:
     - reference: PMID:32952630
       reference_title: "Japanese patients with mitochondrial 3-hydroxy-3-methylglutaryl-CoA synthase deficiency: In vitro functional analysis of five novel HMGCS2 mutations."
@@ -326,6 +336,7 @@ pathophysiology:
   downstream:
   - target: Hypoglycemia
     description: Failure to generate ketone bodies under catabolic stress accompanies hypoglycemia.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -335,6 +346,7 @@ pathophysiology:
       explanation: The systematic review identifies hypoglycemia as a core feature of acute decompensation.
   - target: Metabolic acidosis
     description: Acute decompensation commonly includes severe metabolic acidosis.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:35308163
       reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
@@ -344,6 +356,9 @@ pathophysiology:
       explanation: The Chinese patient series supports metabolic acidosis during acute decompensation.
   - target: Seizure
     description: Severe acute crises may include seizures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuroglycopenia and acid-base disturbance during severe metabolic decompensation.
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -353,6 +368,9 @@ pathophysiology:
       explanation: The systematic review lists seizures among common first-episode symptoms.
   - target: Hepatomegaly
     description: Hepatic metabolic stress during crises is associated with hepatomegaly.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic metabolic stress and altered fatty-acid handling during acute crises.
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -362,6 +380,7 @@ pathophysiology:
       explanation: The systematic review lists hepatomegaly among common first-episode symptoms.
   - target: Hypoketotic hypoglycemia
     description: Ketogenesis failure during catabolic stress produces hypoglycemia with inadequate ketone production.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -371,6 +390,7 @@ pathophysiology:
       explanation: The systematic review identifies hypoglycemia with inadequate ketonuria as the core acute decompensation pattern.
   - target: Vomiting
     description: Catabolic decompensation often presents with vomiting or cyclic-vomiting-like episodes.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:39143735
       reference_title: "Mitochondrial HMG-CoA Synthase Deficiency: A Cyclic Vomiting Mimic Without Reliable Biochemical Markers."
@@ -380,6 +400,9 @@ pathophysiology:
       explanation: The case report links vomiting episodes with hypoglycemia or other metabolic abnormalities in HMGCS2 deficiency.
   - target: Lethargy
     description: Energy failure during acute episodes can manifest as lethargy and altered responsiveness.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuroglycopenia and reduced alternative fuel availability during acute decompensation.
     evidence:
     - reference: PMID:39143735
       reference_title: "Mitochondrial HMG-CoA Synthase Deficiency: A Cyclic Vomiting Mimic Without Reliable Biochemical Markers."
@@ -389,6 +412,9 @@ pathophysiology:
       explanation: The case report documents lethargy during recurrent metabolic episodes.
   - target: Encephalopathy
     description: Severe decompensation can progress to encephalopathy.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Neuroglycopenia, acid-base disturbance, and severe systemic metabolic stress.
     evidence:
     - reference: PMID:40548098
       reference_title: "HMG-CoA Synthase-2 Deficiency: Neonatal Hyperammonemic Coma and Abnormal Metabolic Screening Resembling Maple Syrup Urine Disease."
@@ -398,6 +424,9 @@ pathophysiology:
       explanation: The neonatal case report states encephalopathy among characteristic severe decompensation features.
   - target: Coma
     description: Severe neonatal or childhood crises may progress to coma.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Severe neuroglycopenia and acid-base disturbance during crisis.
     evidence:
     - reference: PMID:40548098
       reference_title: "HMG-CoA Synthase-2 Deficiency: Neonatal Hyperammonemic Coma and Abnormal Metabolic Screening Resembling Maple Syrup Urine Disease."
@@ -407,6 +436,7 @@ pathophysiology:
       explanation: The neonatal case presented with coma during metabolic decompensation.
   - target: Hyperammonemia
     description: Severe crisis physiology can include hyperammonemia, particularly in neonatal presentations.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: PMID:35308163
       reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
@@ -416,6 +446,9 @@ pathophysiology:
       explanation: The Chinese patient series supports hyperammonemia as a crisis-associated biochemical feature.
   - target: Dyspnea
     description: Acute metabolic acidosis and decompensation can present with dyspnea.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Respiratory compensation and respiratory distress during acid-base disturbance.
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."
@@ -425,6 +458,9 @@ pathophysiology:
       explanation: The systematic review lists dyspnea among first-episode symptoms.
   - target: Elevated hepatic transaminase
     description: Hepatic stress during acute crises can include increased aminotransferases.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - Hepatic cellular stress during acute metabolic decompensation.
     evidence:
     - reference: PMID:35308163
       reference_title: "Clinical, Biochemical, Molecular, and Outcome Features of Mitochondrial 3-Hydroxy-3-Methylglutaryl-CoA Synthase Deficiency in 10 Chinese Patients."
@@ -434,6 +470,7 @@ pathophysiology:
       explanation: The Chinese patient series documents increased aminotransferase during severe acute presentations.
   - target: Abnormal metabolism or homeostasis
     description: Acute decompensation represents the systemic metabolic-homeostasis phenotype caused by failed fasting ketogenesis.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:35701
       reference_title: "3-hydroxy-3-methylglutaryl-CoA synthase deficiency (Orphanet structured-database record)"
@@ -481,6 +518,7 @@ pathophysiology:
   downstream:
   - target: Dicarboxylic aciduria
     description: Acute organic acid profiles commonly show dicarboxylic aciduria.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39798988
       reference_title: "Mitochondrial HMG-CoA synthase deficiency."


### PR DESCRIPTION
## Summary
- Added causal_link_type classifications to the 18 previously unclassified downstream edges in 3-Hydroxy-3-Methylglutaryl-CoA synthase deficiency.
- Added intermediate_mechanisms for compressed indirect edges where the omitted mechanism is explicit enough to name.
- Updated updated_date for the curated YAML change.

## Validation
- just validate kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
- uv run python -m dismech.graph --validate kb/disorders/3-Hydroxy-3-Methylglutaryl-CoA_Synthase_Deficiency.yaml
- Manual snippet audit: checked=95 missing=0 no_cache=0
- Graph audit: pathophysiology=4 phenotypes=15 biochemical=4 edges=22; unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0
- git diff --check