### PR TITLE
Connect Hartnup disease pathograph edges

### DIFF
--- a/kb/disorders/Hartnup_Disease.yaml
+++ b/kb/disorders/Hartnup_Disease.yaml
@@ -1,7 +1,7 @@
 name: Hartnup Disease
 category: Mendelian
 creation_date: '2026-05-04T00:00:00Z'
-updated_date: '2026-05-18T09:41:07Z'
+updated_date: '2026-05-21T19:29:29Z'
 synonyms:
 - Hartnup disorder
 - Aminoaciduria, Hartnup type
@@ -163,8 +163,24 @@ pathophysiology:
   downstream:
   - target: Renal and intestinal neutral amino acid transport defect
     description: Reduced B0AT1 activity impairs reabsorption and absorption of neutral amino acids in kidney and intestine.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15286788
+      reference_title: "Hartnup disorder is caused by mutations in the gene encoding the neutral amino acid transporter SLC6A19."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "reduced neutral amino acid transport"
+      explanation: Functional testing links SLC6A19/B0AT1 variants to reduced neutral amino acid transport.
   - target: B0AT1 endoplasmic-reticulum retention
     description: Some disease-causing variants impair trafficking of B0AT1 to the plasma membrane.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40852587
+      reference_title: "Hartnup disease-causing SLC6A19 mutations lead to B0AT1 aberrant trafficking and ACE2 mis-localisation implicating the endoplasmic reticulum protein quality control."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "were found to be retained in the endoplasmic reticulum"
+      explanation: The trafficking study directly supports ER retention of Hartnup-associated B0AT1 variants.
 - name: CLTRN amino acid transport regulator involvement
   description: >
     CLTRN encodes collectrin, an amino-acid transport regulator listed by Orphanet
@@ -198,6 +214,9 @@ pathophysiology:
   downstream:
   - target: Renal and intestinal neutral amino acid transport defect
     description: CLTRN is modeled as an auxiliary amino-acid transport regulator that converges on the epithelial neutral amino acid transport phenotype.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - collectrin-dependent SLC6A19/B0AT1 surface expression in kidney epithelium
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -248,6 +267,14 @@ pathophysiology:
   downstream:
   - target: Renal and intestinal neutral amino acid transport defect
     description: ER retention reduces delivery of functional B0AT1 to the epithelial cell surface.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:40852587
+      reference_title: "Hartnup disease-causing SLC6A19 mutations lead to B0AT1 aberrant trafficking and ACE2 mis-localisation implicating the endoplasmic reticulum protein quality control."
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "by impairing amino acid transport and may influence ACE2-mediated physiological"
+      explanation: ER-retained B0AT1 variants impair amino acid transport, supporting the edge to the epithelial transport defect.
 - name: Renal and intestinal neutral amino acid transport defect
   description: >
     Defective B0AT1-mediated transport causes impaired renal reabsorption and
@@ -303,12 +330,39 @@ pathophysiology:
   downstream:
   - target: Neutral hyperaminoaciduria
     description: Failed renal reabsorption produces excessive urinary neutral amino acids.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:2116
+      reference_title: "Hartnup disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008353 | Neutral hyperaminoaciduria | Very frequent (99-80%)"
+      explanation: Orphanet records neutral hyperaminoaciduria as the common biochemical phenotype of the transport defect.
   - target: Malabsorption
     description: Impaired intestinal neutral amino acid transport contributes to reduced nutrient absorption.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:2116
+      reference_title: "Hartnup disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002024 | Malabsorption | Frequent (79-30%)"
+      explanation: Orphanet records malabsorption as a frequent phenotype of Hartnup disease.
   - target: Tryptophan and nicotinamide availability reduction
     description: Reduced intestinal tryptophan absorption can limit niacin/nicotinamide availability.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - reduced intestinal tryptophan absorption and reduced niacin precursor supply
+    evidence:
+    - reference: PMID:2472426
+      reference_title: "Circumvention of defective neutral amino acid transport in Hartnup disease using tryptophan ethyl ester."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "baseline tryptophan concentrations in serum"
+      explanation: Low baseline serum tryptophan supports reduced systemic tryptophan availability downstream of the transport defect.
   - target: Low systemic tryptophan availability
     description: Impaired intestinal neutral amino acid transport can reduce systemic and CSF tryptophan availability.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:2472426
       reference_title: "Circumvention of defective neutral amino acid transport in Hartnup disease using tryptophan ethyl ester."
@@ -318,6 +372,7 @@ pathophysiology:
       explanation: A symptomatic child had low baseline serum and CSF tryptophan before transport-bypass therapy.
   - target: Increased urinary indican
     description: Abnormal tryptophan transport and handling is reflected by elevated urinary indican.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -327,6 +382,7 @@ pathophysiology:
       explanation: Orphanet records elevated urinary indican as a frequent biochemical phenotype.
   - target: Elevated urinary indican level
     description: Elevated urinary indican is the phenotype-level expression of abnormal tryptophan handling.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -336,6 +392,7 @@ pathophysiology:
       explanation: Orphanet records elevated urinary indican as frequent.
   - target: Abnormal urinary color
     description: Abnormal urinary color is grouped with abnormal urinary amino-acid and tryptophan-derived metabolites.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -386,6 +443,16 @@ pathophysiology:
   downstream:
   - target: Pellagra-like neurocutaneous manifestations
     description: Functional niacin/nicotinamide deficiency can drive photosensitive rash and neurologic or psychiatric features.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - functional niacin or nicotinamide deficiency from reduced tryptophan precursor supply
