### PR TITLE
Improve CTX pathograph connectivity

### DIFF
--- a/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
+++ b/kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
@@ -1,7 +1,7 @@
 name: Cerebrotendinous xanthomatosis
 category: Mendelian
 creation_date: '2026-05-03T19:07:11Z'
-updated_date: '2026-05-19T10:37:45Z'
+updated_date: '2026-05-21T21:06:27Z'
 synonyms:
 - CTX
 - Sterol 27-hydroxylase deficiency
@@ -239,9 +239,23 @@ pathophysiology:
   - target: Chenodeoxycholic acid deficiency and disinhibited bile acid precursor synthesis
     description: Loss of sterol 27-hydroxylase reduces chenodeoxycholic acid synthesis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:4031069
+      reference_title: "Biosynthesis of bile acids in cerebrotendinous xanthomatosis. Relationship of bile acid pool sizes and synthesis rates to hydroxylations at C-12, C-25, and C-26."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "depressed primary bile acid synthesis in cerebrotendinous xanthomatosis with a reduction in chenodeoxycholic acid formation"
+      explanation: Human bile-acid synthesis data link CYP27A1 sterol side-chain oxidation failure to reduced CDCA formation.
   - target: Abnormal enzyme/coenzyme activity
     description: CYP27A1 loss causes deficient sterol 27-hydroxylase activity.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:4031069
+      reference_title: "Biosynthesis of bile acids in cerebrotendinous xanthomatosis. Relationship of bile acid pool sizes and synthesis rates to hydroxylations at C-12, C-25, and C-26."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "To examine the defect in side-chain oxidation during the formation of bile acids"
+      explanation: Human biochemical study supports the abnormal sterol side-chain oxidation activity modeled as the enzyme/coenzyme phenotype.
 - name: Chenodeoxycholic acid deficiency and disinhibited bile acid precursor synthesis
   description: >
     Reduced chenodeoxycholic acid synthesis weakens bile-acid feedback control
@@ -281,12 +295,33 @@ pathophysiology:
   - target: Cholestanol and bile alcohol accumulation
     description: Excess bile-acid precursors are converted into cholestanol and bile alcohols.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20494109
+      reference_title: "Cerebrotendinous xanthomatosis: an inborn error in bile acid synthesis with defined mutations but still a challenge."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "This leads to a marked accumulation of 7alpha-hydroxylated bile acid precursors, in particular 7alpha-hydroxy-4-cholesten-3-one."
+      explanation: Review explains that disinhibited bile-acid precursor synthesis causes abnormal sterol precursor accumulation.
   - target: Chenodeoxycholic acid
     description: Reduced CYP27A1-dependent bile-acid synthesis lowers chenodeoxycholic acid.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "decreased chenodeoxycholic acid (CDCA)"
+      explanation: GeneReviews identifies decreased CDCA as a diagnostic biochemical consequence of CTX bile-acid synthesis failure.
   - target: Prolonged neonatal jaundice
     description: Infantile bile-acid synthetic failure can present as neonatal cholestasis or prolonged jaundice.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Chronic diarrhea from infancy and/or neonatal cholestasis may be the earliest clinical manifestation."
+      explanation: GeneReviews links the early bile-acid synthesis disease phase to neonatal cholestasis, corresponding to the jaundice phenotype.
 - name: Cholestanol and bile alcohol accumulation
   description: >
     Abnormal sterol precursor flux causes high plasma and tissue cholestanol and
@@ -326,15 +361,43 @@ pathophysiology:
   - target: Plasma and tissue cholestanol
     description: Abnormal sterol metabolism produces elevated plasma and tissue cholestanol.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "high plasma and tissue cholestanol concentration"
+      explanation: GeneReviews identifies elevated plasma and tissue cholestanol as the biochemical readout of sterol accumulation.
   - target: Bile alcohols and glyconjugates
     description: CYP27A1 deficiency increases bile alcohols and their glyconjugates.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "increased concentration of bile alcohols and their glyconjugates"
+      explanation: GeneReviews identifies elevated bile alcohols and glyconjugates as a biochemical readout of abnormal bile-acid precursor metabolism.
   - target: Sterol deposition in tendons
     description: Elevated cholestanol and cholesterol deposit in tendon tissue.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23759795
