### PR TITLE
Add GSD I downstream edge evidence

### DIFF
--- a/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
+++ b/kb/disorders/Glycogen_Storage_Disease_Type_I.yaml
@@ -1,6 +1,6 @@
 name: Glycogen Storage Disease Type I
 creation_date: '2026-03-08T12:00:00Z'
-updated_date: '2026-05-21T06:12:42Z'
+updated_date: '2026-05-21T20:47:59Z'
 category: Mendelian
 description: >
   Glycogen storage disease type I (GSD I), also known as von Gierke disease, is an
@@ -152,29 +152,85 @@ pathophysiology:
   - target: Secondary metabolic derangements
     description: The G6P hydrolysis block shunts accumulated substrate into lactate, lipid, and urate-producing pathways.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatomegaly, severe hypoglycemia with or without seizures, lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews lists the secondary metabolic abnormalities that arise with untreated GSD I.
   - target: Blood glucose
     description: Impaired hepatic and renal glucose release lowers fasting blood glucose.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "severe hypoglycemia due to fasting intolerance."
+      explanation: GeneReviews supports decreased fasting blood glucose as the direct clinical readout of impaired glucose release.
   - target: Glucose-6-phosphatase enzyme activity
     description: GSD Ia directly reduces measurable hepatic glucose-6-phosphatase catalytic activity.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatic enzyme\nactivity analysis is only available for glucose-6-phosphatase catalytic activity"
+      explanation: GeneReviews supports hepatic glucose-6-phosphatase catalytic activity as the measurable enzyme activity for GSD Ia.
   - target: Fasting hypoglycemia
     description: Failure to release free glucose during fasting clinically manifests as fasting hypoglycemia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "severe hypoglycemia due to fasting intolerance."
+      explanation: GeneReviews directly links fasting intolerance to severe hypoglycemia.
   - target: Seizures
     description: Severe or prolonged hypoglycemia can manifest with seizures.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Fasting hypoglycemia
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "severe hypoglycemia with or without seizures"
+      explanation: GeneReviews supports seizures as a manifestation of severe hypoglycemia in untreated GSD I.
   - target: Hepatomegaly
     description: Hepatic glycogen and fat accumulation enlarges the liver.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "accumulation of glycogen and fat in the liver and kidneys\nresulting in hepatomegaly and nephromegaly."
+      explanation: GeneReviews directly links liver glycogen/fat accumulation to hepatomegaly.
   - target: Nephromegaly
     description: Renal glycogen and fat accumulation enlarges the kidneys.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "accumulation of glycogen and fat in the liver and kidneys\nresulting in hepatomegaly and nephromegaly."
+      explanation: GeneReviews directly links kidney glycogen/fat accumulation to nephromegaly.
   - target: Hepatic steatosis
     description: Excess hepatic glucose-6-phosphate flux promotes fat accumulation in the liver.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "accumulation of glycogen and fat in the liver and kidneys"
+      explanation: GeneReviews supports hepatic fat accumulation as part of the core GSD I storage phenotype.
   - target: Neutropenia and neutrophil dysfunction in GSD Ib
     description: In GSD Ib, SLC37A4/G6PT deficiency links the shared glucose-homeostasis defect to neutropenia and neutrophil dysfunction.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -254,26 +310,75 @@ pathophysiology:
   - target: Blood lactate
     description: Excess glycolytic flux raises lactate.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews supports lactate accumulation clinically as lactic acidosis in untreated GSD I.
   - target: Lactic acidosis
     description: Lactate accumulation produces lactic acidosis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews lists lactic acidosis among core untreated GSD I metabolic manifestations.
   - target: Serum triglycerides
     description: Increased de novo lipogenesis raises serum triglycerides.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews supports elevated triglycerides clinically as hypertriglyceridemia in untreated GSD I.
   - target: Hypertriglyceridemia
     description: Elevated serum triglycerides are the clinical biochemical phenotype.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews lists hypertriglyceridemia among core untreated GSD I metabolic manifestations.
   - target: Serum cholesterol
     description: Increased lipid synthesis raises serum cholesterol.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lipid panel, serum uric"
