### PR TITLE
Improve PRPS1 deficiency pathograph connectivity

### DIFF
--- a/kb/disorders/PRPS1_Deficiency_Spectrum.yaml
+++ b/kb/disorders/PRPS1_Deficiency_Spectrum.yaml
@@ -1,6 +1,6 @@
 name: PRPS1 Deficiency Spectrum
 creation_date: "2026-04-04T00:00:00Z"
-updated_date: "2026-05-05T04:42:36Z"
+updated_date: "2026-05-21T22:12:29Z"
 description: >-
   PRPS1 deficiency is an X-linked phenotypic continuum caused by
   loss-of-function PRPS1 variants that reduce phosphoribosylpyrophosphate
@@ -158,6 +158,21 @@ pathophysiology:
       explanation: >-
         Enzyme loss is linked to impaired purine biosynthesis and downstream
         purine-metabolite abnormalities.
+  - target: PRS-I enzyme activity
+    description: >-
+      PRPS1 loss of function is directly observed as reduced or undetectable
+      PRS-I enzyme activity in patient-derived assay systems.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:24528855
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Enzymatically, PRS-I activity was undetectable in the index subject,
+        reduced in his less affected sister, and normal in his unaffected mother.
+      explanation: >-
+        Family enzyme assays show that PRPS1 deficiency directly lowers PRS-I
+        enzyme activity.
 - name: Impaired PRPP-dependent nucleotide biosynthesis
   description: >-
     PRS-I produces PRPP, which is used for purine, pyrimidine, and NAD-pathway
@@ -259,6 +274,52 @@ pathophysiology:
       explanation: >-
         Severe sibling cases expand the clinical spectrum beyond classic Arts,
         CMTX5, and DFN2 clusters.
+  - target: Urinary hypoxanthine
+    description: >-
+      Impaired purine biosynthesis is reflected by undetectable urinary
+      hypoxanthine in affected patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The loss-of-function mutations of PRPS1 likely result in impaired purine
+        biosynthesis, which is supported by the undetectable hypoxanthine in
+        urine and the reduced uric acid levels in serum from patients.
+      explanation: >-
+        Patient biochemical findings connect impaired purine biosynthesis to
+        low urinary hypoxanthine.
+  - target: Serum uric acid
+    description: >-
+      Impaired purine biosynthesis is reflected by reduced serum uric acid in
+      affected patients.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The loss-of-function mutations of PRPS1 likely result in impaired purine
+        biosynthesis, which is supported by the undetectable hypoxanthine in
+        urine and the reduced uric acid levels in serum from patients.
+      explanation: >-
+        Patient biochemical findings connect impaired purine biosynthesis to
+        reduced serum uric acid.
+  - target: Erythrocyte guanine nucleotides
+    description: >-
+      Severe PRPS1 deficiency can lower erythrocyte guanine nucleotide pools.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Nucleotide analysis in erythrocytes revealed abnormally low guanosine
+        triphosphate and guanosine diphosphate.
+      explanation: >-
+        Patient erythrocyte nucleotide analysis supports reduced guanine
+        nucleotides as a readout of impaired nucleotide availability.
 - name: Neurologic auditory and ocular vulnerability
   description: >-
     PRPS1 deficiency preferentially affects hearing, peripheral and central
@@ -291,21 +352,140 @@ pathophysiology:
       spectrum in affected males.
   downstream:
   - target: Sensorineural Hearing Loss
+    description: >-
+      Auditory vulnerability manifests as sensorineural hearing loss across the
+      PRPS1 deficiency continuum.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:23190330
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        Hearing loss in male patients with PRPS1 mutations is bilateral,
+        moderate to profound, and can be prelingual or postlingual, progressive
+        or non-progressive.
+      explanation: >-
+        Review evidence supports sensorineural hearing loss as a downstream
+        manifestation of PRPS1 deficiency.
   - target: Peripheral Neuropathy
+    description: >-
+      Neurologic vulnerability includes peripheral neuropathy in CMTX5 and severe
+      Arts syndrome presentations.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:26089585
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        moderate PRS-I deficiency (CMTX5) and severe PRS-I deficiency (Arts
+        syndrome) present with peripheral or optic neuropathy, prelingual
+        progressive sensorineural hearing loss, and central nervous system
+        impairment
+      explanation: >-
+        Review evidence links PRS-I deficiency severity to peripheral neuropathy.
   - target: Ataxia
+    description: >-
+      Arts syndrome neurologic involvement includes early-onset ataxia.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Arts syndrome is an X-linked disorder characterized by mental retardation,
+        early-onset hypotonia, ataxia, delayed motor development, hearing
+        impairment, and optic atrophy.
+      explanation: >-
+        Original Arts syndrome family evidence includes ataxia downstream of
+        PRPS1 deficiency.
   - target: Global Developmental Delay