+    evidence:
+    - reference: PMID:7955499
+      reference_title: "Hartnup disease presenting in an adult."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "A young woman presented with pellagra."
+      explanation: The adult case links Hartnup disease to pellagra-like manifestations.
 - name: Pellagra-like neurocutaneous manifestations
   description: >
     In susceptible patients, the transport defect manifests as photosensitive
@@ -408,12 +475,37 @@ pathophysiology:
   downstream:
   - target: Cutaneous photosensitivity
     description: Pellagra-like skin disease includes photosensitivity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:2116
+      reference_title: "Hartnup disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "mainly characterized by skin photosensitivity, ocular and neuropsychiatric features"
+      explanation: Orphanet identifies skin photosensitivity as a core Hartnup disease manifestation.
   - target: Ataxia
     description: Cerebellar manifestations include ataxia.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15286787
+      reference_title: "Mutations in SLC6A19, encoding B0AT1, cause Hartnup disorder."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ataxia and psychosis."
+      explanation: The SLC6A19 discovery paper lists ataxia among Hartnup disease symptoms.
   - target: Psychosis
     description: Neuropsychiatric manifestations can include psychosis.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:15286787
+      reference_title: "Mutations in SLC6A19, encoding B0AT1, cause Hartnup disorder."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ataxia and psychosis."
+      explanation: The SLC6A19 discovery paper lists psychosis among Hartnup disease symptoms.
   - target: Skin rash
     description: Pellagra-like dermatitis includes rash.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:15286787
       reference_title: "Mutations in SLC6A19, encoding B0AT1, cause Hartnup disorder."
@@ -423,6 +515,7 @@ pathophysiology:
       explanation: The SLC6A19 discovery paper includes pellagra-like rashes among Hartnup symptoms.
   - target: Emotional lability
     description: Emotional lability is grouped with Hartnup neuropsychiatric manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -432,6 +525,7 @@ pathophysiology:
       explanation: Orphanet records emotional lability as very frequent.
   - target: Hallucinations
     description: Hallucinations are grouped with Hartnup neuropsychiatric manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -441,6 +535,7 @@ pathophysiology:
       explanation: Orphanet records hallucinations as very frequent.
   - target: Anxiety
     description: Anxiety is grouped with Hartnup neuropsychiatric manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -450,6 +545,7 @@ pathophysiology:
       explanation: Orphanet records anxiety as very frequent.
   - target: Hypotonia
     description: Hypotonia is grouped with Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -459,6 +555,7 @@ pathophysiology:
       explanation: Orphanet records hypotonia as very frequent.
   - target: Hyperreflexia
     description: Hyperreflexia is grouped with Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -468,6 +565,7 @@ pathophysiology:
       explanation: Orphanet records hyperreflexia as very frequent.
   - target: Tremor
     description: Tremor is grouped with Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -477,6 +575,7 @@ pathophysiology:
       explanation: Orphanet records tremor as frequent.
   - target: Migraine
     description: Migraine is grouped with Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -486,6 +585,7 @@ pathophysiology:
       explanation: Orphanet records migraine as very frequent.
   - target: EEG abnormality
     description: EEG abnormality is grouped with Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -495,6 +595,7 @@ pathophysiology:
       explanation: Orphanet records EEG abnormality as very frequent.
   - target: Seizure
     description: Seizures are grouped with occasional Hartnup neurologic manifestations.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -504,6 +605,7 @@ pathophysiology:
       explanation: Orphanet records seizures as occasional.
   - target: Photophobia
     description: Photophobia is grouped with Hartnup ocular features.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -513,6 +615,7 @@ pathophysiology:
       explanation: Orphanet records photophobia as frequent.
   - target: Nystagmus
     description: Nystagmus is grouped with Hartnup ocular-neurologic features.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -522,6 +625,7 @@ pathophysiology:
       explanation: Orphanet records nystagmus as frequent.
   - target: Strabismus
     description: Strabismus is grouped with Hartnup ocular features.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"
@@ -531,6 +635,7 @@ pathophysiology:
       explanation: Orphanet records strabismus as frequent.
   - target: Abnormality of vision
     description: Visual abnormality is grouped with Hartnup ocular features.
+    causal_link_type: DIRECT
     evidence:
     - reference: ORPHA:2116
       reference_title: "Hartnup disease (Orphanet structured-database record)"


### PR DESCRIPTION
## Summary
- Added causal_link_type classifications to all 29 Hartnup disease downstream edges.
- Added evidence to the 10 downstream edges that previously had no edge-level evidence, using already-cited cached sources.
- Added intermediate_mechanisms for compressed indirect transport-to-niacin and CLTRN/B0AT1 surface-expression edges.
- Updated updated_date for the curated YAML change.

## Validation
- just validate kb/disorders/Hartnup_Disease.yaml
- uv run python -m dismech.graph --validate kb/disorders/Hartnup_Disease.yaml
- Manual snippet audit: checked=101 missing=0 no_cache=0
- Graph audit: pathophysiology=6 phenotypes=21 biochemical=3 edges=29; unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0
- git diff --check

Recurring validator cache churn in PMID_24904092/PMID_31292197 was restored before commit.