### PR TITLE
Improve Farber disease pathograph connectivity

### DIFF
--- a/kb/disorders/Farber_Disease.yaml
+++ b/kb/disorders/Farber_Disease.yaml
@@ -1,7 +1,7 @@
 name: Farber Disease
 category: Mendelian
 creation_date: "2026-05-05T11:17:39Z"
-updated_date: "2026-05-09T05:21:44Z"
+updated_date: "2026-05-21T22:43:22Z"
 synonyms:
 - Acid ceramidase deficiency
 - Farber lipogranulomatosis
@@ -218,6 +218,33 @@ pathophysiology:
   - target: Ceramide catabolism blockade
     description: Deficient acid ceramidase directly blocks ceramide hydrolysis.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:29692406
+      reference_title: Structural basis for the activation of acid ceramidase.
+      supports: SUPPORT
+      evidence_source: IN_VITRO
+      snippet: "Acid ceramidase (aCDase, ASAH1) hydrolyzes lysosomal membrane ceramide into sphingosine"
+      explanation: Structural and biochemical work defines the reaction blocked by ASAH1 acid ceramidase loss of function.
+  - target: Reduced acid ceramidase activity
+    description: ASAH1 loss of function is measured biochemically as reduced acid ceramidase activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Definite diagnosis of FD patients can be established by measuring ACDase enzymatic activity and/or sequencing the ASAH1 gene."
+      explanation: Human diagnostic evidence supports acid ceramidase activity as a direct biochemical readout of ASAH1 deficiency.
+  - target: Abnormal acid ceramidase activity
+    description: The proximal enzyme defect also appears as the laboratory phenotype of decreased acid ceramidase activity.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:23707712
+      reference_title: "Molecular basis of acid ceramidase deficiency in a neonatal form of Farber disease: identification of the first large deletion in ASAH1 gene."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "any functionally active acid ceramidase is absent in patient cells"
+      explanation: Patient-cell evidence supports the decreased acid ceramidase activity phenotype.
 - name: Ceramide catabolism blockade
   description: >
     Deficient acid ceramidase decreases lysosomal ceramide catabolism, preventing
@@ -251,6 +278,13 @@ pathophysiology:
   - target: Lysosomal ceramide storage
     description: Blocked ceramide catabolism causes lysosomal ceramide accumulation.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:36830643
+      reference_title: "Acid Ceramidase Deficiency: Bridging Gaps between Clinical Presentation, Mouse Models, and Future Therapeutic Interventions."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "These mutations lead to reduced ACDase activity and ceramide (Cer) accumulation in many tissues."
+      explanation: Review evidence links reduced acid ceramidase activity to tissue ceramide accumulation.
 - name: Lysosomal ceramide storage
   description: >
     Ceramide accumulates in lysosomes and tissues, creating the storage burden
@@ -289,6 +323,13 @@ pathophysiology:
   - target: Lipid-laden macrophage granulomas
     description: Ceramide storage is associated with granulomas containing lipid-filled macrophages.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "They also develop granuloma-like lesions, principally at cartilage sites, that are composed of immune cells including lipid-filled macrophages and neutrophils."
+      explanation: Human and mouse Farber disease evidence connects storage disease to macrophage-rich granuloma-like lesions.
   - target: Cytokine and ceramide plasma signature
     description: >
       Ceramide storage and storage-associated inflammation are reflected in the
@@ -324,10 +365,46 @@ pathophysiology:
       explanation: >
         The same human plasma study identifies the combined cytokine and
         ceramide signature as a disease-associated readout.
+  - target: Increased ceramide species
+    description: Lysosomal ceramide storage is reflected by increased disease-associated ceramide species.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "a-OH-C18-Cer, dhC12-Cer, dhC24:1-Cer, and C22:1-Cer-1P accumulated in plasma from patients with FD."
+      explanation: Patient plasma lipidomics supports increased ceramide species as a biochemical manifestation of ceramide storage.
   - target: Central nervous system storage injury
     description: Ceramide storage can involve CNS cell types and contribute to neurologic disease.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:28342444