+    description: >-
+      Severe PRPS1 deficiency produces developmental delay as part of the
+      neurologic phenotype.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:37927483
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Arts syndrome, or severe PRPS1 deficiency, is an X-linked condition
+        characterized by congenital sensorineural hearing loss, optic atrophy,
+        developmental delays, ataxia, hypotonia, and recurrent infections that
+        can cause progressive clinical decline
+      explanation: >-
+        Case report review lists developmental delays in severe PRPS1 deficiency.
+  - target: Motor Delay
+    description: >-
+      Severe neurologic involvement includes delayed motor development.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Arts syndrome is an X-linked disorder characterized by mental retardation,
+        early-onset hypotonia, ataxia, delayed motor development, hearing
+        impairment, and optic atrophy.
+      explanation: >-
+        Original Arts syndrome family evidence supports delayed motor development
+        as a downstream neurologic manifestation.
   - target: Intellectual Disability
+    description: >-
+      Severe neurologic involvement includes intellectual disability.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27256512
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Arts syndrome is characterized by early-onset hypotonia, ataxia,
+        intellectual disability, sensorineural hearing impairment, progressive
+        optic atrophy, and a tendency to develop infections.
+      explanation: >-
+        Case report evidence includes intellectual disability in Arts syndrome.
   - target: Hypotonia
+    description: >-
+      Severe neurologic involvement includes early-onset hypotonia.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27256512
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The initial symptoms of the 1-year-old proband were hypotonia and ataxia,
+        worsening recurrent infection-triggered muscle weakness, motor and
+        intellectual developmental delay, and hearing loss.
+      explanation: >-
+        Case report evidence identifies hypotonia as an initial symptom.
   - target: Optic Atrophy
+    description: >-
+      Ocular vulnerability includes progressive optic atrophy.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27256512
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Arts syndrome is characterized by early-onset hypotonia, ataxia,
+        intellectual disability, sensorineural hearing impairment, progressive
+        optic atrophy, and a tendency to develop infections.
+      explanation: >-
+        Case report evidence links Arts syndrome to progressive optic atrophy.
   - target: Retinal Dystrophy
+    description: >-
+      Ocular vulnerability can include retinal dystrophy in the progressive
+      ophthalmologic spectrum.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:20301738
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: >-
+        progressive ophthalmologic involvement (retinal dystrophy and optic
+        atrophy)
+      explanation: >-
+        GeneReviews identifies retinal dystrophy as part of progressive
+        ophthalmologic involvement.
 - name: Immune vulnerability in Arts syndrome
   description: >-
     Severe Arts syndrome includes recurrent, often respiratory, infections.
@@ -338,7 +518,37 @@ pathophysiology:
       precursor supplementation.
   downstream:
   - target: Recurrent Respiratory Infections
+    description: >-
+      Immune vulnerability in severe Arts syndrome manifests as recurrent severe
+      respiratory infections.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:33532242
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Classically, affected males present with sensorineural hearing loss,
+        optic atrophy, muscular hypotonia, developmental impairment, and
+        recurrent severe respiratory infections early in life.
+      explanation: >-
+        Human case evidence connects Arts syndrome with recurrent severe
+        respiratory infections.
+  - target: Muscle Weakness
+    description: >-
+      Infection-associated clinical worsening in Arts syndrome can include muscle
+      weakness.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27256512
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        The initial symptoms of the 1-year-old proband were hypotonia and ataxia,
+        worsening recurrent infection-triggered muscle weakness, motor and
+        intellectual developmental delay, and hearing loss.
+      explanation: >-
+        Case report evidence supports infection-triggered muscle weakness as a
+        downstream severe Arts syndrome manifestation.
 - name: Expanded severe multisystem involvement
   description: >-
     Rare severe PRPS1 deficiency presentations can include intrauterine growth
@@ -366,13 +576,91 @@ pathophysiology:
       deficiency spectrum.
   downstream:
   - target: Intrauterine Growth Restriction
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes prenatal growth
+      restriction.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        intrauterine growth restriction, dysmorphic facial features, severe
+        intellectual disability and spastic quadraparesis.
+      explanation: >-
+        Severe sibling cases document intrauterine growth restriction in the
+        expanded PRPS1 deficiency spectrum.
   - target: Spastic Tetraparesis
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes spastic quadriparesis,
+      represented by spastic tetraparesis.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        intrauterine growth restriction, dysmorphic facial features, severe
+        intellectual disability and spastic quadraparesis.
+      explanation: >-
+        Severe sibling cases document spastic quadriparesis/tetraparesis.
   - target: White Matter Disease
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes white matter disease.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Prenatal growth restriction, retinal dystrophy, diabetes insipidus and
+        white matter disease: expanding the spectrum of PRPS1-related disorders.
+      explanation: >-
+        The severe sibling report title explicitly places white matter disease in
+        the PRPS1-related disorder spectrum.
   - target: Diabetes Insipidus
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes diabetes insipidus.
     causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Additional phenotypic features include macular coloboma-like lesions with