+      reference_title: "Cerebrotendinous xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "accumulation of cholesterol and cholestanol in brain and tendons caused by a mutation in the sterol 27-hydroxylase gene (CYP27A1)."
+      explanation: Review directly links CYP27A1-related cholestanol/cholesterol accumulation to tendon deposition.
   - target: CNS sterol deposition and white-matter injury
     description: Cholestanol and sterol precursor accumulation injures brain white matter and neural structures.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23759795
+      reference_title: "Cerebrotendinous xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "CTX patients with white matter lesions and vacuolation are described."
+      explanation: Review supports CNS white-matter lesions as a downstream pathology of CTX sterol accumulation.
   - target: Peripheral nerve involvement
     description: >
       Accumulated cholestanol in neuronal membranes is modeled as an upstream
@@ -371,6 +434,13 @@ pathophysiology:
   - target: Ocular cholestanol deposition and cataractogenesis
     description: Multisystemic cholestanol deposition includes the eye and contributes to early cataract disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1186/s13023-025-03889-9
+      reference_title: "Cholic acid as a treatment for cerebrotendinous xanthomatosis: a comprehensive review of safety and efficacy"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "leading to multisystemic cholestanol deposition in membranes, including those of neurons, smooth muscle cells, tendons, and the eye."
+      explanation: Review-level CTX pathophysiology supports eye involvement within multisystemic cholestanol deposition.
   - target: Skeletal, bone-density, and appendicular involvement
     description: >
       CTX can include bone and appendicular involvement; cached evidence does
@@ -389,6 +459,13 @@ pathophysiology:
   - target: Chronic diarrhea
     description: Bile-acid synthetic failure and abnormal sterol metabolism contribute to early gastrointestinal disease.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Chronic diarrhea from infancy and/or neonatal cholestasis may be the earliest clinical manifestation."
+      explanation: GeneReviews identifies chronic infantile diarrhea as an early CTX manifestation in the bile-acid synthesis disease phase.
 - name: Sterol deposition in tendons
   description: >
     Cholestanol and cholesterol accumulation in tendon tissue causes tendon
@@ -421,9 +498,23 @@ pathophysiology:
   - target: Tendon xanthomatosis
     description: Sterol accumulation in tendons causes xanthomatous enlargement.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "tendon xanthomas"
+      explanation: GeneReviews identifies tendon xanthomas as the clinical manifestation of tendon sterol deposition.
   - target: Abnormality of the Achilles tendon
     description: Achilles tendon involvement is a characteristic tendon xanthoma location.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0005109 | Abnormality of the Achilles tendon | Frequent"
+      explanation: Orphanet reports Achilles tendon abnormality as a frequent CTX phenotype downstream of tendon xanthomatosis.
 - name: Skeletal, bone-density, and appendicular involvement
   description: >
     CTX includes bone-density loss and distal appendicular findings in the
@@ -527,27 +618,83 @@ pathophysiology:
   - target: Cerebellar, corticospinal, and bulbar pathway dysfunction
     description: CNS sterol deposition and white-matter injury involve cerebellar and long-tract pathways.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cognitive decline, spastic paraplegia, cerebellar ataxia"
+      explanation: Human CTX series supports cerebellar and corticospinal pathway manifestations downstream of CNS involvement.
   - target: Extrapyramidal and neuropsychiatric involvement
     description: Progressive CNS disease includes extrapyramidal, cognitive, and psychiatric manifestations.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "progressive neurologic dysfunction (dementia, psychiatric disturbances, pyramidal and/or cerebellar signs, dystonia, atypical parkinsonism, peripheral neuropathy, and seizures)"
+      explanation: GeneReviews supports extrapyramidal, cognitive, and psychiatric manifestations as part of progressive CTX neurologic disease.
   - target: CTX neuronal axonopathy
     description: Patient-derived neuronal models show CTX-associated biochemical changes and axonal defects.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: DOI:10.1186/s13023-023-02666-w
+      reference_title: "Chenodeoxycholic acid rescues axonal degeneration in induced pluripotent stem cell-derived neurons from spastic paraplegia type 5 and cerebrotendinous xanthomatosis patients"
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "CTX and SPG5 patient iPSC-derived cortical PNs recapitulated several disease-specific biochemical changes and axonal defects of both diseases."
+      explanation: Patient-derived neuronal models support CTX-associated axonal defects downstream of the CNS metabolic lesion.
   - target: Cognitive impairment
     description: Progressive CNS injury causes cognitive decline and dementia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "dementia with slow deterioration in intellectual abilities"