+      reference_title: Acid Ceramidase Deficiency in Mice Results in a Broad Range of Central Nervous System Abnormalities.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "Storage compound distribution was analyzed by mass spectrometry imaging and morphologic analyses and revealed involvement of a wide range of central nervous system cell types"
+      explanation: Mouse model evidence supports CNS storage as a downstream consequence of acid ceramidase deficiency.
   - target: Respiratory system involvement
     description: Multisystem ceramide storage can involve the respiratory system.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "respiratory and neurologic involvement"
+      explanation: Orphanet places respiratory involvement within the Farber disease clinical spectrum.
+  - target: Failure to thrive
+    description: Severe multisystem storage disease can manifest as failure to thrive.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001508 | Failure to thrive | Frequent (79-30%)"
+      explanation: Orphanet records failure to thrive as a frequent Farber disease phenotype.
   - target: Retinal ceramide storage and macrophage activation
     description: >
       Tissue ceramide storage extends to the retina, where acid ceramidase
@@ -380,14 +457,63 @@ pathophysiology:
   - target: Periarticular subcutaneous nodules
     description: Granulomatous macrophage infiltration produces subcutaneous and periarticular nodules.
     causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Subcutaneous nodules, common to all reported FD patients, are composed of lipid-filled macrophages"
+      explanation: Patient nodule histology supports lipid-filled macrophage granulomas as the source of subcutaneous nodules.
   - target: Arthritis
     description: Cartilage and periarticular inflammation contributes to arthritis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001369 | Arthritis | Very frequent (99-80%)"
+      explanation: Orphanet records arthritis as a very frequent Farber disease phenotype.
   - target: Arthralgia
     description: Cartilage and periarticular inflammation contributes to painful joints.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Joint abnormalities (e.g., contractures, pain) may also occur in Juvenile Idiopathic Arthritis (JIA), resulting in the misdiagnosis of Farber patients"
+      explanation: Human Farber disease discussion supports joint pain as part of the inflammatory joint presentation.
   - target: Flexion contracture
     description: Periarticular storage and inflammation contribute to joint contractures.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:30029679
+      reference_title: "Acid ceramidase deficiency: Farber disease and SMA-PME."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "accumulation of joint contractures"
+      explanation: Review of human Farber disease supports joint contractures in the classical phenotype.
   - target: Joint swelling
     description: Periarticular inflammation contributes to swollen joints.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:36830643
+      reference_title: "Acid Ceramidase Deficiency: Bridging Gaps between Clinical Presentation, Mouse Models, and Future Therapeutic Interventions."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Classic signs of FD include, but are not limited to, a hoarse voice, distended joints"
+      explanation: Review evidence supports distended joints as a classic Farber disease sign.
+  - target: Hoarse voice
+    description: Macrophage-filled laryngeal nodules contribute to progressive hoarseness.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:28275553
+      reference_title: "Enzyme replacement therapy for Farber disease: Proof-of-concept studies in cells and mice."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "resolution of the macrophage-filled subcutaneous and laryngeal nodules in Farber disease patients after HSCT"
+      explanation: Clinical HSCT experience supports macrophage-filled laryngeal nodules as part of the Farber disease nodular phenotype.
 - name: Cytokine and ceramide plasma signature
   description: >
     Farber disease plasma shows a distinct inflammatory cytokine and ceramide
@@ -422,8 +548,24 @@ pathophysiology:
   downstream:
   - target: Arthritis
     description: Inflammatory mediator activation contributes to rheumatologic presentation and JIA-like misdiagnosis.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "MIP-1a, IP-10, IL-6, and IL-12 are implicated in arthritis"
+      explanation: Patient and mouse cytokine profiling supports inflammatory mediators as contributors to the arthritis-like presentation.
   - target: Joint swelling
     description: Inflammatory mediator activation contributes to swollen inflammatory joints.
