### PR TITLE
Add reference_title to Morquio syndrome target_mechanisms evidence items (#1321)

### DIFF
--- a/kb/disorders/Morquio_syndrome.yaml
+++ b/kb/disorders/Morquio_syndrome.yaml
@@ -937,6 +937,7 @@ treatments:
     description: Recombinant GALNS replaces the missing lysosomal enzyme in Type A disease.
     evidence:
     - reference: PMID:26331768
+      reference_title: Safety and clinical activity of elosulfase alfa in pediatric patients with Morquio A syndrome (mucopolysaccharidosis IVA) less than 5 y.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Early intervention with elosulfase alfa is well-tolerated and produces a decrease in uKS and a trend toward improvement in growth."
@@ -946,6 +947,7 @@ treatments:
     description: Lower urinary keratan sulfate indicates partial suppression of the systemic storage burden.
     evidence:
     - reference: PMID:26331768
+      reference_title: Safety and clinical activity of elosulfase alfa in pediatric patients with Morquio A syndrome (mucopolysaccharidosis IVA) less than 5 y.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Early intervention with elosulfase alfa is well-tolerated and produces a decrease in uKS and a trend toward improvement in growth."
@@ -972,6 +974,7 @@ treatments:
     description: Decompression and fusion stabilize the upper cervical spine and inhibit ongoing craniovertebral instability.
     evidence:
     - reference: PMID:29326877
+      reference_title: Natural history of Morquio A patient with tracheal obstruction from birth to death.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Therefore, most patients require several surgeries to alleviate severe orthopedic complications, such as cervical spinal decompression and fusion, limb osteotomy, hemiepiphysiodesis, and hip reconstruction/replacement"
@@ -981,6 +984,7 @@ treatments:
     description: Decompression relieves ongoing cervical cord compression risk.
     evidence:
     - reference: PMID:29326877
+      reference_title: Natural history of Morquio A patient with tracheal obstruction from birth to death.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Therefore, most patients require several surgeries to alleviate severe orthopedic complications, such as cervical spinal decompression and fusion, limb osteotomy, hemiepiphysiodesis, and hip reconstruction/replacement"
@@ -1019,11 +1023,13 @@ treatments:
     description: Airway surgery relieves the structural tracheal obstruction caused by Morquio airway disease.
     evidence:
     - reference: PMID:29326877
+      reference_title: Natural history of Morquio A patient with tracheal obstruction from birth to death.
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "three patients with severe tracheal obstruction and respiratory distress showed improvement in their symptoms after undergoing successful tracheal reconstructive surgery"
       explanation: Symptom improvement after reconstructive surgery supports direct inhibition of the structural airway-narrowing branch.
     - reference: DOI:10.1186/s13023-024-03253-3
+      reference_title: "Novel approach for tracheal resection in Morquio a syndrome with end-stage critical airway obstruction: a UK case series"
       supports: SUPPORT
       evidence_source: HUMAN_CLINICAL
       snippet: "Postoperatively, significant improvements were seen in forced expiratory volume in 1 second (FEV1), with a mean increase of 0.68 litres (95% CI: 0.45-0.91; SD: 0.20)."
@@ -1051,6 +1057,7 @@ treatments:
     description: Rehabilitation reduces secondary disability from chronic musculoskeletal disease without changing the upstream storage defect.
     evidence:
     - reference: PMID:25346323
+      reference_title: International guidelines for the management and treatment of Morquio A syndrome.
       supports: SUPPORT
       evidence_source: OTHER
       snippet: "Physical therapy and pain medication can be beneficial to manage musculoskeletal manifestations in some patients."


### PR DESCRIPTION
## Summary

- Adds 7 missing `reference_title` fields to `target_mechanisms` evidence items in `kb/disorders/Morquio_syndrome.yaml`
- All 4 treatments (elosulfase alfa ERT, cervical decompression/fusion, airway surgery, physical therapy) had `target_mechanisms` evidence blocks missing the `reference_title` field
- All titles were already present on sibling evidence items in the same file — no new reference lookups or snippet validation needed
- Pattern matches PR #2819 (Wolman disease reference title fix, merged 2026-05-17)

## Compliance impact

| Metric | Before | After |
|--------|--------|-------|
| Weighted compliance | 95.1% | 98.5% |

## Remaining gaps (out of scope)

- `datasets: MISSING` — requires identifying registry/trial data, separate effort
- `references[0,1,2].findings[0].evidence: MISSING` — the 3 gene therapy DOIs (`omtm.2024.101313`, `omtn.2024.102211`, `s13023-019-1074-9`) have `content_type: unavailable` in the cache, so no quotable snippet is available without re-fetching

## Relation to #1321

This is the same compliance-fix pattern applied to Morquio that PR #2819 applied to Wolman. With this PR, all 5 LSD epic entries will be at ≥95% weighted compliance:

| Disease | Compliance |
|---------|-----------|
| Hunter syndrome | 100.0% |
| Sandhoff disease | 97.6% |
| Sanfilippo syndrome | 98.0% |
| Morquio syndrome | 98.5% (after this PR) |
| Wolman disease | 97.0% |

## Validation

- `just validate kb/disorders/Morquio_syndrome.yaml` ✅
- `just validate-references kb/disorders/Morquio_syndrome.yaml` ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)