+      explanation: GeneReviews supports progressive cognitive decline as a manifestation of CNS disease in CTX.
   - target: Ataxia
     description: Cerebellar involvement produces ataxia and gait disturbance.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cognitive decline, spastic paraplegia, cerebellar ataxia"
+      explanation: Human CTX series supports cerebellar ataxia as a downstream CNS manifestation.
   - target: Spasticity
     description: Pyramidal tract involvement produces spasticity and hyperreflexia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Pyramidal signs (i.e., spasticity)"
+      explanation: GeneReviews supports spasticity as a pyramidal manifestation of CTX CNS involvement.
   - target: Seizure
     description: Progressive brain involvement can cause seizures.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "peripheral neuropathy, and seizures"
+      explanation: GeneReviews includes seizures among manifestations of progressive neurologic dysfunction in CTX.
   - target: Hyperintensity of cerebral white matter on MRI
     description: White-matter injury is visible on MRI.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "hyperintensity with or without hyposignal is a valuable MRI hallmark."
+      explanation: Human neuroimaging series supports cerebral white-matter hyperintensity as a CTX CNS imaging manifestation.
   - target: Abnormal auditory evoked potentials
     description: CNS pathway involvement can be detected as abnormal auditory evoked potentials.
     causal_link_type: UNKNOWN
@@ -600,9 +747,23 @@ pathophysiology:
   - target: Juvenile cataract
     description: Ocular sterol deposition is associated with early cataract formation.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "cataracts are the first finding, often appearing in the first decade of life."
+      explanation: GeneReviews supports early cataract as a common ocular CTX manifestation.
   - target: Visual impairment
     description: Childhood cataracts can reduce vision.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000505 | Visual impairment | Very frequent"
+      explanation: Orphanet reports visual impairment as very frequent in CTX, supporting visual impact downstream of ocular involvement.
   - target: Optic neuropathy
     description: Ocular and visual pathway involvement includes optic neuropathy.
     causal_link_type: UNKNOWN
@@ -686,6 +847,13 @@ pathophysiology:
   - target: Ataxia
     description: Cerebellar involvement produces ataxia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Cognitive decline, spastic paraplegia, cerebellar ataxia"
+      explanation: Human CTX series directly supports cerebellar ataxia within this pathway branch.
   - target: Nystagmus
     description: Cerebellar and ocular-motor pathway involvement can produce nystagmus.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -699,30 +867,93 @@ pathophysiology:
   - target: Gait disturbance
     description: Cerebellar and long-tract involvement impair gait.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001288 | Gait disturbance | Frequent"
+      explanation: Orphanet reports gait disturbance as frequent, consistent with cerebellar and corticospinal pathway dysfunction.
   - target: Dysarthria
     description: Cerebellar and bulbar involvement can produce dysarthria.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001260 | Dysarthria | Frequent"
+      explanation: Orphanet reports dysarthria as frequent, supporting a bulbar/cerebellar motor manifestation.
   - target: Spasticity
     description: Corticospinal tract involvement produces spasticity.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "Pyramidal signs (i.e., spasticity)"
+      explanation: GeneReviews supports spasticity as a pyramidal tract manifestation in CTX.
   - target: Hyperreflexia
     description: Corticospinal tract involvement produces hyperreflexia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001347 | Hyperreflexia | Frequent"
+      explanation: Orphanet reports hyperreflexia as frequent, supporting corticospinal tract involvement.
   - target: Abnormal pyramidal sign
     description: Corticospinal tract dysfunction produces pyramidal signs.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0007256 | Abnormal pyramidal sign | Frequent"
+      explanation: Orphanet reports pyramidal signs as frequent, supporting the corticospinal branch.
   - target: Babinski sign
     description: Corticospinal tract dysfunction can cause Babinski signs.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003487 | Babinski sign | Frequent"
+      explanation: Orphanet reports Babinski sign as frequent, consistent with corticospinal tract dysfunction.
   - target: Paraparesis
     description: Spastic paraparesis reflects corticospinal pathway involvement.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002385 | Paraparesis | Frequent"
+      explanation: Orphanet reports paraparesis as frequent, supporting long-tract motor involvement.
   - target: Abnormal cerebellum morphology
     description: Cerebellar involvement is reflected in cerebellar imaging abnormalities.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001317 | Abnormal cerebellum morphology | Frequent"