+    causal_link_type: INDIRECT_KNOWN_INTERMEDIATES
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Joint abnormalities (e.g., contractures, pain) may also occur in Juvenile Idiopathic Arthritis (JIA), resulting in the misdiagnosis of Farber patients"
+      explanation: Human Farber disease discussion supports inflammatory joint disease in the Farber/JIA-like presentation.
 - name: Central nervous system storage injury
   description: >
     In severe acid ceramidase deficiency models, storage compounds accumulate in
@@ -466,12 +608,44 @@ pathophysiology:
   downstream:
   - target: Global developmental delay
     description: CNS involvement contributes to developmental delay in affected children.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001263 | Global developmental delay | Frequent (79-30%)"
+      explanation: Orphanet records global developmental delay as a frequent Farber disease phenotype.
   - target: Intellectual disability
     description: CNS involvement contributes to cognitive impairment.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0001249 | Intellectual disability | Frequent (79-30%)"
+      explanation: Orphanet records intellectual disability as a frequent Farber disease phenotype.
   - target: CNS foam cells
     description: CNS storage includes foam-cell and microglial/macrophage pathology.
+    causal_link_type: DIRECT
+    evidence:
+    - reference: PMID:28342444
+      reference_title: Acid Ceramidase Deficiency in Mice Results in a Broad Range of Central Nervous System Abnormalities.
+      supports: SUPPORT
+      evidence_source: MODEL_ORGANISM
+      snippet: "storage-laden CD68+ microglia and/or macrophages were seen as early as 3 weeks of age"
+      explanation: Mouse CNS pathology directly supports storage-laden CNS microglia/macrophages.
   - target: Floppy infant
     description: Early neurologic involvement contributes to infantile hypotonia.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0008947 | Floppy infant | Frequent (79-30%)"
+      explanation: Orphanet records floppy infant as a frequent Farber disease phenotype.
 - name: Retinal ceramide storage and macrophage activation
   description: >
     Farber disease models show retinal ceramide accumulation and macrophage
@@ -503,6 +677,14 @@ pathophysiology:
   downstream:
   - target: Cherry red spot of the macula
     description: Retinal storage disease is consistent with macular cherry-red spot annotation.
+    causal_link_type: INDIRECT_UNKNOWN_INTERMEDIATES
+    evidence:
+    - reference: ORPHA:333
+      reference_title: "Farber disease (Orphanet structured-database record)"
+      supports: SUPPORT
+      evidence_source: OTHER
+      snippet: "HP:0010729 | Cherry red spot of the macula | Frequent (79-30%)"
+      explanation: Orphanet records cherry red spot of the macula as a frequent Farber disease phenotype.
 phenotypes:
 - name: Periarticular subcutaneous nodules
   category: Musculoskeletal
@@ -712,7 +894,7 @@ phenotypes:
     reference_title: Acid Ceramidase Deficiency in Mice Results in a Broad Range of Central Nervous System Abnormalities.
     supports: SUPPORT
     evidence_source: MODEL_ORGANISM
-    snippet: "Storage-laden CD68+ microglia and/or macrophages were seen as early as 3 weeks of age"
+    snippet: "storage-laden CD68+ microglia and/or macrophages were seen as early as 3 weeks of age"
     explanation: Mouse model supports CNS storage-laden macrophage or microglial pathology.
 - name: Cherry red spot of the macula
   category: Ophthalmologic
@@ -776,6 +958,19 @@ biochemical:
   context: >
     Deficient acid ceramidase activity in leukocytes or skin fibroblasts is a
     primary diagnostic biochemical abnormality.