+      explanation: GeneReviews includes lipid-panel surveillance with other metabolic control markers; serum cholesterol is one lipid-panel component of the hyperlipidemia branch.
   - target: Hyperlipidemia
     description: Elevated triglycerides and cholesterol manifest as hyperlipidemia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lipid-lowering medications for\nhyperlipidemia"
+      explanation: GeneReviews identifies hyperlipidemia as a treatment target in GSD I.
   - target: Xanthomas
     description: Severe lipid elevation can manifest as cutaneous xanthomas.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hyperlipidemia
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Xanthoma and diarrhea may be present."
+      explanation: GeneReviews supports xanthomas as a possible GSD I manifestation.
   - target: Diarrhea
     description: Diarrhea can occur in GSD I, although the cached clinical summary does not resolve the intermediate mechanism.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
@@ -289,44 +394,135 @@ pathophysiology:
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hypertriglyceridemia
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "hepatic adenomas with\npotential for malignancy, pancreatitis"
+      explanation: GeneReviews lists pancreatitis among long-term untreated GSD I complications.
   - target: Serum uric acid
     description: Purine degradation and lactate-impaired renal urate clearance raise serum uric acid.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews supports elevated uric acid clinically as hyperuricemia in untreated GSD I.
   - target: Hyperuricemia
     description: Elevated serum uric acid clinically manifests as hyperuricemia.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "lactic acidosis,\nhyperuricemia, and hypertriglyceridemia."
+      explanation: GeneReviews lists hyperuricemia among core untreated GSD I metabolic manifestations.
   - target: Gout
     description: Chronic hyperuricemia predisposes to gout.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
     intermediate_mechanisms:
     - Hyperuricemia
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "renal disease (including\nproximal and distal renal tubular acidosis, renal stones, and kidney failure),\ngout"
+      explanation: GeneReviews lists gout among long-term GSD I complications.
   - target: Hepatocellular adenoma development
     description: Poor metabolic control is associated with liver adenoma risk.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26001652
+      reference_title: "Hepatic glycogen storage disorders: what have we learned in recent years?"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "poor metabolic control is a risk factor for the development of long-term complications, such as liver adenomas,"
+      explanation: This review supports liver adenomas as a long-term complication associated with poor metabolic control in GSD I.
   - target: Osteoporosis
     description: Poor metabolic control is associated with low bone density and osteoporosis.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26001652
+      reference_title: "Hepatic glycogen storage disorders: what have we learned in recent years?"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "low bone density/osteoporosis, and kidney disease in GSD I."
+      explanation: This review supports low bone density/osteoporosis as a long-term complication of poor metabolic control.
   - target: Proteinuria
     description: Poor metabolic control is associated with kidney disease that can present with albuminuria/proteinuria.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:12373568
+      reference_title: "Effect of continuous glucose therapy with uncooked cornstarch on the long-term clinical course of type 1a glycogen storage disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Urinary albumin excretion was increased (>20 micro g/min) in\n31% of subjects"
+      explanation: Long-term follow-up supports albuminuria/proteinuria as a renal complication.
   - target: Renal insufficiency
     description: Chronic kidney involvement can progress to renal insufficiency.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "renal disease (including\nproximal and distal renal tubular acidosis, renal stones, and kidney failure)"
+      explanation: GeneReviews lists renal disease including kidney failure as a long-term GSD I complication.
   - target: Anemia
     description: Long-term follow-up associated anemia and other complications with suboptimal metabolic control.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:12373568
+      reference_title: "Effect of continuous glucose therapy with uncooked cornstarch on the long-term clinical course of type 1a glycogen storage disease."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Of 26 subjects, 13 (50%) had\nanemia."
+      explanation: Long-term follow-up documented anemia in half of the studied GSD Ia subjects.
   - target: Short stature
     description: Chronic metabolic disturbance is associated with impaired growth.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "short stature,\nand a protuberant abdomen."
+      explanation: GeneReviews lists short stature among typical GSD I features.
   - target: Delayed puberty
     description: Untreated chronic metabolic disease is associated with delayed puberty.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "short stature, osteoporosis, delayed puberty, renal disease"
+      explanation: GeneReviews lists delayed puberty among long-term untreated GSD I complications.
   - target: Systemic hypertension
     description: Hypertension is a long-term complication of untreated GSD I, with intermediate mechanisms unresolved in the cached evidence.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "gout, systemic hypertension, pulmonary hypertension"