+      explanation: Orphanet reports cerebellar morphology abnormality as frequent, supporting the cerebellar imaging branch.
   - target: Abnormality of the dentate nucleus
     description: Dentate nucleus involvement is a characteristic MRI abnormality.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0100321 | Abnormality of the dentate nucleus | Occasional"
+      explanation: Orphanet reports dentate nucleus abnormality as an occasional CTX neuroimaging manifestation.
   - target: Abnormal cerebellar peduncle morphology
     description: Cerebellar tract disease can involve the cerebellar peduncles.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -770,12 +1001,33 @@ pathophysiology:
   - target: Dystonia
     description: Extrapyramidal involvement produces dystonia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001332 | Dystonia | Frequent"
+      explanation: Orphanet reports dystonia as frequent, supporting extrapyramidal involvement.
   - target: Parkinsonism
     description: Extrapyramidal involvement can produce atypical parkinsonism.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "atypical parkinsonism"
+      explanation: GeneReviews includes atypical parkinsonism among CTX neurologic manifestations.
   - target: Abnormality of extrapyramidal motor function
     description: Extrapyramidal system involvement causes abnormal extrapyramidal motor function.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002071 | Abnormality of extrapyramidal motor function | Frequent"
+      explanation: Orphanet reports extrapyramidal motor abnormality as frequent.
   - target: Abnormal globus pallidus morphology
     description: Globus pallidus abnormalities are modeled under the extrapyramidal/basal ganglia branch.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
@@ -789,27 +1041,83 @@ pathophysiology:
   - target: Orofacial dyskinesia
     description: Extrapyramidal motor involvement can include orofacial dyskinesia.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0002310 | Orofacial dyskinesia | Frequent"
+      explanation: Orphanet reports orofacial dyskinesia as frequent, supporting extrapyramidal motor involvement.
   - target: Atypical behavior
     description: Neuropsychiatric involvement can cause behavioral change.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000708 | Atypical behavior | Frequent"
+      explanation: Orphanet reports atypical behavior as frequent, supporting neuropsychiatric involvement.
   - target: Depression
     description: Neuropsychiatric involvement can include depression.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000716 | Depression | Occasional"
+      explanation: Orphanet reports depression as an occasional CTX neuropsychiatric manifestation.
   - target: Cognitive impairment
     description: Progressive CNS involvement causes cognitive decline.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "dementia with slow deterioration in intellectual abilities"
+      explanation: GeneReviews supports cognitive decline within the progressive CNS involvement branch.
   - target: Intellectual disability
     description: CTX neurologic involvement can include intellectual disability.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001249 | Intellectual disability | Frequent"
+      explanation: Orphanet reports intellectual disability as frequent, supporting neurodevelopmental involvement in CTX.
   - target: Neurodevelopmental delay
     description: Early neurologic involvement can include developmental delay.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0012758 | Neurodevelopmental delay | Frequent"
+      explanation: Orphanet reports neurodevelopmental delay as frequent, supporting early neurologic involvement.
   - target: Specific learning disability
     description: Cognitive and neurodevelopmental involvement can include learning disability.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001328 | Specific learning disability | Frequent"
+      explanation: Orphanet reports specific learning disability as frequent.
   - target: Progressive psychomotor deterioration
     description: Progressive CNS disease drives psychomotor deterioration.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0007272 | Progressive psychomotor deterioration | Frequent"
+      explanation: Orphanet reports progressive psychomotor deterioration as frequent, supporting progressive CNS disease.
 - name: CTX neuronal axonopathy
   description: >
     Patient-derived cortical projection neurons recapitulate CTX biochemical
@@ -870,22 +1178,75 @@ pathophysiology:
   - target: Peripheral neuropathy
     description: Peripheral nerve injury causes clinical neuropathy.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:33313117
+      reference_title: "Cerebrotendinous xanthomatosis with peripheral neuropathy: a clinical and neurophysiological study in Chinese population."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Peripheral neuropathy was predominant sensorimotor demyelinating type"
+      explanation: Human neurophysiology study supports peripheral neuropathy as the clinical manifestation of CTX peripheral nerve involvement.
   - target: Decreased nerve conduction velocity
     description: Demyelinating neuropathy slows nerve conduction.
     causal_link_type: DIRECT
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0000762 | Decreased nerve conduction velocity | Frequent"
+      explanation: Orphanet reports decreased nerve conduction velocity as frequent, consistent with demyelinating peripheral neuropathy.
   - target: Distal amyotrophy
     description: Chronic peripheral nerve injury can cause distal amyotrophy.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0003693 | Distal amyotrophy | Frequent"