+  readouts:
+  - target: ASAH1 acid ceramidase loss of function
+    relationship: READOUT_OF
+    direction: NEGATIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Reduced leukocyte or fibroblast acid ceramidase activity directly reports ASAH1 acid ceramidase loss of function.
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "ACDase activity is determined in leukocytes collected from peripheral blood or from skin fibroblasts obtained by a biopsy."
+      explanation: Human diagnostic methods support acid ceramidase activity as a direct readout of the enzyme defect.
   evidence:
   - reference: PMID:27915031
     reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
@@ -794,6 +989,24 @@ biochemical:
   context: >
     Farber disease shows ceramide storage in tissues and altered plasma ceramide
     species, including specific ceramide species elevated compared with controls.
+  biomarker_term:
+    preferred_term: ceramide
+    term:
+      id: CHEBI:17761
+      label: ceramide
+  readouts:
+  - target: Lysosomal ceramide storage
+    relationship: READOUT_OF
+    direction: POSITIVE
+    endpoint_context: DIAGNOSTIC
+    interpretation: Increased plasma or tissue ceramide species report the ceramide-storage branch caused by acid ceramidase deficiency.
+    evidence:
+    - reference: PMID:27915031
+      reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "in Farber patient plasmas only alpha-hydroxy-C18-Cer, dhC12-Cer, dhC24:1-Cer, and C22:1-Cer-1-phosphate (C22:1-Cer-1P) were significantly elevated compared to controls"
+      explanation: Patient plasma lipidomics supports elevated ceramide species as a readout of Farber disease ceramide storage.
   evidence:
   - reference: PMID:27915031
     reference_title: Acid Ceramidase Deficiency is characterized by a unique plasma cytokine and ceramide profile that is altered by therapy.
@@ -1034,6 +1247,12 @@ clinical_trials:
 references:
 - reference: ORPHA:333
   title: "Farber disease"
+  found_in:
+  - Farber_Disease-deep-research-fallback.md
+- reference: PMID:29595935
+  title: ASAH1-Related Disorders.
+  tags:
+  - GeneReviews
   found_in:
   - Farber_Disease-deep-research-fallback.md
 - reference: PMID:29048419