+      explanation: GeneReviews lists systemic hypertension among long-term untreated GSD I complications.
   - target: Pulmonary hypertension
     description: Pulmonary hypertension is a long-term complication of untreated GSD I, with intermediate mechanisms unresolved in the cached evidence.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "gout, systemic hypertension, pulmonary hypertension"
+      explanation: GeneReviews lists pulmonary hypertension among long-term untreated GSD I complications.
 - name: Neutropenia and neutrophil dysfunction in GSD Ib
   description: >
     In GSD Ib, deficiency of the ubiquitously expressed glucose-6-phosphate
@@ -383,12 +579,33 @@ pathophysiology:
   - target: Neutropenia (GSD Ib)
     description: Neutrophil apoptosis and impaired homeostasis produce chronic neutropenia in GSD Ib.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:19741523
+      reference_title: "Neutropenia in type Ib glycogen storage disease."
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "apoptosis that underlie neutropenia and neutrophil dysfunction in glycogen"
+      explanation: The review supports neutrophil apoptosis/stress as the basis of neutropenia and neutrophil dysfunction in GSD Ib.
   - target: Recurrent infections (GSD Ib)
     description: Neutropenia and neutrophil dysfunction predispose to recurrent bacterial infections.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "chronic neutropenia\nresulting in recurrent bacterial infections"
+      explanation: GeneReviews directly links chronic neutropenia to recurrent bacterial infections in untreated GSD Ib.
   - target: Oral ulcers (GSD Ib)
     description: Neutrophil dysfunction contributes to mucosal ulceration in GSD Ib.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:38277989
+      reference_title: "Treatment recommendations for glycogen storage disease type IB- associated neutropenia and neutrophil dysfunction with empagliflozin: Consensus from an international workshop."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "neutropenia/neutrophil dysfunction (e.g. mucosal lesions, inflammatory bowel"
+      explanation: Consensus treatment recommendations support mucosal lesions as symptoms caused by GSD Ib neutropenia/neutrophil dysfunction.
 - name: Hepatocellular adenoma development
   description: >
     Hepatocellular adenomas are a major long-term complication of GSD I, occurring
@@ -420,6 +637,13 @@ pathophysiology:
   - target: Hepatocellular adenoma
     description: Adenoma development is the neoplastic phenotype produced by this long-term hepatic complication.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:12373570
+      reference_title: "Glycogen storage disease type I: pathophysiology of liver adenomas."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Hepatic adenomas occur in 22%-75% of\naffected adults"
+      explanation: This review directly supports hepatic adenomas as the neoplastic phenotype of this GSD I complication.
 - name: Platelet and von Willebrand factor dysfunction
   description: >
     GSD I can include impaired platelet function and reduced or dysfunctional
@@ -452,9 +676,23 @@ pathophysiology:
   - target: Epistaxis
     description: Bleeding diathesis manifests as frequent nosebleeds.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "bleeding tendency with frequent epistaxis and menorrhagia"
+      explanation: GeneReviews links platelet/von Willebrand factor dysfunction to epistaxis.
   - target: Menorrhagia
     description: Bleeding diathesis manifests as heavy menstrual bleeding in females.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301489
+      reference_title: "Glycogen Storage Disease Type I."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "bleeding tendency with frequent epistaxis and menorrhagia"
+      explanation: GeneReviews links platelet/von Willebrand factor dysfunction to menorrhagia.
 phenotypes:
 - name: Hepatomegaly
   category: Gastrointestinal


### PR DESCRIPTION
## Summary
- add edge-level evidence to existing GSD I downstream graph edges that already had causal link types
- preserve the existing graph shape and biochemical readout structure
- keep the scope to `kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`

## Validation
- `just validate kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`
- `uv run python -m dismech.graph --validate kb/disorders/Glycogen_Storage_Disease_Type_I.yaml`
- manual snippet audit: `checked=120 missing=0 no_cache=0`
- graph audit: `pathophysiology=5 phenotypes=27 biochemical=6 edges=37; unexplained_phenotypes=0; biochemical_not_downstream=0; edges_without_evidence=0; edges_without_causal_link_type=0; biochemical_readouts_missing=0`
- `git diff --check`