### PR TITLE
Wire FDA FEV1 surrogate endpoint into COPD (#2495)

### DIFF
--- a/kb/disorders/Chronic_Obstructive_Pulmonary_Disease.yaml
+++ b/kb/disorders/Chronic_Obstructive_Pulmonary_Disease.yaml
@@ -636,6 +636,67 @@ biochemical:
     supports: SUPPORT
     snippet: Levels of interleukin 6 (IL-6), high-sensitivity C-reactive protein (hs-CRP), and granulocyte colony stimulating factor (G-CSF) were higher in participants with OVS and COPD compared with healthy controls and participants with OSA.
     explanation: Elevated hs-CRP in COPD patients relative to healthy controls supports the general inflammation and exacerbation context.
+- name: Forced Expiratory Volume in 1 Second (FEV1)
+  presence: Reduced, with a low post-bronchodilator FEV1/FVC ratio confirming persistent airflow limitation; partially reversible or more slowly declining with bronchodilator and anti-inflammatory therapy.
+  context: >-
+    Spirometric pulmonary function measure (percent of predicted FEV1, together
+    with the FEV1/FVC ratio) used to diagnose COPD, grade severity of airflow
+    limitation, monitor disease progression, and assess pharmacodynamic response
+    to bronchodilator and anti-inflammatory therapy. FEV1 is recognized by the
+    FDA as a validated surrogate endpoint supporting traditional approval of COPD
+    drugs.
+  biomarker_term:
+    preferred_term: Forced Expiratory Volume in 1 Second (FEV1)
+    term:
+      id: NCIT:C38084
+      label: Forced Expiratory Volume in 1 Second
+  synonyms:
+  - FEV1
+  - percent predicted FEV1
+  - FEV1/FVC ratio
+  readouts:
+  - target: Airflow Limitation
+    relationship: PHARMACODYNAMIC_MARKER_OF
+    direction: NEGATIVE
+    endpoint_context: PHARMACODYNAMIC
+    regulatory_endpoint_refs:
+    - FDA-SE-adult-noncancer-013
+    interpretation: >-
+      Higher or less-declining percent-predicted FEV1 indicates reduced airflow
+      limitation; treatment-induced improvement in FEV1 reports the
+      pharmacodynamic response to bronchodilator and anti-inflammatory therapy
+      and underpins the FDA surrogate-endpoint basis for traditional approval of
+      COPD drugs.
+    evidence:
+    - reference: PMID:19716960
+      reference_title: "Roflumilast in symptomatic chronic obstructive pulmonary disease: two randomised clinical trials."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "Primary endpoints were change in prebronchodilator forced expiratory volume in 1 s (FEV(1)) and the rate of exacerbations that were moderate (glucocorticosteroid-treated) or severe."
+      explanation: >-
+        The pivotal placebo-controlled trials of the phosphodiesterase-4
+        inhibitor roflumilast used change in prebronchodilator FEV1 as a primary
+        endpoint, establishing FEV1 as a regulatory efficacy readout for COPD
+        drug approval.
+    - reference: PMID:19716960
+      reference_title: "Roflumilast in symptomatic chronic obstructive pulmonary disease: two randomised clinical trials."
+      supports: SUPPORT
+      evidence_source: HUMAN_CLINICAL
+      snippet: "In a pooled analysis, prebronchodilator FEV(1) increased by 48 mL with roflumilast compared with placebo (p<0.0001)."
+      explanation: >-
+        FEV1 improved measurably with anti-inflammatory therapy versus placebo,
+        confirming FEV1 as a treatment-responsive pharmacodynamic marker of
+        airflow limitation in COPD.
+  evidence:
+  - reference: PMID:18836213
+    reference_title: "A 4-year trial of tiotropium in chronic obstructive pulmonary disease."
+    supports: SUPPORT
+    evidence_source: HUMAN_CLINICAL
+    snippet: "The patients were at least 40 years of age, with a forced expiratory volume in 1 second (FEV(1)) of 70% or less after bronchodilation and a ratio of FEV(1) to forced vital capacity (FVC) of 70% or less."
+    explanation: >-
+      Reduced FEV1 and a low FEV1/FVC ratio are the spirometric criteria used to
+      define and grade airflow limitation in COPD, supporting FEV1 as the core
+      monitoring and severity biomarker.
 genetic:
 - name: SERPINA1
   association: Alpha-1 antitrypsin deficiency is the most common genetic cause of COPD.

--- a/references_cache/PMID_18836213.md
+++ b/references_cache/PMID_18836213.md
@@ -1,0 +1,181 @@
+---
+reference_id: "PMID:18836213"
+title: A 4-year trial of tiotropium in chronic obstructive pulmonary disease.
+authors:
+- Tashkin DP
+- Celli B
+- Senn S
+- Burkhart D
+- Kesten S
+- Menjoge S
+- Decramer M
+- UPLIFT Study Investigators
+journal: N Engl J Med
+year: '2008'
+doi: 10.1056/NEJMoa0805800
+keywords:
+- Adult
+- Aged
+- "Bronchodilator Agents/adverse effects, pharmacology, therapeutic use"
+- "Cholinergic Antagonists/adverse effects, pharmacology, therapeutic use"
+- Disease Progression
+- Double-Blind Method
+- "Drug Therapy, Combination"
+- Female
+- Forced Expiratory Volume/drug effects
+- Humans
+- Kaplan-Meier Estimate
+- Male
+- Middle Aged
+- Proportional Hazards Models
+- "Pulmonary Disease, Chronic Obstructive/drug therapy, mortality, physiopathology"
+- Quality of Life
+- "Scopolamine Derivatives/adverse effects, pharmacology, therapeutic use"
+- Tiotropium Bromide
+- Vital Capacity/drug effects
+content_type: abstract_only
+---
+
+# A 4-year trial of tiotropium in chronic obstructive pulmonary disease.
+**Authors:** Tashkin DP, Celli B, Senn S, Burkhart D, Kesten S, Menjoge S, Decramer M, UPLIFT Study Investigators
+**Journal:** N Engl J Med (2008)
+**DOI:** [10.1056/NEJMoa0805800](https://doi.org/10.1056/NEJMoa0805800)
+
+## Content
+
+1. N Engl J Med. 2008 Oct 9;359(15):1543-54. doi: 10.1056/NEJMoa0805800. Epub
+2008  Oct 5.
+
+A 4-year trial of tiotropium in chronic obstructive pulmonary disease.
+
+Tashkin DP(1), Celli B, Senn S, Burkhart D, Kesten S, Menjoge S, Decramer M; 
+UPLIFT Study Investigators.
+
+Collaborators: Schiavi E, Figueroa Casas JC, Rhodius E, Gené R, Benito Sáenz C, 
+Giugno E, Di Bartolo C, De Salvo MC, Abbate E, López AM, Steinfort C, Peters M, 
+Carroll P, Simpson G, Freiberg D, Fogarty P, Watts R, Wheatley J, Vetter N, 
+Burghuber O, Hesse C, Flicker M, Kähler C, Bral G, Carron K, Coolen D, De Backer 
+W, De Beukelaar T, Decramer M, Deman R, Dewispelaere B, Driesen P, Elinck W, 
+Mentens Y, Vandeurzen K, Van Renterghem D, Van Zandweghe L, Verhaeghe W, Vincken 
+W, Delaunois L, Duchatelet P, Noseda A, Nuttin G, Rodenstein D, Thibaut-Baudrez 
+A, Vandermoten G, Wackenier-Genard P, Baldassarre S, Schlesser M, Barreto SS, 
+Corrêa JC, da Silva LC, Fiss E, Chibante AM, de Mattos WL, Fritscher CC, de 
+Oliveira JA, Pizzichini E, Neves M, Cruz A, Pereira CA, Cukier A, Stirbulov R, 
+Jardim JR, Kalandrova K, Novakova M, Hartman P, Jensovsky V, Vacek J, Kasak V, 
+Erban J, Kalina P, Chlumsky J, Musil J, Hojka I, Havlikova A, Mares J, Klenha K, 
+Vondra V, Havlik M, Parakova Z, Vlcek J, Dvorakova J, Mazacova H, Velart D, 
+Pospisil L, Zajicova O, Kolman P, Binková I, Fratrik J, Lange P, Backer V, Dahl 
+R, Harving H, Tønnesen P, Munch E, Rasmussen OB, Tougaard L, Egede F, Hansen NC, 
+Høegholm A, Rasmussen FV, Jakobsen KS, Wessels J, Frandsen JL, Evald T, Hilskov 
+J, Garsdal P, Nielsen C, Haahr S, Korsgaard J, Revsbeck PA, Hansen JG, Soerensen 
+T, Arnved JR, Møller A, Enevoldsen H, Døssing M, Christensen P, Christensen KD, 
+Frølund L, Venho K, Pietiläinen M, Saarelainen P, Kotaniemi J, Männistö J, 
+Aubier M, Pigearias B, Malaquin F, Grunchec N, Bernabeu L, Carme B, Prud'homme 
+A, Bonte F, Boz D, Meunier R, Rasolojaona MT, Apprill M, Fargeon R, Bernard P, 
+Tirouvanziam F, Legendre M, Jasnot JY, Barczok M, Becker JC, Pilz M, Grimm-Sachs 
+V, Jahn M, Kemmerich B, Vorderstrasse W, Klein G, Kroemer B, Lehnert J, Redlich 
+R, Schmidtmann S, Schultz T, Weber HH, Siafakas N, Anagnostopoulou O, Toubis M, 
+Gourgoulianis K, Sichletides L, Kakoura M, Christaki P, Lychros I, Spiropoulos 
+K, Bousmoukilia S, Hui DS, Yu WC, Chan HS, Wong ML, Baliko Z, Bisits M, 
+Böszörményi G, Marton M, Fonay K, Györi Z, Hajdu L, Lukács J, Kovacs G, Magyar 
+P, Nagy G, Namenyi M, Meszaros E, Petö L, Somfay A, Kiraly Z, Strausz J, Szalai 
+Z, Szilasi M, Szima B, Sztancsik Z, Costello R, Burke C, Paggiaro PL, Mazzocchi 
+P, Cattaneo C, Peccini F, Dottorini M, Dottorini M, Tazza R, Pirina P, Ginesu F, 
+Ortu R, Sugamiele M, Mastroberardino M, Anzalone G, Canonica GW, De Benedetto F, 
+Falcone F, Greco P, Papi A, Ciaccia A, Vincenti R, Parentini G, Tubaldi A, De 
+Rose V, Ferretti G, Gasparini S, Legnani D, Ligia GP, Padua V, Santelli G, Mazza 
+F, Boccieri MG, Cogo R, Pegna AL, Pistolesi M, Colorizio V, Zanon P, Nishimura 
+M, Yamauchi K, Ogawa H, Hattori T, Ichinose M, Kimura K, Kaneko N, Seyama K, 
+Fukuchi Y, Kubo K, Taniguchi H, Hirata K, Tohda Y, Aizawa H, Matsumoto S, 
+Sakalauskas R, Bagdonas A, Nargela RV, Mahayiddin AA, Harun R, Liam CK, Ortiz 
+Peregrina JR, Díaz Castañón JJ, Posadas Valay R, Sansores Martínez RH, Domínguez 
+Peregrina A, van Noord J, Aalbers R, Creemers JP, Dalinghaus WH, Eland ME, 
+Pannekoek BJ, Pasma HR, Rudolphus A, Damsté HE, Evers WB, Gans SJ, Timmer H, 
+Westbroek J, Black P, Epton M, Dahle R, Eivindson A, Asmervik J, Lier PA, 
+Cañizares-Fernandez L, Guzman-Banzon A, Aquino T, Sy-Naval S, Trinidad T, 
+Gorecka D, Plusa TP, Pisarczyk-Bogacka E, Gorski P, Kozielski J, Pierzchala W, 
+Szczeklik A, Kuna P, Slominksi JM, Almeida J, Sá R, Bárbara C, Pato R, Moita J, 
+Cardoso J, Chuchalin AG, Ovtcharenko S, Nonikov V, Ilkovich M, Tsoi A, Wang YT, 
+Lo C, Lim TK, Kristufek P, Chovan L, Rozborilova E, Salat D, Plutinsky J, 
+Suskovic S, Kosnik M, Turel M, Rezar L, Ulcar-Kostic S, Ras GJ, Du Toit JJ, 
+Herbst L, van der Linden M, Nel AM, Jansen JJ, Bester FC, Colyn HJ, Abdullah I, 
+Abdullah IA, Bateman E, Heredia Budó JL, Marín Pardo J, Miravitlles M, Izquierdo 
+Alonso JL, Val Adán P, Morera J, Ferrer J, Alvarez-Sala JL, Fernández Francés J, 
+Fuentes Otero F, Ferreiro Alvarez MJ, Verea Hernando H, Marín Pérez A, Hernández 
+Flix S, Sueiro Bendito A, Bandrés Gimeno R, Montemayor T, Fernández-Montes CV, 
+Navas Vazquez S, Sobradillo Peña V, Rubio Goday M, Baloira Villar A, Blanquer 
+Olivas R, Romero Candeira S, Agustí A, Ancochea J, Marín Trigo JM, Rodríguez 
+González-Moro JM, Brotons B, Merino J, Perpiñá Tordera M, Ortega Ruiz F, López 
+Encuentra A, Batista JJ, Suárez Pinilla FJ, Agüero R, Russi E, Solèr M, Tamm M, 
+Bräendli O, Pons M, Tschopp JM, Hess T, Kuo HP, Shiao GM, Pothirat C, Wongtim S, 
+Kiatboonsri S, Dejsomritrutai W, Boonsawat W, Erk M, Tuncay E, Celikel T, 
+Caglayan B, Tabak L, Cöplü L, Ardiç S, Ucar N, Mirici A, Kocabas A, Erginel S, 
+Cimrin AH, Mansur A, Bucknall C, Griffiths P, Halpin D, Morgan M, Morice A, 
+Anderson P, Plant P, Britton M, Harrison T, Crooks S, Shales D, Douglas G, 
+Gravil J, Altose MD, Amgott T, Andrews CP, Cote C, Averill F, Bailey W, Bensch 
+G, Bleecker ER, Koh D, Block M, Braman S, Brannen AL, Brazinsky SA, Bruya T, 
+Callahan D, Celli B, Condemi JJ, Corser B, Osmanski J, Craig T, Degraff A, 
+Doherty DE, Anderson M, Doner M, Donohue J, Eichenhorn M, Ettinger N, Govert J, 
+Folz R, Lasky J, Kovitz K, Friedman M, Giessel G, Pomerantz R, Castillo G, 
+Greenwald GI, Hanania N, Hautamaki RD, Henderson W 4th, Heyder A, Hyers T, 
+Ilowite J, Janes M, Kahn R, Harder R, Kaiser H, Kanner RE, Kaye M, Kreitzer S, 
+Lawlor D, Leech I, Levine B, Littner M, Jarmukli N, Liu J, Lorch DG, Mahler D, 
+Make B, Mandel M, Mathur P, Meyer DH, Milam MG, Mohsenifar Z, Moriarty T, Otoshi 
+J, Patel R, Pratt A, Prenner B, Rehm J, Repsher L, Ries A, Rock KB, Sharafkhaneh 
+A, San Pedro G, Scanlon PD, Scheinberg P, Schelbar EJ, Schul J, Fine J, Segall 
+N, Seibert A, Serfillipi GL, Spirn I, Sussman R, Tashkin D, Wachtel A, Westerman 
+J, Wise RA, Zielinski R, ZuWallack R, Ferguson G, Gelb A, Kuschner W, Mahutte K, 
+Martinez F, Plautz M, Rochester C, Schilero G, Tino G, Turino G, Keppel J.
+
+Author information:
+(1)David Geffen School of Medicine at the University of California, Los Angeles 
+90095-1690,USA. dtashkin@mednet.ucla.edu
+
+Comment in
+    N Engl J Med. 2008 Oct 9;359(15):1616-8. doi: 10.1056/NEJMe0807387.
+    N Engl J Med. 2009 Jan 8;360(2):185; author reply 187. doi: 
+10.1056/NEJMc082265.
+    N Engl J Med. 2009 Jan 8;360(2):185; author reply 187.
+    N Engl J Med. 2009 Jan 8;360(2):185-6; author reply 187.
+    N Engl J Med. 2009 Jan 8;360(2):186-7; author reply 187.
+    N Engl J Med. 2009 Jan 8;360(2):186; author reply 187.
+    Ann Intern Med. 2009 Jan 20;150(2):JC1-7. doi: 
+10.7326/0003-4819-150-2-200901200-02007.
+    Expert Opin Pharmacother. 2009 Mar;10(4):719-22. doi: 
+10.1517/14656560902740804.
+    Evid Based Med. 2009 Apr;14(2):42-3. doi: 10.1136/ebm.14.2.43.
+
+BACKGROUND: Previous studies showing that tiotropium improves multiple end 
+points in patients with chronic obstructive pulmonary disease (COPD) led us to 
+examine the long-term effects of tiotropium therapy.
+METHODS: In this randomized, double-blind trial, we compared 4 years of therapy 
+with either tiotropium or placebo in patients with COPD who were permitted to 
+use all respiratory medications except inhaled anticholinergic drugs. The 
+patients were at least 40 years of age, with a forced expiratory volume in 1 
+second (FEV(1)) of 70% or less after bronchodilation and a ratio of FEV(1) to 
+forced vital capacity (FVC) of 70% or less. Coprimary end points were the rate 
+of decline in the mean FEV(1) before and after bronchodilation beginning on day 
+30. Secondary end points included measures of FVC, changes in response on St. 
+George's Respiratory Questionnaire (SGRQ), exacerbations of COPD, and mortality.
+RESULTS: Of a total of 5993 patients (mean age, 65+/-8 years) with a mean FEV(1) 
+of 1.32+/-0.44 liters after bronchodilation (48% of predicted value), we 
+randomly assigned 2987 to the tiotropium group and 3006 to the placebo group. 
+Mean absolute improvements in FEV(1) in the tiotropium group were maintained 
+throughout the trial (ranging from 87 to 103 ml before bronchodilation and from 
+47 to 65 ml after bronchodilation), as compared with the placebo group 
+(P<0.001). After day 30, the differences between the two groups in the rate of 
+decline in the mean FEV(1) before and after bronchodilation were not 
+significant. The mean absolute total score on the SGRQ was improved (lower) in 
+the tiotropium group, as compared with the placebo group, at each time point 
+throughout the 4-year period (ranging from 2.3 to 3.3 units, P<0.001). At 4 
+years and 30 days, tiotropium was associated with a reduction in the risks of 
+exacerbations, related hospitalizations, and respiratory failure.
+CONCLUSIONS: In patients with COPD, therapy with tiotropium was associated with 
+improvements in lung function, quality of life, and exacerbations during a 
+4-year period but did not significantly reduce the rate of decline in FEV(1). 
+(ClinicalTrials.gov number, NCT00144339.)
+
+2008 Massachusetts Medical Society
+
+DOI: 10.1056/NEJMoa0805800
+PMID: 18836213 [Indexed for MEDLINE]

--- a/references_cache/PMID_19716960.md
+++ b/references_cache/PMID_19716960.md
@@ -1,0 +1,267 @@
+---
+reference_id: "PMID:19716960"
+title: "Roflumilast in symptomatic chronic obstructive pulmonary disease: two randomised clinical trials."
+authors:
+- Calverley PM
+- Rabe KF
+- Goehring UM
+- Kristiansen S
+- Fabbri LM
+- Martinez FJ
+- M2-124 and M2-125 study groups
+journal: Lancet
+year: '2009'
+doi: 10.1016/S0140-6736(09)61255-1
+keywords:
+- "Administration, Oral"
+- Adrenergic beta-Agonists/therapeutic use
+- Aged
+- "Aminopyridines/pharmacology, therapeutic use"
+- Analysis of Variance
+- "Benzamides/pharmacology, therapeutic use"
+- Cholinergic Antagonists/therapeutic use
+- "Cyclopropanes/pharmacology, therapeutic use"
+- Double-Blind Method
+- "Drug Therapy, Combination"
+- Female
+- Forced Expiratory Volume/drug effects
+- Humans
+- Male
+- Middle Aged
+- Phosphodiesterase 4 Inhibitors
+- "Phosphodiesterase Inhibitors/pharmacology, therapeutic use"
+- Proportional Hazards Models
+- "Pulmonary Disease, Chronic Obstructive/diagnosis, drug therapy, etiology"
+- Regression Analysis
+- Severity of Illness Index
+- Smoking/epidemiology
+- Treatment Outcome
+- Vital Capacity/drug effects
+content_type: abstract_only
+---
+
+# Roflumilast in symptomatic chronic obstructive pulmonary disease: two randomised clinical trials.
+**Authors:** Calverley PM, Rabe KF, Goehring UM, Kristiansen S, Fabbri LM, Martinez FJ, M2-124 and M2-125 study groups
+**Journal:** Lancet (2009)
+**DOI:** [10.1016/S0140-6736(09)61255-1](https://doi.org/10.1016/S0140-6736(09)61255-1)
+
+## Content
+
+1. Lancet. 2009 Aug 29;374(9691):685-94. doi: 10.1016/S0140-6736(09)61255-1.
+
+Roflumilast in symptomatic chronic obstructive pulmonary disease: two randomised 
+clinical trials.
+
+Calverley PM(1), Rabe KF, Goehring UM, Kristiansen S, Fabbri LM, Martinez FJ; 
+M2-124 and M2-125 study groups.
+
+Collaborators: Abdool-Gaffar MS, Abdullah IA, Abdullah I, Abernathy MG, Jaoude 
+SA, Adler M, Agoro AB, Ahmad I, Ahmed M, Ahmed T, Ainsworth P, Aisanov Z, Aisiku 
+I, Al-Asadi L, Alwine LK, Ambert L, Amer E, Amin D, Ancochea J, Anderson M, 
+Andrews C, Anthony J, Antonovsky Y, Archuleta M, Ashley RG, Atkinson AR, Aubier, 
+Awad N, Bailey A, Baker J, Baker AM, Bálint B, Balli EA, Baloira A, Bamberg R, 
+Barber M, Barbers R, Bardin P, Bartkowiak A, Bateman E, Batura-Gabryel H, 
+Baumbach R, Baz M, Beck E, Becker JC, Behiels S, Beliveau W, Bell C, Bensch G, 
+Berlinches P, Bernabeu L, Bernstein DI, Bertley J, Bettendorf A, Bhargava S, 
+Bishop G, Bitter-Suerman S, Blagden M, Blanquer R, Bleecker E, Blumenthal B, 
+Bogdan M, Booth W, Boscia J, Botnick W, Boucher P, Boulytcheva N, Bowler S, 
+Boyer GR, Boz D, Bradley JK, Brannen A, Bray W, Brazinsky SA, Brennan K, 
+Brockmyre A, Brogan TA, Broker R, Brownlie R, Brüggen H, Bruya TE, Bure M, Burk 
+JR, Butler JA, Caillaud D, Camosy P, Candal F, Carpenter K, Celdrán J, Centanni 
+S, Cerveri I, Chanez P, Chang J, Chapman G, Chereyskaya NK, Chia M, Chinsky K, 
+Chisdak M, Chrostowski D, Chuchalin A, Clay PG, Cohen K, Collette R, Collins KL, 
+Confalonieri M, Cooper JA Jr, Cordasco E, Corley L 3rd, Corne, Corren J, Cote C, 
+Coulet P, Covelli H, Cowen P, Cowie B, Craig TJ, Crothers E, Csanadi, Cukier A, 
+Cummings A, Daly J, Daniel S, Darrah A, Daul C, Davis L, Viegas CA, De Busk C, 
+de God I, DeGarmo RG, Delgado JP, Deslauriers G, Despot J, Parreno LD, Diamond 
+E, DiMarco A, Dixon C, Dineen J, Doboszynska A, Doris J, Dransfield MT, D'Souza 
+G, Dupouy J, D'Urzo A, Dvoretski L, Eade J, Eaton S, Echave J, Efimov AV, 
+Egerton T, Elkayam D, Eller J, Ellison WT, Ellstrom K, Elton DR, Epstein JD, Erb 
+D, Ettinger NA, Falcone F, Fei R, Fein E, Feldman G, Fennell DF, Fera T, 
+Ferguson G, Ferguson L, Pereira LF, Feussner W, Fisher M, Fisher R, Fiss E, 
+Fiterman J, Fitzgerald M, Fletcher EC, Fouquert L, Franklin P, Fritscher CC, 
+Fritzsche A, Fuentes D, Fuentes F, Gabrys J, Gagnon M, Gainaru D, Galustyan A, 
+Gaona RE Jr, de Vinuesa GG, Gauthier JS, Gehling U, Gentina T, Gibert W, Gillies 
+J, Gilman RM, Ginns L, Girgis K, Given J, Gong H Jr, Gottschlich G, Gowda V, 
+Grambau G, Greenwald G, Greenwald J, Grellier P, Gross N, Grunvald E, Gustman P, 
+Haase PU, Hagaman D, Hamling J, Hammett D, Hanania N, Hansen V, Harat R, Harris 
+J, Harris A, Hartmann R, Hellems S, Henderson W, Henry RE, Heredia JL, Herer B, 
+Hetzel JL, Heyder AM, Hill D, Hiller FC 2nd, Hirani N, Höller W, Holmes M, Homik 
+L, Horner SR, Horowitz ID, Howarth P, Hunt GW, Hyers T, Hyvernat P, Iqbal IM, 
+Irusen EM, Ishina TI, Iyer RP, Jagannath K, Jain S, Jamnig H, Janes M, Jansen 
+JJ, Jardim JR, Jayne J, Johnson C, Jones S, Joubert J, Journeay GE, Jullian H, 
+Jumper C, Kaelin TD Jr, Kafé H, Kähler C, Kahn FW, Kaladas J, Kaplan A, Karpel 
+J, Karrasch J, Katragadda S, Kawley FA, Kaye MG, Kecskés T, Keith P, Kelly A, 
+Kelsen S, Kerkering M, Kerwin EM, Khronusova Y, Khurana S, Kimura SH, Kinch H, 
+Kingsley J, Kleerup EC, Kleinsteuber WK, Knox A, Koenig S, Komlev A, Kooy J, 
+Kopyt NP, Korduan M, Kormos T, Koser A, Koura F, Kovács L, Kovalski RJ, Kraft M, 
+Krishna J, Krumpe P, Kuberka Z, Kumar TM, Kureishy S, Kuschner W, Kyle C, 
+Lahasky D, Lakin G, Lam A, Lam S, Laman D, Lane E, Langan J, Lanier RC, Lapa JR, 
+Larivée P, Larj M, Lasky J, Lau E, Laumen R, Lawless JF, Le Brozec B, Leduc JJ, 
+Lee T, Lee D, Leeds W, Lejay D, Lenox R, Liebenberg GC, Liebman D, Linnhoff A, 
+Lisberg EE, Liu MC, Llorca E, Lockey RF, Look DC 3rd, Ludwig-Sengpiel A, Lumry 
+WR, Lundgren FL, Maggiacomo FP, Mahesh PA, Mahutte CK, Malanga A, Malik O, 
+Maltais F, Mandel M, Manur A, Marciel R, Marcushamer S, Mark GA, Martinelli J, 
+Martinez R, Mascolo M, Mazza G, Mc Coll I, McCaughey, McConnell J, McDavid R, 
+McEvoy C, McFadden ER, McGoldrick H, McIvor A, McKinnon C, Meade A, Mello C, 
+Mesquita AM, Meyer J, Meyer A, Mezey R, Millard MW, Miller D, Mirzai T, 
+Mitlehner W, Moder G, Mollen M, Mooney P, Morelli J, Moriarty T, Morice A, Moser 
+NJ, Mounier D, Muller D, Müller H, Murillo B, Murphy K, Nadeemullah M, Nagaraja 
+C, Nalepa P, Nel A, Nelson HS, Newman J, Nielson R, Nikitins I, Niphadkar P, 
+Nolen T, Nonikov V, Novojenov VG, Nussdorfer T, Obaray A, O'Brien JA, Oliveira 
+J, Olivieri D, Olivieri M, Olson D, O'Mahony MF, O'Mahony W, Onder RF Jr, Ong S, 
+Orpen I, Osea E, Pacin M, Panos RJ, Parker I, Patel A, Patil P, Pearle JL, 
+Pecastaing G, Perera S, Pérez de Llano LA, Peters M, Peterson G, Pettenkofer J, 
+Pfeifer MW, Phillips M, Piasecki R, Pierce K, Pierzchala W, Pieters R, Pigearias 
+B, Pistolesi M, Pizzichini E, Player R, Póczi M, Pohl W, Polk O Jr, Popova V, 
+Popovich K, Prabhu R, Prins M, Prokop-Staszecka A, Proninia S, Pudi K, Pue C, 
+Pullman J, Raad GL, Rab-Hasan R, Rakvács M, Raman P, Ramraje N, Ras G, Rastogi 
+P, Ratner P, Regula J, Rehman SM, Renzi P, Richmond GJ, Riff D, Robinson MT, 
+Suarez JR, Rodriguez-Cintron W, Rossi A, Rousseau W, Sahasrabudhe T, Sahoo RC, 
+Salvaterra C, Salvi S, Samson M, San Pedro G, Sánchez I, Toril FS, Sarnaik RM, 
+Sarosi G, Sauer R, Savani D, Scanlon PD, Schachter EN, Schacter G, Schlezak J, 
+Schneider D, Schroeder CE, Schuller D, Scott G, Seale P, Sedavnykh I, Sehgal S, 
+Sellman R, Serrano JA, Sevette C, Shale D, Shapero P, Sharafkhaneh A, Sharma R, 
+Shaver J, Sherman C, Sheski F, Sibille JS, Sidorenko IV, Sigal B, Silva RL, 
+Silverthorn A, Simanenkov V, Singh V, Sinkowitz DM, Sirajuddeen S, Sitar S, 
+Skobeloff E, Sligh T, Small D, Smith C, Snell P, Snyder B, Soler JJ, Soowamber 
+M, Spanevello A, Spangenthal S, Srikanth K, Rao NS, Stang M, Steffen H, 
+Steinfort C, Stewart GE, Stirbulov R, Stocks JM, Storms WW, Streit B, Struble R, 
+Strzinek R, Stubbs RA, Sturm P, Sudhoff H, Suen J, Sussman R, Swarnakar R, 
+Sweilem M, Szalai Z, Szlachcic Y, Szmidt M, Sztancsik Z, Tan R, Tanaseanu C, 
+Tanasescu C, Tarpay M, Terlecka W, Terol B, Therrien R, Thien F, Thompson P, 
+Thornton D, Tidman R, Tillinghast AJ, Tillis W, Timar M, Torres D 2nd, Trapp J, 
+Trauth HA, Trebas-Pietras E, Truwit J, Turotte C, Tytus R, Updegrove JD, 
+Vallieres C, Várkonyi I, Venske WU, Verkindre C, Viera E, Viljoen JJ, Vinkler I, 
+Visser S, von Versen L, Voves R, Wade J, Wade TM, Wade TA, Wanderer A, Watz H, 
+Webster DE, Weihrich A, Wesolowski S, Westney G, White MV, White A, Willsie SK, 
+Winder JA, Wolfe R, Young D, Yusen R, Yusim JD, Zamel N, Ziedalski T, Zorina E, 
+Zuck P, Zwetchkenbaum J, Seale P, Thompson P, Holmes M, Bardin P, Peters M, 
+Phillips M, Chia M, Steinfort C, Nikitins I, Karrasch J, Bowler S, Thien T, Pohl 
+W, Sweilem M, Voves R, Höller W, Moder G, Jamnig H, Kähler C, Fiss E, Cukier A, 
+Jardim JR, Stirbulov R, Lapa JR, Pizzichini E, Fritscher CC, Fiterman J, Silva 
+RL, Hetzel JL, Oliveira J, de Godoy I, Pereira LF, Marciel R, Viegas CA, 
+Lundgren FL, Maltais F, Hirani N, Fera T, Gauthier JS, Bishop G, McIvor A, Zamel 
+N, Larivée P, Booth W, Small D, Amer E, Gagnon M, Kelly A, Boucher P, Homik L, 
+Renzi P, Kooy J, Anthony J, Keith P, Lau E, O'Mahony MF, Soowamber M, D'Urzo A, 
+Deslauriers G, Lam A, Marcushamer S, Mazza G, O'Mahony W, Lam S, Tytus R, 
+Behiels S, Iyer RP, Schacter G, Therrien R, Collette R, Turotte C, Bailey A, 
+Cowie B, Ferguson L, Vallieres C, Bertley J, Kaplan A, Atkinson AR, Csanadi, 
+Chanez P, Aubier, Sevette C, Hyvernat P, Zuck P, Pecastaing G, Kafé H, Dupouy J, 
+Coulet P, Pigearias B, Le Brozec B, Jullian H, Lejay D, Dominique L, Grellier P, 
+Fouquert L, Boyer GR, Bernabeu L, Verkindre C, Bettendorf A, Bure M, Herer B, 
+Gentina T, Caillaud D, Boz D, Mounier D, Le Brozec B, Muller D, Terol B, Leduc 
+JJ, Feussner W, Trauth HA, Gehling U, Brüggen H, Laumen R, Becker JC, Steffen H, 
+Venske WU, Linnhoff A, Korduan M, von Versen L, Pettenkofer J, Mitlehner W, 
+Eller J, Hartmann R, Fritzsche A, Bitter-Suermann S, Watz H, Beck E, 
+Ludwig-Sengpiel A, Sudhoff H, Weihrich A, Sauer R, Haase PU, Pfeifer MW, Müller 
+H, Bamberg R, Póczi M, Szalai Z, Timar M, Várkonyi I, Schlezak J, Sztancsik Z, 
+Bálint B, Kormos T, Rakvács M, Vinkler I, Kecskés T, Kuberka Z, Kovács L, Awad 
+N, Singh V, D'Souza G, Kumar TM, Raman P, Mesquita AM, Jagannath K, Srikanth K, 
+Niphadkar P, Saho RC, Nagaraja C, Patil P, Rao NS, Ramraje N, Salvi S, Sarnaik 
+RM, Gowda V, Sirajuddeen S, Mahesh PA, Sahasrabudhe T, Swarnakar R, Bhargava S, 
+Olivieri D, Falcone F, Rossi A, Confalonieri M, Cerveri I, Centanni S, Pistolesi 
+M, Donner C, Olivieri M, Spanevello A, Gillies J, Trebas-Pietras E, Doboszynska 
+A, Szmidt M, Terlecka W, Pierzchala W, Wesolowski S, Gabrys J, Harat R, 
+Prokop-Staszecka A, Batura-Gabryel H, Regula J, Nalepa P, Tanaseanu C, Tanasescu 
+C, Bogdan M, Gainaru D, Ambert L, Proninia S, Ishina TI, Antonovsky Y, Sedavnykh 
+I, Boulytcheva N, Dvoretski L, Komlev A, Chuchalin A, Zorina E, Nonikov V, 
+Sidorenko IV, Galustyan A, Simanenkov V, Popova V, Chereyskaya NK, Novojenov VG, 
+Aisanov Z, Efimov AV, Prins M, Bateman E, Jansen JJ, Nel A, Joubert J, Abdullah 
+IA, Abdool-Gaffar MS, Visser S, Ras G, Abdullah I, Liebenberg GC, Viljoen JJ, 
+Iruse EM, O'Brien JA, Sánchez I, Ancochea J, Echave J, Celdrán J, Suarez JR, 
+Berlinches P, Heredia JL, Llorca E, Toril FS, de Vinuesa GG, Fuentes F, Blanquer 
+R, Soler JJ, Serrano JA, Baloira A, Parreno LD, de Llano LA, Adler M, Knox A, 
+Blagden M, Hamling J, Mooney P, Howarth P, McKinnon C, Langan J, Brownlie R, 
+Calverley P, Ainsworth P, Orpen I, Manur A, Egerton T, Chapman G, Pieters R, 
+Anderson M, Crothers E, McGoldrick H, Morice A, Kyle C, Corne, Parker I, Mc Coll 
+I, McCaughey, Kinch H, Dixon C, Cummings A, Darrah A, Shale D, Sharma R, 
+Cordasco E, Jaoude SA, Corren J, Elkayam D, Greenwald G, Harris J, Pacin M, 
+Candal F, Sellman R, Koenig S, Truwit J, Brazinsky SA, Ettinger NA, Sussman R, 
+Liu MC, Lumry WR, Baker J, Lee T, Horowitz ID, Murphy K, Wolfe R, Daul C, 
+Gottschlich G, Greenwald J, Journeay GE, Shapero P, Sibille JS, Maggiacomo FP, 
+Cote C, Bleecker E, Lahasky D, Sherman C, Gilman RM, Gross N, Olson D, Kahn FW, 
+Brennan K, Krumpe P, Pearle JL, Bray W, Moriarty T, Kleinsteuber WK, Trapp J, 
+Lasky J, Mello C, Tan R, Kaye MG, Stang M, Covelli H, Snyder B, Peterson G, 
+White MV, Henderson W, Blumenthal B, Brogan TA, Schroeder CE, Bradley JK, Raad 
+GL, Popovich K, Ashley RG, Chisdak M, Zwetchkenbaum J, Sigal B, Hyers T, Hanania 
+N, Richmond GJ, Broker R, San Pedro G, Samson M, Scott G, Heyder AM, Updegrove 
+JD, Archuleta M, Erb D, Lakin G, Davis L, Nolen T, Burk JR, Fuentes D, Martinez 
+R, Millard MW, Sharafkhaneh A, Webster DE, Fennell DF, Lane E, Mandel M, 
+Martinelli J, Struble R, Cowen P, Kimura SH, Feldman G, Gibert W, Ong S, Patel 
+A, Pudi K, Rab-Hasan R, Robinson MT, Aisiku I, Despot J, DiMarco A, Girgis K, 
+Sinkowitz DM, Strzinek R, Thornton D, McFadden ER, Alwine LK, Delgado JP, 
+Kuschner W, Elton DR, Bruya TE, Mirzai T, Miller D, Snell P, McEvoy C, Piasecki 
+R, Rastogi P, Harris A, Player R, Ahmad I, Chrostowski D, Cohen K, Doris J, Fei 
+R, Ferguson G, Gong H Jr, Szlachcic Y, Hellems S, Johnson C, Kopyt NP, Kovalski 
+RJ, Kraft M, Lockey RF, Ahmed M, Mark GA, Fisher M, Kleerup EC, Panos RJ, 
+Bartkowiak A, Lanier RC, Bell C, Larj M, Liebman D, Brannen A, Murillo B, 
+Nielson R, Dineen J, Brockmyre A, Shaver J, Stubbs RA, Grunvald E, Wade J, 
+Gustman P, Jumper C, Butler JA, Ellstrom K, Rodriguez-Cintron W, Ginns L, Sehgal 
+S, Fein E, Barbers R, McConnell J, Moser NJ, Nussdorfer T, Yusen R, Krishna J, 
+Rousseau W, Kingsley J, Mascolo M, Meyer J, Ziedalski T, Westney G, Rehman SM, 
+Sturm P, Sheski F, Silverthorn A, Sitar S, Agoro AB, Tillinghast AJ, Savani D, 
+Schuller D, Stewart GE, Bernstein DI, Nelson HS, Skobeloff E, Winder JA, 
+Beliveau W, Diamond E, Andrews C, Craig TJ, Kerwin EM, Bensch G, Lisberg EE, 
+White A, Kaladas J, Pullman J, Gaona RE Jr, Willsie SK, Clay PG, Hill D, Ratner 
+P, Kaelin T Jr, Ellison WT, Baker AM, Tidman R, Ahmed T, Cooper JA Jr, Epstein 
+JD, Hiller FC 2nd, Horner SR, Karpel J, Kelsen S, Mahutte CK, Hagaman D, 
+Spangenthal S, Amin D, Hunt GW, Kawley FA, Tarpay M, Given J, Eaton S, Jayne J, 
+Janes M, Baz M, Baumbach R, Wanderer A, Pierce K, Carpenter K, Onder RF Jr, 
+Henry RE, Eade J, Khronusova Y, Chinsky K, Mollen M, DeGarmo RG, Perera S, 
+Dransfield MT, Smith C, Stocks JM, Collins KL, Fitzgerald M, Storms WW, Torres D 
+2nd, Scanlon PD, Osea E, Streit B, Botnick W, Viera E, Look DC 3rd, Riff D, 
+Sligh T, Camosy P, Boscia J, Fisher R, Al-Asadi L, Balli EA, Barber M, Corley L 
+3rd, Daniel S, Fletcher EC, Franklin P, Grambau G, Iqbal IM, Kerkering M, 
+Kureishy S, Lawless JF, Nadeemullah M, Newman J, Yusim JD, Wade TM, Young D, De 
+Busk C, Katragadda S, Koura F, Laman D, Lee D, Lenox R, Malik O, Leeds W, Meyer 
+A, Prabhu R, Schneider D, Jones S, Daly J, Khurana S, Obaray A, Salvaterra C, 
+Wade TA, Hammett D, Hansen V, Jain S, Malanga A, Sarosi G, Tillis W, Suen J, 
+Abernathy MG, Mezey R, McDavid R, Pue C, Meade A, Morelli J, Polk O Jr, Koser A.
+
+Author information:
+(1)School of Clinical Sciences, Liverpool, UK. pmacal@liverpool.ac.uk
+
+Erratum in
+    Lancet. 2010 Oct 2;376(9747):1146.
+
+Comment in
+    Lancet. 2012 Feb 25;379(9817):710-1; author reply 711-2. doi: 
+10.1016/S0140-6736(12)60304-3.
+    Chest. 2014 May;145(5):937-9. doi: 10.1378/chest.14-0112.
+    Chest. 2014 May;145(5):939-42. doi: 10.1378/chest.14-0114.
+
+BACKGROUND: The phosphodiesterase-4 inhibitor roflumilast can improve lung 
+function and prevent exacerbations in certain patients with chronic obstructive 
+pulmonary disease (COPD). We therefore investigated whether roflumilast would 
+reduce the frequency of exacerbations requiring corticosteroids in patients with 
+COPD.
+METHODS: In two placebo-controlled, double-blind, multicentre trials (M2-124 and 
+M2-125) with identical design that were done in two different populations in an 
+outpatient setting, patients with COPD older than 40 years, with severe airflow 
+limitation, bronchitic symptoms, and a history of exacerbations were randomly 
+assigned to oral roflumilast (500 microg once per day) or placebo for 52 weeks. 
+Primary endpoints were change in prebronchodilator forced expiratory volume in 1 
+s (FEV(1)) and the rate of exacerbations that were moderate 
+(glucocorticosteroid-treated) or severe. Analysis was by intention to treat. The 
+trials are registered with ClinicalTrials.gov, number NCT00297102 for M2-124, 
+and NCT00297115 for M2-125.
+FINDINGS: Patients were assigned to treatment, stratified according to smoking 
+status and treatment with longacting beta(2) agonists, and given roflumilast 
+(n=1537) or placebo (n=1554). In both studies, the prespecified primary 
+endpoints were achieved and were similar in magnitude. In a pooled analysis, 
+prebronchodilator FEV(1) increased by 48 mL with roflumilast compared with 
+placebo (p<0.0001). The rate of exacerbations that were moderate or severe per 
+patient per year was 1.14 with roflumilast and 1.37 with placebo (reduction 17% 
+[95% CI 8-25], p<0.0003). Adverse events were more common with roflumilast (1040 
+[67%]) than with placebo (963 [62%]); 219 (14%) patients in the roflumilast 
+group and 177 (12%) in the placebo group discontinued because of adverse events. 
+In the pooled analysis, the difference in weight change during the study between 
+the roflumilast and placebo groups was -2.17 kg.
+INTERPRETATION: Since different subsets of patients exist within the broad 
+spectrum of COPD, targeted specific therapies could improve disease management. 
+This possibility should be explored further in prospective studies.
+FUNDING: Nycomed.
+
+DOI: 10.1016/S0140-6736(09)61255-1
+PMID: 19716960 [Indexed for MEDLINE]


### PR DESCRIPTION
## Summary

Wires the one FDA surrogate-endpoint row that the FDA-SE index already asserts as an `EXACT_DISMECH_MATCH` for **Chronic Obstructive Pulmonary Disease** into the disease entry, continuing the per-disease reverse-bridge work for #2495.

- Adds a `Forced Expiratory Volume in 1 Second (FEV1)` entry to `biochemical:` in `kb/disorders/Chronic_Obstructive_Pulmonary_Disease.yaml` (`NCIT:C38084`).
- Adds a `BiomarkerReadout` linking FEV1 to the existing **Airflow Limitation** pathophysiology node (`relationship: PHARMACODYNAMIC_MARKER_OF`, `direction: NEGATIVE`, `endpoint_context: PHARMACODYNAMIC`).
- Bridges to FDA surrogate endpoint row `FDA-SE-adult-noncancer-013` (FEV1, validated surrogate endpoint, traditional approval) via `regulatory_endpoint_refs`.
- Mirrors the merged Cystic Fibrosis reverse-bridge pattern (#3035).

## Selection rationale (high-effort scanner run)

Scanned the unassigned high-effort `curation` queue (`label:curation -label:low_effort -label:medium_effort`). The single in-scope **PR** (#2898) was already escalated to maintainers for a merge-strategy decision in its most recent comment — re-touching it is the documented anti-pattern. The cancer-batch **issues** (#1112/#1115/#1117/#1118/#1119/#1120) all have entries on `main`, multiple in-flight draft PRs, and were touched within the last ~36 h. #2495 was less recently touched and — critically — its reverse-bridge pattern was **validated by the merge of #3035** (Cystic Fibrosis FEV1), making "wire the next EXACT-match disease" a clean, accepted one-run deliverable rather than a nibble or a comment-treadmill step. COPD is the natural follow-on: same biomarker (FEV1), one unambiguous `EXACT_DISMECH_MATCH` row.

## Evidence

All snippets are exact quotes verified against cached PubMed abstracts:

| PMID | Trial | Drug class (matches FDA row) | Role |
|------|-------|------------------------------|------|
| `19716960` | Roflumilast M2-124 / M2-125 | Phosphodiesterase-4 inhibitor | FEV1 as primary endpoint; FEV1 treatment response |
| `18836213` | UPLIFT (tiotropium, 4-year) | Anticholinergic | FEV1 / FEV1-FVC ratio defines & grades COPD airflow limitation |

Both drug classes (PDE4 inhibitor, anticholinergic) are named in the FDA row's `drug_mechanism_of_action`.

## What this PR intentionally does NOT do

- No schema changes — `BiomarkerReadout` / `regulatory_endpoint_refs` already exist (#2500).
- No edits to the FDA-SE index `kb/surrogate_endpoints/fda_surrogate_endpoints.yaml`.
- Does not address the remaining ~28 reverse-bridges across other files — each needs genuine per-disease curation and is best landed one disease per run.
- Reverted incidental `normalize-cache` churn (UBERON/enum caches, two unrelated reference-cache files) so the diff is scoped to one disorder file + the two newly fetched reference-cache files.

## Validation

- `just validate kb/disorders/Chronic_Obstructive_Pulmonary_Disease.yaml` → all validations passed (schema + terms + references)
- `just validate-terms kb/disorders/Chronic_Obstructive_Pulmonary_Disease.yaml` → ✅ passed
- `just check-reference-cache-frontmatter` → OK
- `uv run pytest tests/test_data.py -k "Chronic_Obstructive or biomarker or readout or surrogate"` → 7 passed

Opened as **draft** pending the maintainer decision flagged on #2495 (re-scope/close #2495 vs. keep it open as the tracker for one-disease-per-run reverse-bridge PRs). The curated content is correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)