### PR TITLE
Deprecate updated_date: schema-only split from #2898

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,18 +170,17 @@ Model organism evidence should not be the only support for human phenotypes; kee
 
 ### Entry Metadata Dates
 
-Each `Disease` entry should include lifecycle timestamps:
+Each `Disease` entry should include a creation timestamp:
 
 ```yaml
 creation_date: "2025-06-12T20:16:27Z"
-updated_date: "2025-07-03T11:05:10Z"
 ```
 
 Rules:
 - Use ISO 8601 / RFC 3339 datetime strings.
 - Keep `creation_date` stable after first creation.
-- Update `updated_date` whenever curated content changes.
 - Prefer UTC (`Z` suffix) for consistency.
+- **Do not add `updated_date` to new entries.** The field is deprecated — git history is the authoritative change log. Existing entries that still carry `updated_date` may retain it until a future bulk cleanup.
 
 Quick classification rules (use these before tagging):
 - HUMAN_CLINICAL: human patients, cohorts, case reports, clinical trials (NCT), epidemiology.

--- a/app/index.html
+++ b/app/index.html
@@ -683,13 +683,16 @@
                 }
 
                 const dateField = field === 'created' ? 'creation_date' : 'updated_date';
-                sorted.sort((a, b) => this.compareByDate(a, b, dateField, direction));
+                const fallbackField = field === 'updated' ? 'creation_date' : null;
+                sorted.sort((a, b) => this.compareByDate(a, b, dateField, direction, fallbackField));
                 return sorted;
             }
 
-            compareByDate(a, b, field, direction) {
-                const aTime = this.parseIsoDate(a[field]);
-                const bTime = this.parseIsoDate(b[field]);
+            compareByDate(a, b, field, direction, fallbackField = null) {
+                const aRaw = a[field] || (fallbackField ? a[fallbackField] : null);
+                const bRaw = b[field] || (fallbackField ? b[fallbackField] : null);
+                const aTime = this.parseIsoDate(aRaw);
+                const bTime = this.parseIsoDate(bRaw);
                 const aMissing = aTime === null;
                 const bMissing = bTime === null;
 

--- a/src/dismech/schema/dismech.yaml
+++ b/src/dismech/schema/dismech.yaml
@@ -2573,10 +2573,13 @@ slots:
   updated_date:
     description: >-
       ISO 8601/RFC 3339 timestamp string for when this disease entry was last
-      updated (e.g., 2025-06-12T20:16:27Z)
+      updated (e.g., 2025-06-12T20:16:27Z). Deprecated: use git history for
+      authoritative change timestamps. Existing entries may retain this field;
+      new entries should omit it.
     range: string
     pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+\-]\d{2}:\d{2})$'
-    recommended: true
+    recommended: false
+    deprecated: true
   curation_history:
     description: Audit trail of AI-assisted curation events
     multivalued: true


### PR DESCRIPTION
## Summary

Closes #2892. Supersedes the unmergeable #2898 with a minimal, conflict-free split.

**What this PR does (3 files only):**

- `src/dismech/schema/dismech.yaml` — marks `updated_date` as `deprecated: true` and `recommended: false`. Existing kb entries that still carry the field continue to validate; new entries should omit it.
- `CLAUDE.md` — removes the instruction to set `updated_date` on every content change; notes that git history is authoritative and the field should not be added to new entries.
- `app/index.html` — fixes the browser "Updated" sort to fall back to `creation_date` when `updated_date` is absent, addressing the concern raised by @caufieldjh in #2892 that removing the field would break sorting.

**What this PR intentionally omits:**

The bulk removal of `updated_date:` lines from ~1,120 kb files. That step is cosmetic once the field is deprecated (existing values are harmless), and it was the sole cause of the 13+ merge-conflict cycles that stranded #2898. A follow-up scripted commit can do the bulk cleanup in a quiet window, or it can simply be left in place.

## Why not update #2898?

PR #2898 changed 1,128 files. Every new disorder PR that landed on `main` re-introduced an `updated_date:` line in its file, immediately returning #2898 to `CONFLICTING`. After 13+ conflict-sync rounds the previous scanner run explicitly escalated for a human merge-strategy decision. This PR implements the recommended "split" strategy from that escalation comment.

## Test plan

- [x] `just validate kb/disorders/Asthma.yaml` — passes (new entry without `updated_date`)
- [x] `just validate kb/disorders/Cystic_Fibrosis.yaml` — passes (existing entry with `updated_date` still validates)
- [x] `just validate kb/disorders/Marfan_Syndrome.yaml` — passes (backward compatibility confirmed)
- [ ] Browser "Updated (Newest first)" sort falls back to `creation_date` for entries without `updated_date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)