--- a/references_cache/PMID_29595935.md
+++ b/references_cache/PMID_29595935.md
@@ -1,0 +1,91 @@
+---
+reference_id: "PMID:29595935"
+title: ASAH1-Related Disorders.
+authors:
+- Adam MP
+- Bick S
+- Mirzaa GM
+- Pagon RA
+- Wallace SE
+- Amemiya A
+- Dyment DA
+- Bennett SAL
+- Medin JA
+- Levade T
+year: '1993'
+content_type: abstract_only
+---
+
+# ASAH1-Related Disorders.
+**Authors:** Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, Dyment DA, Bennett SAL, Medin JA, Levade T
+
+## Content
+
+1. ASAH1-Related Disorders.
+
+Dyment DA(1), Bennett SAL(2), Medin JA(3), Levade T(4).
+
+In: Adam MP, Bick S, Mirzaa GM, Pagon RA, Wallace SE, Amemiya A, editors.
+GeneReviews(®) [Internet]. Seattle (WA): University of Washington, Seattle;
+1993–2026.
+2018 Mar 29.
+
+Author information:
+(1)Children's Hospital of Eastern Ontario Research Institute, Department of
+Biochemistry, Microbiology, and Immunology, University of Ottawa, Ottawa,
+Ontario, Canada
+(2)Department of Biochemistry, Microbiology, and Immunology, University of
+Ottawa, Ottawa, Ontario, Canada
+(3)Departments of Pediatrics and Biochemistry, Medical College of Wisconsin,
+Milwaukee, Wisconsin
+(4)Laboratoire de Biochimie Métabolique, CHU Toulouse, INSERM U1037, Centre de
+Recherches en Cancérologie de Toulouse, Université Paul Sabatier, Toulouse,
+France
+
+CLINICAL CHARACTERISTICS: The spectrum of ASAH1-related disorders ranges from
+Farber disease (FD) to spinal muscular atrophy with progressive myoclonic
+epilepsy (SMA-PME). Classic FD is characterized by onset in the first weeks of
+life of painful, progressive deformity of the major joints; palpable
+subcutaneous nodules of joints and mechanical pressure points; and a hoarse cry
+resulting from granulomas of the larynx and epiglottis. Life expectancy is
+usually less than two years. In the other less common types of FD, onset,
+severity, and primary manifestations vary. SMA-PME is characterized by
+early-childhood-onset progressive lower motor neuron disease manifest typically
+between ages three and seven years as proximal lower-extremity weakness,
+followed by progressive myoclonic and atonic seizures, tremulousness/tremor, and
+sensorineural hearing loss. Myoclonic epilepsy typically begins in late
+childhood after the onset of weakness and can include jerking of the upper
+limbs, action myoclonus, myoclonic status, and eyelid myoclonus. Other findings
+include generalized tremor, and cognitive decline. The time from disease onset
+to death from respiratory complications is usually five to 15 years.
+DIAGNOSIS/TESTING: The diagnosis of an ASAH1-related disorder is established in
+a proband with suggestive clinical findings by identification of biallelic
+pathogenic variants in ASAH1 and/or decreased activity of the enzyme acid
+ceramidase in peripheral blood leukocytes or cultured skin fibroblasts.
+MANAGEMENT: Treatment of manifestations is symptomatic and multidisciplinary.
+For FD: Management may include gastrostomy tube placement, surgical removal of
+oral and airway granulomas, and treatment of seizures as per standard practice.
+Hematopoietic stem cell transplantation may be an option in affected individuals
+who do not have significant neurologic involvement. For SMA-PME: Management may
+include standard treatment for hearing loss, scoliosis, seizures, and tremor.
+Weakness can be mitigated with the use of orthotics, wheelchairs, or other
+assistive devices. Surveillance: For FD: At each visit assess growth with
+emphasis on feeding and nutritional status; airway, joint mobility, and
+developmental milestones. For SMA-PME: At each visit monitor growth with
+emphasis on feeding and nutritional status, pulmonary function, back for
+evidence of scoliosis, strength, seizure control, functional capacity (e.g.,
+mobility, communication); assess hearing annually.
+GENETIC COUNSELING: ASAH1-related disorders are inherited in an autosomal
+recessive manner. At conception, each sib of an affected individual has a 25%
+chance of being affected, a 50% chance of being an asymptomatic carrier, and a
+25% chance of being unaffected and not a carrier. Sibs with the same two
+pathogenic variants would be expected to have the same (or very similar)
+phenotype. Once the ASAH1 pathogenic variants have been identified in an
+affected family member, carrier testing for at-risk relatives and prenatal and
+preimplantation genetic testing are possible.
+
+Copyright © 1993-2026, University of Washington, Seattle. GeneReviews is a
+registered trademark of the University of Washington, Seattle. All rights
+reserved. Test.
+
+PMID: 29595935


### PR DESCRIPTION
## Summary
- add evidence and causal link types across Farber disease downstream edges
- connect previously unreachable Hoarse voice, Failure to thrive, and Abnormal acid ceramidase activity
- connect biochemical entries downstream and add readout metadata for reduced acid ceramidase activity and increased ceramide species
- repair a pre-existing CNS foam-cell snippet mismatch against PMID:28342444

## Validation
- just validate kb/disorders/Farber_Disease.yaml
- just validate-terms kb/disorders/Farber_Disease.yaml
- just validate-references kb/disorders/Farber_Disease.yaml
- uv run python -m dismech.graph --validate kb/disorders/Farber_Disease.yaml
- independent snippet audit: checked=98 missing=0 no_cache=0
- graph audit: unexplained_phenotypes=0 biochemical_not_downstream=0 edges_without_evidence=0 edges_without_causal_link_type=0 biochemical_readouts_missing=0

## Scope
- only kb/disorders/Farber_Disease.yaml is changed
- recurring unrelated reference-cache normalization churn was restored