### PR TITLE
Add Lafora disease causal link types

### DIFF
--- a/kb/disorders/Lafora_Disease.yaml
+++ b/kb/disorders/Lafora_Disease.yaml
@@ -1,6 +1,6 @@
 name: Lafora_Disease
 creation_date: '2026-03-08T00:00:00Z'
-updated_date: '2026-05-21T11:18:18Z'
+updated_date: '2026-05-21T19:45:22Z'
 category: Mendelian
 description: >
   Lafora disease is a rare, fatal form of progressive myoclonus epilepsy (PME type 2)
@@ -402,6 +402,7 @@ pathophysiology:
     description: >
       Unrestrained PTG-driven GYS1 activity produces glycogen with overlong
       chains that precipitate as polyglucosan.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39806098
       reference_title: "Glycogen synthase GYS1 overactivation contributes to glycogen insolubility and malto-oligoglucan-associated neurodegenerative disease."
@@ -560,6 +561,7 @@ pathophysiology:
     description: >
       Lafora body accumulation, particularly in astrocytes, induces reactive
       astrogliosis and triggers a broad inflammatory transcriptional program.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:39806098
       reference_title: "Glycogen synthase GYS1 overactivation contributes to glycogen insolubility and malto-oligoglucan-associated neurodegenerative disease."
@@ -571,6 +573,9 @@ pathophysiology:
     description: >
       Glycogen accumulation secondarily impairs macroautophagy and the
       autophagic clearance of damaged mitochondria.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - intracellular glycogen aggregate burden disrupting autophagic flux
     evidence:
     - reference: PMID:24452334
       reference_title: "Glycogen accumulation underlies neurodegeneration and autophagy impairment in Lafora disease."
@@ -583,6 +588,9 @@ pathophysiology:
       Lafora body accumulation in cortical neurons and perisynaptic astrocytes
       progressively disturbs synaptic function and shifts cortical networks
       toward sustained hyperexcitability.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - glycogen-driven hippocampal synaptic electrophysiologic impairment
     evidence:
     - reference: PMID:24452334
       reference_title: "Glycogen accumulation underlies neurodegeneration and autophagy impairment in Lafora disease."
@@ -594,6 +602,11 @@ pathophysiology:
     description: >
       Lafora body burden is a principal driver of progressive neurodegeneration
       in mouse models, validated by genetic rescue experiments.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    intermediate_mechanisms:
+    - neuroinflammation
+    - autophagy impairment
+    - synaptic dysfunction
     evidence:
     - reference: PMID:30143794
       reference_title: "Lafora disease - from pathogenesis to treatment strategies."
@@ -871,6 +884,7 @@ pathophysiology:
       Sustained sensorimotor cortex hyperexcitability with impaired inhibition
       generates the action and stimulus-sensitive myoclonus that defines the
       progressive myoclonus epilepsy phenotype.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:15623692
       reference_title: "Sensorimotor cortex excitability in Unverricht-Lundborg disease and Lafora body disease."
@@ -882,6 +896,7 @@ pathophysiology:
     description: >
       Cortical hyperexcitability and loss of inhibitory tone produce
       progressive epileptic seizures that become drug-resistant.
+    causal_link_type: DIRECT
     evidence:
     - reference: PMID:24452334
       reference_title: "Glycogen accumulation underlies neurodegeneration and autophagy impairment in Lafora disease."


### PR DESCRIPTION
## Summary
- Added causal_link_type classifications to the 7 previously unclassified Lafora disease downstream edges.
- Added intermediate_mechanisms for compressed Lafora-body-to-autophagy/synaptic/neurodegeneration skip edges.
- Updated updated_date for the curated YAML change.

## Validation
- just validate kb/disorders/Lafora_Disease.yaml
- uv run python -m dismech.graph --validate kb/disorders/Lafora_Disease.yaml
- Manual snippet audit: checked=138 missing=0 no_cache=0
- Graph audit: pathophysiology=10 phenotypes=19 biochemical=4 edges=38; unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0
- git diff --check

Recurring validator cache churn in PMID_24904092/PMID_31292197 was restored before commit.