### PR TITLE
Connect Familial Hypercholesterolemia causal edges

### DIFF
--- a/kb/disorders/Familial_Hypercholesterolemia.yaml
+++ b/kb/disorders/Familial_Hypercholesterolemia.yaml
@@ -1,6 +1,6 @@
 name: Familial Hypercholesterolemia
 creation_date: "2026-03-06T00:00:00Z"
-updated_date: "2026-05-18T23:26:01Z"
+updated_date: "2026-05-21T19:15:00Z"
 description: >
   Familial hypercholesterolemia (FH) is a common autosomal dominant disorder of
   lipid metabolism characterized by significantly elevated serum low-density
@@ -161,6 +161,7 @@ pathophysiology:
   downstream:
   - target: Reduced Hepatic LDL Clearance
     description: Loss of functional LDLR directly reduces receptor-mediated uptake of circulating LDL particles.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:1301956
       reference_title: "Molecular genetics of the LDL receptor gene in familial hypercholesterolemia."
@@ -203,6 +204,7 @@ pathophysiology:
   downstream:
   - target: Reduced Hepatic LDL Clearance
     description: Defective LDL particle binding prevents normal receptor-mediated clearance despite preserved receptor expression.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:24404629
       reference_title: "Familial Hypercholesterolemia."
@@ -244,6 +246,7 @@ pathophysiology:
   downstream:
   - target: PCSK9-Mediated LDLR Degradation
     description: PCSK9 gain-of-function turns the inherited defect into accelerated post-endocytic LDLR degradation.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:24404629
       reference_title: "Familial Hypercholesterolemia."
@@ -286,6 +289,7 @@ pathophysiology:
   downstream:
   - target: Reduced Hepatic LDL Clearance
     description: LDLRAP1-related FH converges on the same proximal defect of impaired LDL uptake.
+    causal_link_type: DIRECT
     evidence:
     - reference: DOI:10.3390/ijms24043224
       supports: SUPPORT
@@ -376,6 +380,7 @@ pathophysiology:
   downstream:
   - target: Reduced Hepatic LDL Clearance
     description: Accelerated destruction of mature LDLR leaves too few surface receptors for normal LDL clearance.
+    causal_link_type: DIRECT
     evidence:
     - reference: DOI:10.1073/pnas.0409736102
       supports: SUPPORT
@@ -415,6 +420,7 @@ pathophysiology:
   downstream:
   - target: Elevated Circulating LDL Cholesterol
     description: When hepatocytes cannot clear LDL efficiently, circulating LDL-C accumulates lifelong.
+    causal_link_type: DIRECT
     evidence:
     - reference: DOI:10.3390/ijms24043224
       supports: SUPPORT
@@ -472,8 +478,25 @@ pathophysiology:
       explanation: >
         Elevated plasma LDL is the specific biochemical phenotype represented
         by increased LDL cholesterol concentration.
+  - target: LDL Cholesterol (LDL-C)
+    description: >
+      Measured LDL-C is the biochemical biomarker corresponding to the elevated
+      circulating LDL cholesterol mechanism.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24404629
+      reference_title: "Familial Hypercholesterolemia."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A clinical diagnosis of FH can be established in a proband with characteristic clinical features and significantly elevated LDL-C levels"
+      explanation: >
+        GeneReviews identifies significantly elevated LDL-C levels as the
+        diagnostic biochemical readout of the elevated LDL-C mechanism.
   - target: Oxidized LDL Infiltration of Arterial Intima
     description: Persistently elevated LDL loads the arterial wall and initiates intimal lipid retention.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - subendothelial LDL retention and oxidative modification
     evidence:
     - reference: PMID:24404629
       reference_title: "Familial Hypercholesterolemia."
@@ -483,6 +506,9 @@ pathophysiology:
       explanation: Connects LDL-C excess to early arterial plaque deposition.
   - target: Extra-arterial Cholesterol Deposition
     description: The same chronic LDL excess also drives lipid deposition in tendon, skin, cornea, and valve tissue.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - chronic tissue retention of cholesterol-rich lipoproteins
     evidence:
     - reference: DOI:10.3390/ijms25031637
       supports: SUPPORT