+      explanation: Orphanet reports distal amyotrophy as frequent, supporting motor consequences of chronic peripheral neuropathy.
   - target: Pes cavus
     description: Chronic peripheral neuropathy can contribute to pes cavus.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001761 | Pes cavus | Frequent"
+      explanation: Orphanet reports pes cavus as frequent, supporting distal foot morphology changes in the peripheral neuropathy branch.
   - target: Gait disturbance
     description: Peripheral neuropathy contributes to gait impairment.
     causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:909
+      reference_title: "Cerebrotendinous xanthomatosis (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001288 | Gait disturbance | Frequent"
+      explanation: Orphanet reports gait disturbance as frequent, consistent with peripheral neuropathy contributing to gait impairment.
 biochemical:
 - name: Plasma and tissue cholestanol
   presence: Elevated
   context: Defining biochemical abnormality used diagnostically and for monitoring response.
+  biomarker_term:
+    preferred_term: cholestanol
+    term:
+      id: CHEBI:86570
+      label: (5alpha)-cholestan-3beta-ol
+  readouts:
+  - target: Cholestanol and bile alcohol accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated plasma or tissue cholestanol reports the sterol-accumulation branch caused by CYP27A1 deficiency.
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "high plasma and tissue cholestanol concentration"
+      explanation: GeneReviews identifies high plasma and tissue cholestanol as a defining CTX biochemical abnormality.
   evidence:
   - reference: PMID:20301583
     reference_title: "Cerebrotendinous Xanthomatosis."
@@ -896,6 +1257,24 @@ biochemical:
 - name: Chenodeoxycholic acid
   presence: Decreased
   context: Primary bile acid deficiency caused by impaired CYP27A1-dependent synthesis.
+  biomarker_term:
+    preferred_term: chenodeoxycholic acid
+    term:
+      id: CHEBI:16755
+      label: chenodeoxycholic acid
+  readouts:
+  - target: Chenodeoxycholic acid deficiency and disinhibited bile acid precursor synthesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Decreased chenodeoxycholic acid reports impaired CYP27A1-dependent primary bile-acid synthesis.
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "decreased chenodeoxycholic acid (CDCA)"
+      explanation: GeneReviews identifies decreased CDCA as part of the diagnostic biochemical profile.
   evidence:
   - reference: PMID:20301583
     reference_title: "Cerebrotendinous Xanthomatosis."
@@ -906,6 +1285,24 @@ biochemical:
 - name: Bile alcohols and glyconjugates
   presence: Elevated
   context: Abnormal bile acid pathway intermediates accumulate when CYP27A1 activity is deficient.
+  biomarker_term:
+    preferred_term: bile alcohol
+    term:
+      id: CHEBI:50420
+      label: bile alcohol
+  readouts:
+  - target: Cholestanol and bile alcohol accumulation
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Elevated bile alcohols and glyconjugates report abnormal bile-acid precursor metabolism in CTX.
+    evidence:
+    - reference: PMID:20301583
+      reference_title: "Cerebrotendinous Xanthomatosis."
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "increased concentration of bile alcohols and their glyconjugates"
+      explanation: GeneReviews identifies elevated bile alcohols and glyconjugates as part of the CTX biochemical profile.
   evidence:
   - reference: PMID:20301583
     reference_title: "Cerebrotendinous Xanthomatosis."


### PR DESCRIPTION
## Summary
- Add edge-level evidence across the CTX downstream graph.
- Add biomarker terms and readout links for cholestanol, CDCA, and bile alcohols.
- Keep the PR scoped to kb/disorders/Cerebrotendinous_Xanthomatosis.yaml only.

## Validation
- just validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- just validate-references kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- just validate-terms kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- uv run python -m dismech.graph --validate kb/disorders/Cerebrotendinous_Xanthomatosis.yaml
- manual graph audit: 0 unexplained phenotypes, 0 biochemical not downstream, 0 missing edge evidence, 0 missing causal link types, 0 missing biochemical readouts
- manual snippet audit: checked=186 missing=0 no_cache=0

Note: just validate-graphs across all disorders still fails on unrelated pre-existing graph targets outside CTX; CTX-specific graph validation passes.