### PR TITLE
Add phenotype evidence to Prostate Adenocarcinoma (#1115)

### DIFF
--- a/kb/disorders/Prostate_Adenocarcinoma.yaml
+++ b/kb/disorders/Prostate_Adenocarcinoma.yaml
@@ -232,6 +232,13 @@ phenotypes:
     Localized tumors can present with obstructive or irritative urinary symptoms
     including frequency, nocturia, hesitancy, and dysuria.
   notes: Composite LUTS phenotype spanning urinary frequency, nocturia, hesitancy, and dysuria; no single precise HPO term is assigned here.
+  evidence:
+  - reference: PMID:42074717
+    reference_title: 'Prevalence of Benign Prostatic Hyperplasia and Prostate Cancer Among Men Presenting with Lower Urinary Tract Symptoms at a Tertiary Referral Hospital in Dar es Salaam, Tanzania: A Retrospective Cross-Sectional Study.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Lower urinary tract symptoms (LUTSs) are among the most common urological complaints in older men, frequently arising from benign prostatic hyperplasia (BPH) or prostate cancer (PCa)."
+    explanation: This supports lower urinary tract symptoms as a common presenting complaint that can arise from prostate cancer.
 - category: Genitourinary
   name: Hematuria
   description: Gross or microscopic hematuria may occur, particularly with more locally advanced disease.
@@ -240,6 +247,13 @@ phenotypes:
     term:
       id: HP:0000790
       label: Hematuria
+  evidence:
+  - reference: PMID:41134363
+    reference_title: 'Prostatic artery embolization for palliative control of hematuria in locally advanced or metastatic prostate cancer: a systematic review.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prostatic artery embolization (PAE) has emerged as a minimally invasive option for the palliative control of hematuria in locally advanced or metastatic prostate cancer."
+    explanation: This supports hematuria as a clinically significant manifestation of locally advanced or metastatic prostate cancer.
 - category: Musculoskeletal
   name: Bone Pain
   description: >-
@@ -250,6 +264,13 @@ phenotypes:
     term:
       id: HP:0002653
       label: Bone pain
+  evidence:
+  - reference: PMID:39169855
+    reference_title: 'Role of osteoclast inhibitors in prostate cancer bone metastasis; a narrative review.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "Prostate cancer metastasizes most commonly to the skeleton thus leading to significant morbidity ranging from pain, pathological fractures to spinal cord compression and are the primary cause of patient disability and reduced quality of life."
+    explanation: This supports bone pain as a characteristic morbidity of skeletal metastasis in prostate cancer.
 - category: Constitutional
   name: Fatigue
   description: Fatigue accompanies advanced disease burden, anemia, and systemic therapy effects.
@@ -258,6 +279,13 @@ phenotypes:
     term:
       id: HP:0012378
       label: Fatigue
+  evidence:
+  - reference: PMID:39761938
+    reference_title: 'Efficacy and safety of PARP inhibitors in prostate cancer: An umbrella review of systematic reviews and meta-analyses.'
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "PARPi therapies increased the incidence of adverse events (AEs), including fatigue, nausea, anemia, neutropenia, and thrombocytopenia."
+    explanation: This supports fatigue (alongside anemia) as a systemic therapy effect in prostate cancer, consistent with fatigue as a treatment-related manifestation.
 biochemical:
 - name: Prostate-Specific Antigen (PSA)
   notes: >-

--- a/references_cache/PMID_39169855.md
+++ b/references_cache/PMID_39169855.md
@@ -1,0 +1,88 @@
+---
+reference_id: "PMID:39169855"
+title: Role of osteoclast inhibitors in prostate cancer bone metastasis; a narrative review.
+authors:
+- Wani SA
+- Qudrat S
+- Zubair H
+- Iqbal Z
+- Gulzar B
+- Aziz S
+- Inayat A
+- Safi D
+- Kamran A
+journal: J Oncol Pharm Pract
+year: '2025'
+doi: 10.1177/10781552241275943
+keywords:
+- Humans
+- Male
+- "Prostatic Neoplasms/pathology, drug therapy"
+- "Bone Neoplasms/secondary, drug therapy"
+- "Osteoclasts/drug effects, pathology"
+- "Bone Density Conservation Agents/therapeutic use, pharmacology"
+- Quality of Life
+- Denosumab/therapeutic use
+- Diphosphonates/therapeutic use
+content_type: abstract_only
+---
+
+# Role of osteoclast inhibitors in prostate cancer bone metastasis; a narrative review.
+**Authors:** Wani SA, Qudrat S, Zubair H, Iqbal Z, Gulzar B, Aziz S, Inayat A, Safi D, Kamran A
+**Journal:** J Oncol Pharm Pract (2025)
+**DOI:** [10.1177/10781552241275943](https://doi.org/10.1177/10781552241275943)
+
+## Content
+
+1. J Oncol Pharm Pract. 2025 Jan;31(1):119-127. doi: 10.1177/10781552241275943. 
+Epub 2024 Aug 22.
+
+Role of osteoclast inhibitors in prostate cancer bone metastasis; a narrative 
+review.
+
+Wani SA(1), Qudrat S(2), Zubair H(3), Iqbal Z(4), Gulzar B(1), Aziz S(5), Inayat 
+A(6), Safi D(7), Kamran A(8).
+
+Author information:
+(1)Department of Internal Medicine, Government medical college, Srinagar, India.
+(2)internal Medicine, Khyber teaching hospital, Peshawar, Pakistan.
+(3)Internal Medicine, Rawalpindi medical university, Rawalpindi, Pakistan.
+(4)Internal Medicine, Virginia commonwealth university, Richmond, USA.
+(5)Internal Medicine, Khyber medical university, Peshawar, Pakistan.
+(6)Internal Medicine, HSHS St Mary's Hospital, Decatur, Illinois, USA.
+(7)Internal Medicine, WVU hospital, Morgantown, WV, USA.
+(8)Internal Medicine, Charleston Area Medical center, Charleston, USA.
+
+OBJECTIVE: To study the role of Osteoclast inhibitors in advanced prostate 
+cancer metastasis treatment and their efficacy in reducing skeletal related 
+events.
+METHODS: DATA SOURCE: A comprehensive search was done using search terms as 
+"osteoclast inhibitors" "Bisphosphonates" "Zoledronic acid" " pamidronate" " 
+Alendronate" "Denosumab" " Prostate cancer metastasis" in pubmed and Google 
+scholar. Relevant articles were screened and collected . The collected articles 
+were used to frame the review and data showing use of Osteoclast inhibitors In 
+prostate cancer bone metastasis was collected.
+DATA SUMMARY: Prostate cancer metastasizes most commonly to the skeleton thus 
+leading to significant morbidity ranging from pain, pathological fractures to 
+spinal cord compression and are the primary cause of patient disability and 
+reduced quality of life.Initially, radiation therapy and radiopharmaceuticals 
+were the mainstay of treatment however the role of Bisphosphonates and denosumab 
+has become an integral part of therapy to manage metastatic prostate cancer. 
+These agents significantly decrease skeletal related events and enhance patients 
+quality of life. Emerging therapies like Radium-223 have also shown promise in 
+reducing skeletal related events and also improving survival rates in patients 
+with bone metastasis. Other treatment options which are being used are systemic 
+agents like Docetaxel, cabazitaxel, hormonal therapies like abiraterone and 
+enzalutamide. Immunotherapy with sipuleucel-T has demonstrated a reduction in 
+mortality among prostate cancer patients with metastasis, highlighting the need 
+for further research in this area. Ongoing studies are investigating novel 
+agents that target both tumor cells and the bone microenvironment.
+CONCLUSION: Osteoclast inhibitors are effective in reducing skeletal related 
+events in advanced bone metastasis and improve the quality of life of patients.
+
+DOI: 10.1177/10781552241275943
+PMID: 39169855 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of conflicting interestsThe authors 
+declared no potential conflicts of interest with respect to the research, 
+authorship, and/or publication of this article.

--- a/references_cache/PMID_39761938.md
+++ b/references_cache/PMID_39761938.md
@@ -1,0 +1,85 @@
+---
+reference_id: "PMID:39761938"
+title: "Efficacy and safety of PARP inhibitors in prostate cancer: An umbrella review of systematic reviews and meta-analyses."
+authors:
+- Tzang CC
+- Wu HW
+- Luo CA
+- Li YT
+- Kang YF
+- Hsieh CM
+- Lee CY
+- Hsu TC
+- Tzang BS
+journal: Crit Rev Oncol Hematol
+year: '2025'
+doi: 10.1016/j.critrevonc.2024.104609
+keywords:
+- Humans
+- Male
+- BRCA1 Protein/genetics
+- BRCA2 Protein/genetics
+- Meta-Analysis as Topic
+- "Poly(ADP-ribose) Polymerase Inhibitors/therapeutic use, adverse effects"
+- "Prostatic Neoplasms/drug therapy, genetics, mortality"
+- Systematic Reviews as Topic
+- Treatment Outcome
+content_type: abstract_only
+---
+
+# Efficacy and safety of PARP inhibitors in prostate cancer: An umbrella review of systematic reviews and meta-analyses.
+**Authors:** Tzang CC, Wu HW, Luo CA, Li YT, Kang YF, Hsieh CM, Lee CY, Hsu TC, Tzang BS
+**Journal:** Crit Rev Oncol Hematol (2025)
+**DOI:** [10.1016/j.critrevonc.2024.104609](https://doi.org/10.1016/j.critrevonc.2024.104609)
+
+## Content
+
+1. Crit Rev Oncol Hematol. 2025 Mar;207:104609. doi: 
+10.1016/j.critrevonc.2024.104609. Epub 2025 Jan 4.
+
+Efficacy and safety of PARP inhibitors in prostate cancer: An umbrella review of 
+systematic reviews and meta-analyses.
+
+Tzang CC(1), Wu HW(1), Luo CA(1), Li YT(1), Kang YF(1), Hsieh CM(1), Lee CY(1), 
+Hsu TC(2), Tzang BS(3).
+
+Author information:
+(1)School of Medicine, College of Medicine, National Taiwan University, Taipei 
+100, Taiwan.
+(2)Institute of Medicine, Chung Shan Medical University, Taichung 402, Taiwan; 
+Department of Clinical Laboratory, Chung Shan Medical University 
+Hospital, Taichung 402, Taiwan; Immunology Research Center, Chung Shan Medical 
+University, Taichung 402, Taiwan. Electronic address: htc@csmu.edu.tw.
+(3)Institute of Medicine, Chung Shan Medical University, Taichung 402, Taiwan; 
+Department of Clinical Laboratory, Chung Shan Medical University 
+Hospital, Taichung 402, Taiwan; Immunology Research Center, Chung Shan Medical 
+University, Taichung 402, Taiwan; Department of Biochemistry, School of 
+Medicine, Chung Shan Medical University, Taichung 402, Taiwan. Electronic 
+address: bstzang@csmu.edu.tw.
+
+Prostate cancer is a significant cause of cancer-related deaths in men. Poly 
+(ADP-ribose) polymerase inhibitors (PARPi) have been shown to improve 
+progression-free survival, especially in patients with BRCA1/2 mutations and 
+deficiencies in homologous recombination repair (HRR). We conducted systematic 
+reviews and meta-analyses and found that PARPi, combined with androgen receptor 
+inhibitors, significantly improved overall survival (OS) and progression-free 
+survival (PFS) in BRCA1/2-mutant and HRR-deficient patients. PARPi therapies 
+increased the incidence of adverse events (AEs), including fatigue, nausea, 
+anemia, neutropenia, and thrombocytopenia. Among different PARP inhibitors, 
+Olaparib, Talazoparib, and Rucaparib demonstrated the strongest efficacy in 
+improving OS and PFS but were also linked to higher rates of AEs. Combination 
+therapies with PARPi and hormonal treatments proved more effective than 
+monotherapy, especially in genetically targeted subgroups like BRCA1/2-mutant 
+patients. This umbrella review demonstrates that PARPi treatment significantly 
+improves clinical outcomes, particularly in BRCA1/2-mutant and HRR-deficient 
+mCRPC patients.
+
+Copyright © 2025 Elsevier B.V. All rights reserved.
+
+DOI: 10.1016/j.critrevonc.2024.104609
+PMID: 39761938 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declaration of Competing Interest The authors 
+declare that they have no known competing financial interests or personal 
+relationships that could have appeared to influence the work reported in this 
+paper.

--- a/references_cache/PMID_41134363.md
+++ b/references_cache/PMID_41134363.md
@@ -1,0 +1,77 @@
+---
+reference_id: "PMID:41134363"
+title: "Prostatic artery embolization for palliative control of hematuria in locally advanced or metastatic prostate cancer: a systematic review."
+authors:
+- Dehvari S
+- Razipour I
+- Bemana R
+- Alisofi M
+- Keshtan SB
+- Baserisalehi N
+- Ourang Z
+journal: Abdom Radiol (NY)
+year: '2026'
+doi: 10.1007/s00261-025-05250-x
+keywords:
+- Humans
+- Male
+- "Hematuria/therapy, etiology"
+- "Prostatic Neoplasms/pathology, complications, therapy"
+- Palliative Care/methods
+- "Embolization, Therapeutic/methods"
+- Prostate/blood supply
+content_type: abstract_only
+---
+
+# Prostatic artery embolization for palliative control of hematuria in locally advanced or metastatic prostate cancer: a systematic review.
+**Authors:** Dehvari S, Razipour I, Bemana R, Alisofi M, Keshtan SB, Baserisalehi N, Ourang Z
+**Journal:** Abdom Radiol (NY) (2026)
+**DOI:** [10.1007/s00261-025-05250-x](https://doi.org/10.1007/s00261-025-05250-x)
+
+## Content
+
+1. Abdom Radiol (NY). 2026 May;51(5):2583-2595. doi: 10.1007/s00261-025-05250-x. 
+Epub 2025 Oct 24.
+
+Prostatic artery embolization for palliative control of hematuria in locally 
+advanced or metastatic prostate cancer: a systematic review.
+
+Dehvari S(1), Razipour I(2), Bemana R(3), Alisofi M(1), Keshtan SB(4), 
+Baserisalehi N(2), Ourang Z(5).
+
+Author information:
+(1)Zahedan University of Medical Sciences, Zahedan, Iran, Islamic Republic of.
+(2)Shiraz University of Medical Sciences, shiraz, Iran, Islamic Republic of.
+(3)Jahrom University of Medical Sciences, Jahrom, Iran, Islamic Republic of.
+(4)Birjand University of Medical Sciences, Birjand, Iran, Islamic Republic of.
+(5)Arak University of Medical Sciences, Arak, Iran, Islamic Republic of. 
+Dr.zahraourang@gmail.com.
+
+PURPOSE: Prostatic artery embolization (PAE) has emerged as a minimally invasive 
+option for the palliative control of hematuria in locally advanced or metastatic 
+prostate cancer. This systematic review focuses on the efficacy and safety of 
+PAE for this indication, while also synthesizing available data on secondary 
+outcomes such as urinary retention and pain.
+METHODS: A comprehensive search of PubMed/MEDLINE, Scopus, and Web of Science 
+identified eight primary studies (four retrospective case series, one 
+prospective cohort, and three case reports). Methodological quality was assessed 
+using Joanna Briggs Institute (JBI) checklists and the Newcastle-Ottawa Scale 
+(NOS).
+RESULTS: PAE demonstrated high technical success (89-100%) and immediate 
+hemostatic control (67-100%), with durable symptom relief in most patients. 
+Functional improvements in urinary retention (50-80% catheter-free rates) and 
+pain (≈ 70% improvement) were observed, though outcomes varied. Major 
+complications were rare (< 3%), supporting PAE's safety over traditional options 
+like TURP (higher bleeding risk) or EBRT (delayed response).
+CONCLUSION: PAE offers rapid, low-risk palliation for advanced prostate cancer 
+symptoms. While it is a valuable alternative for high-risk patients, comparative 
+trials are needed to define its role in obstruction and pain management.
+
+© 2025. The Author(s), under exclusive licence to Springer Science+Business 
+Media, LLC, part of Springer Nature.
+
+DOI: 10.1007/s00261-025-05250-x
+PMID: 41134363 [Indexed for MEDLINE]
+
+Conflict of interest statement: Declarations. Competing interests: The authors 
+declare no competing interests.

--- a/references_cache/PMID_42074717.md
+++ b/references_cache/PMID_42074717.md
@@ -1,0 +1,84 @@
+---
+reference_id: "PMID:42074717"
+title: "Prevalence of Benign Prostatic Hyperplasia and Prostate Cancer Among Men Presenting with Lower Urinary Tract Symptoms at a Tertiary Referral Hospital in Dar es Salaam, Tanzania: A Retrospective Cross-Sectional Study."
+authors:
+- Amin AIA
+- Samhan LM
+- Zaidi ARZ
+- Ali Amin AI
+- Faroog Z
+- Almalki BSR
+- Alghalyini B
+journal: J Clin Med
+year: '2026'
+doi: 10.3390/jcm15082914
+content_type: abstract_only
+---
+
+# Prevalence of Benign Prostatic Hyperplasia and Prostate Cancer Among Men Presenting with Lower Urinary Tract Symptoms at a Tertiary Referral Hospital in Dar es Salaam, Tanzania: A Retrospective Cross-Sectional Study.
+**Authors:** Amin AIA, Samhan LM, Zaidi ARZ, Ali Amin AI, Faroog Z, Almalki BSR, Alghalyini B
+**Journal:** J Clin Med (2026)
+**DOI:** [10.3390/jcm15082914](https://doi.org/10.3390/jcm15082914)
+
+## Content
+
+1. J Clin Med. 2026 Apr 11;15(8):2914. doi: 10.3390/jcm15082914.
+
+Prevalence of Benign Prostatic Hyperplasia and Prostate Cancer Among Men 
+Presenting with Lower Urinary Tract Symptoms at a Tertiary Referral Hospital in 
+Dar es Salaam, Tanzania: A Retrospective Cross-Sectional Study.
+
+Amin AIA(1), Samhan LM(2), Zaidi ARZ(3), Ali Amin AI(1), Faroog Z(2), Almalki 
+BSR(2), Alghalyini B(3).
+
+Author information:
+(1)College of Medicine, University of Medical Sciences and Technology, Khartoum 
+P.O. Box 12810, Sudan.
+(2)College of Medicine, Alfaisal University, Riyadh 11533, Saudi Arabia.
+(3)Department of Family & Community Medicine, College of Medicine, Alfaisal 
+University, Riyadh 11533, Saudi Arabia.
+
+Background: Lower urinary tract symptoms (LUTSs) are among the most common 
+urological complaints in older men, frequently arising from benign prostatic 
+hyperplasia (BPH) or prostate cancer (PCa). While both conditions share 
+overlapping symptomatology, the way each condition progresses and is managed 
+differs considerably. In sub-Saharan Africa, data on the relative burden of BPH 
+and PCa among men presenting with LUTSs are scarce. This study aimed to 
+determine the prevalence of histologically confirmed BPH and PCa among men 
+presenting with LUTSs at a major tertiary referral center in Tanzania and to 
+explore the association between specific urinary symptoms and histopathological 
+diagnoses. Methods: A retrospective cross-sectional study was conducted at 
+Muhimbili National Hospital (MNH), Dar es Salaam, Tanzania, reviewing medical 
+records of adult male patients aged ≥50 years who presented with LUTSs and 
+underwent prostatic biopsy between January and December 2023. A total of 133 
+patients were included through simple random sampling from an eligible 
+population of 260. Data on demographics, comorbidities, International Prostate 
+Symptom Score (IPSS), serum prostate-specific antigen (PSA), prostate volume, 
+and histopathological biopsy outcomes were extracted using a purpose-built 
+digital form. This study was conducted in compliance with the Strengthening the 
+Reporting of Observational Studies in Epidemiology (STROBE) guidelines. Results: 
+Most patients (39.8%) were aged 70 to 79 years. Hypertension was the most 
+frequent comorbidity among those with chronic disease (31.65%), followed by 
+diabetes mellitus (12.03%). The mean serum PSA was 465.1 ng/mL (SD = 1610.1), 
+and the mean prostate volume was 80.6 cm3 (SD = 75.6). Histopathologically, 
+57.9% of biopsies were benign and 40.6% were malignant. The most commonly 
+reported IPSS symptoms were urinary frequency (78.2%), weak stream (78.2%), and 
+incomplete emptying (64.7%). Most patients (59.4%) had severe IPSSs. 
+Statistically significant associations were observed between biopsy outcomes and 
+incomplete emptying (p = 0.011), frequency (p = 0.014), weak stream (p = 0.022), 
+nocturia (p = 0.001), urge incontinence (p = 0.004), and post-void dribbling (p 
+< 0.001). IPSS severity was significantly associated with biopsy diagnosis (p < 
+0.001), with 63% of malignant cases presenting with moderate symptom scores. 
+Conclusions: BPH was the predominant histopathological diagnosis among men 
+presenting with LUTSs at this tertiary center, while prostate cancer accounted 
+for a substantial minority of cases. Certain individual LUTSs, particularly 
+nocturia, urge incontinence, and post-void dribbling, demonstrated significant 
+associations with malignant histopathology. These findings underscore the 
+necessity for systematic histopathological evaluation in all men presenting with 
+LUTSs in resource-limited settings, irrespective of symptom severity.
+
+DOI: 10.3390/jcm15082914
+PMCID: PMC13116364
+PMID: 42074717
+
+Conflict of interest statement: The authors declare no conflicts of interest.


### PR DESCRIPTION
## Summary

Closes a concrete compliance gap on `kb/disorders/Prostate_Adenocarcinoma.yaml` (issue #1115): all four phenotypes previously had **no evidence**. This PR adds one PMID-backed evidence item to each.

| Phenotype | Reference | Evidence type |
|---|---|---|
| Lower Urinary Tract Symptoms | PMID:42074717 | retrospective cross-sectional study |
| Hematuria | PMID:41134363 | systematic review |
| Bone Pain | PMID:39169855 | narrative review |
| Fatigue | PMID:39761938 | umbrella review of systematic reviews/meta-analyses |

Each `snippet:` is an exact quote from the cited abstract. Reference cache files were generated with `just fetch-reference` (never hand-edited).

**Compliance:** Global 82.5% → **88.1%**; weighted 84.0% → **89.9%**. `phenotypes[].evidence` went 0/4 → 4/4.

## Validation

- `just validate kb/disorders/Prostate_Adenocarcinoma.yaml` — ✅ schema + terms + references
- `just validate-terms kb/disorders/Prostate_Adenocarcinoma.yaml` — ✅ passed
- `just check-reference-cache-frontmatter` — ✅ OK
- Snippets manually confirmed as exact (whitespace-normalized) substrings of each cached abstract

## What was intentionally NOT changed

- No new pathophysiology, treatments, or ontology terms — scope is strictly the unsupported-phenotype evidence gap.
- The remaining issue-body item (`has_subtypes` cross-link to `BRCA_Mutant_Prostate_Cancer` / `Metastatic_Prostate_Cancer`) is left untouched: it is a governance question flagged under #1307, not curation debt.
- Incidental term/reference cache normalization drift surfaced by the validators was reverted to keep this PR scoped.

Refs #1115

🤖 Generated with [Claude Code](https://claude.com/claude-code)