@@ -518,6 +544,9 @@ pathophysiology:
   downstream:
   - target: Macrophage Recruitment to Arterial Intima
     description: Intimal oxidized LDL promotes leukocyte attraction and macrophage influx.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - endothelial activation and chemokine-mediated monocyte recruitment
     evidence:
     - reference: PMID:30165986
       reference_title: "Impact of Lipids on Cardiovascular Health: JACC Health Promotion Series."
@@ -558,6 +587,9 @@ pathophysiology:
   downstream:
   - target: Macrophage-Derived Foam Cell Formation
     description: Recruited macrophages internalize oxidized lipoproteins and transition toward foam cells.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - scavenger receptor-mediated oxidized LDL uptake
     evidence:
     - reference: DOI:10.1038/s41467-024-46336-2
       supports: SUPPORT
@@ -596,6 +628,9 @@ pathophysiology:
   downstream:
   - target: Atherosclerotic Plaque Development
     description: Foam-cell accumulation drives fatty-streak maturation and plaque development.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - fatty-streak maturation with lipid-rich inflammatory lesion growth
     evidence:
     - reference: PMID:28444290
       reference_title: "Low-density lipoproteins cause atherosclerotic cardiovascular disease. 1. Evidence from genetic, epidemiologic, and clinical studies. A consensus statement from the European Atherosclerosis Society Consensus Panel."
@@ -635,6 +670,9 @@ pathophysiology:
   downstream:
   - target: Premature Atherosclerotic Cardiovascular Disease
     description: Ongoing plaque growth produces early coronary, cerebrovascular, and peripheral vascular disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - progressive arterial narrowing, plaque instability, and ischemic events
     evidence:
     - reference: DOI:10.3390/ijms25031637
       supports: SUPPORT
@@ -778,6 +816,7 @@ pathophysiology:
   downstream:
   - target: Tendon and Cutaneous Cholesterol Deposition
     description: Cholesterol deposition in tendons and skin explains tendon xanthomas, cutaneous xanthomas, and periorbital xanthelasma.
+    causal_link_type: DIRECT
     evidence:
     - reference: DOI:10.3390/ijms25031637
       supports: SUPPORT
@@ -786,6 +825,7 @@ pathophysiology:
       explanation: Provides a direct bridge from LDL excess to tendon and cutaneous xanthomatous phenotypes.
   - target: Corneal Cholesterol Deposition
     description: Corneal peripheral deposition explains premature corneal arcus.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:24404629
       reference_title: "Familial Hypercholesterolemia."
@@ -795,6 +835,9 @@ pathophysiology:
       explanation: Directly explains corneal arcus as corneal cholesterol deposition.
   - target: Aortic Valve Lipid Deposition and Calcification
     description: In severe FH, valvular and aortic root deposition produces calcific aortic valve disease.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - valvular lipid retention followed by fibrocalcific remodeling
     evidence:
     - reference: PMID:24404629
       reference_title: "Familial Hypercholesterolemia."


### PR DESCRIPTION
## Summary
- Added causal_link_type classifications to the 15 previously unclassified Familial Hypercholesterolemia downstream edges.
- Added intermediate_mechanisms for compressed indirect LDL-to-atherosclerosis and tissue-deposition edges.
- Connected the LDL Cholesterol (LDL-C) biochemical biomarker as a direct downstream readout of Elevated Circulating LDL Cholesterol.
- Updated updated_date for the curated YAML change.

## Validation
- just validate kb/disorders/Familial_Hypercholesterolemia.yaml
- uv run python -m dismech.graph --validate kb/disorders/Familial_Hypercholesterolemia.yaml
- Manual snippet audit: checked=136 missing=0 no_cache=0
- Graph audit: pathophysiology=17 phenotypes=14 biochemical=1 edges=31; unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0
- git diff --check