+        retinal dystrophy, severe short stature and diabetes insipidus.
+      explanation: >-
+        Severe sibling cases document diabetes insipidus in the expanded PRPS1
+        deficiency spectrum.
+  - target: Short Stature
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes severe short stature.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        Additional phenotypic features include macular coloboma-like lesions with
+        retinal dystrophy, severe short stature and diabetes insipidus.
+      explanation: >-
+        Severe sibling cases document severe short stature in the expanded PRPS1
+        deficiency spectrum.
+  - target: Dysmorphic Facial Features
+    description: >-
+      Severe expanded-spectrum PRPS1 deficiency includes dysmorphic facial
+      features.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        intrauterine growth restriction, dysmorphic facial features, severe
+        intellectual disability and spastic quadraparesis.
+      explanation: >-
+        Severe sibling cases document dysmorphic facial features in the expanded
+        PRPS1 deficiency spectrum.
 phenotypes:
 - category: Hearing
   name: Sensorineural Hearing Loss
@@ -825,6 +1113,22 @@ biochemical:
     Reduced phosphoribosylpyrophosphate synthetase 1 activity is the proximal
     biochemical defect in PRPS1 deficiency and correlates with severity across
     the continuum.
+  readouts:
+  - target: PRS-I loss of function
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced PRS-I enzyme activity directly reports the proximal PRPS1 loss-of-function mechanism.
+    evidence:
+    - reference: PMID:24528855
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Enzymatically, PRS-I activity was undetectable in the index subject,
+        reduced in his less affected sister, and normal in his unaffected mother.
+      explanation: >-
+        Family enzyme assays support PRS-I enzyme activity as a direct biochemical
+        readout of the proximal mechanism.
   evidence:
   - reference: PMID:17701896
     supports: SUPPORT
@@ -856,6 +1160,23 @@ biochemical:
   context: >-
     Undetectable urinary hypoxanthine supports impaired purine biosynthesis in
     Arts syndrome due to PRPS1 loss of function.
+  readouts:
+  - target: Impaired PRPP-dependent nucleotide biosynthesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Undetectable urinary hypoxanthine reports impaired purine biosynthesis downstream of PRPP deficiency.
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        impaired purine biosynthesis, which is supported by the undetectable
+        hypoxanthine in urine and the reduced uric acid levels in serum from
+        patients.
+      explanation: >-
+        Patient biochemical findings support urinary hypoxanthine as a readout of
+        impaired purine biosynthesis.
   evidence:
   - reference: PMID:17701896
     supports: SUPPORT
@@ -876,6 +1197,23 @@ biochemical:
   context: >-
     Reduced serum uric acid is a downstream purine-metabolism marker in Arts
     syndrome due to impaired purine biosynthesis.
+  readouts:
+  - target: Impaired PRPP-dependent nucleotide biosynthesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced serum uric acid reports impaired purine biosynthesis downstream of PRPP deficiency.
+    evidence:
+    - reference: PMID:17701896
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: >-
+        impaired purine biosynthesis, which is supported by the undetectable
+        hypoxanthine in urine and the reduced uric acid levels in serum from
+        patients.
+      explanation: >-
+        Patient biochemical findings support serum uric acid as a readout of
+        impaired purine biosynthesis.
   evidence:
   - reference: PMID:17701896
     supports: SUPPORT
@@ -896,6 +1234,22 @@ biochemical:
   context: >-
     Abnormally low erythrocyte GTP and GDP in severe PRPS1 deficiency support
     impaired nucleotide biosynthetic capacity.
+  readouts:
+  - target: Impaired PRPP-dependent nucleotide biosynthesis
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Low erythrocyte GTP and GDP report impaired nucleotide availability in severe PRPS1 deficiency.
+    evidence:
+    - reference: PMID:24961627
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: >-
+        Nucleotide analysis in erythrocytes revealed abnormally low guanosine
+        triphosphate and guanosine diphosphate.
+      explanation: >-
+        Patient erythrocyte analysis supports guanine nucleotide levels as a
+        readout of impaired nucleotide biosynthesis.
   evidence:
   - reference: PMID:24961627
     supports: SUPPORT
@@ -1072,3 +1426,10 @@ treatments:
       GeneReviews supports carrier testing and reproductive counseling once the
       familial variant is known.
 datasets:
+references:
+- reference: PMID:20301738
+  title: Phosphoribosylpyrophosphate Synthetase Deficiency.
+  tags:
+  - GeneReviews
+  found_in:
+  - PRPS1_Deficiency_Spectrum-deep-research-falcon.md


### PR DESCRIPTION
## Summary
- add evidence-backed downstream links from PRS-I loss and impaired PRPP-dependent nucleotide biosynthesis to biochemical readouts
- add edge evidence across neurologic, ocular, immune, growth, endocrine, and severe multisystem phenotype branches
- connect previously unreachable Motor Delay, Short Stature, Muscle Weakness, and Dysmorphic Facial Features
- add readout metadata for PRS-I enzyme activity, urinary hypoxanthine, serum uric acid, and erythrocyte guanine nucleotides

## Validation
- just validate kb/disorders/PRPS1_Deficiency_Spectrum.yaml
- just validate-terms kb/disorders/PRPS1_Deficiency_Spectrum.yaml
- uv run python -m dismech.graph --validate kb/disorders/PRPS1_Deficiency_Spectrum.yaml
- independent snippet audit: checked=82 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0

## Scope
- only kb/disorders/PRPS1_Deficiency_Spectrum.yaml is changed
- unrelated validation cache churn was restored